### PR TITLE
Update go.sum to bump advanced rate limit policy version to v0.1.3 

### DIFF
--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -1,7 +1,5 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.1.23 h1:ruzEjDbVZkpVrqb1RrZGxKQWkAHAWxlXv+E3vjT0rXw=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.1.23/go.mod h1:bTA7dPUDgG9F4RVsoSMtfCx06QXEu8RRUM795eT5IDk=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -37,10 +35,14 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk v0.3.8 h1:zQEjxdVsk11NxYVSrtf/QQSK2ZpAFFyD8GNgcVWTVtc=
 github.com/wso2/api-platform/sdk v0.3.8/go.mod h1:sY7oEU0IBf+FzUnnBmW0DjqmXZ+vGikGH3Ar9sNgrdc=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.1.3 h1:p2deaCPT2iAqGbTv60mknTkT3mosH7qL3cqJygMTlqU=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.1.3/go.mod h1:zjPJeiHlwgHVoPOcS3/F0NYEwqd+IIwXlE2gvjDcAIk=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=


### PR DESCRIPTION
$subject