### PR TITLE
Change CEL Path Strings to Support Only Major Policy Versions

### DIFF
--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v0.1.3
+version: v0.1.4
 description: |
   Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas,
   weighted rate limiting, flexible key extraction, and both in-memory and Redis backends. Supports
@@ -317,7 +317,7 @@ systemParameters:
           but can allow up to 2x burst at window boundaries.
       enum: ["gcra", "fixed-window"]
       default: "gcra"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
 
     backend:
       type: string
@@ -326,7 +326,7 @@ systemParameters:
         'redis' for distributed rate limiting across multiple gateway instances.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
 
     redis:
       type: object
@@ -337,7 +337,7 @@ systemParameters:
           type: string
           description: Redis server hostname or IP address
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
 
         port:
           type: integer
@@ -345,17 +345,17 @@ systemParameters:
           minimum: 1
           maximum: 65535
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
 
         password:
           type: string
           description: Redis authentication password (optional)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
 
         username:
           type: string
           description: Redis ACL username (optional, Redis 6+)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
 
         db:
           type: integer
@@ -363,13 +363,13 @@ systemParameters:
           minimum: 0
           maximum: 15
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
 
         keyPrefix:
           type: string
           description: Prefix for all Redis keys to avoid conflicts
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.key_prefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.key_prefix}"
 
         failureMode:
           type: string
@@ -378,25 +378,25 @@ systemParameters:
             'closed' denies requests. Recommended: 'open' for availability.
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.failure_mode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failure_mode}"
 
         connectionTimeout:
           type: string
           description: Redis connection timeout (Go duration string)
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.connection_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connection_timeout}"
 
         readTimeout:
           type: string
           description: Redis read timeout (Go duration string)
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.read_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.read_timeout}"
 
         writeTimeout:
           type: string
           description: Redis write timeout (Go duration string)
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.write_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.write_timeout}"
 
     memory:
       type: object
@@ -411,7 +411,7 @@ systemParameters:
           minimum: 100
           maximum: 10000000
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.max_entries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.max_entries}"
 
         cleanupInterval:
           type: string
@@ -419,7 +419,7 @@ systemParameters:
             Interval for cleaning up expired entries (Go duration string).
             Use "0" to disable periodic cleanup.
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.cleanup_interval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanup_interval}"
 
     headers:
       type: object
@@ -432,7 +432,7 @@ systemParameters:
             Include X-RateLimit-* headers (de facto industry standard).
             Headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.headers.include_x_rate_limit}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_x_rate_limit}"
 
         includeIETF:
           type: boolean
@@ -440,7 +440,7 @@ systemParameters:
             Include IETF RateLimit headers (draft standard).
             Headers: RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, RateLimit-Policy
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.headers.include_ietf}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_ietf}"
 
         includeRetryAfter:
           type: boolean
@@ -448,4 +448,4 @@ systemParameters:
             Include Retry-After header when rate limited (RFC 7231).
             Only set on 429 responses.
           default: true
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.headers.include_retry_after}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.headers.include_retry_after}"

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-ratelimit
-version: v0.1.2
+version: v0.1.3
 description: |
   Simple request rate limiting policy that limits the number of requests per time window.
   Uses route name as the rate limit key. For advanced rate limiting with multi-dimensional
@@ -51,7 +51,7 @@ systemParameters:
           but can allow up to 2x burst at window boundaries.
       enum: ["gcra", "fixed-window"]
       default: "gcra"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
 
     backend:
       type: string
@@ -60,7 +60,7 @@ systemParameters:
         'redis' for distributed rate limiting across multiple gateway instances.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
 
     redis:
       type: object
@@ -71,7 +71,7 @@ systemParameters:
           type: string
           description: Redis server hostname or IP address
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
 
         port:
           type: integer
@@ -79,17 +79,17 @@ systemParameters:
           minimum: 1
           maximum: 65535
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
 
         password:
           type: string
           description: Redis authentication password (optional)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
 
         username:
           type: string
           description: Redis ACL username (optional, Redis 6+)
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
 
         db:
           type: integer
@@ -97,13 +97,13 @@ systemParameters:
           minimum: 0
           maximum: 15
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
 
         keyPrefix:
           type: string
           description: Prefix for all Redis keys to avoid conflicts
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.key_prefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.key_prefix}"
 
         failureMode:
           type: string
