### PR TITLE
Updating JWT Policy to extract UserID from the claims

### DIFF
--- a/policies/jwt-auth/go.mod
+++ b/policies/jwt-auth/go.mod
@@ -3,6 +3,11 @@ module github.com/wso2/gateway-controllers/policies/jwt-auth
 go 1.25.1
 
 require (
-	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/wso2/api-platform/sdk v0.3.1
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/wso2/api-platform/sdk v0.3.9
+)
+
+require (
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 )

--- a/policies/jwt-auth/go.sum
+++ b/policies/jwt-auth/go.sum
@@ -1,4 +1,8 @@
-github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
-github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-github.com/wso2/api-platform/sdk v0.3.1 h1:Wr4n+xiJMOH1oqOMyGhiw9bTxCR97OTO5VZMPpp07lc=
-github.com/wso2/api-platform/sdk v0.3.1/go.mod h1:amQIiBlKZEeFFbDhYzIOj47ADc5mDPMNzhR40SByqB8=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/wso2/api-platform/sdk v0.3.9 h1:zL2knXB7ZYrGvhCV6SnVwDEfK/YkcEx8gXw8I/Ty+u0=
+github.com/wso2/api-platform/sdk v0.3.9/go.mod h1:pEUne6LknzYXF7htjYWNTTa3Lku3DfhI26dwFnEzK1A=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v0.1.1
+version: v0.1.2
 description: |
   Validates JWT access tokens using one or more JWKS providers (key managers).
   System-level configuration holds key manager endpoints and fetch behavior.
@@ -45,6 +45,13 @@ parameters:
     authHeaderPrefix:
       type: string
       description: Override for the authorization header scheme prefix (e.g., "Bearer", "JWT"). If specified at user-level, takes precedence over system configuration for this route.
+
+    userIdClaim:
+      type: string
+      description: >-
+        Claim name to extract the user ID from the JWT token for analytics.
+        If not specified, defaults to "sub" claim.
+      default: sub
 
 systemParameters:          
   type: object


### PR DESCRIPTION
## Purpose
- This PR updates the existing jwt-auth policy functionality by adding modification to extract the userID from the user provider or default claim and attach it to the AuthContext which will be used by the analytics pipeline

- Related PR: https://github.com/wso2/api-platform/pull/866
- Fix for: https://github.com/wso2/api-platform/issues/852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable user ID extraction from JWT claims (defaults to "sub") to populate analytics context and improve user tracking.
  * Policy configuration schema updated to expose the userIdClaim parameter.

* **Tests**
  * Added extensive tests covering default, custom, missing, numeric, empty, and mapped claim scenarios to validate user ID extraction behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->