### PR TITLE
Populating the AuthContext to match the new format

### DIFF
--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -215,14 +215,13 @@ func (p *APIKeyPolicy) handleAuthSuccess(ctx *policy.RequestContext) policy.Requ
 	ctx.Metadata[MetadataKeyAuthMethod] = "api-key"
 
 	// Populate AuthContext struct (AppID/UserID left empty until store supports returning them)
-	if ctx.SharedContext != nil {
-		if ctx.SharedContext.AuthContext == nil {
-			ctx.SharedContext.AuthContext = &policy.AuthContext{}
-		}
-		ac := ctx.SharedContext.AuthContext
-		ac.Authenticated = true
-		ac.AuthType = "apikey"
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
 	}
+	ac := ctx.SharedContext.AuthContext
+	ac.Authenticated = true
+	ac.AuthType = "api-key"
+	
 
 	slog.Debug("API Key Auth Policy: Authentication metadata set",
 		"authSuccess", true,
@@ -256,6 +255,14 @@ func (p *APIKeyPolicy) handleAuthFailure(ctx *policy.RequestContext, statusCode 
 	// Set metadata indicating failed authentication
 	ctx.Metadata[MetadataKeyAuthSuccess] = false
 	ctx.Metadata[MetadataKeyAuthMethod] = "api-key"
+
+	// Populate AuthContext for failed authentication
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
+	}
+	ctx.SharedContext.AuthContext.Authenticated = false
+	ctx.SharedContext.AuthContext.AuthType = "api-key"
+	
 
 	headers := map[string]string{
 		"content-type": "application/json",

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -214,6 +214,16 @@ func (p *APIKeyPolicy) handleAuthSuccess(ctx *policy.RequestContext) policy.Requ
 	ctx.Metadata[MetadataKeyAuthSuccess] = true
 	ctx.Metadata[MetadataKeyAuthMethod] = "api-key"
 
+	// Populate AuthContext struct (AppID/UserID left empty until store supports returning them)
+	if ctx.SharedContext != nil {
+		if ctx.SharedContext.AuthContext == nil {
+			ctx.SharedContext.AuthContext = &policy.AuthContext{}
+		}
+		ac := ctx.SharedContext.AuthContext
+		ac.Authenticated = true
+		ac.AuthType = "apikey"
+	}
+
 	slog.Debug("API Key Auth Policy: Authentication metadata set",
 		"authSuccess", true,
 		"authMethod", "api-key",

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -221,7 +221,8 @@ func (p *APIKeyPolicy) handleAuthSuccess(ctx *policy.RequestContext) policy.Requ
 	ac := ctx.SharedContext.AuthContext
 	ac.Authenticated = true
 	ac.AuthType = "api-key"
-	
+	ac.UserID = "" // Todo: Populate the UserID with the application or user associated with the API key once the store supports it
+	ac.APIKey = &policy.APIKeyAuthDetails{}
 
 	slog.Debug("API Key Auth Policy: Authentication metadata set",
 		"authSuccess", true,
@@ -262,7 +263,7 @@ func (p *APIKeyPolicy) handleAuthFailure(ctx *policy.RequestContext, statusCode 
 	}
 	ctx.SharedContext.AuthContext.Authenticated = false
 	ctx.SharedContext.AuthContext.AuthType = "api-key"
-	
+	ctx.SharedContext.AuthContext.APIKey = &policy.APIKeyAuthDetails{}
 
 	headers := map[string]string{
 		"content-type": "application/json",

--- a/policies/basic-auth/basicauth.go
+++ b/policies/basic-auth/basicauth.go
@@ -153,16 +153,15 @@ func (p *BasicAuthPolicy) handleAuthSuccess(ctx *policy.RequestContext, username
 	ctx.Metadata[MetadataKeyAuthMethod] = "basic"
 
 	// Populate AuthContext struct
-	if ctx.SharedContext != nil {
-		if ctx.SharedContext.AuthContext == nil {
-			ctx.SharedContext.AuthContext = &policy.AuthContext{}
-		}
-		ac := ctx.SharedContext.AuthContext
-		ac.Authenticated = true
-		ac.AuthType = "basic"
-		ac.Subject = username
-		ac.UserID = username
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
 	}
+	ac := ctx.SharedContext.AuthContext
+	ac.Authenticated = true
+	ac.AuthType = "basic"
+	ac.Subject = username
+	ac.UserID = username
+	
 
 	// Continue to upstream with no modifications
 	return policy.UpstreamRequestModifications{}
@@ -178,6 +177,14 @@ func (p *BasicAuthPolicy) handleAuthFailure(ctx *policy.RequestContext, allowUna
 	// Set metadata indicating failed authentication
 	ctx.Metadata[MetadataKeyAuthSuccess] = false
 	ctx.Metadata[MetadataKeyAuthMethod] = "basic"
+
+	// Populate AuthContext for failed authentication
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
+	}
+	ctx.SharedContext.AuthContext.Authenticated = false
+	ctx.SharedContext.AuthContext.AuthType = "basic"
+	
 
 	// If allowUnauthenticated is true, allow request to proceed
 	if allowUnauthenticated {

--- a/policies/basic-auth/basicauth.go
+++ b/policies/basic-auth/basicauth.go
@@ -152,6 +152,18 @@ func (p *BasicAuthPolicy) handleAuthSuccess(ctx *policy.RequestContext, username
 	ctx.Metadata[MetadataKeyAuthUser] = username
 	ctx.Metadata[MetadataKeyAuthMethod] = "basic"
 
+	// Populate AuthContext struct
+	if ctx.SharedContext != nil {
+		if ctx.SharedContext.AuthContext == nil {
+			ctx.SharedContext.AuthContext = &policy.AuthContext{}
+		}
+		ac := ctx.SharedContext.AuthContext
+		ac.Authenticated = true
+		ac.AuthType = "basic"
+		ac.Subject = username
+		ac.UserID = username
+	}
+
 	// Continue to upstream with no modifications
 	return policy.UpstreamRequestModifications{}
 }

--- a/policies/basic-auth/basicauth.go
+++ b/policies/basic-auth/basicauth.go
@@ -161,7 +161,7 @@ func (p *BasicAuthPolicy) handleAuthSuccess(ctx *policy.RequestContext, username
 	ac.AuthType = "basic"
 	ac.Subject = username
 	ac.UserID = username
-	
+	ac.Basic = &policy.BasicAuthDetails{}
 
 	// Continue to upstream with no modifications
 	return policy.UpstreamRequestModifications{}
@@ -184,7 +184,7 @@ func (p *BasicAuthPolicy) handleAuthFailure(ctx *policy.RequestContext, allowUna
 	}
 	ctx.SharedContext.AuthContext.Authenticated = false
 	ctx.SharedContext.AuthContext.AuthType = "basic"
-	
+	ctx.SharedContext.AuthContext.Basic = &policy.BasicAuthDetails{}
 
 	// If allowUnauthenticated is true, allow request to proceed
 	if allowUnauthenticated {

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -47,9 +47,6 @@ const (
 	MetadataKeySubject      = "auth.subject"
 	MetadataValidatedClaims = "auth.validatedClaims"
 
-	// AuthContext key for user ID (used for analytics)
-	AuthContextKeyUserID = "x-wso2-user-id"
-
 	// Default claim to extract user ID from
 	DefaultUserIdClaim = "sub"
 )
@@ -1272,6 +1269,71 @@ func parseScopes(scopeClaim, scpClaim interface{}) []string {
 	return scopes
 }
 
+// standardJWTClaimNames are claim names that are mapped to AuthContext fields or are standard and not copied to Properties
+var standardJWTClaimNames = map[string]bool{
+	"sub": true, "iss": true, "aud": true, "exp": true, "nbf": true, "iat": true,
+	"scope": true, "scp": true, "jti": true,
+}
+
+// populateAuthContext fills the SDK AuthContext struct from validated JWT claims
+func (p *JwtAuthPolicy) populateAuthContext(ctx *policy.RequestContext, claims jwt.MapClaims, userIdClaim string) {
+	if ctx.SharedContext == nil {
+		return
+	}
+	// Ensure AuthContext is initialized when it is a pointer (SDK may pass nil)
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
+	}
+	ac := ctx.SharedContext.AuthContext
+	ac.Authenticated = true
+	ac.AuthType = "jwt"
+	ac.Subject = getString(claims["sub"])
+	ac.Issuer = getString(claims["iss"])
+	ac.Audience = audienceToString(claims["aud"])
+	ac.UserID = ""
+	if userIdClaim != "" {
+		if claimValue, exists := claims[userIdClaim]; exists {
+			ac.UserID = claimValueToString(claimValue)
+			slog.Debug("JWT Auth Policy: Set user ID in AuthContext",
+				"claim", userIdClaim,
+				"userId", ac.UserID,
+			)
+		}
+	}
+	scopeStrs := parseScopes(claims["scope"], claims["scp"])
+	if len(scopeStrs) > 0 {
+		if ac.Scopes == nil {
+			ac.Scopes = make(map[string]bool)
+		}
+		for _, s := range scopeStrs {
+			ac.Scopes[s] = true
+		}
+	}
+	// Copy non-standard claims to Properties
+	if ac.Properties == nil {
+		ac.Properties = make(map[string]string)
+	}
+	for k, v := range claims {
+		if standardJWTClaimNames[k] {
+			continue
+		}
+		ac.Properties[k] = claimValueToString(v)
+	}
+}
+
+// audienceToString returns a single string for the aud claim (first element if array)
+func audienceToString(audClaim interface{}) string {
+	if audStr, ok := audClaim.(string); ok {
+		return audStr
+	}
+	if audArr, ok := audClaim.([]interface{}); ok && len(audArr) > 0 {
+		if aStr, ok := audArr[0].(string); ok {
+			return aStr
+		}
+	}
+	return ""
+}
+
 // handleAuthSuccess handles successful authentication
 func (p *JwtAuthPolicy) handleAuthSuccess(ctx *policy.RequestContext, claims jwt.MapClaims, claimMappings map[string]string, userIdClaim string) policy.RequestAction {
 	slog.Debug("JWT Auth Policy: handleAuthSuccess called",
@@ -1298,23 +1360,8 @@ func (p *JwtAuthPolicy) handleAuthSuccess(ctx *policy.RequestContext, claims jwt
 		)
 	}
 
-	// Extract user ID from the specified claim and set it in AuthContext for analytics
-	if userIdClaim != "" {
-		if claimValue, exists := claims[userIdClaim]; exists {
-			userId := claimValueToString(claimValue)
-			if userId != "" {
-				ctx.SharedContext.AuthContext[AuthContextKeyUserID] = userId
-				slog.Debug("JWT Auth Policy: Set user ID in AuthContext",
-					"claim", userIdClaim,
-					"userId", userId,
-				)
-			}
-		} else {
-			slog.Debug("JWT Auth Policy: User ID claim not found or empty",
-				"claim", userIdClaim,
-			)
-		}
-	}
+	// Populate AuthContext struct for analytics and downstream policies
+	p.populateAuthContext(ctx, claims, userIdClaim)
 
 	// Apply claim mappings as headers
 	modifications := policy.UpstreamRequestModifications{

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1277,9 +1277,7 @@ var standardJWTClaimNames = map[string]bool{
 
 // populateAuthContext fills the SDK AuthContext struct from validated JWT claims
 func (p *JwtAuthPolicy) populateAuthContext(ctx *policy.RequestContext, claims jwt.MapClaims, userIdClaim string) {
-	if ctx.SharedContext == nil {
-		return
-	}
+
 	// Ensure AuthContext is initialized when it is a pointer (SDK may pass nil)
 	if ctx.SharedContext.AuthContext == nil {
 		ctx.SharedContext.AuthContext = &policy.AuthContext{}
@@ -1410,6 +1408,14 @@ func (p *JwtAuthPolicy) handleAuthFailure(ctx *policy.RequestContext, statusCode
 	// Set metadata indicating failed authentication
 	ctx.Metadata[MetadataKeyAuthSuccess] = false
 	ctx.Metadata[MetadataKeyAuthMethod] = "jwt"
+
+	// Populate AuthContext for failed authentication
+	if ctx.SharedContext.AuthContext == nil {
+		ctx.SharedContext.AuthContext = &policy.AuthContext{}
+	}
+	ctx.SharedContext.AuthContext.Authenticated = false
+	ctx.SharedContext.AuthContext.AuthType = "jwt"
+	
 
 	headers := map[string]string{
 		"content-type": "application/json",

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1285,9 +1285,6 @@ func (p *JwtAuthPolicy) populateAuthContext(ctx *policy.RequestContext, claims j
 	ac := ctx.SharedContext.AuthContext
 	ac.Authenticated = true
 	ac.AuthType = "jwt"
-	ac.Subject = getString(claims["sub"])
-	ac.Issuer = getString(claims["iss"])
-	ac.Audience = audienceToString(claims["aud"])
 	ac.UserID = ""
 	if userIdClaim != "" {
 		if claimValue, exists := claims[userIdClaim]; exists {
@@ -1307,29 +1304,39 @@ func (p *JwtAuthPolicy) populateAuthContext(ctx *policy.RequestContext, claims j
 			ac.Scopes[s] = true
 		}
 	}
-	// Copy non-standard claims to Properties
-	if ac.Properties == nil {
-		ac.Properties = make(map[string]string)
+
+	// Initialize JWT-specific details
+	ac.JWT = &policy.JWTAuthDetails{
+		Subject:  getString(claims["sub"]),
+		Issuer:   getString(claims["iss"]),
+		Audience: audienceToSlice(claims["aud"]),
+		Claims:   make(map[string]string),
 	}
+
+	// Copy non-standard claims to JWT.Claims
 	for k, v := range claims {
 		if standardJWTClaimNames[k] {
 			continue
 		}
-		ac.Properties[k] = claimValueToString(v)
+		ac.JWT.Claims[k] = claimValueToString(v)
 	}
 }
 
-// audienceToString returns a single string for the aud claim (first element if array)
-func audienceToString(audClaim interface{}) string {
+// audienceToSlice returns all audience values as a string slice
+func audienceToSlice(audClaim interface{}) []string {
 	if audStr, ok := audClaim.(string); ok {
-		return audStr
+		return []string{audStr}
 	}
-	if audArr, ok := audClaim.([]interface{}); ok && len(audArr) > 0 {
-		if aStr, ok := audArr[0].(string); ok {
-			return aStr
+	if audArr, ok := audClaim.([]interface{}); ok {
+		result := make([]string, 0, len(audArr))
+		for _, item := range audArr {
+			if aStr, ok := item.(string); ok {
+				result = append(result, aStr)
+			}
 		}
+		return result
 	}
-	return ""
+	return []string{}
 }
 
 // handleAuthSuccess handles successful authentication
@@ -1415,7 +1422,7 @@ func (p *JwtAuthPolicy) handleAuthFailure(ctx *policy.RequestContext, statusCode
 	}
 	ctx.SharedContext.AuthContext.Authenticated = false
 	ctx.SharedContext.AuthContext.AuthType = "jwt"
-	
+	ctx.SharedContext.AuthContext.JWT = &policy.JWTAuthDetails{}
 
 	headers := map[string]string{
 		"content-type": "application/json",

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -1072,7 +1072,7 @@ func createMockRequestContext(headers map[string][]string) *policy.RequestContex
 		SharedContext: &policy.SharedContext{
 			RequestID:   "test-request-id",
 			Metadata:    make(map[string]interface{}),
-			AuthContext: make(map[string]string), // Initialize AuthContext map
+			AuthContext: &policy.AuthContext{},
 		},
 		Headers: policy.NewHeaders(headers),
 		Body:    nil,
@@ -1441,8 +1441,8 @@ func TestJWTAuthPolicy_UserIdClaim_DefaultSub(t *testing.T) {
 	}
 
 	// Verify user ID was extracted from 'sub' claim
-	if ctx.SharedContext.AuthContext["x-wso2-user-id"] != "user-12345" {
-		t.Errorf("Expected x-wso2-user-id='user-12345', got '%v'", ctx.SharedContext.AuthContext["x-wso2-user-id"])
+	if ctx.SharedContext.AuthContext.UserID != "user-12345" {
+		t.Errorf("Expected AuthContext.UserID='user-12345', got '%v'", ctx.SharedContext.AuthContext.UserID)
 	}
 
 	_, ok := action.(policy.UpstreamRequestModifications)
@@ -1497,8 +1497,8 @@ func TestJWTAuthPolicy_UserIdClaim_CustomClaim(t *testing.T) {
 	}
 
 	// Verify user ID was extracted from 'user_id' claim, not 'sub'
-	if ctx.SharedContext.AuthContext["x-wso2-user-id"] != "custom-user-9999" {
-		t.Errorf("Expected x-wso2-user-id='custom-user-9999', got '%v'", ctx.SharedContext.AuthContext["x-wso2-user-id"])
+	if ctx.SharedContext.AuthContext.UserID != "custom-user-9999" {
+		t.Errorf("Expected AuthContext.UserID='custom-user-9999', got '%v'", ctx.SharedContext.AuthContext.UserID)
 	}
 
 	_, ok := action.(policy.UpstreamRequestModifications)
@@ -1552,8 +1552,8 @@ func TestJWTAuthPolicy_UserIdClaim_EmailClaim(t *testing.T) {
 	}
 
 	// Verify user ID was extracted from 'email' claim
-	if ctx.SharedContext.AuthContext["x-wso2-user-id"] != "alice@example.com" {
-		t.Errorf("Expected x-wso2-user-id='alice@example.com', got '%v'", ctx.SharedContext.AuthContext["x-wso2-user-id"])
+	if ctx.SharedContext.AuthContext.UserID != "alice@example.com" {
+		t.Errorf("Expected AuthContext.UserID='alice@example.com', got '%v'", ctx.SharedContext.AuthContext.UserID)
 	}
 
 	_, ok := action.(policy.UpstreamRequestModifications)
@@ -1608,8 +1608,8 @@ func TestJWTAuthPolicy_UserIdClaim_MissingClaim(t *testing.T) {
 	}
 
 	// Verify user ID was NOT set (or is empty) when claim is missing
-	userId, exists := ctx.SharedContext.AuthContext["x-wso2-user-id"]
-	if exists && userId != "" {
+	userId := ctx.SharedContext.AuthContext.UserID
+	if userId != "" {
 		t.Errorf("Expected x-wso2-user-id to be empty or not set when claim is missing, got '%v'", userId)
 	}
 
@@ -1664,7 +1664,7 @@ func TestJWTAuthPolicy_UserIdClaim_NumericValue(t *testing.T) {
 	}
 
 	// Verify numeric user ID was converted to string
-	userId := ctx.SharedContext.AuthContext["x-wso2-user-id"]
+	userId := ctx.SharedContext.AuthContext.UserID
 	if userId != "987654321" {
 		t.Errorf("Expected x-wso2-user-id='987654321', got '%v'", userId)
 	}
@@ -1719,8 +1719,8 @@ func TestJWTAuthPolicy_UserIdClaim_EmptyString(t *testing.T) {
 	}
 
 	// When userIdClaim is empty string, should NOT extract user ID
-	userId, exists := ctx.SharedContext.AuthContext["x-wso2-user-id"]
-	if exists && userId != "" {
+	userId := ctx.SharedContext.AuthContext.UserID
+	if userId != "" {
 		t.Errorf("Expected x-wso2-user-id to be empty when userIdClaim is empty string, got '%v'", userId)
 	}
 
@@ -1781,8 +1781,8 @@ func TestJWTAuthPolicy_UserIdClaim_WithClaimMappings(t *testing.T) {
 	}
 
 	// Verify user ID was extracted from 'username' claim
-	if ctx.SharedContext.AuthContext["x-wso2-user-id"] != "johndoe" {
-		t.Errorf("Expected x-wso2-user-id='johndoe', got '%v'", ctx.SharedContext.AuthContext["x-wso2-user-id"])
+	if ctx.SharedContext.AuthContext.UserID != "johndoe" {
+		t.Errorf("Expected AuthContext.UserID='johndoe', got '%v'", ctx.SharedContext.AuthContext.UserID)
 	}
 
 	// Verify claim mappings were also applied


### PR DESCRIPTION
## Purpose
This PR adds the changes related to populating the AuthContext to match the new format.
> - Discussion: https://github.com/wso2/api-platform/discussions/1048


- Fix for: https://github.com/issues/assigned?issue=wso2%7Capi-platform%7C1049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication context initialization and tracking enhanced across API Key, Basic Auth, and JWT; authentication state is now recorded for both successes and failures.

* **Refactor**
  * JWT handling centralized to better distinguish standard vs. custom claims.
  * Authentication context converted to a structured object that explicitly carries the extracted user identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->