@@ -112,25 +112,25 @@ systemParameters:
             'closed' denies requests. Recommended: 'open' for availability.
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.failure_mode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failure_mode}"
 
         connectionTimeout:
           type: string
           description: Redis connection timeout (Go duration string)
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.connection_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connection_timeout}"
 
         readTimeout:
           type: string
           description: Redis read timeout (Go duration string)
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.read_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.read_timeout}"
 
         writeTimeout:
           type: string
           description: Redis write timeout (Go duration string)
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.write_timeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.write_timeout}"
 
     memory:
       type: object
@@ -145,7 +145,7 @@ systemParameters:
           minimum: 100
           maximum: 10000000
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.max_entries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.max_entries}"
 
         cleanupInterval:
           type: string
@@ -153,4 +153,4 @@ systemParameters:
             Interval for cleaning up expired entries (Go duration string).
             Use "0" to disable periodic cleanup.
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.cleanup_interval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanup_interval}"

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v0.1.2
+version: v0.1.3
 description: |
   Validates JWT access tokens using one or more JWKS providers (key managers).
   System-level configuration holds key manager endpoints and fetch behavior.
@@ -120,72 +120,72 @@ systemParameters:
                   certificatePath:
                     type: string
                     description: Path to certificate or public key file (e.g., /etc/certs/public.pem).
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.keymanagers}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.keymanagers}"
 
     jwksCacheTtl:
       type: string
       description: Duration string for JWKS caching (e.g., "5m"). If omitted a default is used.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwkscachettl}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwkscachettl}"
 
     jwksFetchTimeout:
       type: string
       description: Timeout for HTTP fetch of JWKS, e.g., "5s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchtimeout}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchtimeout}"
 
     jwksFetchRetryCount:
       type: integer
       description: Number of retries for JWKS fetch on transient failures.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchretrycount}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretrycount}"
 
     jwksFetchRetryInterval:
       type: string
       description: Interval between JWKS fetch retries, e.g., "2s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchretryinterval}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretryinterval}"
 
     allowedAlgorithms:
       type: array
       description: Allowed JWT signing algorithms (e.g., ["RS256","ES256"]).
       items:
         type: string
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.allowedalgorithms}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.allowedalgorithms}"
 
     leeway:
       type: string
       description: Clock skew allowance for exp/nbf checks, e.g., "30s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.leeway}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.leeway}"
 
     authHeaderScheme:
       type: string
       description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, runtime enforces the scheme; if omitted, runtime may accept raw header values or strip known schemes.
       default: Bearer
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.authheaderscheme}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.authheaderscheme}"
 
     headerName:
       type: string
       description: Header name to extract token from (default "Authorization").
       default: Authorization
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.headername}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.headername}"
 
     onFailureStatusCode:
       type: integer
       description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
       default: 401
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.onfailurestatuscode}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
       description: Format of error response on JWT validation failure. Supported values are "json" (structured error), "plain" (plain text), or "minimal" (minimal response).
       default: json
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.errormessageformat}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessageformat}"
     
     errorMessage:
       type: string
       description: Custom error message to include in the response body on authentication failure.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.errormessage}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessage}"
 
     validateIssuer:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.validateissuer}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.validateissuer}"
 
   required: ["keyManagers"]

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v0.1.1
+version: v0.1.2
 description: |
   This policy is used to secure traffic to Model Context Protocol server as defined in the specification 
   (https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). The Gateway acts as the 
