### PR TITLE
Refactor AWS role validation logic in aws-bedrock-guardrail

### DIFF
--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -279,18 +279,17 @@ func validateAWSConfigParams(params map[string]interface{}) error {
 		if !ok {
 			return fmt.Errorf("'awsRoleARN' must be a string")
 		}
-		if awsRoleARN == "" {
-			return fmt.Errorf("'awsRoleARN' cannot be empty")
-		}
 
 		// If role ARN is provided, validate role region
-		if awsRoleRegionRaw, ok := params["awsRoleRegion"]; ok {
-			awsRoleRegion, ok := awsRoleRegionRaw.(string)
-			if !ok {
-				return fmt.Errorf("'awsRoleRegion' must be a string")
-			}
-			if awsRoleRegion == "" {
-				return fmt.Errorf("'awsRoleRegion' cannot be empty")
+		if awsRoleARN != "" {
+			if awsRoleRegionRaw, ok := params["awsRoleRegion"]; ok {
+				awsRoleRegion, ok := awsRoleRegionRaw.(string)
+				if !ok {
+					return fmt.Errorf("'awsRoleRegion' must be a string")
+				}
+				if awsRoleRegion == "" {
+					return fmt.Errorf("'awsRoleRegion' cannot be empty when 'awsRoleARN' is specified")
+				}
 			}
 		}
 	}

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package awsbedrockguardrail
 
 import (
@@ -282,14 +282,19 @@ func validateAWSConfigParams(params map[string]interface{}) error {
 
 		// If role ARN is provided, validate role region
 		if awsRoleARN != "" {
-			if awsRoleRegionRaw, ok := params["awsRoleRegion"]; ok {
-				awsRoleRegion, ok := awsRoleRegionRaw.(string)
-				if !ok {
-					return fmt.Errorf("'awsRoleRegion' must be a string")
-				}
-				if awsRoleRegion == "" {
-					return fmt.Errorf("'awsRoleRegion' cannot be empty when 'awsRoleARN' is specified")
-				}
+			// If role ARN is provided and not empty, validate role region
+			awsRoleRegionRaw, ok := params["awsRoleRegion"]
+			if !ok {
+				return fmt.Errorf("'awsRoleRegion' is required when 'awsRoleARN' is specified")
+			}
+
+			awsRoleRegion, ok := awsRoleRegionRaw.(string)
+			if !ok {
+				return fmt.Errorf("'awsRoleRegion' must be a string")
+			}
+
+			if awsRoleRegion == "" {
+				return fmt.Errorf("'awsRoleRegion' cannot be empty when 'awsRoleARN' is specified")
 			}
 		}
 	}

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: aws-bedrock-guardrail
-version: v0.1.0
+version: v0.1.1
 description: |
   Validates request or response body content against AWS Bedrock Guardrails.
   Supports content filtering, topic detection, word filtering, and PII detection/masking.
@@ -100,12 +100,10 @@ systemParameters:
     awsRoleARN:
       type: string
       description: AWS IAM role ARN to assume (for role-based authentication). If specified, runtime assumes this role instead of using static credentials.
-      minLength: 1
       "wso2/defaultValue": "${config.awsbedrock_role_arn}"
     awsRoleRegion:
       type: string
       description: AWS region for role assumption (required if awsRoleARN is specified).
-      minLength: 1
       "wso2/defaultValue": "${config.awsbedrock_role_region}"
     awsRoleExternalID:
       type: string


### PR DESCRIPTION
## Purpose
> This pull request updates the validation logic for AWS configuration parameters in `awsbedrockguardrail.go` to improve error handling and clarify requirements for the `awsRoleARN` and `awsRoleRegion` fields.

## Goals
> Enable flexible authentication by allowing `awsRoleARN` to be empty for default credential usage and ensuring `awsRoleRegion` is only mandatory when a specific role is defined.

## Approach
> The check for `awsRoleARN` being non-empty has been removed, allowing it to be an empty string. Now, `awsRoleRegion` is only validated when `awsRoleARN` is specified and non-empty, and the error message for an empty `awsRoleRegion` has been clarified to indicate it is only required when `awsRoleARN` is specified.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now treats AWS role and region parameters conditionally: region is required only when a role is specified, avoiding spurious validation errors.
* **Chores**
  * Policy version bumped to v0.1.1 to reflect the validation behavior update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->