@@ -115,80 +115,80 @@ systemParameters:
                   certificatePath:
                     type: string
                     description: Path to certificate or public key file (e.g., /etc/certs/public.pem).
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.keymanagers}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.keymanagers}"
 
     jwksCacheTtl:
       type: string
       description: Duration string for JWKS caching (e.g., "5m"). If omitted a default is used.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwkscachettl}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwkscachettl}"
 
     jwksFetchTimeout:
       type: string
       description: Timeout for HTTP fetch of JWKS, e.g., "5s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchtimeout}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchtimeout}"
 
     jwksFetchRetryCount:
       type: integer
       description: Number of retries for JWKS fetch on transient failures.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchretrycount}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretrycount}"
 
     jwksFetchRetryInterval:
       type: string
       description: Interval between JWKS fetch retries, e.g., "2s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.jwksfetchretryinterval}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.jwksfetchretryinterval}"
 
     allowedAlgorithms:
       type: array
       description: Allowed JWT signing algorithms (e.g., ["RS256","ES256"]).
       items:
         type: string
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.allowedalgorithms}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.allowedalgorithms}"
 
     leeway:
       type: string
       description: Clock skew allowance for exp/nbf checks, e.g., "30s".
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.leeway}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.leeway}"
 
     authHeaderScheme:
       type: string
       description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, runtime enforces the scheme; if omitted, runtime may accept raw header values or strip known schemes.
       default: Bearer
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.authheaderscheme}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.authheaderscheme}"
 
     headerName:
       type: string
       description: Header name to extract token from (default "Authorization").
       default: Authorization
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.headername}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.headername}"
 
     onFailureStatusCode:
       type: integer
       description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
       default: 401
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.onfailurestatuscode}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
       description: Format of error response on JWT validation failure. Supported values are "json" (structured error), "plain" (plain text), or "minimal" (minimal response).
       default: json
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.errormessageformat}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessageformat}"
     
     errorMessage:
       type: string
       description: Custom error message to include in the response body on authentication failure.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.errormessage}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.errormessage}"
 
     validateIssuer:
       type: boolean
       description: Whether to validate the token's issuer claim against configured key managers.
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v010.validateissuer}"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v0.validateissuer}"
     
     gatewayHost:
       type: string
       description: The host of the gateway to be included in the protected metadata URL and response.
       example: mcp1.api-platform.com
       default: localhost
-      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v010.gatewayhost}"
+      "wso2/defaultValue": "${config.policy_configurations.mcpauth_v0.gatewayhost}"
 
 
   required: ["keyManagers"]

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v0.1.0
+version: v0.1.1
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on token counts.
   It dynamically resolves token extraction paths (JSON paths) from the LLM Provider Template
@@ -67,7 +67,7 @@ systemParameters:
         - fixed-window: Simple fixed time window counter.
       enum: ["gcra", "fixed-window"]
       default: "gcra"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.algorithm}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.algorithm}"
 
     backend:
       type: string
@@ -75,7 +75,7 @@ systemParameters:
         Rate limit storage backend. 'memory' or 'redis'.
       enum: ["memory", "redis"]
       default: "memory"
-      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.backend}"
+      "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.backend}"
 
     redis:
       type: object
@@ -85,42 +85,42 @@ systemParameters:
         host:
           type: string
           default: "localhost"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.host}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.host}"
         port:
           type: integer
           default: 6379
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.port}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.port}"
         password:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.password}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.password}"
         username:
           type: string
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.username}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.username}"
         db:
           type: integer
           default: 0
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.db}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.db}"
         keyPrefix:
           type: string
           default: "ratelimit:v1:"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.keyprefix}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.keyprefix}"
         failureMode:
           type: string
           enum: ["open", "closed"]
           default: "open"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.failuremode}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.failuremode}"
         connectionTimeout:
           type: string
           default: "5s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.connectiontimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.connectiontimeout}"
         readTimeout:
           type: string
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.readtimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.readtimeout}"
         writeTimeout:
           type: string
           default: "3s"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.redis.writetimeout}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.redis.writetimeout}"
 
     memory:
       type: object
@@ -130,8 +130,8 @@ systemParameters:
         maxEntries:
           type: integer
           default: 10000
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.maxentries}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.maxentries}"
         cleanupInterval:
           type: string
           default: "5m"
-          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v010.memory.cleanupinterval}"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v0.memory.cleanupinterval}"


### PR DESCRIPTION
## Purpose
This PR adds the modified CEL path strings required for parsing the default values inside the following policies
> - advanced-ratelimit
> - basic-ratelimit
> - jwt-auth
> - mcp-auth
> - token-based-ratelimit

- Related Issue: https://github.com/wso2/api-platform/issues/956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Advanced Rate Limit policy to v0.1.4, Basic Rate Limit to v0.1.3, JWT Authentication to v0.1.3, MCP Authentication to v0.1.2, and Token-Based Rate Limit to v0.1.1.
  * Standardized configuration reference paths across all rate limit and authentication policies.
  * Refined policy descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->