### PR TITLE
Policy updates: param standardization, docs alignment, and expanded unit tests

### DIFF
--- a/docs/aws-bedrock-guardrail/v0.1/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v0.1/docs/aws-bedrock-guardrail.md
@@ -80,7 +80,7 @@ awsbedrock_role_external_id = ""
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/aws-bedrock-guardrail/v0.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v0.2/docs/aws-bedrock-guardrail.md
@@ -80,7 +80,7 @@ awsbedrock_role_external_id = ""
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/azure-content-safety-content-moderation/v0.1/docs/azure-content-safety.md
+++ b/docs/azure-content-safety-content-moderation/v0.1/docs/azure-content-safety.md
@@ -67,7 +67,7 @@ azurecontentsafety_key = "<your-azure-content-safety-key>"
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/azure-content-safety-content-moderation/v0.2/docs/azure-content-safety.md
+++ b/docs/azure-content-safety-content-moderation/v0.2/docs/azure-content-safety.md
@@ -67,7 +67,7 @@ azurecontentsafety_key = "<your-azure-content-safety-key>"
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/azure-content-safety-content-moderation/v0.3/docs/azure-content-safety.md
+++ b/docs/azure-content-safety-content-moderation/v0.3/docs/azure-content-safety.md
@@ -1,0 +1,128 @@
+---
+title: "Overview"
+---
+# Azure Content Safety
+
+## Overview
+
+The Azure Content Safety guardrail validates request and/or response content using Azure Content Safety text moderation. It evaluates hate, sexual, self-harm, and violence categories against configurable severity thresholds.
+
+## Features
+
+- Request-phase and response-phase moderation (configure either or both)
+- Per-category severity threshold control (`-1` to `7`)
+- Optional JSONPath extraction of target content
+- Optional passthrough on external API errors
+- Optional detailed assessment data in blocked responses
+
+## Configuration
+
+This policy uses a two-level configuration model.
+
+### System Parameters (From config.toml)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `azureContentSafetyEndpoint` | string | Yes | Azure Content Safety endpoint URL (without trailing slash). |
+| `azureContentSafetyKey` | string | Yes | Azure Content Safety API subscription key. |
+
+#### Sample System Configuration
+
+```toml
+azurecontentsafety_endpoint = "https://your-resource.cognitiveservices.azure.com"
+azurecontentsafety_key = "<your-azure-content-safety-key>"
+```
+
+### User Parameters (API Definition)
+
+At least one of `request` or `response` is required.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `request` | `AzureContentSafetyConfig` | Conditional | Request content moderation configuration. |
+| `response` | `AzureContentSafetyConfig` | Conditional | Response content moderation configuration. |
+
+#### AzureContentSafetyConfig Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jsonPath` | string | No | `""` | JSONPath to extract content. If empty, full payload text is analyzed. |
+| `passthroughOnError` | boolean | No | `false` | If true, allows traffic when Azure API call fails. |
+| `showAssessment` | boolean | No | `false` | If true, include detailed moderation assessment in blocked response. |
+| `hateSeverityThreshold` | integer | No | `4` | Hate category threshold (`-1` disables category). |
+| `sexualSeverityThreshold` | integer | No | `5` | Sexual category threshold (`-1` disables category). |
+| `selfHarmSeverityThreshold` | integer | No | `3` | Self-harm category threshold (`-1` disables category). |
+| `violenceSeverityThreshold` | integer | No | `4` | Violence category threshold (`-1` disables category). |
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: azure-content-safety-content-moderation
+  gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Request and Response Moderation
+
+```yaml
+policies:
+  - name: azure-content-safety-content-moderation
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[-1].content"
+            hateSeverityThreshold: 2
+            sexualSeverityThreshold: 2
+            selfHarmSeverityThreshold: 2
+            violenceSeverityThreshold: 2
+            showAssessment: true
+          response:
+            jsonPath: "$.choices[0].message.content"
+            hateSeverityThreshold: 2
+            sexualSeverityThreshold: 2
+            selfHarmSeverityThreshold: 2
+            violenceSeverityThreshold: 2
+            showAssessment: true
+```
+
+### Example 2: Request-Only with Selective Categories
+
+```yaml
+policies:
+  - name: azure-content-safety-content-moderation
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[-1].content"
+            hateSeverityThreshold: 3
+            sexualSeverityThreshold: -1
+            selfHarmSeverityThreshold: 2
+            violenceSeverityThreshold: -1
+            passthroughOnError: false
+```
+
+## How It Works
+
+#### Request/Response Phase
+
+1. Extracts text using configured `jsonPath` (or full payload when empty).
+2. Builds enabled category set from thresholds where value is `0..7`.
+3. Calls Azure Content Safety API and receives category severities.
+4. Blocks when any category severity is greater than or equal to configured threshold.
+5. Applies `passthroughOnError` for extraction/API failures.
+
+## Notes
+
+- Threshold `-1` disables that category for evaluation.
+- If all categories are disabled, validation is skipped.
+- Blocked responses use `HTTP 422` with guardrail response type.
+- Keep endpoint format as base resource URL without trailing slash.

--- a/docs/azure-content-safety-content-moderation/v0.3/metadata.json
+++ b/docs/azure-content-safety-content-moderation/v0.3/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "azure-content-safety-content-moderation",
+  "displayName": "Azure Content Safety Content Moderation",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request and response content with Azure Content Safety using configurable per-category severity thresholds and JSONPath extraction."
+}

--- a/docs/content-length-guardrail/v0.1/docs/content-length.md
+++ b/docs/content-length-guardrail/v0.1/docs/content-length.md
@@ -40,7 +40,7 @@ This policy uses a single-level configuration where all parameters are configure
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/content-length-guardrail/v0.2/docs/content-length.md
+++ b/docs/content-length-guardrail/v0.2/docs/content-length.md
@@ -40,7 +40,7 @@ This policy uses a single-level configuration where all parameters are configure
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/model-round-robin/v0.3/docs/model-round-robin.md
+++ b/docs/model-round-robin/v0.3/docs/model-round-robin.md
@@ -1,0 +1,82 @@
+---
+title: "Overview"
+---
+# Model Round Robin
+
+## Overview
+
+The Model Round Robin policy distributes requests across configured models in cyclic order. It helps spread load evenly and can temporarily suspend failed models to reduce repeated failures.
+
+## Features
+
+- Cyclic model selection across configured model list
+- Optional failed-model suspension with configurable duration
+- Support for model extraction/rewrite via provider `requestModel` configuration
+- Automatic skip of currently suspended models
+
+## Configuration
+
+This policy requires configuration in both the API definition and LLM provider template.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `models` | `Model[]` | Yes | - | List of models used for round-robin distribution. |
+| `suspendDuration` | integer | No | `0` | Suspension duration in seconds for failed models (`5xx`/`429`). `0` disables persisted suspension. |
+
+#### Model Configuration
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `model` | string | Yes | Model identifier used for selection and request rewrite. |
+
+### LLM Provider Template Requirement
+
+This policy depends on `requestModel` configuration in the provider template.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `requestModel.location` | string | Yes | Where model is extracted from: `payload`, `header`, `queryParam`, `pathParam`. |
+| `requestModel.identifier` | string | Yes | Extraction key (JSONPath/header/query key/regex pattern by location). |
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: model-round-robin
+  gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Round Robin
+
+```yaml
+policies:
+  - name: model-round-robin
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          models:
+            - model: gpt-4o
+            - model: gpt-4o-mini
+            - model: gpt-4.1
+          suspendDuration: 60
+```
+
+## How It Works
+
+1. Selects next available model from configured list in round-robin order.
+2. Rewrites request model value based on template `requestModel` location.
+3. Tracks upstream failures (`429`/`5xx`) and suspends failed models when configured.
+4. Returns `503` when all configured models are currently unavailable.
+
+## Notes
+
+- `suspendDuration` is optional; use `0` when suspension tracking is not needed.
+- Model extraction and rewrite behavior depend on valid template `requestModel` configuration.
+- Path-based model extraction should use a regex with a capture group for model value.

--- a/docs/model-round-robin/v0.3/metadata.json
+++ b/docs/model-round-robin/v0.3/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "model-round-robin",
+  "displayName": "Model Round Robin",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Distributes requests across configured AI models in round-robin order and can suspend failed models for a configured duration."
+}

--- a/docs/pii-masking-regex/v0.1/docs/pii-masking-regex.md
+++ b/docs/pii-masking-regex/v0.1/docs/pii-masking-regex.md
@@ -39,7 +39,7 @@ Each PII entity in the `piiEntities` array must contain:
 
 The guardrail supports JSONPath expressions to extract and process specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/pii-masking-regex/v0.2/docs/pii-masking-regex.md
+++ b/docs/pii-masking-regex/v0.2/docs/pii-masking-regex.md
@@ -39,7 +39,7 @@ Each PII entity in the `piiEntities` array must contain:
 
 The guardrail supports JSONPath expressions to extract and process specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/pii-masking-regex/v0.3/docs/pii-masking-regex.md
+++ b/docs/pii-masking-regex/v0.3/docs/pii-masking-regex.md
@@ -1,0 +1,121 @@
+---
+title: "Overview"
+---
+# PII Masking Regex Guardrail
+
+## Overview
+
+The PII Masking Regex guardrail detects and protects Personally Identifiable Information (PII) in request and response payloads. It supports built-in detectors (`email`, `phone`, `ssn`) and custom regex-based detectors, with masking (reversible) or redaction (irreversible) behavior.
+
+## Features
+
+- Built-in PII detectors for email, phone, and SSN
+- Custom regex detector support (`customPIIEntities`)
+- Two protection modes: masking and redaction
+- Optional JSONPath extraction before detection
+- Response restoration support when masking mode is used
+
+## Configuration
+
+This policy uses single-level configuration in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `email` | boolean | Conditional | `false` | Enables built-in email detector. |
+| `phone` | boolean | Conditional | `false` | Enables built-in phone detector. |
+| `ssn` | boolean | Conditional | `false` | Enables built-in SSN detector. |
+| `customPIIEntities` | `PIIEntityConfig[]` | Conditional | - | Custom regex detectors. |
+| `jsonPath` | string | No | `"$.messages"` | JSONPath used to extract content before detection. |
+| `redactPII` | boolean | No | `false` | `true` redacts with `*****`; `false` masks with reversible placeholders. |
+
+At least one detector must be configured using one of:
+
+- `email: true`
+- `phone: true`
+- `ssn: true`
+- non-empty `customPIIEntities`
+
+#### PIIEntityConfig Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `piiEntity` | string | Yes | Custom entity key (must match `^[A-Z_]+$`). |
+| `piiRegex` | string | Yes | Go RE2-compatible regex for the entity. |
+
+#### JSONPath Support
+
+Examples:
+
+- `$.messages`
+- `$.messages[-1].content`
+- `$.data.content`
+
+If extraction fails, the policy returns an immediate error response.
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: pii-masking-regex
+  gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Built-In Detectors (Masking Mode)
+
+```yaml
+policies:
+  - name: pii-masking-regex
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          email: true
+          phone: true
+          ssn: true
+          jsonPath: "$.messages[-1].content"
+          redactPII: false
+```
+
+### Example 2: Custom Detector (Redaction Mode)
+
+```yaml
+policies:
+  - name: pii-masking-regex
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          customPIIEntities:
+            - piiEntity: CREDIT_CARD
+              piiRegex: "\\b(?:\\d[ -]*?){13,16}\\b"
+          jsonPath: "$.messages[-1].content"
+          redactPII: true
+```
+
+## How It Works
+
+#### Request Phase
+
+1. Extracts content from `jsonPath` (default `$.messages`).
+2. Applies built-in and custom regex detectors.
+3. In masking mode, replaces matches with placeholders and stores mapping in metadata.
+4. In redaction mode, replaces matches with `*****`.
+
+#### Response Phase
+
+1. If `redactPII=false`, restores placeholders using metadata mappings.
+2. If `redactPII=true`, restoration is skipped.
+
+## Notes
+
+- Built-in regex detectors are provided by policy logic and can be enabled independently.
+- Custom regexes use Go `regexp` (RE2) syntax.
+- Masking mode is suitable when downstream responses need original values restored.
+- Redaction mode is irreversible and should be used when full concealment is required.

--- a/docs/pii-masking-regex/v0.3/metadata.json
+++ b/docs/pii-masking-regex/v0.3/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "pii-masking-regex",
+  "displayName": "PII Masking Regex",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Masks or redacts PII in payloads using built-in and custom regex detectors, with optional response restoration in masking mode."
+}

--- a/docs/prompt-decorator/v0.3/docs/prompt-decorator.md
+++ b/docs/prompt-decorator/v0.3/docs/prompt-decorator.md
@@ -1,0 +1,131 @@
+---
+title: "Overview"
+---
+# Prompt Decorator
+
+## Overview
+
+The Prompt Decorator policy modifies request prompts by prepending or appending configured decoration content. It supports two explicit decoration styles through `promptDecoratorConfig`: `text` for string targets and `messages` for chat-message array targets.
+
+## Features
+
+- Two decoration styles: `text` or `messages`
+- Exactly one style is required per policy instance
+- Optional JSONPath targeting
+- Auto-default JSONPath based on selected style
+- Prepend (`append: false`) or append (`append: true`) behavior
+
+## Configuration
+
+This policy uses single-level configuration in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `promptDecoratorConfig` | object | Yes | - | Decoration configuration. Must include exactly one of `text` or `messages`. |
+| `jsonPath` | string | No | `""` | Target JSONPath. If empty, defaults to `$.messages[-1].content` for `text` and `$.messages` for `messages`. |
+| `append` | boolean | No | `false` | If `true`, append decoration. If `false`, prepend decoration. |
+
+#### PromptDecoratorConfig Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Conditional | Non-empty text decoration for string targets. |
+| `messages` | `PromptMessage[]` | Conditional | Message decorations for array targets. |
+
+Exactly one of `text` or `messages` must be provided.
+
+#### PromptMessage Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `role` | string | Yes | Message role. Allowed: `system`, `user`, `assistant`, `tool`. |
+| `content` | string | Yes | Non-empty message content. |
+
+#### JSONPath Support
+
+Common examples:
+
+- `$.messages[-1].content` for text decoration
+- `$.messages` for message-array decoration
+- `$.data.prompt` for nested string prompt fields
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: prompt-decorator
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Text Decoration
+
+```yaml
+policies:
+  - name: prompt-decorator
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          promptDecoratorConfig:
+            text: "Summarize the following in bullet points:"
+          jsonPath: "$.messages[-1].content"
+          append: false
+```
+
+### Example 2: Message Decoration
+
+```yaml
+policies:
+  - name: prompt-decorator
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          promptDecoratorConfig:
+            messages:
+              - role: system
+                content: "You are a concise assistant."
+          jsonPath: "$.messages"
+          append: false
+```
+
+### Example 3: Inferred JSONPath Defaults
+
+```yaml
+# jsonPath omitted intentionally
+params:
+  promptDecoratorConfig:
+    text: "Answer briefly"
+```
+
+When omitted:
+
+- `text` uses `$.messages[-1].content`
+- `messages` uses `$.messages`
+
+## How It Works
+
+#### Request Phase
+
+1. Validates `promptDecoratorConfig` and `jsonPath`.
+2. Resolves target value from JSON payload.
+3. Applies text or messages decoration according to target type.
+4. Writes updated value back into payload.
+
+#### Response Phase
+
+No response-phase processing is applied.
+
+## Notes
+
+- Empty request bodies are rejected by this policy.
+- If `jsonPath` points to a string, use `promptDecoratorConfig.text`.
+- If `jsonPath` points to an array, use `promptDecoratorConfig.messages`.
+- Invalid role values in `messages` are rejected during policy initialization.

--- a/docs/prompt-decorator/v0.3/metadata.json
+++ b/docs/prompt-decorator/v0.3/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "prompt-decorator",
+  "displayName": "Prompt Decorator",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Decorates prompts using configured text or messages blocks, with prepend or append behavior before upstream processing."
+}

--- a/docs/prompt-template/v0.3/docs/prompt-template.md
+++ b/docs/prompt-template/v0.3/docs/prompt-template.md
@@ -1,0 +1,149 @@
+---
+title: "Overview"
+---
+# Prompt Template
+
+## Overview
+
+The Prompt Template policy resolves `template://...` references in request payloads using configured templates. It supports reusable templates with query-parameter substitution and flexible behavior for missing templates or unresolved placeholders.
+
+## Features
+
+- Reusable named templates via `templates`
+- Template references using `template://<name>?k=v`
+- Placeholder substitution with `[[placeholder]]` syntax
+- Optional JSONPath-scoped replacement
+- Configurable handling for missing templates and unresolved placeholders
+- Supports both array and JSON-string input for `templates`
+
+## Configuration
+
+This policy uses single-level configuration in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `templates` | `TemplateConfig[]` | Yes | - | List of reusable templates. |
+| `jsonPath` | string | No | `""` | JSONPath to limit replacement to one string field. If empty, replacement runs on full payload text. |
+| `onMissingTemplate` | string | No | `error` | Behavior when template name is not found. Values: `error`, `passthrough`. |
+| `onUnresolvedPlaceholder` | string | No | `keep` | Behavior for unresolved `[[...]]` placeholders. Values: `keep`, `empty`, `error`. |
+
+#### TemplateConfig Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Unique template name. Must match `^[a-zA-Z0-9_-]+$`. |
+| `template` | string | Yes | Template text containing optional placeholders like `[[name]]`. |
+
+### Template Reference Format
+
+Template references in payloads use:
+
+```text
+template://<template-name>?<param1>=<value1>&<param2>=<value2>
+```
+
+Placeholders are written as:
+
+```text
+[[parameter-name]]
+```
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: prompt-template
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-template@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Template Resolution Across Full Payload
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: translation-provider
+spec:
+  displayName: Translation Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-template
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            templates:
+              - name: translate
+                template: "Translate from [[from]] to [[to]]: [[text]]"
+```
+
+Request content:
+
+```text
+template://translate?from=english&to=spanish&text=Hello
+```
+
+Resolved content:
+
+```text
+Translate from english to spanish: Hello
+```
+
+### Example 2: JSONPath-Scoped Resolution
+
+```yaml
+policies:
+  - name: prompt-template
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          templates:
+            - name: summarize
+              template: "Summarize in [[length]] words: [[content]]"
+          jsonPath: "$.messages[-1].content"
+          onMissingTemplate: passthrough
+          onUnresolvedPlaceholder: empty
+```
+
+## How It Works
+
+#### Request Phase
+
+1. Loads configured templates into a lookup map.
+2. Finds `template://...` references in target text.
+3. Parses template name and query parameters.
+4. Replaces placeholders in template text.
+5. Applies missing/unresolved behavior settings.
+6. Writes updated content back to payload.
+
+#### Response Phase
+
+No response-phase processing is applied.
+
+## Notes
+
+- `templates` accepts both an object array and a JSON-string payload for compatibility.
+- If `onMissingTemplate=passthrough`, unresolved template references are left unchanged.
+- If `onUnresolvedPlaceholder=error`, request processing returns an immediate error response.
+- `jsonPath` is optional; empty value preserves full-payload replacement behavior.

--- a/docs/prompt-template/v0.3/metadata.json
+++ b/docs/prompt-template/v0.3/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "prompt-template",
+  "displayName": "Prompt Template",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Applies reusable templates to request prompts by resolving template references and placeholder values before upstream processing."
+}

--- a/docs/regex-guardrail/v0.1/docs/regex.md
+++ b/docs/regex-guardrail/v0.1/docs/regex.md
@@ -39,7 +39,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/regex-guardrail/v0.2/docs/regex.md
+++ b/docs/regex-guardrail/v0.2/docs/regex.md
@@ -39,7 +39,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/semantic-cache/v0.3/docs/semantic-caching.md
+++ b/docs/semantic-cache/v0.3/docs/semantic-caching.md
@@ -1,0 +1,150 @@
+---
+title: "Overview"
+---
+# Semantic Caching
+
+## Overview
+
+The Semantic Cache policy caches LLM responses by comparing semantic similarity of request embeddings instead of relying on exact request text matches. On a cache hit, the gateway returns the cached response immediately. On a cache miss, the request is forwarded upstream and successful responses are stored for future reuse.
+
+## Features
+
+- Embedding-based semantic cache lookup
+- Supports `OPENAI`, `MISTRAL`, and `AZURE_OPENAI` embedding providers
+- Supports `REDIS` and `MILVUS` vector stores
+- Configurable similarity threshold (`0.0` to `1.0`)
+- Optional JSONPath extraction for embedding input
+- Automatic cache write for successful (`200`) responses
+- Returns cache-hit responses with `X-Cache-Status: HIT`
+
+## Configuration
+
+The Semantic Cache policy uses a two-level configuration model.
+
+### System Parameters (From config.toml)
+
+These parameters are typically configured globally and can be overridden per policy when needed.
+
+##### Embedding Provider Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `embeddingProvider` | string | Yes | Embedding provider. One of `OPENAI`, `MISTRAL`, `AZURE_OPENAI`. |
+| `embeddingEndpoint` | string | Yes | Embedding endpoint URL. |
+| `embeddingModel` | string | Conditional | Required for `OPENAI` and `MISTRAL`; optional for `AZURE_OPENAI`. |
+| `embeddingDimension` | integer | Yes | Embedding vector dimension expected by the vector store. |
+| `apiKey` | string | Yes | API key for embedding provider authentication. |
+
+##### Vector Database Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `vectorStoreProvider` | string | Yes | Vector store provider. One of `REDIS`, `MILVUS`. |
+| `dbHost` | string | Yes | Vector database host. |
+| `dbPort` | integer | Yes | Vector database port. |
+| `username` | string | No | Database username. |
+| `password` | string | No | Database password. |
+| `database` | string | No | Database name/index. |
+| `ttl` | integer | No | TTL in seconds for cache entries. |
+
+#### Sample System Configuration
+
+```toml
+embedding_provider = "MISTRAL"
+embedding_provider_endpoint = "https://api.mistral.ai/v1/embeddings"
+embedding_provider_model = "mistral-embed"
+embedding_provider_dimension = 1024
+embedding_provider_api_key = ""
+
+vector_db_provider = "REDIS"
+vector_db_provider_host = "redis"
+vector_db_provider_port = 6379
+vector_db_provider_database = "0"
+vector_db_provider_username = "default"
+vector_db_provider_password = "default"
+vector_db_provider_ttl = 3600
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `similarityThreshold` | number | Yes | `0.5` | Minimum similarity (`0.0` to `1.0`) required to return a cached response. |
+| `jsonPath` | string | No | `""` | JSONPath used to extract text for embedding. If empty, the full request body is used. |
+
+#### JSONPath Support
+
+Examples:
+
+- `$.messages[0].content`
+- `$.messages[-1].content`
+- `$.prompt`
+- `$.input`
+- `$` (entire payload)
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: semantic-cache
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Semantic Cache for Chat Completions
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: cached-chat-provider
+spec:
+  displayName: Cached Chat Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: semantic-cache
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            similarityThreshold: 0.85
+            jsonPath: "$.messages[-1].content"
+```
+
+## How It Works
+
+#### Request Phase
+
+1. Extracts text using `jsonPath` (or full payload if empty).
+2. Generates embedding for extracted text.
+3. Looks up semantically similar cached entries using configured threshold.
+4. Returns immediate cached response on hit.
+5. Forwards request upstream on miss.
+
+#### Response Phase
+
+1. Processes only successful (`200`) responses.
+2. Reads request embedding stored in request metadata.
+3. Stores response payload with embedding in vector store.
+
+## Notes
+
+- Cache behavior is best-effort. If embedding generation or vector operations fail, requests continue upstream.
+- Very high thresholds reduce false hits but lower hit rate; very low thresholds increase hit rate but risk irrelevant responses.
+- Only successful upstream responses are cached.

--- a/docs/semantic-cache/v0.3/metadata.json
+++ b/docs/semantic-cache/v0.3/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "semantic-cache",
+  "displayName": "Semantic Cache",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Caches LLM responses using semantic similarity over request embeddings to reduce repeated upstream calls and latency."
+}

--- a/docs/sentence-count-guardrail/v0.1/docs/sentence-count.md
+++ b/docs/sentence-count-guardrail/v0.1/docs/sentence-count.md
@@ -40,7 +40,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/sentence-count-guardrail/v0.2/docs/sentence-count.md
+++ b/docs/sentence-count-guardrail/v0.2/docs/sentence-count.md
@@ -40,7 +40,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/token-based-ratelimit/v0.3/docs/token-based-ratelimit.md
+++ b/docs/token-based-ratelimit/v0.3/docs/token-based-ratelimit.md
@@ -1,0 +1,132 @@
+---
+title: "Overview"
+---
+# Token Based Rate Limiting
+
+## Overview
+
+The Token Based Rate Limiting policy enforces quotas using LLM token usage instead of request count. It supports independent limits for prompt, completion, and total tokens, with one or more time windows for each.
+
+## Features
+
+- Rate limits based on token usage
+- Independent limit sets for prompt/completion/total tokens
+- Multiple limit windows per token type
+- Uses shared advanced-ratelimit backend/algorithm configuration
+- Supports memory and Redis backends
+
+## Configuration
+
+This policy uses a two-level configuration model.
+
+### User Parameters (LLM Provider Definition)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `promptTokenLimits` | `Limit[]` | No | Limits for prompt (input) token usage. |
+| `completionTokenLimits` | `Limit[]` | No | Limits for completion (output) token usage. |
+| `totalTokenLimits` | `Limit[]` | No | Limits for total token usage. |
+
+At least one of the above limit groups should be configured to enforce throttling.
+
+#### Limit Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `count` | integer | Yes | Maximum tokens allowed in the time window. |
+| `duration` | string | Yes | Time window in Go duration format (for example, `1m`, `1h`, `24h`). |
+
+### System Parameters (From config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `algorithm` | string | No | `gcra` | Rate-limit algorithm: `gcra` or `fixed-window`. |
+| `backend` | string | No | `memory` | Backend: `memory` or `redis`. |
+| `redis` | object | No | - | Redis backend settings (used when `backend=redis`). |
+| `memory` | object | No | - | Memory backend settings (used when `backend=memory`). |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "gcra"
+backend = "memory"
+
+[policy_configurations.ratelimit_v0.memory]
+max_entries = 10000
+cleanup_interval = "5m"
+```
+
+**Note:**
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: token-based-ratelimit
+  gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Total Token Limit
+
+```yaml
+policies:
+  - name: token-based-ratelimit
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          totalTokenLimits:
+            - count: 10000
+              duration: "1m"
+```
+
+### Example 2: Prompt and Completion Limits
+
+```yaml
+policies:
+  - name: token-based-ratelimit
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          promptTokenLimits:
+            - count: 5000
+              duration: "1m"
+          completionTokenLimits:
+            - count: 8000
+              duration: "1m"
+```
+
+### Example 3: Multiple Windows
+
+```yaml
+policies:
+  - name: token-based-ratelimit
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          totalTokenLimits:
+            - count: 10000
+              duration: "1m"
+            - count: 500000
+              duration: "24h"
+```
+
+## How It Works
+
+1. Builds token-based limits from configured user parameters.
+2. Uses provider template token extraction paths to read token counts.
+3. Evaluates configured windows via selected backend/algorithm.
+4. Rejects requests with `429` when any configured token quota is exceeded.
+
+## Notes
+
+- Token extraction depends on template mappings for prompt/completion/total usage fields.
+- Configure Redis backend for distributed rate-limit state across multiple gateway replicas.
+- Keep duration values in valid Go duration format.

--- a/docs/token-based-ratelimit/v0.3/metadata.json
+++ b/docs/token-based-ratelimit/v0.3/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "token-based-ratelimit",
+  "displayName": "Token Based Ratelimit",
+  "version": "0.3",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Enforces LLM token usage limits for prompt, completion, and total tokens using configurable windows and shared rate-limit backends."
+}

--- a/docs/url-guardrail/v0.1/docs/url.md
+++ b/docs/url-guardrail/v0.1/docs/url.md
@@ -39,7 +39,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/url-guardrail/v0.2/docs/url.md
+++ b/docs/url-guardrail/v0.2/docs/url.md
@@ -39,7 +39,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/word-count-guardrail/v0.1/docs/word-count.md
+++ b/docs/word-count-guardrail/v0.1/docs/word-count.md
@@ -40,7 +40,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/docs/word-count-guardrail/v0.2/docs/word-count.md
+++ b/docs/word-count-guardrail/v0.2/docs/word-count.md
@@ -40,7 +40,7 @@ This policy requires only a single-level configuration where all parameters are 
 
 The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
 
-- `$.message` - Extracts the `message` field from the root object
+- `$.messages` - Extracts the `messages` field from the root object
 - `$.data.content` - Extracts nested content from `data.content`
 - `$.items[0].text` - Extracts text from the first item in an array
 - `$.messages[0].content` - Extracts content from the first message in a messages array

--- a/policies/api-key-auth/apikey_test.go
+++ b/policies/api-key-auth/apikey_test.go
@@ -1,0 +1,349 @@
+package apikey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apikeycommon "github.com/wso2/api-platform/common/apikey"
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestAPIKeyPolicy_Mode(t *testing.T) {
+	p := &APIKeyPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestGetPolicy_ReturnsSingleton(t *testing.T) {
+	p1, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetPolicy failed: %v", err)
+	}
+	p2, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetPolicy failed: %v", err)
+	}
+	if p1 != p2 {
+		t.Fatalf("expected singleton policy instance")
+	}
+}
+
+func TestAPIKeyPolicy_OnRequest_SuccessFromHeader(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("x-api-key"): {"header-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	if ctx.Metadata[MetadataKeyAuthSuccess] != true {
+		t.Fatalf("expected auth.success=true, got %v", ctx.Metadata[MetadataKeyAuthSuccess])
+	}
+	if ctx.Metadata[MetadataKeyAuthMethod] != "api-key" {
+		t.Fatalf("expected auth.method=api-key, got %v", ctx.Metadata[MetadataKeyAuthMethod])
+	}
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestAPIKeyPolicy_OnRequest_SuccessFromQuery(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-2", "query-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders?x_api_key=query-secret", nil, "api-2", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x_api_key",
+		"in":  "query",
+	})
+
+	if ctx.Metadata[MetadataKeyAuthSuccess] != true {
+		t.Fatalf("expected auth.success=true, got %v", ctx.Metadata[MetadataKeyAuthSuccess])
+	}
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestAPIKeyPolicy_OnRequest_MissingOrInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]interface{}
+	}{
+		{
+			name: "missing key",
+			params: map[string]interface{}{
+				"in": "header",
+			},
+		},
+		{
+			name: "missing in",
+			params: map[string]interface{}{
+				"key": "x-api-key",
+			},
+		},
+		{
+			name: "unsupported in",
+			params: map[string]interface{}{
+				"key": "x-api-key",
+				"in":  "cookie",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAPIKeyStore(t)
+			p := &APIKeyPolicy{}
+			ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+				"x-api-key": {"header-secret"},
+			}, "api-1", "OrdersAPI", "v1", "/orders")
+
+			action := p.OnRequest(ctx, tt.params)
+			assertUnauthorizedJSON(t, action)
+
+			if ctx.Metadata[MetadataKeyAuthSuccess] != false {
+				t.Fatalf("expected auth.success=false, got %v", ctx.Metadata[MetadataKeyAuthSuccess])
+			}
+		})
+	}
+}
+
+func TestAPIKeyPolicy_OnRequest_FailsWhenAPIKeyMissing(t *testing.T) {
+	resetAPIKeyStore(t)
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders?foo=bar", nil, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x_api_key",
+		"in":  "query",
+	})
+
+	assertUnauthorizedJSON(t, action)
+}
+
+func TestAPIKeyPolicy_OnRequest_FailsWhenAPIDetailsMissing(t *testing.T) {
+	resetAPIKeyStore(t)
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+		"x-api-key": {"header-secret"},
+	}, "api-1", "", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	assertUnauthorizedJSON(t, action)
+}
+
+func TestAPIKeyPolicy_OnRequest_FailsWhenValidationReturnsFalse(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "different-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+		"x-api-key": {"wrong-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	assertUnauthorizedJSON(t, action)
+}
+
+func TestAPIKeyPolicy_OnRequest_FailsWhenValidationErrors(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "bad-ops-secret", `not-json`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+		"x-api-key": {"bad-ops-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequest(ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	assertUnauthorizedJSON(t, action)
+}
+
+func TestAPIKeyPolicy_OnResponse_NoOp(t *testing.T) {
+	p := &APIKeyPolicy{}
+	action := p.OnResponse(&policy.ResponseContext{}, nil)
+	if action != nil {
+		t.Fatalf("expected nil response action, got %T", action)
+	}
+}
+
+func TestAPIKeyPolicy_HandleAuthFailure_PlainFormat(t *testing.T) {
+	p := &APIKeyPolicy{}
+	ctx := newRequestContext(t, "GET", "/orders", nil, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.handleAuthFailure(ctx, 401, "plain", "Auth failed", "test failure")
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.Headers["content-type"] != "text/plain" {
+		t.Fatalf("unexpected content-type: %q", resp.Headers["content-type"])
+	}
+	if string(resp.Body) != "Auth failed" {
+		t.Fatalf("unexpected body: %q", string(resp.Body))
+	}
+}
+
+func TestExtractQueryParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		param    string
+		expected string
+	}{
+		{
+			name:     "simple query",
+			path:     "/orders?token=abc123",
+			param:    "token",
+			expected: "abc123",
+		},
+		{
+			name:     "encoded path",
+			path:     "/orders%3Ftoken%3Dabc123",
+			param:    "token",
+			expected: "abc123",
+		},
+		{
+			name:     "multiple values takes first",
+			path:     "/orders?token=first&token=second",
+			param:    "token",
+			expected: "first",
+		},
+		{
+			name:     "missing query",
+			path:     "/orders",
+			param:    "token",
+			expected: "",
+		},
+		{
+			name:     "invalid escaped path",
+			path:     "%",
+			param:    "token",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractQueryParam(tt.path, tt.param)
+			if got != tt.expected {
+				t.Fatalf("unexpected value: got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func newRequestContext(t *testing.T, method, path string, headers map[string][]string, apiID, apiName, apiVersion, opPath string) *policy.RequestContext {
+	t.Helper()
+	if headers == nil {
+		headers = map[string][]string{}
+	}
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:     "req-1",
+			Metadata:      map[string]interface{}{},
+			APIId:         apiID,
+			APIName:       apiName,
+			APIVersion:    apiVersion,
+			OperationPath: opPath,
+		},
+		Headers: policy.NewHeaders(headers),
+		Method:  method,
+		Path:    path,
+	}
+}
+
+func assertUnauthorizedJSON(t *testing.T, action policy.RequestAction) {
+	t.Helper()
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 401 {
+		t.Fatalf("expected status 401, got %d", resp.StatusCode)
+	}
+	if resp.Headers["content-type"] != "application/json" {
+		t.Fatalf("expected content-type application/json, got %q", resp.Headers["content-type"])
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if body["error"] != "Unauthorized" {
+		t.Fatalf("unexpected error value: %v", body["error"])
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "Valid API key required") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func resetAPIKeyStore(t *testing.T) {
+	t.Helper()
+	if err := apikeycommon.GetAPIkeyStoreInstance().ClearAll(); err != nil {
+		t.Fatalf("failed to clear API key store: %v", err)
+	}
+}
+
+func seedExternalAPIKey(t *testing.T, apiID, plainKey, operations string) {
+	t.Helper()
+	key := &apikeycommon.APIKey{
+		ID:          "id-" + sanitizeTestName(t.Name()),
+		Name:        "name-" + sanitizeTestName(t.Name()),
+		DisplayName: "test-key",
+		APIKey:      plainKey,
+		APIId:       apiID,
+		Operations:  operations,
+		Status:      apikeycommon.Active,
+		Source:      "external",
+		IndexKey:    hashExternalIndexKey(plainKey),
+	}
+	if err := apikeycommon.GetAPIkeyStoreInstance().StoreAPIKey(apiID, key); err != nil {
+		t.Fatalf("failed to store API key: %v", err)
+	}
+}
+
+func hashExternalIndexKey(v string) string {
+	h := sha256.Sum256([]byte(strings.TrimSpace(v)))
+	return hex.EncodeToString(h[:])
+}
+
+func sanitizeTestName(v string) string {
+	v = strings.ReplaceAll(v, "/", "-")
+	v = strings.ReplaceAll(v, " ", "-")
+	return strings.ToLower(v)
+}

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -19,7 +19,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         redactPII:
           type: boolean
@@ -48,7 +48,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         passthroughOnError:
           type: boolean

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package azurecontentsafetycontentmoderation
 
 import (
@@ -61,13 +61,13 @@ type AzureContentSafetyContentModerationPolicy struct {
 }
 
 type AzureContentSafetyPolicyParams struct {
-	JsonPath           string
-	PassthroughOnError bool
-	ShowAssessment     bool
-	HateCategory       int
-	SexualCategory     int
-	SelfHarmCategory   int
-	ViolenceCategory   int
+	JsonPath                  string
+	PassthroughOnError        bool
+	ShowAssessment            bool
+	HateSeverityThreshold     int
+	SexualSeverityThreshold   int
+	SelfHarmSeverityThreshold int
+	ViolenceSeverityThreshold int
 }
 
 func GetPolicy(
@@ -122,10 +122,10 @@ func parseRequestResponseParams(params map[string]interface{}) (AzureContentSafe
 	var result AzureContentSafetyPolicyParams
 
 	// Initialize category thresholds to -1 (disabled by default)
-	result.HateCategory = -1
-	result.SexualCategory = -1
-	result.SelfHarmCategory = -1
-	result.ViolenceCategory = -1
+	result.HateSeverityThreshold = -1
+	result.SexualSeverityThreshold = -1
+	result.SelfHarmSeverityThreshold = -1
+	result.ViolenceSeverityThreshold = -1
 
 	// Extract optional jsonPath parameter
 	if jsonPathRaw, ok := params["jsonPath"]; ok {
@@ -159,10 +159,10 @@ func parseRequestResponseParams(params map[string]interface{}) (AzureContentSafe
 		name  string
 		value *int
 	}{
-		{"hateCategory", &result.HateCategory},
-		{"sexualCategory", &result.SexualCategory},
-		{"selfHarmCategory", &result.SelfHarmCategory},
-		{"violenceCategory", &result.ViolenceCategory},
+		{"hateSeverityThreshold", &result.HateSeverityThreshold},
+		{"sexualSeverityThreshold", &result.SexualSeverityThreshold},
+		{"selfHarmSeverityThreshold", &result.SelfHarmSeverityThreshold},
+		{"violenceSeverityThreshold", &result.ViolenceSeverityThreshold},
 	}
 
 	for _, cat := range categories {
@@ -364,10 +364,10 @@ func (p *AzureContentSafetyContentModerationPolicy) validatePayload(payload []by
 // buildCategoryMap builds category threshold map from parameters
 func (p *AzureContentSafetyContentModerationPolicy) buildCategoryMap(params AzureContentSafetyPolicyParams) map[string]int {
 	return map[string]int{
-		"Hate":     params.HateCategory,
-		"Sexual":   params.SexualCategory,
-		"SelfHarm": params.SelfHarmCategory,
-		"Violence": params.ViolenceCategory,
+		"Hate":     params.HateSeverityThreshold,
+		"Sexual":   params.SexualSeverityThreshold,
+		"SelfHarm": params.SelfHarmSeverityThreshold,
+		"Violence": params.ViolenceSeverityThreshold,
 	}
 }
 

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
@@ -121,11 +121,11 @@ func GetPolicy(
 func parseRequestResponseParams(params map[string]interface{}) (AzureContentSafetyPolicyParams, error) {
 	var result AzureContentSafetyPolicyParams
 
-	// Initialize category thresholds to -1 (disabled by default)
-	result.HateSeverityThreshold = -1
-	result.SexualSeverityThreshold = -1
-	result.SelfHarmSeverityThreshold = -1
-	result.ViolenceSeverityThreshold = -1
+	// Initialize category thresholds to policy defaults
+	result.HateSeverityThreshold = 4
+	result.SexualSeverityThreshold = 5
+	result.SelfHarmSeverityThreshold = 3
+	result.ViolenceSeverityThreshold = 4
 
 	// Extract optional jsonPath parameter
 	if jsonPathRaw, ok := params["jsonPath"]; ok {

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
@@ -147,7 +147,7 @@ func TestAzureContentSafetyPolicy_OnRequest_NoRequestConfig_NoOp(t *testing.T) {
 		"azureContentSafetyEndpoint": "https://example.com",
 		"azureContentSafetyKey":      "k",
 		"response": map[string]interface{}{
-			"jsonPath": "$.message",
+			"jsonPath": "$.messages",
 		},
 	})
 
@@ -162,7 +162,7 @@ func TestAzureContentSafetyPolicy_OnResponse_NoResponseConfig_NoOp(t *testing.T)
 		"azureContentSafetyEndpoint": "https://example.com",
 		"azureContentSafetyKey":      "k",
 		"request": map[string]interface{}{
-			"jsonPath": "$.message",
+			"jsonPath": "$.messages",
 		},
 	})
 
@@ -232,7 +232,7 @@ func TestAzureContentSafetyPolicy_APICallError_PassthroughBehavior(t *testing.T)
 		"azureContentSafetyEndpoint": srv.URL,
 		"azureContentSafetyKey":      "k",
 		"request": map[string]interface{}{
-			"jsonPath":           "$.message",
+			"jsonPath":           "$.messages",
 			"passthroughOnError": true,
 		},
 	})
@@ -245,7 +245,7 @@ func TestAzureContentSafetyPolicy_APICallError_PassthroughBehavior(t *testing.T)
 		"azureContentSafetyEndpoint": srv.URL,
 		"azureContentSafetyKey":      "k",
 		"request": map[string]interface{}{
-			"jsonPath":           "$.message",
+			"jsonPath":           "$.messages",
 			"passthroughOnError": false,
 		},
 	})
@@ -267,7 +267,7 @@ func TestAzureContentSafetyPolicy_APISuccess_NoViolation(t *testing.T) {
 		"azureContentSafetyEndpoint": srv.URL,
 		"azureContentSafetyKey":      "k",
 		"request": map[string]interface{}{
-			"jsonPath":              "$.message",
+			"jsonPath":              "$.messages",
 			"hateSeverityThreshold": 4,
 		},
 	})
@@ -288,12 +288,12 @@ func TestAzureContentSafetyPolicy_APIViolation_RequestAndResponse(t *testing.T) 
 		"azureContentSafetyEndpoint": srv.URL,
 		"azureContentSafetyKey":      "k",
 		"request": map[string]interface{}{
-			"jsonPath":              "$.message",
+			"jsonPath":              "$.messages",
 			"hateSeverityThreshold": 3,
 			"showAssessment":        true,
 		},
 		"response": map[string]interface{}{
-			"jsonPath":              "$.message",
+			"jsonPath":              "$.messages",
 			"hateSeverityThreshold": 3,
 			"showAssessment":        true,
 		},

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
@@ -1,0 +1,439 @@
+package azurecontentsafetycontentmoderation
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestAzureContentSafetyPolicy_Mode(t *testing.T) {
+	p := &AzureContentSafetyContentModerationPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestValidateAzureConfigParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "missing endpoint",
+			params:         map[string]interface{}{"azureContentSafetyKey": "k"},
+			wantErrContain: "'azureContentSafetyEndpoint' parameter is required",
+		},
+		{
+			name:           "endpoint wrong type",
+			params:         map[string]interface{}{"azureContentSafetyEndpoint": 1, "azureContentSafetyKey": "k"},
+			wantErrContain: "'azureContentSafetyEndpoint' must be a string",
+		},
+		{
+			name:           "missing key",
+			params:         map[string]interface{}{"azureContentSafetyEndpoint": "https://example.com"},
+			wantErrContain: "'azureContentSafetyKey' parameter is required",
+		},
+		{
+			name:           "key empty",
+			params:         map[string]interface{}{"azureContentSafetyEndpoint": "https://example.com", "azureContentSafetyKey": ""},
+			wantErrContain: "'azureContentSafetyKey' cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAzureConfigParams(tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestParseRequestResponseParams_DefaultsAndErrors(t *testing.T) {
+	got, err := parseRequestResponseParams(map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("expected defaults parse success, got error: %v", err)
+	}
+	if got.HateSeverityThreshold != 4 || got.SexualSeverityThreshold != 5 || got.SelfHarmSeverityThreshold != 3 || got.ViolenceSeverityThreshold != 4 {
+		t.Fatalf("unexpected default thresholds: %+v", got)
+	}
+
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "jsonPath wrong type",
+			params:         map[string]interface{}{"jsonPath": true},
+			wantErrContain: "'jsonPath' must be a string",
+		},
+		{
+			name:           "passthroughOnError wrong type",
+			params:         map[string]interface{}{"passthroughOnError": "true"},
+			wantErrContain: "'passthroughOnError' must be a boolean",
+		},
+		{
+			name:           "showAssessment wrong type",
+			params:         map[string]interface{}{"showAssessment": "true"},
+			wantErrContain: "'showAssessment' must be a boolean",
+		},
+		{
+			name:           "threshold out of range",
+			params:         map[string]interface{}{"hateSeverityThreshold": 8},
+			wantErrContain: "'hateSeverityThreshold' must be between -1 and 7",
+		},
+		{
+			name:           "threshold not integer",
+			params:         map[string]interface{}{"hateSeverityThreshold": 1.5},
+			wantErrContain: "'hateSeverityThreshold' must be a number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseRequestResponseParams(tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestAzureContentSafetyPolicy_GetPolicy_Errors(t *testing.T) {
+	base := map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+	}
+
+	_, err := GetPolicy(policy.PolicyMetadata{}, base)
+	if err == nil || !strings.Contains(err.Error(), "at least one of 'request' or 'response' parameters must be provided") {
+		t.Fatalf("expected request/response presence error, got %v", err)
+	}
+
+	badReq := map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"showAssessment": "true",
+		},
+	}
+	_, err = GetPolicy(policy.PolicyMetadata{}, badReq)
+	if err == nil || !strings.Contains(err.Error(), "invalid request parameters") {
+		t.Fatalf("expected invalid request parameters error, got %v", err)
+	}
+}
+
+func TestAzureContentSafetyPolicy_OnRequest_NoRequestConfig_NoOp(t *testing.T) {
+	p := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"response": map[string]interface{}{
+			"jsonPath": "$.message",
+		},
+	})
+
+	action := p.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestAzureContentSafetyPolicy_OnResponse_NoResponseConfig_NoOp(t *testing.T) {
+	p := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath": "$.message",
+		},
+	})
+
+	action := p.OnResponse(azureResponseContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestAzureContentSafetyPolicy_NoValidCategories_PassThrough(t *testing.T) {
+	p := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"hateSeverityThreshold":     -1,
+			"sexualSeverityThreshold":   -1,
+			"selfHarmSeverityThreshold": -1,
+			"violenceSeverityThreshold": -1,
+		},
+	})
+
+	action := p.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected pass-through when no valid categories, got %T", action)
+	}
+}
+
+func TestAzureContentSafetyPolicy_JSONPathError_PassthroughBehavior(t *testing.T) {
+	pPass := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":           "$.missing.path",
+			"passthroughOnError": true,
+		},
+	})
+	a1 := pPass.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := a1.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected pass-through for jsonPath error when passthrough enabled, got %T", a1)
+	}
+
+	pFail := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": "https://example.com",
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":           "$.missing.path",
+			"passthroughOnError": false,
+			"showAssessment":     true,
+		},
+	})
+	a2 := pFail.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	body := assertAzureRequestError(t, a2, true, "REQUEST")
+	msg := extractAzureMessage(t, body)
+	if _, ok := msg["assessments"]; !ok {
+		t.Fatalf("expected assessments for extraction error with showAssessment=true")
+	}
+}
+
+func TestAzureContentSafetyPolicy_APICallError_PassthroughBehavior(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
+	}))
+	defer srv.Close()
+
+	pPass := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": srv.URL,
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":           "$.message",
+			"passthroughOnError": true,
+		},
+	})
+	a1 := pPass.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := a1.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected pass-through on API error when passthrough enabled, got %T", a1)
+	}
+
+	pFail := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": srv.URL,
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":           "$.message",
+			"passthroughOnError": false,
+		},
+	})
+	a2 := pFail.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	assertAzureRequestError(t, a2, false, "REQUEST")
+}
+
+func TestAzureContentSafetyPolicy_APISuccess_NoViolation(t *testing.T) {
+	srv := azureMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/contentsafety/text:analyze" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"categoriesAnalysis":[{"category":"Hate","severity":1}]}`))
+	})
+	defer srv.Close()
+
+	p := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": srv.URL,
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":              "$.message",
+			"hateSeverityThreshold": 4,
+		},
+	})
+	action := p.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications on non-violation, got %T", action)
+	}
+}
+
+func TestAzureContentSafetyPolicy_APIViolation_RequestAndResponse(t *testing.T) {
+	srv := azureMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"categoriesAnalysis":[{"category":"Hate","severity":5}]}`))
+	})
+	defer srv.Close()
+
+	p := mustGetAzurePolicy(t, map[string]interface{}{
+		"azureContentSafetyEndpoint": srv.URL,
+		"azureContentSafetyKey":      "k",
+		"request": map[string]interface{}{
+			"jsonPath":              "$.message",
+			"hateSeverityThreshold": 3,
+			"showAssessment":        true,
+		},
+		"response": map[string]interface{}{
+			"jsonPath":              "$.message",
+			"hateSeverityThreshold": 3,
+			"showAssessment":        true,
+		},
+	})
+
+	reqAction := p.OnRequest(azureRequestContext(`{"message":"blocked text"}`), nil)
+	reqBody := assertAzureRequestError(t, reqAction, true, "REQUEST")
+	reqMsg := extractAzureMessage(t, reqBody)
+	assessment, ok := reqMsg["assessments"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected assessments object on violation, got %T", reqMsg["assessments"])
+	}
+	if _, ok := assessment["categories"]; !ok {
+		t.Fatalf("expected assessments.categories on violation")
+	}
+
+	respAction := p.OnResponse(azureResponseContext(`{"message":"blocked response"}`), nil)
+	respBody := assertAzureResponseError(t, respAction, true, "RESPONSE")
+	respMsg := extractAzureMessage(t, respBody)
+	if _, ok := respMsg["assessments"]; !ok {
+		t.Fatalf("expected response assessments on violation")
+	}
+}
+
+func mustGetAzurePolicy(t *testing.T, params map[string]interface{}) *AzureContentSafetyContentModerationPolicy {
+	t.Helper()
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	ap, ok := p.(*AzureContentSafetyContentModerationPolicy)
+	if !ok {
+		t.Fatalf("expected *AzureContentSafetyContentModerationPolicy, got %T", p)
+	}
+	return ap
+}
+
+func azureMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if got := r.URL.Query().Get("api-version"); got != "2024-09-01" {
+			t.Fatalf("expected api-version=2024-09-01, got %q", got)
+		}
+		if r.Header.Get("Ocp-Apim-Subscription-Key") == "" {
+			t.Fatalf("expected subscription key header")
+		}
+		handler(w, r)
+	}))
+}
+
+func azureRequestContext(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func azureResponseContext(body string) *policy.ResponseContext {
+	return &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func assertAzureRequestError(t *testing.T, action policy.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+	t.Helper()
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != GuardrailErrorCode {
+		t.Fatalf("unexpected status code: got %d, want %d", resp.StatusCode, GuardrailErrorCode)
+	}
+	body := decodeAzureJSON(t, resp.Body)
+	validateAzureErrorBody(t, body, expectAssessments, wantDirection)
+	return body
+}
+
+func assertAzureResponseError(t *testing.T, action policy.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+	t.Helper()
+	resp, ok := action.(policy.UpstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
+		t.Fatalf("unexpected status code: got %v", resp.StatusCode)
+	}
+	body := decodeAzureJSON(t, resp.Body)
+	validateAzureErrorBody(t, body, expectAssessments, wantDirection)
+	return body
+}
+
+func validateAzureErrorBody(t *testing.T, body map[string]interface{}, expectAssessments bool, wantDirection string) {
+	t.Helper()
+	if got := body["type"]; got != "AZURE_CONTENT_SAFETY_CONTENT_MODERATION" {
+		t.Fatalf("unexpected type: %v", got)
+	}
+	msg := extractAzureMessage(t, body)
+	if got := msg["action"]; got != "GUARDRAIL_INTERVENED" {
+		t.Fatalf("unexpected action: %v", got)
+	}
+	if got := msg["direction"]; got != wantDirection {
+		t.Fatalf("unexpected direction: got %v, want %q", got, wantDirection)
+	}
+	if expectAssessments {
+		if _, ok := msg["assessments"]; !ok {
+			t.Fatalf("expected assessments to be present")
+		}
+	}
+}
+
+func extractAzureMessage(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	msg, ok := body["message"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected body.message object, got %T", body["message"])
+	}
+	return msg
+}
+
+func decodeAzureJSON(t *testing.T, raw []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("failed to decode json: %v", err)
+	}
+	return m
+}

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -10,28 +10,33 @@ parameters:
   properties:
     request:
       type: object
+      x-wso2-policy-advanced-param: false
       description: Specifies content moderation settings for request payloads.
       properties:
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             Specifies the JSONPath used to extract content for moderation. When
             empty, the entire payload is evaluated as plain text.
           default: ""
         passthroughOnError:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             Specifies whether requests continue when the Azure Content Safety
             API call fails. True allows passthrough; false blocks on API errors.
           default: false
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies whether blocked responses include detailed moderation
             assessment information.
           default: false
         hateSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the hate category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.
@@ -40,6 +45,7 @@ parameters:
           default: -1
         sexualSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the sexual category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.
@@ -48,6 +54,7 @@ parameters:
           default: -1
         selfHarmSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the self-harm category severity threshold (0-7). Use -1
             to disable this category. Content at or above the threshold is blocked.
@@ -56,6 +63,7 @@ parameters:
           default: -1
         violenceSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the violence category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.
@@ -64,28 +72,33 @@ parameters:
           default: -1
     response:
       type: object
+      x-wso2-policy-advanced-param: false
       description: Specifies content moderation settings for response payloads.
       properties:
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             Specifies the JSONPath used to extract content for moderation. When
             empty, the entire payload is evaluated as plain text.
           default: ""
         passthroughOnError:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             Specifies whether responses continue when the Azure Content Safety
             API call fails. True allows passthrough; false blocks on API errors.
           default: false
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies whether blocked responses include detailed moderation
             assessment information.
           default: false
         hateSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the hate category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.
@@ -94,6 +107,7 @@ parameters:
           default: -1
         sexualSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the sexual category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.
@@ -102,6 +116,7 @@ parameters:
           default: -1
         selfHarmSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the self-harm category severity threshold (0-7). Use -1
             to disable this category. Content at or above the threshold is blocked.
@@ -110,6 +125,7 @@ parameters:
           default: -1
         violenceSeverityThreshold:
           type: integer
+          x-wso2-policy-advanced-param: false
           description: |
             Specifies the violence category severity threshold (0-7). Use -1 to
             disable this category. Content at or above the threshold is blocked.

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -132,6 +132,9 @@ parameters:
           minimum: -1
           maximum: 7
           default: 4
+  anyOf:
+    - required: [ request ]
+    - required: [ response ]
 
 systemParameters:
   type: object

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: azure-content-safety-content-moderation
-version: v0.2.1
+version: v0.3.0
 description: |
   Validates request and response content with Azure Content Safety moderation
   checks. Supports configurable category thresholds, optional JSONPath
@@ -30,7 +30,7 @@ parameters:
             Specifies whether blocked responses include detailed moderation
             assessment information.
           default: false
-        hateCategory:
+        hateSeverityThreshold:
           type: integer
           description: |
             Specifies the hate category severity threshold (0-7). Use -1 to
@@ -38,7 +38,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        sexualCategory:
+        sexualSeverityThreshold:
           type: integer
           description: |
             Specifies the sexual category severity threshold (0-7). Use -1 to
@@ -46,7 +46,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        selfHarmCategory:
+        selfHarmSeverityThreshold:
           type: integer
           description: |
             Specifies the self-harm category severity threshold (0-7). Use -1
@@ -54,7 +54,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        violenceCategory:
+        violenceSeverityThreshold:
           type: integer
           description: |
             Specifies the violence category severity threshold (0-7). Use -1 to
@@ -84,7 +84,7 @@ parameters:
             Specifies whether blocked responses include detailed moderation
             assessment information.
           default: false
-        hateCategory:
+        hateSeverityThreshold:
           type: integer
           description: |
             Specifies the hate category severity threshold (0-7). Use -1 to
@@ -92,7 +92,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        sexualCategory:
+        sexualSeverityThreshold:
           type: integer
           description: |
             Specifies the sexual category severity threshold (0-7). Use -1 to
@@ -100,7 +100,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        selfHarmCategory:
+        selfHarmSeverityThreshold:
           type: integer
           description: |
             Specifies the self-harm category severity threshold (0-7). Use -1
@@ -108,7 +108,7 @@ parameters:
           minimum: -1
           maximum: 7
           default: -1
-        violenceCategory:
+        violenceSeverityThreshold:
           type: integer
           description: |
             Specifies the violence category severity threshold (0-7). Use -1 to

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -29,7 +29,7 @@ parameters:
           default: false
         showAssessment:
           type: boolean
-          x-wso2-policy-advanced-param: false
+          x-wso2-policy-advanced-param: true
           description: |
             Specifies whether blocked responses include detailed moderation
             assessment information.
@@ -42,7 +42,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 4
         sexualSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -51,7 +51,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 5
         selfHarmSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -60,7 +60,7 @@ parameters:
             to disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 3
         violenceSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -69,7 +69,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 4
     response:
       type: object
       x-wso2-policy-advanced-param: false
@@ -104,7 +104,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 4
         sexualSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -113,7 +113,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 5
         selfHarmSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -122,7 +122,7 @@ parameters:
             to disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 3
         violenceSeverityThreshold:
           type: integer
           x-wso2-policy-advanced-param: false
@@ -131,7 +131,7 @@ parameters:
             disable this category. Content at or above the threshold is blocked.
           minimum: -1
           maximum: 7
-          default: -1
+          default: 4
 
 systemParameters:
   type: object

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -26,7 +26,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean
@@ -60,7 +60,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean

--- a/policies/cors/cors_test.go
+++ b/policies/cors/cors_test.go
@@ -1,0 +1,429 @@
+package cors
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestCorsPolicy_Mode(t *testing.T) {
+	p := &CorsPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestCorsPolicy_GetPolicy_Defaults(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{})
+
+	if !reflect.DeepEqual(p.AllowedOrigins, []string{"*"}) {
+		t.Fatalf("unexpected allowedOrigins: %v", p.AllowedOrigins)
+	}
+	if !reflect.DeepEqual(p.AllowedMethods, []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}) {
+		t.Fatalf("unexpected allowedMethods: %v", p.AllowedMethods)
+	}
+	if !reflect.DeepEqual(p.AllowedHeaders, []string{}) {
+		t.Fatalf("unexpected allowedHeaders: %v", p.AllowedHeaders)
+	}
+	if p.ExposedHeaders != nil {
+		t.Fatalf("expected exposedHeaders=nil by runtime default, got %v", p.ExposedHeaders)
+	}
+	if p.MaxAge != nil {
+		t.Fatalf("expected maxAge=nil by runtime default, got %v", *p.MaxAge)
+	}
+	if p.AllowCredentials != nil {
+		t.Fatalf("expected allowCredentials=nil by runtime default, got %v", *p.AllowCredentials)
+	}
+	if p.ForwardPreflight {
+		t.Fatalf("expected forwardPreflight=false by default")
+	}
+}
+
+func TestCorsPolicy_GetPolicy_NormalizesWildcardLists(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins": []any{"https://a.example.com", "*", "https://b.example.com"},
+		"allowedHeaders": []any{"X-Trace-Id", "*", "Authorization"},
+	})
+
+	if !reflect.DeepEqual(p.AllowedOrigins, []string{"*"}) {
+		t.Fatalf("expected wildcard-only origins, got %v", p.AllowedOrigins)
+	}
+	if !reflect.DeepEqual(p.AllowedHeaders, []string{"*"}) {
+		t.Fatalf("expected wildcard-only headers, got %v", p.AllowedHeaders)
+	}
+}
+
+func TestCorsPolicy_GetPolicy_AllowCredentialsWildcardRejections(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]any
+		wantErrContain string
+	}{
+		{
+			name: "origins wildcard",
+			params: map[string]any{
+				"allowCredentials": true,
+				"allowedOrigins":   []any{"*"},
+				"allowedMethods":   []any{"GET"},
+				"allowedHeaders":   []any{"x-api-key"},
+			},
+			wantErrContain: "cannot have wildcard origin",
+		},
+		{
+			name: "headers wildcard",
+			params: map[string]any{
+				"allowCredentials": true,
+				"allowedOrigins":   []any{"https://allowed.example.com"},
+				"allowedMethods":   []any{"GET"},
+				"allowedHeaders":   []any{"*"},
+			},
+			wantErrContain: "cannot have wildcard headers",
+		},
+		{
+			name: "methods wildcard",
+			params: map[string]any{
+				"allowCredentials": true,
+				"allowedOrigins":   []any{"https://allowed.example.com"},
+				"allowedMethods":   []any{"*"},
+				"allowedHeaders":   []any{"x-api-key"},
+			},
+			wantErrContain: "cannot have wildcard methods",
+		},
+		{
+			name: "exposed headers wildcard",
+			params: map[string]any{
+				"allowCredentials": true,
+				"allowedOrigins":   []any{"https://allowed.example.com"},
+				"allowedMethods":   []any{"GET"},
+				"allowedHeaders":   []any{"x-api-key"},
+				"exposedHeaders":   []any{"*"},
+			},
+			wantErrContain: "cannot have wildcard exposed headers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestCorsPolicy_GetPolicy_InvalidOriginRegex(t *testing.T) {
+	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]any{
+		"allowedOrigins": []any{"[invalid-regex"},
+	})
+	if err == nil {
+		t.Fatalf("expected invalid origin regex error")
+	}
+	if !strings.Contains(err.Error(), "invalid origin regex") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCorsPolicy_GetPolicy_MaxAgeFromFloatAndInt(t *testing.T) {
+	p1 := mustGetCorsPolicy(t, map[string]any{"maxAge": 120})
+	if p1.MaxAge == nil || *p1.MaxAge != 120 {
+		t.Fatalf("expected maxAge=120 from int, got %v", p1.MaxAge)
+	}
+
+	p2 := mustGetCorsPolicy(t, map[string]any{"maxAge": float64(90)})
+	if p2.MaxAge == nil || *p2.MaxAge != 90 {
+		t.Fatalf("expected maxAge=90 from float64, got %v", p2.MaxAge)
+	}
+}
+
+func TestCorsPolicy_OnRequest_PreflightSuccess(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins":   []any{"*"},
+		"allowedMethods":   []any{"GET", "POST"},
+		"allowedHeaders":   []any{"*"},
+		"allowCredentials": false,
+		"maxAge":           3600,
+	})
+
+	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+		"Origin":                        {"https://client.example.com"},
+		"Access-Control-Request-Method": {"GET"},
+		"Access-Control-Request-Headers": {
+			"x-api-key, x-trace-id",
+		},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+	if resp.Headers["Access-Control-Allow-Origin"] != "*" {
+		t.Fatalf("unexpected allow-origin header: %q", resp.Headers["Access-Control-Allow-Origin"])
+	}
+	if resp.Headers["Access-Control-Allow-Methods"] != "GET,POST" {
+		t.Fatalf("unexpected allow-methods header: %q", resp.Headers["Access-Control-Allow-Methods"])
+	}
+	if resp.Headers["Access-Control-Allow-Headers"] != "x-api-key, x-trace-id" {
+		t.Fatalf("unexpected allow-headers: %q", resp.Headers["Access-Control-Allow-Headers"])
+	}
+	if resp.Headers["Access-Control-Max-Age"] != "3600" {
+		t.Fatalf("unexpected max-age: %q", resp.Headers["Access-Control-Max-Age"])
+	}
+	if resp.Headers["Access-Control-Allow-Credentials"] != "false" {
+		t.Fatalf("unexpected allow-credentials: %q", resp.Headers["Access-Control-Allow-Credentials"])
+	}
+}
+
+func TestCorsPolicy_OnRequest_PreflightFailure_NotForwarded(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins": []any{"https://allowed.example.com"},
+		"allowedMethods": []any{"GET"},
+		"allowedHeaders": []any{"x-api-key"},
+	})
+
+	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+		"Origin":                        {"https://blocked.example.com"},
+		"Access-Control-Request-Method": {"DELETE"},
+		"Access-Control-Request-Headers": {
+			"x-not-allowed",
+		},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+	if len(resp.Headers) != 0 {
+		t.Fatalf("expected empty headers on failed preflight, got %v", resp.Headers)
+	}
+}
+
+func TestCorsPolicy_OnRequest_PreflightFailure_Forwarded(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins":   []any{"https://allowed.example.com"},
+		"allowedMethods":   []any{"GET"},
+		"allowedHeaders":   []any{"x-api-key"},
+		"forwardPreflight": true,
+	})
+
+	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+		"Origin":                        {"https://blocked.example.com"},
+		"Access-Control-Request-Method": {"DELETE"},
+		"Access-Control-Request-Headers": {
+			"x-not-allowed",
+		},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestCorsPolicy_OnRequest_NonPreflightAllowedOrigin(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins":   []any{"^https://allowed\\.example\\.com$"},
+		"exposedHeaders":   []any{"X-Trace-Id", "X-RateLimit-Remaining"},
+		"allowCredentials": true,
+	})
+
+	ctx := newCorsRequestContext("GET", map[string][]string{
+		"Origin": {"https://allowed.example.com"},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	if action != nil {
+		t.Fatalf("expected nil action for non-preflight request, got %T", action)
+	}
+
+	corsHeaders, ok := ctx.Metadata["cors_headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected cors_headers metadata to be present")
+	}
+	if corsHeaders["Access-Control-Allow-Origin"] != "https://allowed.example.com" {
+		t.Fatalf("unexpected allow-origin: %q", corsHeaders["Access-Control-Allow-Origin"])
+	}
+	if corsHeaders["Vary"] != "Origin" {
+		t.Fatalf("expected Vary=Origin, got %q", corsHeaders["Vary"])
+	}
+	if corsHeaders["Access-Control-Expose-Headers"] != "X-Trace-Id,X-RateLimit-Remaining" {
+		t.Fatalf("unexpected expose headers: %q", corsHeaders["Access-Control-Expose-Headers"])
+	}
+	if corsHeaders["Access-Control-Allow-Credentials"] != "true" {
+		t.Fatalf("unexpected allow-credentials: %q", corsHeaders["Access-Control-Allow-Credentials"])
+	}
+}
+
+func TestCorsPolicy_OnRequest_NonPreflightDisallowedOriginSetsStrip(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins": []any{"^https://allowed\\.example\\.com$"},
+	})
+
+	ctx := newCorsRequestContext("GET", map[string][]string{
+		"Origin": {"https://blocked.example.com"},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	if action != nil {
+		t.Fatalf("expected nil action for non-preflight request, got %T", action)
+	}
+	if ctx.Metadata["cors_strip"] != true {
+		t.Fatalf("expected cors_strip=true, got %v", ctx.Metadata["cors_strip"])
+	}
+	if _, ok := ctx.Metadata["cors_headers"]; ok {
+		t.Fatalf("did not expect cors_headers when origin is disallowed")
+	}
+}
+
+func TestCorsPolicy_OnRequest_NonPreflightWithoutOriginNoStrip(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins": []any{"^https://allowed\\.example\\.com$"},
+	})
+
+	ctx := newCorsRequestContext("GET", nil)
+	_ = p.OnRequest(ctx, nil)
+
+	if _, ok := ctx.Metadata["cors_strip"]; ok {
+		t.Fatalf("did not expect cors_strip metadata when Origin is absent")
+	}
+	if _, ok := ctx.Metadata["cors_headers"]; ok {
+		t.Fatalf("did not expect cors_headers metadata when Origin is absent")
+	}
+}
+
+func TestCorsPolicy_OnResponse_FromCorsHeadersMetadata(t *testing.T) {
+	p := &CorsPolicy{}
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata: map[string]interface{}{
+				"cors_headers": map[string]string{
+					"Access-Control-Allow-Origin": "*",
+				},
+			},
+		},
+	}
+
+	action := p.OnResponse(ctx, nil)
+	mods, ok := action.(policy.UpstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	if mods.SetHeaders["Access-Control-Allow-Origin"] != "*" {
+		t.Fatalf("unexpected set headers: %v", mods.SetHeaders)
+	}
+}
+
+func TestCorsPolicy_OnResponse_FromCorsStripMetadata(t *testing.T) {
+	p := &CorsPolicy{}
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata: map[string]interface{}{
+				"cors_strip": true,
+			},
+		},
+	}
+
+	action := p.OnResponse(ctx, nil)
+	mods, ok := action.(policy.UpstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	want := []string{
+		"Access-Control-Allow-Origin",
+		"Access-Control-Allow-Credentials",
+		"Access-Control-Expose-Headers",
+	}
+	if !reflect.DeepEqual(mods.RemoveHeaders, want) {
+		t.Fatalf("unexpected remove headers: got %v, want %v", mods.RemoveHeaders, want)
+	}
+}
+
+func TestCorsPolicy_OnResponse_NoMetadata(t *testing.T) {
+	p := &CorsPolicy{}
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+	}
+
+	action := p.OnResponse(ctx, nil)
+	if action != nil {
+		t.Fatalf("expected nil, got %T", action)
+	}
+}
+
+func TestCorsPolicy_OnRequest_PreflightSpecificAllowedHeadersCaseInsensitive(t *testing.T) {
+	p := mustGetCorsPolicy(t, map[string]any{
+		"allowedOrigins": []any{"*"},
+		"allowedMethods": []any{"GET"},
+		"allowedHeaders": []any{"X-Token", "X-Trace-Id"},
+	})
+
+	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+		"Origin":                        {"https://client.example.com"},
+		"Access-Control-Request-Method": {"GET"},
+		"Access-Control-Request-Headers": {
+			"x-token, x-trace-id",
+		},
+	})
+
+	action := p.OnRequest(ctx, nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.Headers["Access-Control-Allow-Headers"] != "X-Token,X-Trace-Id" {
+		t.Fatalf("unexpected allow-headers: %q", resp.Headers["Access-Control-Allow-Headers"])
+	}
+}
+
+func mustGetCorsPolicy(t *testing.T, params map[string]any) *CorsPolicy {
+	t.Helper()
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("GetPolicy failed: %v", err)
+	}
+	cp, ok := p.(*CorsPolicy)
+	if !ok {
+		t.Fatalf("expected *CorsPolicy, got %T", p)
+	}
+	return cp
+}
+
+func newCorsRequestContext(method string, headers map[string][]string) *policy.RequestContext {
+	if headers == nil {
+		headers = map[string][]string{}
+	}
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: policy.NewHeaders(headers),
+		Method:  method,
+	}
+}

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -9,6 +9,7 @@ parameters:
   properties:
     models:
       type: array
+      x-wso2-policy-advanced-param: false
       description: Specifies the list of models used for round-robin request
         distribution.
       items:
@@ -23,6 +24,7 @@ parameters:
       minItems: 1
     suspendDuration:
       type: integer
+      x-wso2-policy-advanced-param: true
       description: |
         Specifies the suspension time in seconds for failed models. If omitted,
         failed-model state is not persisted.

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v0.2.1
+version: v0.3.0
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.

--- a/policies/model-round-robin/roundrobin_test.go
+++ b/policies/model-round-robin/roundrobin_test.go
@@ -1,0 +1,405 @@
+package modelroundrobin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestModelRoundRobinPolicy_Mode(t *testing.T) {
+	p := &ModelRoundRobinPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestModelRoundRobinPolicy_GetPolicy_ParseErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "missing models",
+			params:         map[string]interface{}{},
+			wantErrContain: "'models' parameter is required",
+		},
+		{
+			name: "models wrong type",
+			params: map[string]interface{}{
+				"models": "not-array",
+			},
+			wantErrContain: "'models' must be an array",
+		},
+		{
+			name: "models empty",
+			params: map[string]interface{}{
+				"models": []interface{}{},
+			},
+			wantErrContain: "'models' array must contain at least one model",
+		},
+		{
+			name: "model item not object",
+			params: map[string]interface{}{
+				"models": []interface{}{"a"},
+			},
+			wantErrContain: "'models[0]' must be an object",
+		},
+		{
+			name: "model missing name",
+			params: map[string]interface{}{
+				"models": []interface{}{map[string]interface{}{}},
+			},
+			wantErrContain: "'models[0].model' is required",
+		},
+		{
+			name: "model name wrong type",
+			params: map[string]interface{}{
+				"models": []interface{}{
+					map[string]interface{}{"model": 1},
+				},
+			},
+			wantErrContain: "'models[0].model' must be a string",
+		},
+		{
+			name: "model name empty",
+			params: map[string]interface{}{
+				"models": []interface{}{
+					map[string]interface{}{"model": ""},
+				},
+			},
+			wantErrContain: "'models[0].model' must have a minimum length of 1",
+		},
+		{
+			name: "suspendDuration invalid",
+			params: map[string]interface{}{
+				"models":          baseRRModels(),
+				"suspendDuration": "30",
+			},
+			wantErrContain: "'suspendDuration' must be an integer",
+		},
+		{
+			name: "suspendDuration negative",
+			params: map[string]interface{}{
+				"models":          baseRRModels(),
+				"suspendDuration": -1,
+			},
+			wantErrContain: "'suspendDuration' must be >= 0",
+		},
+		{
+			name: "requestModel missing",
+			params: map[string]interface{}{
+				"models": baseRRModels(),
+			},
+			wantErrContain: "'requestModel' configuration is required",
+		},
+		{
+			name: "requestModel wrong type",
+			params: map[string]interface{}{
+				"models":       baseRRModels(),
+				"requestModel": "x",
+			},
+			wantErrContain: "'requestModel' must be an object",
+		},
+		{
+			name: "requestModel location missing",
+			params: map[string]interface{}{
+				"models":       baseRRModels(),
+				"requestModel": map[string]interface{}{"identifier": "$.model"},
+			},
+			wantErrContain: "'requestModel.location' is required",
+		},
+		{
+			name: "requestModel location invalid",
+			params: map[string]interface{}{
+				"models": baseRRModels(),
+				"requestModel": map[string]interface{}{
+					"location":   "cookie",
+					"identifier": "$.model",
+				},
+			},
+			wantErrContain: "'requestModel.location' must be one of: payload, header, queryParam, pathParam",
+		},
+		{
+			name: "requestModel identifier missing",
+			params: map[string]interface{}{
+				"models": baseRRModels(),
+				"requestModel": map[string]interface{}{
+					"location": "payload",
+				},
+			},
+			wantErrContain: "'requestModel.identifier' is required",
+		},
+		{
+			name: "requestModel identifier wrong type",
+			params: map[string]interface{}{
+				"models": baseRRModels(),
+				"requestModel": map[string]interface{}{
+					"location":   "payload",
+					"identifier": 1,
+				},
+			},
+			wantErrContain: "'requestModel.identifier' must be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestModelRoundRobinPolicy_GetPolicy_SuccessAndDefaults(t *testing.T) {
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models":          baseRRModels(),
+		"suspendDuration": float64(30),
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	})
+
+	if len(p.params.Models) != 2 {
+		t.Fatalf("expected two models, got %d", len(p.params.Models))
+	}
+	if p.params.SuspendDuration != 30 {
+		t.Fatalf("expected suspendDuration=30, got %d", p.params.SuspendDuration)
+	}
+}
+
+func TestModelRoundRobinPolicy_OnRequest_PayloadRoundRobin(t *testing.T) {
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": baseRRModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	})
+
+	ctx1 := rrRequestContextWithBody(`{"model":"original","x":"y"}`)
+	action1 := p.OnRequest(ctx1, nil)
+	mods1 := mustRRRequestMods(t, action1)
+	got1 := decodeJSONMapRR(t, mods1.Body)
+	if got1["model"] != "gpt-4" {
+		t.Fatalf("expected first selected model gpt-4, got %v", got1["model"])
+	}
+	if ctx1.Metadata[MetadataKeyOriginalModel] != "original" {
+		t.Fatalf("expected original model metadata to be set")
+	}
+	if ctx1.Metadata[MetadataKeySelectedModel] != "gpt-4" {
+		t.Fatalf("expected selected model metadata to be set")
+	}
+
+	ctx2 := rrRequestContextWithBody(`{"model":"original2"}`)
+	action2 := p.OnRequest(ctx2, nil)
+	mods2 := mustRRRequestMods(t, action2)
+	got2 := decodeJSONMapRR(t, mods2.Body)
+	if got2["model"] != "gpt-35" {
+		t.Fatalf("expected second selected model gpt-35, got %v", got2["model"])
+	}
+}
+
+func TestModelRoundRobinPolicy_OnRequest_QueryParamAndPathParamMutation(t *testing.T) {
+	pQuery := mustGetRRPolicy(t, map[string]interface{}{
+		"models": baseRRModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "queryParam",
+			"identifier": "model",
+		},
+	})
+	queryCtx := rrRequestContextWithPath("/v1/chat?model=old&x=1")
+	queryAction := pQuery.OnRequest(queryCtx, nil)
+	queryMods := mustRRRequestMods(t, queryAction)
+	if got := queryMods.SetHeaders[":path"]; !strings.Contains(got, "model=gpt-4") {
+		t.Fatalf("expected query path to include new model, got %q", got)
+	}
+
+	pPath := mustGetRRPolicy(t, map[string]interface{}{
+		"models": baseRRModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "pathParam",
+			"identifier": `/models/([^/]+)`,
+		},
+	})
+	pathCtx := rrRequestContextWithPath("/v1/models/old/completions?x=1")
+	pathAction := pPath.OnRequest(pathCtx, nil)
+	pathMods := mustRRRequestMods(t, pathAction)
+	if got := pathMods.SetHeaders[":path"]; !strings.Contains(got, "/models/gpt-4/") {
+		t.Fatalf("expected path to include new model, got %q", got)
+	}
+}
+
+func TestModelRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": baseRRModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "header",
+			"identifier": "x-model",
+		},
+	})
+
+	until := time.Now().Add(10 * time.Minute)
+	p.suspendedModels["gpt-4"] = until
+	p.suspendedModels["gpt-35"] = until
+
+	action := p.OnRequest(rrRequestContextWithHeaders(map[string][]string{"x-model": {"orig"}}), nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse when all models suspended, got %T", action)
+	}
+	if resp.StatusCode != 503 {
+		t.Fatalf("unexpected status code: got %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestModelRoundRobinPolicy_OnResponse_SuspendsModelOnError(t *testing.T) {
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models":          baseRRModels(),
+		"suspendDuration": 60,
+		"requestModel": map[string]interface{}{
+			"location":   "header",
+			"identifier": "x-model",
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-id",
+			Metadata: map[string]interface{}{
+				MetadataKeySelectedModel: "gpt-4",
+			},
+		},
+		ResponseStatus: 500,
+	}
+
+	action := p.OnResponse(ctx, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	until, exists := p.suspendedModels["gpt-4"]
+	if !exists {
+		t.Fatalf("expected model to be suspended")
+	}
+	if !until.After(time.Now()) {
+		t.Fatalf("expected suspension expiry in future")
+	}
+}
+
+func TestModelRoundRobinPolicy_SelectNextAvailableModel_SkipsAndRecoversSuspended(t *testing.T) {
+	p := &ModelRoundRobinPolicy{
+		currentIndex:    0,
+		suspendedModels: map[string]time.Time{"a": time.Now().Add(5 * time.Minute)},
+	}
+	models := []ModelConfig{{Model: "a"}, {Model: "b"}}
+
+	got := p.selectNextAvailableModel(models)
+	if got == nil || got.Model != "b" {
+		t.Fatalf("expected to skip suspended a and pick b, got %+v", got)
+	}
+
+	p.suspendedModels["a"] = time.Now().Add(-1 * time.Minute)
+	got2 := p.selectNextAvailableModel(models)
+	if got2 == nil || got2.Model != "a" {
+		t.Fatalf("expected expired suspension model a to be selected, got %+v", got2)
+	}
+}
+
+func TestModelRoundRobinPolicy_ExtractInt(t *testing.T) {
+	if v, err := extractInt(3); err != nil || v != 3 {
+		t.Fatalf("expected int extraction to work, got v=%d err=%v", v, err)
+	}
+	if v, err := extractInt(float64(4)); err != nil || v != 4 {
+		t.Fatalf("expected float integer extraction to work, got v=%d err=%v", v, err)
+	}
+	if _, err := extractInt(float64(4.2)); err == nil {
+		t.Fatalf("expected error for non-integer float")
+	}
+}
+
+func mustGetRRPolicy(t *testing.T, params map[string]interface{}) *ModelRoundRobinPolicy {
+	t.Helper()
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	rp, ok := p.(*ModelRoundRobinPolicy)
+	if !ok {
+		t.Fatalf("expected *ModelRoundRobinPolicy, got %T", p)
+	}
+	return rp
+}
+
+func mustRRRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+	t.Helper()
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	return mods
+}
+
+func decodeJSONMapRR(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("failed to unmarshal json body: %v", err)
+	}
+	return m
+}
+
+func rrRequestContextWithBody(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func rrRequestContextWithPath(path string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Path: path,
+	}
+}
+
+func rrRequestContextWithHeaders(headers map[string][]string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: policy.NewHeaders(headers),
+	}
+}
+
+func baseRRModels() []interface{} {
+	return []interface{}{
+		map[string]interface{}{"model": "gpt-4"},
+		map[string]interface{}{"model": "gpt-35"},
+	}
+}

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -11,6 +11,7 @@ parameters:
   properties:
     models:
       type: array
+      x-wso2-policy-advanced-param: false
       description: List of models with weights for weighted round-robin distribution
       items:
         type: object
@@ -33,6 +34,7 @@ parameters:
       minItems: 1
     suspendDuration:
       type: integer
+      x-wso2-policy-advanced-param: true
       description: |
         Suspend duration in seconds for failed models.
         If not configured, knowledge about failed invocations is not persisted.

--- a/policies/model-weighted-round-robin/weightedroundrobin_test.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin_test.go
@@ -1,0 +1,358 @@
+package modelweightedroundrobin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestModelWeightedRoundRobinPolicy_Mode(t *testing.T) {
+	p := &ModelWeightedRoundRobinPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_GetPolicy_ParseErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "missing models",
+			params:         map[string]interface{}{},
+			wantErrContain: "'models' parameter is required",
+		},
+		{
+			name: "models wrong type",
+			params: map[string]interface{}{
+				"models": "not-array",
+			},
+			wantErrContain: "'models' must be an array",
+		},
+		{
+			name: "models empty",
+			params: map[string]interface{}{
+				"models": []interface{}{},
+			},
+			wantErrContain: "'models' array must contain at least one model",
+		},
+		{
+			name: "missing weight",
+			params: map[string]interface{}{
+				"models": []interface{}{
+					map[string]interface{}{"model": "gpt-4"},
+				},
+			},
+			wantErrContain: "'models[0].weight' is required",
+		},
+		{
+			name: "weight not integer",
+			params: map[string]interface{}{
+				"models": []interface{}{
+					map[string]interface{}{"model": "gpt-4", "weight": 1.5},
+				},
+			},
+			wantErrContain: "'models[0].weight' must be an integer",
+		},
+		{
+			name: "weight too low",
+			params: map[string]interface{}{
+				"models": []interface{}{
+					map[string]interface{}{"model": "gpt-4", "weight": 0},
+				},
+			},
+			wantErrContain: "'models[0].weight' must be >= 1",
+		},
+		{
+			name: "suspendDuration invalid",
+			params: map[string]interface{}{
+				"models":          baseWeightedModels(),
+				"suspendDuration": "10",
+			},
+			wantErrContain: "'suspendDuration' must be an integer",
+		},
+		{
+			name: "requestModel missing",
+			params: map[string]interface{}{
+				"models": baseWeightedModels(),
+			},
+			wantErrContain: "'requestModel' configuration is required",
+		},
+		{
+			name: "requestModel invalid location",
+			params: map[string]interface{}{
+				"models": baseWeightedModels(),
+				"requestModel": map[string]interface{}{
+					"location":   "cookie",
+					"identifier": "$.model",
+				},
+			},
+			wantErrContain: "'requestModel.location' must be one of: payload, header, queryParam, pathParam",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_GetPolicy_SuccessAndSequence(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models":          baseWeightedModels(),
+		"suspendDuration": float64(20),
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	})
+
+	if len(p.params.Models) != 2 {
+		t.Fatalf("expected two models, got %d", len(p.params.Models))
+	}
+	if p.params.SuspendDuration != 20 {
+		t.Fatalf("expected suspendDuration=20, got %d", p.params.SuspendDuration)
+	}
+	// weight 2 + 1 => sequence length 3
+	if len(p.weightedSequence) != 3 {
+		t.Fatalf("expected weighted sequence length 3, got %d", len(p.weightedSequence))
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_BuildWeightedSequence(t *testing.T) {
+	models := []*WeightedModel{
+		{Model: "a", Weight: 2},
+		{Model: "b", Weight: 1},
+		{Model: "c", Weight: 0},
+	}
+	seq := buildWeightedSequence(models)
+	if len(seq) != 3 {
+		t.Fatalf("expected sequence length 3, got %d", len(seq))
+	}
+	if seq[0].Model != "a" || seq[1].Model != "a" || seq[2].Model != "b" {
+		t.Fatalf("unexpected sequence order: %+v", []string{seq[0].Model, seq[1].Model, seq[2].Model})
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnRequest_PayloadWeightedSelection(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": baseWeightedModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	})
+
+	// weight distribution: gpt-4, gpt-4, gpt-35, ...
+	ctx1 := weightedRequestContextWithBody(`{"model":"orig"}`)
+	a1 := p.OnRequest(ctx1, nil)
+	m1 := mustWeightedRequestMods(t, a1)
+	j1 := decodeJSONMapWeighted(t, m1.Body)
+	if j1["model"] != "gpt-4" {
+		t.Fatalf("expected first model gpt-4, got %v", j1["model"])
+	}
+
+	ctx2 := weightedRequestContextWithBody(`{"model":"orig2"}`)
+	a2 := p.OnRequest(ctx2, nil)
+	m2 := mustWeightedRequestMods(t, a2)
+	j2 := decodeJSONMapWeighted(t, m2.Body)
+	if j2["model"] != "gpt-4" {
+		t.Fatalf("expected second model gpt-4, got %v", j2["model"])
+	}
+
+	ctx3 := weightedRequestContextWithBody(`{"model":"orig3"}`)
+	a3 := p.OnRequest(ctx3, nil)
+	m3 := mustWeightedRequestMods(t, a3)
+	j3 := decodeJSONMapWeighted(t, m3.Body)
+	if j3["model"] != "gpt-35" {
+		t.Fatalf("expected third model gpt-35, got %v", j3["model"])
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnRequest_QueryAndPathMutation(t *testing.T) {
+	pQuery := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": baseWeightedModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "queryParam",
+			"identifier": "model",
+		},
+	})
+	queryCtx := weightedRequestContextWithPath("/v1/chat?model=old")
+	queryAction := pQuery.OnRequest(queryCtx, nil)
+	queryMods := mustWeightedRequestMods(t, queryAction)
+	if got := queryMods.SetHeaders[":path"]; !strings.Contains(got, "model=gpt-4") {
+		t.Fatalf("expected query path to include new model, got %q", got)
+	}
+
+	pPath := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": baseWeightedModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "pathParam",
+			"identifier": `/models/([^/]+)`,
+		},
+	})
+	pathCtx := weightedRequestContextWithPath("/v1/models/old/completions")
+	pathAction := pPath.OnRequest(pathCtx, nil)
+	pathMods := mustWeightedRequestMods(t, pathAction)
+	if got := pathMods.SetHeaders[":path"]; !strings.Contains(got, "/models/gpt-4/") {
+		t.Fatalf("expected path to include new model, got %q", got)
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": baseWeightedModels(),
+		"requestModel": map[string]interface{}{
+			"location":   "header",
+			"identifier": "x-model",
+		},
+	})
+
+	until := time.Now().Add(10 * time.Minute)
+	p.suspendedModels["gpt-4"] = until
+	p.suspendedModels["gpt-35"] = until
+
+	action := p.OnRequest(weightedRequestContextWithHeaders(map[string][]string{"x-model": {"orig"}}), nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse when all models suspended, got %T", action)
+	}
+	if resp.StatusCode != 503 {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnResponse_SuspendsSelectedModel(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models":          baseWeightedModels(),
+		"suspendDuration": 30,
+		"requestModel": map[string]interface{}{
+			"location":   "header",
+			"identifier": "x-model",
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "id",
+			Metadata: map[string]interface{}{
+				MetadataKeySelectedModel: "gpt-4",
+			},
+		},
+		ResponseStatus: 429,
+	}
+	action := p.OnResponse(ctx, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	if until, exists := p.suspendedModels["gpt-4"]; !exists || !until.After(time.Now()) {
+		t.Fatalf("expected selected model to be suspended")
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_SelectNextAvailable_SkipsSuspended(t *testing.T) {
+	p := &ModelWeightedRoundRobinPolicy{
+		suspendedModels: map[string]time.Time{
+			"a": time.Now().Add(5 * time.Minute),
+		},
+		weightedSequence: []*WeightedModel{
+			{Model: "a", Weight: 2},
+			{Model: "b", Weight: 1},
+		},
+	}
+
+	got := p.selectNextAvailableWeightedModel()
+	if got == nil || got.Model != "b" {
+		t.Fatalf("expected to skip suspended model a and pick b, got %+v", got)
+	}
+}
+
+func mustGetWeightedPolicy(t *testing.T, params map[string]interface{}) *ModelWeightedRoundRobinPolicy {
+	t.Helper()
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	wp, ok := p.(*ModelWeightedRoundRobinPolicy)
+	if !ok {
+		t.Fatalf("expected *ModelWeightedRoundRobinPolicy, got %T", p)
+	}
+	return wp
+}
+
+func mustWeightedRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+	t.Helper()
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	return mods
+}
+
+func decodeJSONMapWeighted(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("failed to unmarshal json body: %v", err)
+	}
+	return m
+}
+
+func weightedRequestContextWithBody(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func weightedRequestContextWithPath(path string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Path: path,
+	}
+}
+
+func weightedRequestContextWithHeaders(headers map[string][]string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: policy.NewHeaders(headers),
+	}
+}
+
+func baseWeightedModels() []interface{} {
+	return []interface{}{
+		map[string]interface{}{"model": "gpt-4", "weight": 2},
+		map[string]interface{}{"model": "gpt-35", "weight": 1},
+	}
+}

--- a/policies/pii-masking-regex/piimaskingregex_test.go
+++ b/policies/pii-masking-regex/piimaskingregex_test.go
@@ -1,0 +1,366 @@
+package piimaskingregex
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestPIIMaskingRegexPolicy_Mode(t *testing.T) {
+	p := &PIIMaskingRegexPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestPIIMaskingRegexPolicy_GetPolicy_ParseErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "no detectors",
+			params:         map[string]interface{}{},
+			wantErrContain: "at least one PII detector must be configured",
+		},
+		{
+			name: "customPIIEntities wrong type",
+			params: map[string]interface{}{
+				"customPIIEntities": 1,
+			},
+			wantErrContain: "'customPIIEntities' must be an array or JSON string",
+		},
+		{
+			name: "customPIIEntities malformed json",
+			params: map[string]interface{}{
+				"customPIIEntities": `[{"piiEntity":"EMAIL","piiRegex":"abc"}`,
+			},
+			wantErrContain: "error unmarshaling PII entities",
+		},
+		{
+			name: "customPIIEntities element non-object",
+			params: map[string]interface{}{
+				"customPIIEntities": []interface{}{"x"},
+			},
+			wantErrContain: "'customPIIEntities[0]' must be an object",
+		},
+		{
+			name: "custom piiEntity invalid",
+			params: map[string]interface{}{
+				"customPIIEntities": []interface{}{
+					map[string]interface{}{"piiEntity": "email", "piiRegex": "a+"},
+				},
+			},
+			wantErrContain: "'customPIIEntities[0].piiEntity' must match ^[A-Z_]+$",
+		},
+		{
+			name: "custom piiRegex invalid",
+			params: map[string]interface{}{
+				"customPIIEntities": []interface{}{
+					map[string]interface{}{"piiEntity": "EMAIL", "piiRegex": "["},
+				},
+			},
+			wantErrContain: "'customPIIEntities[0].piiRegex' is invalid",
+		},
+		{
+			name: "duplicate custom piiEntity",
+			params: map[string]interface{}{
+				"customPIIEntities": []interface{}{
+					map[string]interface{}{"piiEntity": "EMAIL", "piiRegex": "a+"},
+					map[string]interface{}{"piiEntity": "EMAIL", "piiRegex": "b+"},
+				},
+			},
+			wantErrContain: `duplicate piiEntity: "EMAIL"`,
+		},
+		{
+			name: "duplicate builtin and custom",
+			params: map[string]interface{}{
+				"customPIIEntities": []interface{}{
+					map[string]interface{}{"piiEntity": "EMAIL", "piiRegex": "a+"},
+				},
+				"email": true,
+			},
+			wantErrContain: `duplicate piiEntity: "EMAIL"`,
+		},
+		{
+			name: "email wrong type",
+			params: map[string]interface{}{
+				"email": "true",
+			},
+			wantErrContain: "'email' must be a boolean",
+		},
+		{
+			name: "jsonPath wrong type",
+			params: map[string]interface{}{
+				"email":    true,
+				"jsonPath": false,
+			},
+			wantErrContain: "'jsonPath' must be a string",
+		},
+		{
+			name: "redactPII wrong type",
+			params: map[string]interface{}{
+				"email":     true,
+				"redactPII": "true",
+			},
+			wantErrContain: "'redactPII' must be a boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestPIIMaskingRegexPolicy_GetPolicy_DefaultsAndBuiltins(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email": true,
+		"phone": true,
+		"ssn":   true,
+	})
+
+	if got := p.params.JsonPath; got != "$.messages" {
+		t.Fatalf("expected default jsonPath '$.messages', got %q", got)
+	}
+	if p.params.RedactPII {
+		t.Fatalf("expected default redactPII=false")
+	}
+	if len(p.params.PIIEntities) != 3 {
+		t.Fatalf("expected 3 built-in detectors, got %d", len(p.params.PIIEntities))
+	}
+}
+
+func TestPIIMaskingRegexPolicy_GetPolicy_CustomJSONString(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"customPIIEntities": `[{"piiEntity":"ORDER_ID","piiRegex":"ORD-[0-9]+"}]`,
+		"jsonPath":          "$.content",
+		"redactPII":         true,
+	})
+
+	if got := p.params.JsonPath; got != "$.content" {
+		t.Fatalf("expected custom jsonPath, got %q", got)
+	}
+	if !p.params.RedactPII {
+		t.Fatalf("expected redactPII=true")
+	}
+	if _, ok := p.params.PIIEntities["ORDER_ID"]; !ok {
+		t.Fatalf("expected ORDER_ID custom detector")
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnRequest_MaskAndStoreMetadata(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email": true,
+	})
+
+	ctx := piiRequestContext(`{"messages":"Contact me at a.user@example.com please"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustPIIRequestMods(t, action)
+	if len(mods.Body) == 0 {
+		t.Fatalf("expected modified body")
+	}
+
+	out := decodeJSONMapPII(t, mods.Body)
+	msg, _ := out["messages"].(string)
+	matched, err := regexp.MatchString(`\[EMAIL_[0-9a-f]{4}\]`, msg)
+	if err != nil {
+		t.Fatalf("failed regex match: %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected masked email placeholder, got %q", msg)
+	}
+
+	metaVal, exists := ctx.Metadata[MetadataKeyPIIEntities]
+	if !exists {
+		t.Fatalf("expected pii metadata to be stored")
+	}
+	mapping, ok := metaVal.(map[string]string)
+	if !ok || len(mapping) == 0 {
+		t.Fatalf("expected pii metadata mapping, got %T", metaVal)
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnRequest_RedactMode(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email":     true,
+		"redactPII": true,
+	})
+
+	ctx := piiRequestContext(`{"messages":"email a.user@example.com"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustPIIRequestMods(t, action)
+	out := decodeJSONMapPII(t, mods.Body)
+	msg, _ := out["messages"].(string)
+	if !strings.Contains(msg, "*****") {
+		t.Fatalf("expected redacted content, got %q", msg)
+	}
+	if _, exists := ctx.Metadata[MetadataKeyPIIEntities]; exists {
+		t.Fatalf("did not expect metadata mapping in redact mode")
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnRequest_NoMatch_NoOp(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email": true,
+	})
+
+	ctx := piiRequestContext(`{"messages":"no pii here"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustPIIRequestMods(t, action)
+	if mods.Body != nil {
+		t.Fatalf("expected no modifications when no pii match, got body=%s", string(mods.Body))
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnRequest_JSONPathError(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email":    true,
+		"jsonPath": "$.missing.value",
+	})
+
+	ctx := piiRequestContext(`{"messages":"a.user@example.com"}`)
+	action := p.OnRequest(ctx, nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse for extraction error, got %T", action)
+	}
+	if resp.StatusCode != APIMInternalErrorCode {
+		t.Fatalf("unexpected status code: %d", resp.StatusCode)
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnResponse_RestoreMaskedPII(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email": true,
+	})
+
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata: map[string]interface{}{
+				MetadataKeyPIIEntities: map[string]string{
+					"a.user@example.com": "[EMAIL_0000]",
+				},
+			},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte(`{"answer":"Found [EMAIL_0000]"}`),
+			Present: true,
+		},
+	}
+	action := p.OnResponse(ctx, nil)
+	mods, ok := action.(policy.UpstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	if !strings.Contains(string(mods.Body), "a.user@example.com") {
+		t.Fatalf("expected placeholder to be restored, got %s", string(mods.Body))
+	}
+}
+
+func TestPIIMaskingRegexPolicy_OnResponse_NoOpCases(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{
+		"email": true,
+	})
+
+	// No metadata
+	ctx1 := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte(`{"x":"y"}`),
+			Present: true,
+		},
+	}
+	a1 := p.OnResponse(ctx1, nil)
+	if _, ok := a1.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", a1)
+	}
+
+	// Redact mode always no-op for response restoration
+	pRedact := mustGetPIIPolicy(t, map[string]interface{}{
+		"email":     true,
+		"redactPII": true,
+	})
+	ctx2 := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata: map[string]interface{}{
+				MetadataKeyPIIEntities: map[string]string{"a.user@example.com": "[EMAIL_0000]"},
+			},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte(`{"x":"[EMAIL_0000]"}`),
+			Present: true,
+		},
+	}
+	a2 := pRedact.OnResponse(ctx2, nil)
+	if _, ok := a2.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", a2)
+	}
+}
+
+func mustGetPIIPolicy(t *testing.T, params map[string]interface{}) *PIIMaskingRegexPolicy {
+	t.Helper()
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	pp, ok := p.(*PIIMaskingRegexPolicy)
+	if !ok {
+		t.Fatalf("expected *PIIMaskingRegexPolicy, got %T", p)
+	}
+	return pp
+}
+
+func mustPIIRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+	t.Helper()
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	return mods
+}
+
+func piiRequestContext(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func decodeJSONMapPII(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("failed to unmarshal json: %v", err)
+	}
+	return m
+}

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: pii-masking-regex
-version: v0.2.1
+version: v0.3.0
 description: |
   Masks or redacts Personally Identifiable Information (PII) in request and
   response payloads using configured regex patterns. Supports reversible

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -8,11 +8,31 @@ description: |
 parameters:
   type: object
   properties:
-    piiEntities:
-      type: array
+    email:
+      type: boolean
+      x-wso2-policy-advanced-param: false
       description: |
-        Specifies PII entity definitions used for detection. Each item contains
-        an entity name and the regex pattern used to match it.
+        Specifies whether built-in EMAIL detection is enabled.
+      default: false
+    phone:
+      type: boolean
+      x-wso2-policy-advanced-param: false
+      description: |
+        Specifies whether built-in PHONE detection is enabled.
+      default: false
+    ssn:
+      type: boolean
+      x-wso2-policy-advanced-param: false
+      description: |
+        Specifies whether built-in SSN detection is enabled.
+      default: false
+    customPIIEntities:
+      type: array
+      x-wso2-policy-advanced-param: true
+      description: |
+        Specifies custom PII entity definitions used for detection. Each item
+        contains an entity name and the regex pattern used to match it.
+      minItems: 1
       items:
         type: object
         properties:
@@ -29,18 +49,36 @@ parameters:
         - piiRegex
     jsonPath:
       type: string
+      x-wso2-policy-advanced-param: true
       description: |
         Specifies the JSONPath used to extract the value to process. When
         empty, the entire payload is processed as plain text.
-      default: ""
+      default: "$.messages"
     redactPII:
       type: boolean
+      x-wso2-policy-advanced-param: true
       description: |
         Specifies whether matched PII is permanently redacted as "*****"
         (true) or masked with reversible placeholders (false).
       default: false
-  required:
-  - piiEntities
+  anyOf:
+    - required:
+      - customPIIEntities
+    - required:
+      - email
+      properties:
+        email:
+          const: true
+    - required:
+      - phone
+      properties:
+        phone:
+          const: true
+    - required:
+      - ssn
+      properties:
+        ssn:
+          const: true
 
 systemParameters:         
   type: object

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -8,25 +8,66 @@ parameters:
   type: object
   properties:
     promptDecoratorConfig:
-      type: string
+      type: object
+      x-wso2-policy-advanced-param: true
       description: |
-        Specifies a JSON string that defines decorations, typically as role and
-        content entries, applied during request mediation.
-      minLength: 1
+        Specifies prompt decoration configuration. Provide exactly one of
+        `text` or `messages`.
+      additionalProperties: false
+      properties:
+        text:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            Specifies text decoration applied when targeting a string prompt.
+          minLength: 1
+        messages:
+          type: array
+          x-wso2-policy-advanced-param: false
+          description: |
+            Specifies chat message decorations applied when targeting a messages
+            array.
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              role:
+                type: string
+                x-wso2-policy-advanced-param: true
+                enum:
+                  - system
+                  - user
+                  - assistant
+                  - tool
+              content:
+                type: string
+                x-wso2-policy-advanced-param: true
+                minLength: 1
+            required:
+              - role
+              - content
+      oneOf:
+        - required:
+            - text
+        - required:
+            - messages
     jsonPath:
       type: string
-      description: Specifies the JSONPath expression used to locate the prompt
-        segment to decorate.
-      default: "$.messages"
-      minLength: 1
+      x-wso2-policy-advanced-param: true
+      description: |
+        Specifies the JSONPath expression used to locate the prompt segment to
+        decorate. If omitted, defaults to "$.messages[-1].content" for `text`
+        decorations and "$.messages" for `messages` decorations.
+      default: ""
     append:
       type: boolean
+      x-wso2-policy-advanced-param: true
       description: Specifies whether decorated content is appended (true) or
         prepended (false) to the selected prompt segment.
       default: false
   required:
     - promptDecoratorConfig
-    - jsonPath
 
 systemParameters:
   type: object

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-decorator
-version: v0.2.1
+version: v0.3.0
 description: |
   Applies configured prompt decorations to request payloads before upstream
   processing.

--- a/policies/prompt-decorator/promptdecorator_test.go
+++ b/policies/prompt-decorator/promptdecorator_test.go
@@ -1,0 +1,735 @@
+package promptdecorator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestPromptDecoratorPolicy_Mode(t *testing.T) {
+	p := &PromptDecoratorPolicy{}
+
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnResponse_NoOp(t *testing.T) {
+	p := &PromptDecoratorPolicy{}
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+	}
+
+	action := p.OnResponse(ctx, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestPromptDecoratorPolicy_GetPolicy_TextConfig_Defaults(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Be concise.",
+		},
+	})
+
+	if p.params.PromptDecoratorConfig.Text == nil {
+		t.Fatalf("expected text config to be set")
+	}
+	if got := *p.params.PromptDecoratorConfig.Text; got != "Be concise." {
+		t.Fatalf("unexpected text decoration: got %q", got)
+	}
+	if got := p.params.JsonPath; got != defaultTextDecorationJSONPath {
+		t.Fatalf("unexpected default jsonPath: got %q, want %q", got, defaultTextDecorationJSONPath)
+	}
+	if p.params.Append {
+		t.Fatalf("expected append default false")
+	}
+}
+
+func TestPromptDecoratorPolicy_GetPolicy_MessagesConfig_DefaultsAndRoleNormalization(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{
+					"role":    "SYSTEM",
+					"content": "You are helpful.",
+				},
+			},
+		},
+	})
+
+	if len(p.params.PromptDecoratorConfig.Messages) != 1 {
+		t.Fatalf("expected one message decoration, got %d", len(p.params.PromptDecoratorConfig.Messages))
+	}
+	if got := p.params.PromptDecoratorConfig.Messages[0].Role; got != "system" {
+		t.Fatalf("expected normalized role 'system', got %q", got)
+	}
+	if got := p.params.JsonPath; got != defaultMessagesDecorationJSONPath {
+		t.Fatalf("unexpected default jsonPath: got %q, want %q", got, defaultMessagesDecorationJSONPath)
+	}
+}
+
+func TestPromptDecoratorPolicy_GetPolicy_ConfigFromJSONString(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": `{"text":"Use markdown."}`,
+		"append":                true,
+	})
+
+	if p.params.PromptDecoratorConfig.Text == nil {
+		t.Fatalf("expected text config")
+	}
+	if got := *p.params.PromptDecoratorConfig.Text; got != "Use markdown." {
+		t.Fatalf("unexpected text config value: %q", got)
+	}
+	if !p.params.Append {
+		t.Fatalf("expected append=true")
+	}
+}
+
+func TestPromptDecoratorPolicy_GetPolicy_InvalidParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "missing promptDecoratorConfig",
+			params:         map[string]interface{}{},
+			wantErrContain: "'promptDecoratorConfig' parameter is required",
+		},
+		{
+			name: "promptDecoratorConfig wrong type",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": 123,
+			},
+			wantErrContain: "'promptDecoratorConfig' must be a JSON string or object",
+		},
+		{
+			name: "promptDecoratorConfig malformed json string",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": `{"text":"hello"`,
+			},
+			wantErrContain: "error unmarshaling promptDecoratorConfig",
+		},
+		{
+			name: "text and messages both configured",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"text": "hello",
+					"messages": []interface{}{
+						map[string]interface{}{"role": "system", "content": "x"},
+					},
+				},
+			},
+			wantErrContain: "'promptDecoratorConfig' must define exactly one of 'text' or 'messages'",
+		},
+		{
+			name: "neither text nor messages configured",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{},
+			},
+			wantErrContain: "'promptDecoratorConfig' must define one of 'text' or 'messages'",
+		},
+		{
+			name: "text empty",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"text": "   ",
+				},
+			},
+			wantErrContain: "'promptDecoratorConfig.text' must be a non-empty string",
+		},
+		{
+			name: "messages role empty",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"messages": []interface{}{
+						map[string]interface{}{"role": " ", "content": "x"},
+					},
+				},
+			},
+			wantErrContain: "'promptDecoratorConfig.messages[0].role' must be a non-empty string",
+		},
+		{
+			name: "messages role invalid",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"messages": []interface{}{
+						map[string]interface{}{"role": "moderator", "content": "x"},
+					},
+				},
+			},
+			wantErrContain: "'promptDecoratorConfig.messages[0].role' must be one of [system,user,assistant,tool]",
+		},
+		{
+			name: "messages content empty",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"messages": []interface{}{
+						map[string]interface{}{"role": "system", "content": "  "},
+					},
+				},
+			},
+			wantErrContain: "'promptDecoratorConfig.messages[0].content' must be a non-empty string",
+		},
+		{
+			name: "jsonPath wrong type",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"text": "x",
+				},
+				"jsonPath": true,
+			},
+			wantErrContain: "'jsonPath' must be a string",
+		},
+		{
+			name: "append wrong type",
+			params: map[string]interface{}{
+				"promptDecoratorConfig": map[string]interface{}{
+					"text": "x",
+				},
+				"append": "true",
+			},
+			wantErrContain: "'append' must be a boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_TextDefaultPath_Prepend(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Be concise.",
+		},
+	})
+
+	ctx := newRequestContextWithBody(`{
+		"messages":[
+			{"role":"system","content":"rules"},
+			{"role":"user","content":"Summarize this text"}
+		]
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	messages := mustMessages(t, payload["messages"])
+	last := messages[len(messages)-1]
+	if got := last["content"]; got != "Be concise. Summarize this text" {
+		t.Fatalf("unexpected decorated content: got %q", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_TextDefaultPath_Append(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "in bullet points.",
+		},
+		"append": true,
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"Explain TCP"}]}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	messages := mustMessages(t, payload["messages"])
+	if got := messages[0]["content"]; got != "Explain TCP in bullet points." {
+		t.Fatalf("unexpected decorated content: got %q", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_TextCustomPath(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Use JSON output.",
+		},
+		"jsonPath": "$.input.prompt",
+	})
+
+	ctx := newRequestContextWithBody(`{
+		"input":{"prompt":"Create a plan"},
+		"messages":[{"role":"user","content":"unchanged"}]
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	input, ok := payload["input"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected input object, got %T", payload["input"])
+	}
+	if got := input["prompt"]; got != "Use JSON output. Create a plan" {
+		t.Fatalf("unexpected prompt: got %v", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_MessagesDefaultPath_Prepend(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "You are concise."},
+				map[string]interface{}{"role": "assistant", "content": "Acknowledge briefly."},
+			},
+		},
+	})
+
+	ctx := newRequestContextWithBody(`{
+		"messages":[
+			{"role":"user","content":"Hello"},
+			{"role":"assistant","content":"Hi"}
+		]
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	messages := mustMessages(t, payload["messages"])
+	if len(messages) != 4 {
+		t.Fatalf("expected 4 messages after prepend, got %d", len(messages))
+	}
+	if got := messages[0]["role"]; got != "system" {
+		t.Fatalf("unexpected first role: %v", got)
+	}
+	if got := messages[0]["content"]; got != "You are concise." {
+		t.Fatalf("unexpected first content: %v", got)
+	}
+	if got := messages[2]["content"]; got != "Hello" {
+		t.Fatalf("expected original messages to remain in order after prepended decorations")
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_MessagesDefaultPath_Append(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "tool", "content": "trace-id=123"},
+			},
+		},
+		"append": true,
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	messages := mustMessages(t, payload["messages"])
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages after append, got %d", len(messages))
+	}
+	if got := messages[1]["role"]; got != "tool" {
+		t.Fatalf("unexpected appended role: %v", got)
+	}
+	if got := messages[1]["content"]; got != "trace-id=123" {
+		t.Fatalf("unexpected appended content: %v", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_MessagesCustomPath(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "Only decorate history."},
+			},
+		},
+		"jsonPath": "$.conversation.history",
+	})
+
+	ctx := newRequestContextWithBody(`{
+		"conversation":{"history":[{"role":"user","content":"hello"}]},
+		"messages":[{"role":"user","content":"keep me"}]
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	conversation := payload["conversation"].(map[string]interface{})
+	history := mustMessages(t, conversation["history"])
+	if len(history) != 2 {
+		t.Fatalf("expected history length 2, got %d", len(history))
+	}
+	if got := history[0]["content"]; got != "Only decorate history." {
+		t.Fatalf("unexpected history decoration: %v", got)
+	}
+	messages := mustMessages(t, payload["messages"])
+	if got := messages[0]["content"]; got != "keep me" {
+		t.Fatalf("non-target array should remain unchanged, got %v", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_EmptyBodyReturnsError(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "x",
+		},
+	})
+
+	tests := []struct {
+		name string
+		ctx  *policy.RequestContext
+	}{
+		{
+			name: "nil body",
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{
+					RequestID: "test-request-id",
+					Metadata:  map[string]interface{}{},
+				},
+				Body: nil,
+			},
+		},
+		{
+			name: "empty body content",
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{
+					RequestID: "test-request-id",
+					Metadata:  map[string]interface{}{},
+				},
+				Body: &policy.Body{
+					Content: []byte{},
+					Present: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := p.OnRequest(tt.ctx, nil)
+			assertDecoratorError(t, action, "Empty request body")
+		})
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_InvalidJSONReturnsError(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "x",
+		},
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Error parsing JSON payload")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_JSONPathNotFoundReturnsError(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "x",
+		},
+		"jsonPath": "$.missing.path",
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Error extracting value from JSONPath")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_TargetTypeMismatch_StringPathWithMessagesConfig(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "x"},
+			},
+		},
+		"jsonPath": "$.messages[-1].content",
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Invalid configuration for string target")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_TargetTypeMismatch_ArrayPathWithTextConfig(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "x",
+		},
+		"jsonPath": "$.messages",
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Invalid configuration for messages target")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_ArrayContainsNonMapElementReturnsError(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "x"},
+			},
+		},
+		"jsonPath": "$.messages",
+	})
+
+	ctx := newRequestContextWithBody(`{"messages":[1,{"role":"user","content":"hello"}]}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Array contains non-map elements")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_ExtractedValueWrongTypeReturnsError(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "x",
+		},
+		"jsonPath": "$.temperature",
+	})
+
+	ctx := newRequestContextWithBody(`{"temperature":0.7}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Extracted value must be a string or an array of message objects")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_JSONPathWithArrayIndex_TextTarget(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Decorate",
+		},
+		"jsonPath": "$.messages[0].content",
+	})
+
+	ctx := newRequestContextWithBody(`{
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":"second"}
+		]
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	payload := decodeJSONMap(t, mods.Body)
+	messages := mustMessages(t, payload["messages"])
+	if got := messages[0]["content"]; got != "Decorate first" {
+		t.Fatalf("unexpected first message content: %v", got)
+	}
+	if got := messages[1]["content"]; got != "second" {
+		t.Fatalf("unexpected second message content: %v", got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_JSONPathNavigationFailure(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Decorate",
+		},
+		"jsonPath": "$.messages[0].content",
+	})
+
+	// ExtractValueFromJsonpath accepts this path (messages[0].content exists),
+	// but update path navigation fails because messages is object, not array.
+	ctx := newRequestContextWithBody(`{
+		"messages":{"0":{"content":"hello"}}
+	}`)
+	action := p.OnRequest(ctx, nil)
+	assertDecoratorError(t, action, "Error extracting value from JSONPath")
+}
+
+func TestPromptDecoratorPolicy_OnRequest_JSONPathEmptyStringUsesDefaultByConfigType(t *testing.T) {
+	textPolicy := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{"text": "Prefix"},
+		"jsonPath":              "",
+	})
+	if got := textPolicy.params.JsonPath; got != defaultTextDecorationJSONPath {
+		t.Fatalf("expected text default path %q, got %q", defaultTextDecorationJSONPath, got)
+	}
+
+	messagesPolicy := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "x"},
+			},
+		},
+		"jsonPath": "",
+	})
+	if got := messagesPolicy.params.JsonPath; got != defaultMessagesDecorationJSONPath {
+		t.Fatalf("expected messages default path %q, got %q", defaultMessagesDecorationJSONPath, got)
+	}
+}
+
+func TestPromptDecoratorPolicy_OnRequest_ConcurrentAccess(t *testing.T) {
+	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
+		"promptDecoratorConfig": map[string]interface{}{
+			"text": "Guardrail:",
+		},
+	})
+
+	const workers = 50
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			msg := fmt.Sprintf("prompt-%d", i)
+			ctx := newRequestContextWithBody(fmt.Sprintf(`{"messages":[{"role":"user","content":"%s"}]}`, msg))
+
+			action := p.OnRequest(ctx, nil)
+			mods, ok := action.(policy.UpstreamRequestModifications)
+			if !ok {
+				errCh <- fmt.Errorf("expected UpstreamRequestModifications, got %T", action)
+				return
+			}
+			payload := decodeJSONMapNoFail(mods.Body)
+			if payload == nil {
+				errCh <- fmt.Errorf("failed to decode modified payload")
+				return
+			}
+			messages := mustMessagesNoFail(payload["messages"])
+			if messages == nil || len(messages) != 1 {
+				errCh <- fmt.Errorf("invalid messages after modification")
+				return
+			}
+			want := "Guardrail: " + msg
+			if got, _ := messages[0]["content"].(string); got != want {
+				errCh <- fmt.Errorf("unexpected decorated content: got %q, want %q", got, want)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+func mustGetPromptDecoratorPolicy(t *testing.T, params map[string]interface{}) *PromptDecoratorPolicy {
+	t.Helper()
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	policyImpl, ok := p.(*PromptDecoratorPolicy)
+	if !ok {
+		t.Fatalf("expected *PromptDecoratorPolicy, got %T", p)
+	}
+	return policyImpl
+}
+
+func mustRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+	t.Helper()
+
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	return mods
+}
+
+func assertDecoratorError(t *testing.T, action policy.RequestAction, wantMessagePrefix string) policy.ImmediateResponse {
+	t.Helper()
+
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 500 {
+		t.Fatalf("expected status 500, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("failed to unmarshal error response body: %v", err)
+	}
+	if got := body["type"]; got != "PROMPT_DECORATOR_ERROR" {
+		t.Fatalf("unexpected error type: got %v, want %q", got, "PROMPT_DECORATOR_ERROR")
+	}
+	msg, ok := body["message"].(string)
+	if !ok {
+		t.Fatalf("expected string error message, got %T", body["message"])
+	}
+	if !strings.HasPrefix(msg, wantMessagePrefix) {
+		t.Fatalf("unexpected error message: got %q, want prefix %q", msg, wantMessagePrefix)
+	}
+
+	return resp
+}
+
+func decodeJSONMap(t *testing.T, payload []byte) map[string]interface{} {
+	t.Helper()
+	result := decodeJSONMapNoFail(payload)
+	if result == nil {
+		t.Fatalf("failed to decode JSON payload: %s", string(payload))
+	}
+	return result
+}
+
+func decodeJSONMapNoFail(payload []byte) map[string]interface{} {
+	var result map[string]interface{}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+func mustMessages(t *testing.T, v interface{}) []map[string]interface{} {
+	t.Helper()
+	msgs := mustMessagesNoFail(v)
+	if msgs == nil {
+		t.Fatalf("expected []map[string]interface{}, got %T", v)
+	}
+	return msgs
+}
+
+func mustMessagesNoFail(v interface{}) []map[string]interface{} {
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, item := range raw {
+		msg, ok := item.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func newRequestContextWithBody(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}

--- a/policies/prompt-template/policy-definition.yaml
+++ b/policies/prompt-template/policy-definition.yaml
@@ -7,14 +7,68 @@ description: |
 parameters:
   type: object
   properties:
-    promptTemplateConfig:
-      type: string
+    templates:
+      type: array
+      x-wso2-policy-advanced-param: false
       description: |
-        Specifies a JSON string that defines one or more templates. Each template
-        must include a unique `name` and a `prompt` used during request mediation.
-      minLength: 1
+        Specifies one or more reusable prompt templates. Each template must
+        include a unique name and template content.
+      minItems: 1
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            type: string
+            x-wso2-policy-advanced-param: false
+            description: |
+              Specifies the unique template name used in `template://<name>`
+              references.
+            minLength: 1
+            pattern: "^[a-zA-Z0-9_-]+$"
+          template:
+            type: string
+            x-wso2-policy-advanced-param: false
+            description: |
+              Specifies the template text. Query parameters are substituted
+              using placeholders in the form `[[parameter]]`.
+            minLength: 1
+        required:
+          - name
+          - template
+    jsonPath:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: |
+        Specifies the JSONPath to limit template resolution to a specific
+        string field. If empty, template references are resolved across the
+        entire request payload string.
+      default: ""
+    onMissingTemplate:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: |
+        Specifies behavior when a referenced template name is not found.
+        `error` returns an immediate error response, `passthrough` leaves the
+        original template reference unchanged.
+      enum:
+        - error
+        - passthrough
+      default: error
+    onUnresolvedPlaceholder:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: |
+        Specifies behavior when placeholders remain unresolved after query
+        substitution. `keep` keeps placeholders as-is, `empty` replaces them
+        with an empty string, and `error` returns an immediate error response.
+      enum:
+        - keep
+        - empty
+        - error
+      default: keep
   required:
-    - promptTemplateConfig
+    - templates
 
 systemParameters:
   type: object

--- a/policies/prompt-template/policy-definition.yaml
+++ b/policies/prompt-template/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-template
-version: v0.2.1
+version: v0.3.0
 description: |
   Applies configured prompt templates to request payloads to transform prompts
   before upstream processing.

--- a/policies/prompt-template/prompttemplate.go
+++ b/policies/prompt-template/prompttemplate.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package prompttemplate
 
 import (
@@ -23,17 +23,31 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	utils "github.com/wso2/api-platform/sdk/utils"
 )
 
 var (
 	// promptTemplateRegex matches template://<template-name>?<params> patterns
 	// Example: template://translate?from=english&to=spanish or template://translate
 	promptTemplateRegex = regexp.MustCompile(`template://[a-zA-Z0-9_-]+(?:\?[^\s"']*)?`)
+	// unresolvedPlaceholderRegex matches [[parameter]] placeholders.
+	unresolvedPlaceholderRegex = regexp.MustCompile(`\[\[([a-zA-Z0-9_-]+)\]\]`)
 	// textCleanRegex removes leading and trailing quotes from JSON-escaped strings
 	textCleanRegex = regexp.MustCompile(`^"|"$`)
+	// templateNameRegex validates template names.
+	templateNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+)
+
+const (
+	OnMissingTemplateError       = "error"
+	OnMissingTemplatePassthrough = "passthrough"
+	OnUnresolvedPlaceholderKeep  = "keep"
+	OnUnresolvedPlaceholderEmpty = "empty"
+	OnUnresolvedPlaceholderError = "error"
 )
 
 // PromptTemplatePolicy implements prompt templating by applying custom templates
@@ -42,12 +56,17 @@ type PromptTemplatePolicy struct {
 }
 
 type TemplateConfig struct {
-	Name   string `json:"name"`
-	Prompt string `json:"prompt"`
+	Name     string `json:"name"`
+	Template string `json:"template"`
 }
 
 type PromptTemplatePolicyParams struct {
-	PromptTemplateConfig []TemplateConfig
+	Templates []TemplateConfig
+	JsonPath  string
+	// error or passthrough
+	OnMissingTemplate string
+	// keep, empty, or error
+	OnUnresolvedPlaceholder string
 	// Templates map for quick lookup by name
 	templates map[string]string
 }
@@ -71,55 +90,107 @@ func GetPolicy(
 // parseParams parses and validates parameters from map to struct
 func parseParams(params map[string]interface{}) (PromptTemplatePolicyParams, error) {
 	var result PromptTemplatePolicyParams
-	// Extract required promptTemplateConfig parameter
-	promptTemplateConfigRaw, ok := params["promptTemplateConfig"]
+
+	// Extract required templates parameter.
+	templatesRaw, ok := params["templates"]
 	if !ok {
-		return result, fmt.Errorf("'promptTemplateConfig' parameter is required")
+		return result, fmt.Errorf("'templates' parameter is required")
 	}
 
-	var promptTemplateConfig []TemplateConfig
-	switch v := promptTemplateConfigRaw.(type) {
+	var templateConfigs []TemplateConfig
+	switch v := templatesRaw.(type) {
 	case string:
-		if err := json.Unmarshal([]byte(v), &promptTemplateConfig); err != nil {
-			return result, fmt.Errorf("error unmarshaling promptTemplateConfig: %w", err)
+		if err := json.Unmarshal([]byte(v), &templateConfigs); err != nil {
+			return result, fmt.Errorf("error unmarshaling templates: %w", err)
 		}
 	case []interface{}:
-		// Convert array of interfaces to TemplateConfig array
-		promptTemplateConfig = make([]TemplateConfig, 0, len(v))
+		// Convert array of interfaces to TemplateConfig array.
+		templateConfigs = make([]TemplateConfig, 0, len(v))
 		for idx, item := range v {
 			if itemMap, ok := item.(map[string]interface{}); ok {
 				var templateConfig TemplateConfig
 				jsonBytes, err := json.Marshal(itemMap)
 				if err != nil {
-					return result, fmt.Errorf("error marshaling promptTemplateConfig[%d]: %w", idx, err)
+					return result, fmt.Errorf("error marshaling templates[%d]: %w", idx, err)
 				}
 				if err := json.Unmarshal(jsonBytes, &templateConfig); err != nil {
-					return result, fmt.Errorf("error unmarshaling promptTemplateConfig[%d]: %w", idx, err)
+					return result, fmt.Errorf("error unmarshaling templates[%d]: %w", idx, err)
 				}
-				promptTemplateConfig = append(promptTemplateConfig, templateConfig)
+				templateConfigs = append(templateConfigs, templateConfig)
 			} else {
-				return result, fmt.Errorf("'promptTemplateConfig[%d]' must be an object", idx)
+				return result, fmt.Errorf("'templates[%d]' must be an object", idx)
 			}
 		}
 	default:
-		return result, fmt.Errorf("'promptTemplateConfig' must be a JSON string or array")
+		return result, fmt.Errorf("'templates' must be an array or JSON string")
 	}
 
-	if len(promptTemplateConfig) == 0 {
-		return result, fmt.Errorf("'promptTemplateConfig' cannot be empty")
+	if len(templateConfigs) == 0 {
+		return result, fmt.Errorf("'templates' cannot be empty")
 	}
-	result.PromptTemplateConfig = promptTemplateConfig
+	result.Templates = templateConfigs
 
-	// Build templates map for quick lookup by name
+	// Build templates map for quick lookup by name.
 	result.templates = make(map[string]string)
-	for _, templateConfig := range promptTemplateConfig {
-		if templateConfig.Name == "" {
-			return result, fmt.Errorf("template name cannot be empty")
+	for i, templateConfig := range templateConfigs {
+		name := strings.TrimSpace(templateConfig.Name)
+		if name == "" {
+			return result, fmt.Errorf("'templates[%d].name' cannot be empty", i)
 		}
-		if templateConfig.Prompt == "" {
-			return result, fmt.Errorf("template prompt cannot be empty for template '%s'", templateConfig.Name)
+		if !templateNameRegex.MatchString(name) {
+			return result, fmt.Errorf("'templates[%d].name' must match ^[a-zA-Z0-9_-]+$", i)
 		}
-		result.templates[templateConfig.Name] = templateConfig.Prompt
+		templateText := strings.TrimSpace(templateConfig.Template)
+		if templateText == "" {
+			return result, fmt.Errorf("'templates[%d].template' cannot be empty", i)
+		}
+		if _, exists := result.templates[name]; exists {
+			return result, fmt.Errorf("duplicate template name: %q", name)
+		}
+		result.templates[name] = templateText
+		result.Templates[i].Name = name
+		result.Templates[i].Template = templateText
+	}
+
+	// Extract optional jsonPath parameter.
+	if jsonPathRaw, ok := params["jsonPath"]; ok {
+		jsonPath, ok := jsonPathRaw.(string)
+		if !ok {
+			return result, fmt.Errorf("'jsonPath' must be a string")
+		}
+		result.JsonPath = strings.TrimSpace(jsonPath)
+	}
+
+	// Extract optional onMissingTemplate parameter.
+	result.OnMissingTemplate = OnMissingTemplateError
+	if valRaw, ok := params["onMissingTemplate"]; ok {
+		val, ok := valRaw.(string)
+		if !ok {
+			return result, fmt.Errorf("'onMissingTemplate' must be a string")
+		}
+		val = strings.ToLower(strings.TrimSpace(val))
+		switch val {
+		case OnMissingTemplateError, OnMissingTemplatePassthrough:
+			result.OnMissingTemplate = val
+		default:
+			return result, fmt.Errorf("'onMissingTemplate' must be one of [error,passthrough]")
+		}
+	}
+
+	// Extract optional onUnresolvedPlaceholder parameter.
+	result.OnUnresolvedPlaceholder = OnUnresolvedPlaceholderKeep
+	if valRaw, ok := params["onUnresolvedPlaceholder"]; ok {
+		val, ok := valRaw.(string)
+		if !ok {
+			return result, fmt.Errorf("'onUnresolvedPlaceholder' must be a string")
+		}
+		val = strings.ToLower(strings.TrimSpace(val))
+		switch val {
+		case OnUnresolvedPlaceholderKeep, OnUnresolvedPlaceholderEmpty, OnUnresolvedPlaceholderError:
+			result.OnUnresolvedPlaceholder = val
+		default:
+			return result, fmt.Errorf("'onUnresolvedPlaceholder' must be one of [keep,empty,error]")
+		}
 	}
 
 	// Collect template names for logging
@@ -127,7 +198,13 @@ func parseParams(params map[string]interface{}) (PromptTemplatePolicyParams, err
 	for name := range result.templates {
 		templateNames = append(templateNames, name)
 	}
-	slog.Debug("PromptTemplate: Policy initialized", "templateCount", len(result.templates), "templateNames", templateNames)
+	slog.Debug("PromptTemplate: Policy initialized",
+		"templateCount", len(result.templates),
+		"templateNames", templateNames,
+		"jsonPath", result.JsonPath,
+		"onMissingTemplate", result.OnMissingTemplate,
+		"onUnresolvedPlaceholder", result.OnUnresolvedPlaceholder,
+	)
 
 	return result, nil
 }
@@ -149,86 +226,163 @@ func (p *PromptTemplatePolicy) OnRequest(ctx *policy.RequestContext, params map[
 		content = ctx.Body.Content
 	}
 
-	// Convert to string to search for template:// patterns
-	jsonContent := string(content)
-	if jsonContent == "" {
+	if len(content) == 0 {
 		return policy.UpstreamRequestModifications{}
 	}
 
-	updatedJsonContent := jsonContent
-
-	// Find all template://<template-name>?<params> patterns (query params are optional)
-	matches := promptTemplateRegex.FindAllString(jsonContent, -1)
-	if len(matches) > 0 {
-		slog.Debug("PromptTemplate: Found template patterns", "count", len(matches))
-	}
-	for _, matched := range matches {
-		// Parse the matched string as a URI
-		// Example: template://translate?from=english&to=spanish or template://translate
-		parsedURL, err := url.Parse(matched)
+	// If jsonPath is empty, resolve template references across the whole payload
+	// string (legacy behavior).
+	if p.params.JsonPath == "" {
+		updatedContent, err := p.resolveTemplatesInText(string(content), true)
 		if err != nil {
-			// Skip invalid URIs
-			continue
+			return p.buildErrorResponse("Error resolving templates", err)
 		}
-
-		templateName := parsedURL.Host // "translate"
-		query := parsedURL.RawQuery    // "from=english&to=spanish"
-
-		// Look up template by name
-		templatePrompt, exists := p.params.templates[templateName]
-		if !exists {
-			slog.Debug("PromptTemplate: Template not found", "templateName", templateName)
-			// Template not found, return error
-			return p.buildErrorResponse(fmt.Sprintf("Template '%s' not found", templateName), nil)
+		if updatedContent == string(content) {
+			return policy.UpstreamRequestModifications{}
 		}
-
-		// Parse query parameters
-		paramsMap := make(map[string]string)
-		if query != "" {
-			queryParams, err := url.ParseQuery(query)
-			if err == nil {
-				for key, values := range queryParams {
-					if len(values) > 0 {
-						// URL decode the value
-						decodedValue, err := url.QueryUnescape(values[0])
-						if err == nil {
-							paramsMap[key] = decodedValue
-						} else {
-							paramsMap[key] = values[0]
-						}
-					}
-				}
-			}
+		return policy.UpstreamRequestModifications{
+			Body: []byte(updatedContent),
 		}
-
-		// Replace placeholders in template (format: [[parameter-name]])
-		resolvedPrompt := templatePrompt
-		for key, value := range paramsMap {
-			placeholder := "[[" + key + "]]"
-			resolvedPrompt = strings.ReplaceAll(resolvedPrompt, placeholder, value)
-		}
-
-		// Escape the resolved prompt for JSON (add quotes and escape special chars)
-		escapedPromptBytes, err := json.Marshal(resolvedPrompt)
-		if err != nil {
-			slog.Debug("PromptTemplate: Error marshaling resolved prompt to JSON", "templateName", templateName, "error", err)
-			// If marshaling fails, return error
-			return p.buildErrorResponse("Error marshaling resolved prompt to JSON", err)
-		}
-		escapedPrompt := string(escapedPromptBytes)
-		escapedPrompt = textCleanRegex.ReplaceAllString(escapedPrompt, "")
-
-		slog.Debug("PromptTemplate: Resolved template", "templateName", templateName, "paramCount", len(paramsMap), "resolvedLength", len(resolvedPrompt))
-		// Replace all occurrences of the matched template:// pattern with the resolved prompt
-		updatedJsonContent = strings.ReplaceAll(updatedJsonContent, matched, escapedPrompt)
 	}
 
-	// Convert back to bytes
-	updatedPayload := []byte(updatedJsonContent)
+	// jsonPath configured: resolve template references in the extracted string only.
+	var payloadData map[string]interface{}
+	if err := json.Unmarshal(content, &payloadData); err != nil {
+		return p.buildErrorResponse("Error parsing JSON payload", err)
+	}
+
+	extractedValue, err := p.extractStringAtPath(content, p.params.JsonPath)
+	if err != nil {
+		return p.buildErrorResponse("Error extracting value from JSONPath", err)
+	}
+
+	updatedValue, err := p.resolveTemplatesInText(extractedValue, false)
+	if err != nil {
+		return p.buildErrorResponse("Error resolving templates", err)
+	}
+	if updatedValue == extractedValue {
+		return policy.UpstreamRequestModifications{}
+	}
+
+	if err := utils.SetValueAtJSONPath(payloadData, p.params.JsonPath, updatedValue); err != nil {
+		return p.buildErrorResponse("Error updating JSONPath", err)
+	}
+
+	updatedPayload, err := json.Marshal(payloadData)
+	if err != nil {
+		return p.buildErrorResponse("Error marshaling updated JSON payload", err)
+	}
 
 	return policy.UpstreamRequestModifications{
 		Body: updatedPayload,
 	}
+}
+
+func (p *PromptTemplatePolicy) resolveTemplatesInText(content string, escapeForJSON bool) (string, error) {
+	matches := promptTemplateRegex.FindAllString(content, -1)
+	if len(matches) == 0 {
+		return content, nil
+	}
+
+	updatedContent := content
+	for _, matched := range matches {
+		resolvedPrompt, shouldReplace, err := p.resolveTemplateReference(matched)
+		if err != nil {
+			return "", err
+		}
+		if !shouldReplace {
+			continue
+		}
+
+		replacement := resolvedPrompt
+		if escapeForJSON {
+			escaped, err := p.escapeForJSONString(replacement)
+			if err != nil {
+				return "", err
+			}
+			replacement = escaped
+		}
+		updatedContent = strings.ReplaceAll(updatedContent, matched, replacement)
+	}
+
+	return updatedContent, nil
+}
+
+func (p *PromptTemplatePolicy) resolveTemplateReference(reference string) (string, bool, error) {
+	parsedURL, err := url.Parse(reference)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid template reference %q: %w", reference, err)
+	}
+
+	templateName := parsedURL.Host
+	templateText, exists := p.params.templates[templateName]
+	if !exists {
+		if p.params.OnMissingTemplate == OnMissingTemplatePassthrough {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("template %q not found", templateName)
+	}
+
+	// Parse query parameters for placeholder replacement.
+	paramsMap := make(map[string]string)
+	if parsedURL.RawQuery != "" {
+		queryParams, err := url.ParseQuery(parsedURL.RawQuery)
+		if err == nil {
+			for key, values := range queryParams {
+				if len(values) > 0 {
+					paramsMap[key] = values[0]
+				}
+			}
+		}
+	}
+
+	resolvedPrompt := templateText
+	for key, value := range paramsMap {
+		placeholder := "[[" + key + "]]"
+		resolvedPrompt = strings.ReplaceAll(resolvedPrompt, placeholder, value)
+	}
+
+	unresolvedMatches := unresolvedPlaceholderRegex.FindAllStringSubmatch(resolvedPrompt, -1)
+	if len(unresolvedMatches) > 0 {
+		switch p.params.OnUnresolvedPlaceholder {
+		case OnUnresolvedPlaceholderKeep:
+			// Keep unresolved placeholders as-is.
+		case OnUnresolvedPlaceholderEmpty:
+			resolvedPrompt = unresolvedPlaceholderRegex.ReplaceAllString(resolvedPrompt, "")
+		case OnUnresolvedPlaceholderError:
+			names := make([]string, 0, len(unresolvedMatches))
+			for _, match := range unresolvedMatches {
+				if len(match) > 1 {
+					names = append(names, match[1])
+				}
+			}
+			slices.Sort(names)
+			names = slices.Compact(names)
+			return "", false, fmt.Errorf("unresolved placeholders in template %q: %s", templateName, strings.Join(names, ","))
+		}
+	}
+
+	return resolvedPrompt, true, nil
+}
+
+func (p *PromptTemplatePolicy) escapeForJSONString(value string) (string, error) {
+	escapedPromptBytes, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling resolved prompt to JSON: %w", err)
+	}
+	escapedPrompt := string(escapedPromptBytes)
+	escapedPrompt = textCleanRegex.ReplaceAllString(escapedPrompt, "")
+	return escapedPrompt, nil
+}
+
+func (p *PromptTemplatePolicy) extractStringAtPath(payload []byte, jsonPath string) (string, error) {
+	extractedValue, err := utils.ExtractStringValueFromJsonpath(payload, jsonPath)
+	if err != nil {
+		return "", err
+	}
+	// Normalize quoted JSON strings.
+	extractedValue = textCleanRegex.ReplaceAllString(extractedValue, "")
+	return extractedValue, nil
 }
 
 // OnResponse is not used for this policy

--- a/policies/prompt-template/prompttemplate_test.go
+++ b/policies/prompt-template/prompttemplate_test.go
@@ -1,0 +1,711 @@
+package prompttemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestPromptTemplatePolicy_Mode(t *testing.T) {
+	p := &PromptTemplatePolicy{}
+
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestPromptTemplatePolicy_OnResponse_NoOp(t *testing.T) {
+	p := &PromptTemplatePolicy{}
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+	}
+
+	action := p.OnResponse(ctx, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestPromptTemplatePolicy_GetPolicy_MinimalSuccess(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	if len(p.params.Templates) != 1 {
+		t.Fatalf("expected one template, got %d", len(p.params.Templates))
+	}
+	if p.params.JsonPath != "" {
+		t.Fatalf("expected default jsonPath to be empty, got %q", p.params.JsonPath)
+	}
+	if p.params.OnMissingTemplate != OnMissingTemplateError {
+		t.Fatalf("expected default onMissingTemplate=%q, got %q", OnMissingTemplateError, p.params.OnMissingTemplate)
+	}
+	if p.params.OnUnresolvedPlaceholder != OnUnresolvedPlaceholderKeep {
+		t.Fatalf("expected default onUnresolvedPlaceholder=%q, got %q", OnUnresolvedPlaceholderKeep, p.params.OnUnresolvedPlaceholder)
+	}
+}
+
+func TestPromptTemplatePolicy_GetPolicy_InvalidParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name:           "missing templates",
+			params:         map[string]interface{}{},
+			wantErrContain: "'templates' parameter is required",
+		},
+		{
+			name: "wrong templates type",
+			params: map[string]interface{}{
+				"templates": 42,
+			},
+			wantErrContain: "'templates' must be an array or JSON string",
+		},
+		{
+			name: "empty templates array",
+			params: map[string]interface{}{
+				"templates": []interface{}{},
+			},
+			wantErrContain: "'templates' cannot be empty",
+		},
+		{
+			name: "malformed templates json string",
+			params: map[string]interface{}{
+				"templates": `[{"name":"greet","template":"Hi [[name]]"}`,
+			},
+			wantErrContain: "error unmarshaling templates",
+		},
+		{
+			name: "templates item is not object",
+			params: map[string]interface{}{
+				"templates": []interface{}{"bad"},
+			},
+			wantErrContain: "'templates[0]' must be an object",
+		},
+		{
+			name: "empty name",
+			params: map[string]interface{}{
+				"templates": []interface{}{
+					map[string]interface{}{
+						"name":     " ",
+						"template": "Hi [[name]]",
+					},
+				},
+			},
+			wantErrContain: "'templates[0].name' cannot be empty",
+		},
+		{
+			name: "invalid name pattern",
+			params: map[string]interface{}{
+				"templates": []interface{}{
+					map[string]interface{}{
+						"name":     "bad name",
+						"template": "Hi [[name]]",
+					},
+				},
+			},
+			wantErrContain: "'templates[0].name' must match ^[a-zA-Z0-9_-]+$",
+		},
+		{
+			name: "duplicate names",
+			params: map[string]interface{}{
+				"templates": []interface{}{
+					map[string]interface{}{
+						"name":     "greet",
+						"template": "Hi [[name]]",
+					},
+					map[string]interface{}{
+						"name":     "greet",
+						"template": "Hello [[name]]",
+					},
+				},
+			},
+			wantErrContain: `duplicate template name: "greet"`,
+		},
+		{
+			name: "empty template",
+			params: map[string]interface{}{
+				"templates": []interface{}{
+					map[string]interface{}{
+						"name":     "greet",
+						"template": " ",
+					},
+				},
+			},
+			wantErrContain: "'templates[0].template' cannot be empty",
+		},
+		{
+			name: "jsonPath wrong type",
+			params: map[string]interface{}{
+				"templates": baseTemplatesArray(),
+				"jsonPath":  true,
+			},
+			wantErrContain: "'jsonPath' must be a string",
+		},
+		{
+			name: "onMissingTemplate invalid value",
+			params: map[string]interface{}{
+				"templates":         baseTemplatesArray(),
+				"onMissingTemplate": "ignore",
+			},
+			wantErrContain: "'onMissingTemplate' must be one of [error,passthrough]",
+		},
+		{
+			name: "onUnresolvedPlaceholder invalid value",
+			params: map[string]interface{}{
+				"templates":               baseTemplatesArray(),
+				"onUnresolvedPlaceholder": "skip",
+			},
+			wantErrContain: "'onUnresolvedPlaceholder' must be one of [keep,empty,error]",
+		},
+		{
+			name: "legacy config only should fail",
+			params: map[string]interface{}{
+				"promptTemplateConfig": `[{"name":"greet","prompt":"Hi [[name]]"}]`,
+			},
+			wantErrContain: "'templates' parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestPromptTemplatePolicy_GetPolicy_TemplatesJSONStringWorks(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": `[{"name":"greet","template":"Hi [[name]]"}]`,
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Sam"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	if len(mods.Body) == 0 {
+		t.Fatalf("expected modified body")
+	}
+	body := decodeJSONMap(t, mods.Body)
+	if got := body["prompt"]; got != "Hi Sam" {
+		t.Fatalf("unexpected prompt: got %v, want %q", got, "Hi Sam")
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_NoBodyOrEmptyBody(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	tests := []struct {
+		name string
+		ctx  *policy.RequestContext
+	}{
+		{
+			name: "nil body",
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{
+					RequestID: "test-request-id",
+					Metadata:  map[string]interface{}{},
+				},
+				Body: nil,
+			},
+		},
+		{
+			name: "empty body",
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{
+					RequestID: "test-request-id",
+					Metadata:  map[string]interface{}{},
+				},
+				Body: &policy.Body{
+					Content: []byte{},
+					Present: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := p.OnRequest(tt.ctx, nil)
+			mods := mustRequestMods(t, action)
+			if mods.Body != nil {
+				t.Fatalf("expected no body modifications, got %s", string(mods.Body))
+			}
+		})
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_FullPayloadSingleReplacement(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	body := decodeJSONMap(t, mods.Body)
+	if got := body["prompt"]; got != "Hello Ann" {
+		t.Fatalf("unexpected prompt: got %v, want %q", got, "Hello Ann")
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_NoTemplateReferences_NoChanges(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	ctx := newRequestContextWithBody(`{"prompt":"plain prompt text"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+
+	if mods.Body != nil {
+		t.Fatalf("expected no body changes, got %s", string(mods.Body))
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_FullPayloadMultipleReplacements(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+			map[string]interface{}{"name": "bye", "template": "Bye [[name]]"},
+		},
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{
+		"a":"template://greet?name=Ann",
+		"b":"template://greet?name=Bob",
+		"c":"template://bye?name=Ann"
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["a"]; got != "Hello Ann" {
+		t.Fatalf("unexpected a: got %v", got)
+	}
+	if got := body["b"]; got != "Hello Bob" {
+		t.Fatalf("unexpected b: got %v", got)
+	}
+	if got := body["c"]; got != "Bye Ann" {
+		t.Fatalf("unexpected c: got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_URLQueryDecoding(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "intro", "template": "Hello [[name]] from [[city]]"},
+		},
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://intro?name=John+Doe&city=New%20York"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["prompt"]; got != "Hello John Doe from New York" {
+		t.Fatalf("unexpected prompt: got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_EscapesQuotesAndNewlines(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{
+				"name":     "multi",
+				"template": "Line1 [[text]]\nLine2 \"quoted\"",
+			},
+		},
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://multi?text=hello%20world"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	want := "Line1 hello world\nLine2 \"quoted\""
+	if got := body["prompt"]; got != want {
+		t.Fatalf("unexpected prompt: got %q, want %q", got, want)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_MissingTemplate_DefaultError(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://unknown?name=Ann"}`)
+	action := p.OnRequest(ctx, nil)
+	assertTemplateError(t, action, "Error resolving templates")
+}
+
+func TestPromptTemplatePolicy_OnRequest_MissingTemplate_Passthrough(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+		},
+		"onMissingTemplate": "passthrough",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{
+		"a":"template://greet?name=Ann",
+		"b":"template://unknown?name=Bob"
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["a"]; got != "Hello Ann" {
+		t.Fatalf("unexpected resolved value: got %v", got)
+	}
+	if got := body["b"]; got != "template://unknown?name=Bob" {
+		t.Fatalf("expected missing template reference to passthrough, got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_DefaultKeep(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hi [[name]] from [[city]]"},
+		},
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["prompt"]; got != "Hi Ann from [[city]]" {
+		t.Fatalf("unexpected keep behavior: got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_Empty(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hi [[name]] from [[city]]"},
+		},
+		"onUnresolvedPlaceholder": "empty",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["prompt"]; got != "Hi Ann from " {
+		t.Fatalf("unexpected empty behavior: got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_ErrorDeterministic(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "[[x]] [[x]] [[y]]"},
+		},
+		"onUnresolvedPlaceholder": "error",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"prompt":"template://greet"}`)
+	action := p.OnRequest(ctx, nil)
+	resp := assertTemplateError(t, action, "Error resolving templates")
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("failed to unmarshal error body: %v", err)
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "x,y") {
+		t.Fatalf("expected deterministic unresolved placeholder list in message, got %q", msg)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_JSONPath_UpdatesOnlyTarget(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+		},
+		"jsonPath": "$.target",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{
+		"target":"template://greet?name=Ann",
+		"other":"template://greet?name=Bob",
+		"nested":{"value":"template://greet?name=Cat"}
+	}`)
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	if got := body["target"]; got != "Hello Ann" {
+		t.Fatalf("unexpected target value: got %v", got)
+	}
+	if got := body["other"]; got != "template://greet?name=Bob" {
+		t.Fatalf("expected non-target field to remain unchanged, got %v", got)
+	}
+	nested, ok := body["nested"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested object, got %T", body["nested"])
+	}
+	if got := nested["value"]; got != "template://greet?name=Cat" {
+		t.Fatalf("expected nested field to remain unchanged, got %v", got)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidPathReturnsError(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+		},
+		"jsonPath": "$.missing.value",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"target":"template://greet?name=Ann"}`)
+	action := p.OnRequest(ctx, nil)
+	assertTemplateError(t, action, "Error extracting value from JSONPath")
+}
+
+func TestPromptTemplatePolicy_OnRequest_JSONPath_NonStringTargetReturnsError(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+		},
+		"jsonPath": "$.target",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"target":{"value":"template://greet?name=Ann"}}`)
+	action := p.OnRequest(ctx, nil)
+	assertTemplateError(t, action, "Error extracting value from JSONPath")
+}
+
+func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidJSONReturnsError(t *testing.T) {
+	params := map[string]interface{}{
+		"templates": []interface{}{
+			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
+		},
+		"jsonPath": "$.target",
+	}
+	p := mustGetPromptTemplatePolicy(t, params)
+
+	ctx := newRequestContextWithBody(`{"target":"template://greet?name=Ann"`)
+	action := p.OnRequest(ctx, nil)
+	assertTemplateError(t, action, "Error parsing JSON payload")
+}
+
+func TestPromptTemplatePolicy_OnRequest_StressManyTemplatesAndReferences(t *testing.T) {
+	templateCount := 25
+	templates := make([]interface{}, 0, templateCount)
+	payloadMap := make(map[string]interface{}, templateCount)
+
+	for i := 0; i < templateCount; i++ {
+		name := fmt.Sprintf("t%d", i)
+		templates = append(templates, map[string]interface{}{
+			"name":     name,
+			"template": fmt.Sprintf("Value-%d [[v]]", i),
+		})
+		payloadMap[fmt.Sprintf("p%d", i)] = fmt.Sprintf("template://%s?v=%d", name, i)
+	}
+
+	payload, err := json.Marshal(payloadMap)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	p := mustGetPromptTemplatePolicy(t, map[string]interface{}{
+		"templates": templates,
+	})
+
+	ctx := newRequestContextWithBody(string(payload))
+	action := p.OnRequest(ctx, nil)
+	mods := mustRequestMods(t, action)
+	body := decodeJSONMap(t, mods.Body)
+
+	for i := 0; i < templateCount; i++ {
+		key := fmt.Sprintf("p%d", i)
+		want := fmt.Sprintf("Value-%d %d", i, i)
+		if got := body[key]; got != want {
+			t.Fatalf("unexpected resolved value for %s: got %v, want %q", key, got, want)
+		}
+	}
+}
+
+func TestPromptTemplatePolicy_ResolveTemplateReference_MalformedURI(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	_, _, err := p.resolveTemplateReference("template://%zz")
+	if err == nil {
+		t.Fatalf("expected parse error for malformed URI")
+	}
+	if !strings.Contains(err.Error(), "invalid template reference") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPromptTemplatePolicy_OnRequest_ConcurrentAccess(t *testing.T) {
+	p := mustGetPromptTemplatePolicy(t, baseParams())
+
+	const workers = 50
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			name := fmt.Sprintf("User%d", i)
+			ctx := newRequestContextWithBody(fmt.Sprintf(`{"prompt":"template://greet?name=%s"}`, name))
+
+			action := p.OnRequest(ctx, nil)
+			mods, ok := action.(policy.UpstreamRequestModifications)
+			if !ok {
+				errCh <- fmt.Errorf("expected UpstreamRequestModifications, got %T", action)
+				return
+			}
+			if len(mods.Body) == 0 {
+				errCh <- fmt.Errorf("expected modified body")
+				return
+			}
+
+			body := decodeJSONMapNoFail(mods.Body)
+			want := "Hello " + name
+			if got, _ := body["prompt"].(string); got != want {
+				errCh <- fmt.Errorf("unexpected prompt: got %q, want %q", got, want)
+				return
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+func mustGetPromptTemplatePolicy(t *testing.T, params map[string]interface{}) *PromptTemplatePolicy {
+	t.Helper()
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	policyImpl, ok := p.(*PromptTemplatePolicy)
+	if !ok {
+		t.Fatalf("expected *PromptTemplatePolicy, got %T", p)
+	}
+	return policyImpl
+}
+
+func mustRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+	t.Helper()
+
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	return mods
+}
+
+func assertTemplateError(t *testing.T, action policy.RequestAction, wantMessagePrefix string) policy.ImmediateResponse {
+	t.Helper()
+
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 500 {
+		t.Fatalf("expected status 500, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("failed to unmarshal response body: %v", err)
+	}
+	if got := body["type"]; got != "PROMPT_TEMPLATE_ERROR" {
+		t.Fatalf("unexpected error type: got %v, want %q", got, "PROMPT_TEMPLATE_ERROR")
+	}
+	msg, ok := body["message"].(string)
+	if !ok {
+		t.Fatalf("expected string message, got %T", body["message"])
+	}
+	if !strings.HasPrefix(msg, wantMessagePrefix) {
+		t.Fatalf("unexpected message: got %q, want prefix %q", msg, wantMessagePrefix)
+	}
+
+	return resp
+}
+
+func decodeJSONMap(t *testing.T, payload []byte) map[string]interface{} {
+	t.Helper()
+
+	result := decodeJSONMapNoFail(payload)
+	if result == nil {
+		t.Fatalf("failed to decode json payload: %s", string(payload))
+	}
+	return result
+}
+
+func decodeJSONMapNoFail(payload []byte) map[string]interface{} {
+	var result map[string]interface{}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+func newRequestContextWithBody(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func baseTemplatesArray() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"name":     "greet",
+			"template": "Hello [[name]]",
+		},
+	}
+}
+
+func baseParams() map[string]interface{} {
+	return map[string]interface{}{
+		"templates": baseTemplatesArray(),
+	}
+}

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -25,7 +25,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: "$.messages"
         invert:
           type: boolean
@@ -59,7 +59,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: "$.messages"
         invert:
           type: boolean

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -11,27 +11,32 @@ parameters:
   properties:
     request:
       type: object
+      x-wso2-policy-advanced-param: false
       description: Configuration for request phase validation
       properties:
         regex:
           type: string
+          x-wso2-policy-advanced-param: false
           description: Regular expression pattern to match against the content
           minLength: 1
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
-          default: ""
+          default: "$.messages"
         invert:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, validation passes when regex does NOT match (inverted logic).
             If false (default), validation passes when regex matches.
           default: false
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, includes detailed assessment information in error responses.
             If false, returns minimal error information.
@@ -40,33 +45,41 @@ parameters:
       - regex
     response:
       type: object
+      x-wso2-policy-advanced-param: false
       description: Configuration for response phase validation
       properties:
         regex:
           type: string
+          x-wso2-policy-advanced-param: false
           description: Regular expression pattern to match against the content
           minLength: 1
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
             Examples: "$.message", "$.data.content", "$.items[0].text"
-          default: ""
+          default: "$.messages"
         invert:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, validation passes when regex does NOT match (inverted logic).
             If false (default), validation passes when regex matches.
           default: false
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, includes detailed assessment information in error responses.
             If false, returns minimal error information.
           default: false
       required:
       - regex
+  anyOf:
+    - required: [ request ]
+    - required: [ response ]
 
 systemParameters:
   type: object

--- a/policies/regex-guardrail/regexguardrail.go
+++ b/policies/regex-guardrail/regexguardrail.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package regexguardrail
 
 import (
@@ -29,6 +29,7 @@ import (
 
 const (
 	GuardrailErrorCode = 422
+	DefaultJSONPath    = "$.messages"
 )
 
 // RegexGuardrailPolicy implements regex-based content validation
@@ -84,7 +85,11 @@ func GetPolicy(
 
 // parseParams parses and validates parameters from map to struct
 func parseParams(params map[string]interface{}) (RegexGuardrailPolicyParams, error) {
-	var result RegexGuardrailPolicyParams
+	result := RegexGuardrailPolicyParams{
+		JsonPath:       DefaultJSONPath,
+		Invert:         false,
+		ShowAssessment: false,
+	}
 
 	// Validate and extract regex parameter (required)
 	regexRaw, ok := params["regex"]

--- a/policies/regex-guardrail/regexguardrail_test.go
+++ b/policies/regex-guardrail/regexguardrail_test.go
@@ -75,7 +75,7 @@ func TestRegexGuardrailPolicy_GetPolicy_RequestAndResponse(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "hello",
-			"jsonPath":       "$.message",
+			"jsonPath":       "$.messages",
 			"invert":         true,
 			"showAssessment": true,
 		},
@@ -93,7 +93,7 @@ func TestRegexGuardrailPolicy_GetPolicy_RequestAndResponse(t *testing.T) {
 	if p.requestParams.Regex != "hello" || p.responseParams.Regex != "world" {
 		t.Fatalf("unexpected regex values: req=%q resp=%q", p.requestParams.Regex, p.responseParams.Regex)
 	}
-	if p.requestParams.JsonPath != "$.message" || p.responseParams.JsonPath != "$.output" {
+	if p.requestParams.JsonPath != "$.messages" || p.responseParams.JsonPath != "$.output" {
 		t.Fatalf("unexpected jsonPath values: req=%q resp=%q", p.requestParams.JsonPath, p.responseParams.JsonPath)
 	}
 	if !p.requestParams.Invert || p.responseParams.Invert {
@@ -313,11 +313,11 @@ func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
 	passPolicy := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":    "forbidden",
-			"jsonPath": "$.message",
+			"jsonPath": "$.messages",
 			"invert":   true,
 		},
 	})
-	passAction := passPolicy.OnRequest(newRequestContextWithBody(`{"message":"allowed content"}`), nil)
+	passAction := passPolicy.OnRequest(newRequestContextWithBody(`{"messages":"allowed content"}`), nil)
 	if _, ok := passAction.(policy.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass with invert=true on non-match, got %T", passAction)
 	}
@@ -325,11 +325,11 @@ func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
 	failPolicy := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":    "forbidden",
-			"jsonPath": "$.message",
+			"jsonPath": "$.messages",
 			"invert":   true,
 		},
 	})
-	failAction := failPolicy.OnRequest(newRequestContextWithBody(`{"message":"contains forbidden term"}`), nil)
+	failAction := failPolicy.OnRequest(newRequestContextWithBody(`{"messages":"contains forbidden term"}`), nil)
 	assertRequestErrorResponse(t, failAction, false, "REQUEST")
 }
 
@@ -337,12 +337,12 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentFalse(t *te
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "abc",
-			"jsonPath":       "$.message",
+			"jsonPath":       "$.messages",
 			"showAssessment": false,
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"message":"does not match"}`), nil)
+	action := p.OnRequest(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
 	body := assertRequestErrorResponse(t, action, false, "REQUEST")
 
 	message := extractMessageAssessment(t, body)
@@ -355,12 +355,12 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentTrue(t *tes
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "abc",
-			"jsonPath":       "$.message",
+			"jsonPath":       "$.messages",
 			"showAssessment": true,
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"message":"does not match"}`), nil)
+	action := p.OnRequest(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
 	body := assertRequestErrorResponse(t, action, true, "REQUEST")
 
 	message := extractMessageAssessment(t, body)

--- a/policies/regex-guardrail/regexguardrail_test.go
+++ b/policies/regex-guardrail/regexguardrail_test.go
@@ -1,0 +1,605 @@
+package regexguardrail
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestRegexGuardrailPolicy_Mode(t *testing.T) {
+	p := &RegexGuardrailPolicy{}
+
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestRegexGuardrailPolicy_GetPolicy_Defaults_RequestOnly(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	if !p.hasRequestParams {
+		t.Fatalf("expected request params to be enabled")
+	}
+	if p.hasResponseParams {
+		t.Fatalf("expected response params to be disabled")
+	}
+	if got := p.requestParams.JsonPath; got != DefaultJSONPath {
+		t.Fatalf("unexpected default jsonPath: got %q, want %q", got, DefaultJSONPath)
+	}
+	if p.requestParams.Invert {
+		t.Fatalf("expected default invert=false")
+	}
+	if p.requestParams.ShowAssessment {
+		t.Fatalf("expected default showAssessment=false")
+	}
+}
+
+func TestRegexGuardrailPolicy_GetPolicy_Defaults_ResponseOnly(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	if p.hasRequestParams {
+		t.Fatalf("expected request params to be disabled")
+	}
+	if !p.hasResponseParams {
+		t.Fatalf("expected response params to be enabled")
+	}
+	if got := p.responseParams.JsonPath; got != DefaultJSONPath {
+		t.Fatalf("unexpected default jsonPath: got %q, want %q", got, DefaultJSONPath)
+	}
+	if p.responseParams.Invert {
+		t.Fatalf("expected default invert=false")
+	}
+	if p.responseParams.ShowAssessment {
+		t.Fatalf("expected default showAssessment=false")
+	}
+}
+
+func TestRegexGuardrailPolicy_GetPolicy_RequestAndResponse(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":          "hello",
+			"jsonPath":       "$.message",
+			"invert":         true,
+			"showAssessment": true,
+		},
+		"response": map[string]interface{}{
+			"regex":          "world",
+			"jsonPath":       "$.output",
+			"invert":         false,
+			"showAssessment": true,
+		},
+	})
+
+	if !p.hasRequestParams || !p.hasResponseParams {
+		t.Fatalf("expected both request and response params enabled")
+	}
+	if p.requestParams.Regex != "hello" || p.responseParams.Regex != "world" {
+		t.Fatalf("unexpected regex values: req=%q resp=%q", p.requestParams.Regex, p.responseParams.Regex)
+	}
+	if p.requestParams.JsonPath != "$.message" || p.responseParams.JsonPath != "$.output" {
+		t.Fatalf("unexpected jsonPath values: req=%q resp=%q", p.requestParams.JsonPath, p.responseParams.JsonPath)
+	}
+	if !p.requestParams.Invert || p.responseParams.Invert {
+		t.Fatalf("unexpected invert values: req=%v resp=%v", p.requestParams.Invert, p.responseParams.Invert)
+	}
+	if !p.requestParams.ShowAssessment || !p.responseParams.ShowAssessment {
+		t.Fatalf("expected showAssessment=true for both")
+	}
+}
+
+func TestRegexGuardrailPolicy_GetPolicy_Errors(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name: "neither request nor response",
+			params: map[string]interface{}{
+				"foo": "bar",
+			},
+			wantErrContain: "at least one of 'request' or 'response' parameters must be provided",
+		},
+		{
+			name: "request regex missing",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{},
+			},
+			wantErrContain: "invalid request parameters: 'regex' parameter is required",
+		},
+		{
+			name: "response regex wrong type",
+			params: map[string]interface{}{
+				"response": map[string]interface{}{
+					"regex": 123,
+				},
+			},
+			wantErrContain: "invalid response parameters: 'regex' must be a string",
+		},
+		{
+			name: "regex empty",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{
+					"regex": "",
+				},
+			},
+			wantErrContain: "invalid request parameters: 'regex' cannot be empty",
+		},
+		{
+			name: "regex invalid pattern",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{
+					"regex": "[abc",
+				},
+			},
+			wantErrContain: "invalid request parameters: invalid regex pattern",
+		},
+		{
+			name: "jsonPath wrong type",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{
+					"regex":    "hello",
+					"jsonPath": true,
+				},
+			},
+			wantErrContain: "invalid request parameters: 'jsonPath' must be a string",
+		},
+		{
+			name: "invert wrong type",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{
+					"regex":  "hello",
+					"invert": "true",
+				},
+			},
+			wantErrContain: "invalid request parameters: 'invert' must be a boolean",
+		},
+		{
+			name: "showAssessment wrong type",
+			params: map[string]interface{}{
+				"request": map[string]interface{}{
+					"regex":          "hello",
+					"showAssessment": "true",
+				},
+			},
+			wantErrContain: "invalid request parameters: 'showAssessment' must be a boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContain) {
+				t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+			}
+		})
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_NoRequestConfig_NoOp(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnResponse_NoResponseConfig_NoOp(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	action := p.OnResponse(newResponseContextWithBody(`{"message":"hello"}`), nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_EmptyBody_NoOp(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte{},
+			Present: false,
+		},
+	}
+	action := p.OnRequest(ctx, nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnResponse_EmptyBody_NoOp(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-id",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte{},
+			Present: false,
+		},
+	}
+	action := p.OnResponse(ctx, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_DefaultJSONPath_Success(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"messages":"hello world"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_CustomJSONPath_Success(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":    "secret",
+			"jsonPath": "$.messages[0].content",
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"my secret token"}]}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_EmptyJSONPath_UsesWholePayload(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":    "sam",
+			"jsonPath": "",
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"name":"sam"}`), nil)
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
+	passPolicy := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":    "forbidden",
+			"jsonPath": "$.message",
+			"invert":   true,
+		},
+	})
+	passAction := passPolicy.OnRequest(newRequestContextWithBody(`{"message":"allowed content"}`), nil)
+	if _, ok := passAction.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected pass with invert=true on non-match, got %T", passAction)
+	}
+
+	failPolicy := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":    "forbidden",
+			"jsonPath": "$.message",
+			"invert":   true,
+		},
+	})
+	failAction := failPolicy.OnRequest(newRequestContextWithBody(`{"message":"contains forbidden term"}`), nil)
+	assertRequestErrorResponse(t, failAction, false, "REQUEST")
+}
+
+func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentFalse(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":          "abc",
+			"jsonPath":       "$.message",
+			"showAssessment": false,
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"message":"does not match"}`), nil)
+	body := assertRequestErrorResponse(t, action, false, "REQUEST")
+
+	message := extractMessageAssessment(t, body)
+	if _, exists := message["assessments"]; exists {
+		t.Fatalf("did not expect assessments when showAssessment=false")
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentTrue(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":          "abc",
+			"jsonPath":       "$.message",
+			"showAssessment": true,
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"message":"does not match"}`), nil)
+	body := assertRequestErrorResponse(t, action, true, "REQUEST")
+
+	message := extractMessageAssessment(t, body)
+	assessments, ok := message["assessments"].(string)
+	if !ok || !strings.Contains(assessments, "Violation of regular expression detected") {
+		t.Fatalf("expected detailed assessments for violation, got %v", message["assessments"])
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_ExtractionError_ShowAssessmentTrue(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex":          "abc",
+			"jsonPath":       "$.missing.path",
+			"showAssessment": true,
+		},
+	})
+
+	action := p.OnRequest(newRequestContextWithBody(`{"message":"abc"}`), nil)
+	body := assertRequestErrorResponse(t, action, true, "REQUEST")
+	message := extractMessageAssessment(t, body)
+
+	assessments, ok := message["assessments"].(string)
+	if !ok || !strings.Contains(assessments, "key not found") {
+		t.Fatalf("expected extraction error details in assessments, got %v", message["assessments"])
+	}
+}
+
+func TestRegexGuardrailPolicy_OnRequest_DefaultJSONPath_ArrayPayload_ExtractionError(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"regex": "hello",
+		},
+	})
+
+	// Default jsonPath is $.messages; this payload has messages as an array, which
+	// is not extractable as string/number by ExtractStringValueFromJsonpath.
+	action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"hello"}]}`), nil)
+	assertRequestErrorResponse(t, action, false, "REQUEST")
+}
+
+func TestRegexGuardrailPolicy_OnResponse_Success(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex":    "ok",
+			"jsonPath": "$.status",
+		},
+	})
+
+	action := p.OnResponse(newResponseContextWithBody(`{"status":"ok"}`), nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentFalse(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex":          "ok",
+			"jsonPath":       "$.status",
+			"showAssessment": false,
+		},
+	})
+
+	action := p.OnResponse(newResponseContextWithBody(`{"status":"failed"}`), nil)
+	body := assertResponseErrorResponse(t, action, false, "RESPONSE")
+	message := extractMessageAssessment(t, body)
+	if _, exists := message["assessments"]; exists {
+		t.Fatalf("did not expect assessments when showAssessment=false")
+	}
+}
+
+func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentTrue(t *testing.T) {
+	p := mustGetRegexPolicy(t, map[string]interface{}{
+		"response": map[string]interface{}{
+			"regex":          "ok",
+			"jsonPath":       "$.status",
+			"showAssessment": true,
+		},
+	})
+
+	action := p.OnResponse(newResponseContextWithBody(`{"status":"failed"}`), nil)
+	body := assertResponseErrorResponse(t, action, true, "RESPONSE")
+	message := extractMessageAssessment(t, body)
+	if _, exists := message["assessments"]; !exists {
+		t.Fatalf("expected assessments when showAssessment=true")
+	}
+}
+
+func TestRegexGuardrailPolicy_BuildAssessmentObject(t *testing.T) {
+	p := &RegexGuardrailPolicy{}
+
+	req := p.buildAssessmentObject("reason", nil, false, false)
+	if got := req["direction"]; got != "REQUEST" {
+		t.Fatalf("unexpected request direction: %v", got)
+	}
+	if got := req["actionReason"]; got != "Violation of regular expression detected." {
+		t.Fatalf("unexpected request actionReason: %v", got)
+	}
+
+	respWithErr := p.buildAssessmentObject("Error extracting value from JSONPath", errSentinel("boom"), true, true)
+	if got := respWithErr["direction"]; got != "RESPONSE" {
+		t.Fatalf("unexpected response direction: %v", got)
+	}
+	if got := respWithErr["actionReason"]; got != "Error extracting value from JSONPath" {
+		t.Fatalf("unexpected response actionReason: %v", got)
+	}
+	if got := respWithErr["assessments"]; got != "boom" {
+		t.Fatalf("unexpected response assessments: %v", got)
+	}
+}
+
+func mustGetRegexPolicy(t *testing.T, params map[string]interface{}) *RegexGuardrailPolicy {
+	t.Helper()
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	rp, ok := p.(*RegexGuardrailPolicy)
+	if !ok {
+		t.Fatalf("expected *RegexGuardrailPolicy, got %T", p)
+	}
+	return rp
+}
+
+func assertRequestErrorResponse(t *testing.T, action policy.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+	t.Helper()
+
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != GuardrailErrorCode {
+		t.Fatalf("unexpected status code: got %d, want %d", resp.StatusCode, GuardrailErrorCode)
+	}
+	if resp.Headers["Content-Type"] != "application/json" {
+		t.Fatalf("unexpected content type header: %v", resp.Headers["Content-Type"])
+	}
+
+	body := decodeJSONMap(t, resp.Body)
+	if got := body["type"]; got != "REGEX_GUARDRAIL" {
+		t.Fatalf("unexpected type: %v", got)
+	}
+	assessment := extractMessageAssessment(t, body)
+	validateAssessmentCore(t, assessment, expectAssessments, wantDirection)
+	return body
+}
+
+func assertResponseErrorResponse(t *testing.T, action policy.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+	t.Helper()
+
+	resp, ok := action.(policy.UpstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
+		t.Fatalf("unexpected status code: got %v, want %d", resp.StatusCode, GuardrailErrorCode)
+	}
+	if resp.SetHeaders["Content-Type"] != "application/json" {
+		t.Fatalf("unexpected content type header: %v", resp.SetHeaders["Content-Type"])
+	}
+
+	body := decodeJSONMap(t, resp.Body)
+	if got := body["type"]; got != "REGEX_GUARDRAIL" {
+		t.Fatalf("unexpected type: %v", got)
+	}
+	assessment := extractMessageAssessment(t, body)
+	validateAssessmentCore(t, assessment, expectAssessments, wantDirection)
+	return body
+}
+
+func validateAssessmentCore(t *testing.T, assessment map[string]interface{}, expectAssessments bool, wantDirection string) {
+	t.Helper()
+
+	if got := assessment["action"]; got != "GUARDRAIL_INTERVENED" {
+		t.Fatalf("unexpected action: %v", got)
+	}
+	if got := assessment["interveningGuardrail"]; got != "regex-guardrail" {
+		t.Fatalf("unexpected interveningGuardrail: %v", got)
+	}
+	if got := assessment["direction"]; got != wantDirection {
+		t.Fatalf("unexpected direction: got %v, want %q", got, wantDirection)
+	}
+	if expectAssessments {
+		if _, exists := assessment["assessments"]; !exists {
+			t.Fatalf("expected assessments to be present")
+		}
+	}
+}
+
+func extractMessageAssessment(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+
+	msg, ok := body["message"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected body.message as object, got %T", body["message"])
+	}
+	return msg
+}
+
+func decodeJSONMap(t *testing.T, payload []byte) map[string]interface{} {
+	t.Helper()
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		t.Fatalf("failed to unmarshal JSON body: %v; body=%s", err, string(payload))
+	}
+	return result
+}
+
+func newRequestContextWithBody(body string) *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+		Body: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+func newResponseContextWithBody(body string) *policy.ResponseContext {
+	return &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseBody: &policy.Body{
+			Content: []byte(body),
+			Present: body != "",
+		},
+	}
+}
+
+type errSentinel string
+
+func (e errSentinel) Error() string {
+	return string(e)
+}

--- a/policies/semantic-cache/policy-definition.yaml
+++ b/policies/semantic-cache/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-cache
-version: v0.2.2
+version: v0.3.0
 description: |
   Caches LLM responses using semantic similarity over request embeddings to
   reduce repeated upstream calls. Returns cached responses on similarity hits

--- a/policies/semantic-cache/semanticcache_test.go
+++ b/policies/semantic-cache/semanticcache_test.go
@@ -1,0 +1,647 @@
+package semanticcache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
+	vectordbproviders "github.com/wso2/api-platform/sdk/utils/vectordbproviders"
+)
+
+type mockEmbeddingProvider struct {
+	getEmbeddingFn func(input string) ([]float32, error)
+}
+
+func (m *mockEmbeddingProvider) Init(config embeddingproviders.EmbeddingProviderConfig) error {
+	return nil
+}
+
+func (m *mockEmbeddingProvider) GetType() string {
+	return "MOCK"
+}
+
+func (m *mockEmbeddingProvider) GetEmbedding(input string) ([]float32, error) {
+	if m.getEmbeddingFn != nil {
+		return m.getEmbeddingFn(input)
+	}
+	return []float32{0.1, 0.2}, nil
+}
+
+func (m *mockEmbeddingProvider) GetEmbeddings(inputs []string) ([][]float32, error) {
+	result := make([][]float32, len(inputs))
+	for i := range inputs {
+		result[i] = []float32{0.1, 0.2}
+	}
+	return result, nil
+}
+
+type mockVectorDBProvider struct {
+	retrieveFn func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error)
+	storeFn    func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error
+}
+
+func (m *mockVectorDBProvider) Init(config vectordbproviders.VectorDBProviderConfig) error {
+	return nil
+}
+
+func (m *mockVectorDBProvider) GetType() string {
+	return "MOCK_DB"
+}
+
+func (m *mockVectorDBProvider) CreateIndex() error {
+	return nil
+}
+
+func (m *mockVectorDBProvider) Store(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+	if m.storeFn != nil {
+		return m.storeFn(embeddings, response, filter)
+	}
+	return nil
+}
+
+func (m *mockVectorDBProvider) Retrieve(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+	if m.retrieveFn != nil {
+		return m.retrieveFn(embeddings, filter)
+	}
+	return vectordbproviders.CacheResponse{}, nil
+}
+
+func (m *mockVectorDBProvider) Close() error {
+	return nil
+}
+
+func TestSemanticCachePolicy_Mode(t *testing.T) {
+	p := &SemanticCachePolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestGetPolicy_InvalidParams(t *testing.T) {
+	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid params") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		assert         func(t *testing.T, p *SemanticCachePolicy)
+		wantErrContain string
+	}{
+		{
+			name: "openai success",
+			params: map[string]interface{}{
+				"embeddingProvider":   "OPENAI",
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": 0.55,
+				"embeddingEndpoint":   "http://example.com",
+				"embeddingModel":      "text-embedding-3-small",
+				"apiKey":              "secret",
+				"dbHost":              "localhost",
+				"dbPort":              6379,
+				"embeddingDimension":  1536,
+				"username":            "user",
+				"password":            "pass",
+				"database":            "1",
+				"ttl":                 3600,
+				"jsonPath":            "$.messages[-1].content",
+			},
+			assert: func(t *testing.T, p *SemanticCachePolicy) {
+				if p.threshold != 0.55 {
+					t.Fatalf("unexpected threshold: %v", p.threshold)
+				}
+				if p.embeddingConfig.AuthHeaderName != "Authorization" {
+					t.Fatalf("unexpected auth header name: %q", p.embeddingConfig.AuthHeaderName)
+				}
+				if p.vectorStoreConfig.Threshold != "0.55" {
+					t.Fatalf("unexpected vector threshold: %q", p.vectorStoreConfig.Threshold)
+				}
+				if p.vectorStoreConfig.DBPort != 6379 {
+					t.Fatalf("unexpected db port: %d", p.vectorStoreConfig.DBPort)
+				}
+				if p.jsonPath != "$.messages[-1].content" {
+					t.Fatalf("unexpected jsonPath: %q", p.jsonPath)
+				}
+			},
+		},
+		{
+			name: "azure without model",
+			params: map[string]interface{}{
+				"embeddingProvider":   "AZURE_OPENAI",
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": "0.5",
+				"embeddingEndpoint":   "http://example.com",
+				"apiKey":              "secret",
+				"dbHost":              "localhost",
+				"dbPort":              "6379",
+				"embeddingDimension":  "1536",
+			},
+			assert: func(t *testing.T, p *SemanticCachePolicy) {
+				if p.embeddingConfig.AuthHeaderName != "api-key" {
+					t.Fatalf("unexpected auth header: %q", p.embeddingConfig.AuthHeaderName)
+				}
+				if p.embeddingConfig.EmbeddingModel != "" {
+					t.Fatalf("expected empty embedding model for azure, got %q", p.embeddingConfig.EmbeddingModel)
+				}
+			},
+		},
+		{
+			name: "missing embedding provider",
+			params: map[string]interface{}{
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": 0.5,
+			},
+			wantErrContain: "'embeddingProvider' parameter is required",
+		},
+		{
+			name: "missing vector store provider",
+			params: map[string]interface{}{
+				"embeddingProvider":   "OPENAI",
+				"similarityThreshold": 0.5,
+			},
+			wantErrContain: "'vectorStoreProvider' parameter is required",
+		},
+		{
+			name: "missing similarity threshold",
+			params: map[string]interface{}{
+				"embeddingProvider":   "OPENAI",
+				"vectorStoreProvider": "REDIS",
+			},
+			wantErrContain: "'similarityThreshold' parameter is required",
+		},
+		{
+			name: "threshold out of range",
+			params: map[string]interface{}{
+				"embeddingProvider":   "OPENAI",
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": 2.0,
+			},
+			wantErrContain: "'similarityThreshold' must be between 0.0 and 1.0",
+		},
+		{
+			name: "openai missing model",
+			params: map[string]interface{}{
+				"embeddingProvider":   "OPENAI",
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": 0.5,
+				"embeddingEndpoint":   "http://example.com",
+				"apiKey":              "secret",
+				"dbHost":              "localhost",
+				"dbPort":              6379,
+				"embeddingDimension":  1536,
+			},
+			wantErrContain: "'embeddingModel' is required for OPENAI provider",
+		},
+		{
+			name: "invalid dbPort numeric",
+			params: map[string]interface{}{
+				"embeddingProvider":   "AZURE_OPENAI",
+				"vectorStoreProvider": "REDIS",
+				"similarityThreshold": 0.5,
+				"embeddingEndpoint":   "http://example.com",
+				"apiKey":              "secret",
+				"dbHost":              "localhost",
+				"dbPort":              12.5,
+				"embeddingDimension":  1536,
+			},
+			wantErrContain: "'dbPort' must be a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &SemanticCachePolicy{}
+			err := parseParams(tt.params, p)
+			if tt.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseParams failed: %v", err)
+			}
+			if tt.assert != nil {
+				tt.assert(t, p)
+			}
+		})
+	}
+}
+
+func TestExtractFloat64(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		want      float64
+		wantError bool
+	}{
+		{name: "float64", value: float64(0.5), want: 0.5},
+		{name: "float32", value: float32(0.5), want: 0.5},
+		{name: "int", value: int(1), want: 1},
+		{name: "int64", value: int64(2), want: 2},
+		{name: "string", value: "0.7", want: 0.7},
+		{name: "bad string", value: "x", wantError: true},
+		{name: "invalid type", value: true, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractFloat64(tt.value)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractFloat64 failed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected value: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractInt(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		want      int
+		wantError bool
+	}{
+		{name: "int", value: int(3), want: 3},
+		{name: "int64", value: int64(4), want: 4},
+		{name: "float64 integer", value: float64(5), want: 5},
+		{name: "string", value: "6", want: 6},
+		{name: "float64 non integer", value: float64(1.1), wantError: true},
+		{name: "bad string", value: "x", wantError: true},
+		{name: "invalid type", value: true, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractInt(tt.value)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractInt failed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected value: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSemanticCachePolicy_OnRequest(t *testing.T) {
+	tests := []struct {
+		name             string
+		policy           *SemanticCachePolicy
+		ctx              *policy.RequestContext
+		wantImmediate    bool
+		wantStatus       int
+		wantCacheStatus  string
+		wantMetadataSave bool
+	}{
+		{
+			name: "empty body passes through",
+			policy: &SemanticCachePolicy{
+				embeddingProvider:   &mockEmbeddingProvider{},
+				vectorStoreProvider: &mockVectorDBProvider{},
+				threshold:           0.5,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policy.Body{Content: nil, Present: false},
+			},
+			wantImmediate: false,
+		},
+		{
+			name: "jsonpath extraction failure returns error",
+			policy: &SemanticCachePolicy{
+				embeddingProvider:   &mockEmbeddingProvider{},
+				vectorStoreProvider: &mockVectorDBProvider{},
+				jsonPath:            "$.missing",
+				threshold:           0.5,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policy.Body{Content: []byte(`{"prompt":"hello"}`), Present: true},
+			},
+			wantImmediate: true,
+			wantStatus:    400,
+		},
+		{
+			name: "embedding provider error passes through",
+			policy: &SemanticCachePolicy{
+				embeddingProvider: &mockEmbeddingProvider{getEmbeddingFn: func(input string) ([]float32, error) {
+					return nil, errors.New("embedding failed")
+				}},
+				vectorStoreProvider: &mockVectorDBProvider{},
+				threshold:           0.5,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			},
+			wantImmediate: false,
+		},
+		{
+			name: "cache miss passes through and stores embedding",
+			policy: &SemanticCachePolicy{
+				embeddingProvider: &mockEmbeddingProvider{getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{0.2, 0.3}, nil
+				}},
+				vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+					if filter["api_id"] != "Books:v1" {
+						t.Fatalf("unexpected api_id in filter: %v", filter["api_id"])
+					}
+					if filter["threshold"] != "0.70" {
+						t.Fatalf("unexpected threshold in filter: %v", filter["threshold"])
+					}
+					if _, ok := filter["ctx"].(context.Context); !ok {
+						t.Fatalf("expected context.Context in filter")
+					}
+					return vectordbproviders.CacheResponse{}, nil
+				}},
+				threshold: 0.7,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			},
+			wantImmediate:    false,
+			wantMetadataSave: true,
+		},
+		{
+			name: "cache hit returns immediate response",
+			policy: &SemanticCachePolicy{
+				embeddingProvider: &mockEmbeddingProvider{getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{0.2, 0.3}, nil
+				}},
+				vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+					return vectordbproviders.CacheResponse{ResponsePayload: map[string]interface{}{"answer": "cached"}}, nil
+				}},
+				threshold: 0.5,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			},
+			wantImmediate:   true,
+			wantStatus:      200,
+			wantCacheStatus: "HIT",
+		},
+		{
+			name: "retrieve error passes through",
+			policy: &SemanticCachePolicy{
+				embeddingProvider: &mockEmbeddingProvider{},
+				vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+					return vectordbproviders.CacheResponse{}, errors.New("redis down")
+				}},
+				threshold: 0.5,
+			},
+			ctx: &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			},
+			wantImmediate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := tt.policy.OnRequest(tt.ctx, nil)
+
+			if !tt.wantImmediate {
+				if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+					t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+				}
+				if tt.wantMetadataSave {
+					if _, ok := tt.ctx.Metadata[MetadataKeyEmbedding].(string); !ok {
+						t.Fatalf("expected embedding to be stored in metadata")
+					}
+				}
+				return
+			}
+
+			resp, ok := action.(policy.ImmediateResponse)
+			if !ok {
+				t.Fatalf("expected ImmediateResponse, got %T", action)
+			}
+			if resp.StatusCode != tt.wantStatus {
+				t.Fatalf("unexpected status: got %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if tt.wantCacheStatus != "" {
+				if resp.Headers["X-Cache-Status"] != tt.wantCacheStatus {
+					t.Fatalf("unexpected cache status: %q", resp.Headers["X-Cache-Status"])
+				}
+				var body map[string]interface{}
+				if err := json.Unmarshal(resp.Body, &body); err != nil {
+					t.Fatalf("invalid JSON body: %v", err)
+				}
+				if body["answer"] != "cached" {
+					t.Fatalf("unexpected cached payload: %v", body)
+				}
+			}
+		})
+	}
+}
+
+func TestSemanticCachePolicy_OnResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		policy    *SemanticCachePolicy
+		ctx       *policy.ResponseContext
+		assertion func(t *testing.T, action policy.ResponseAction)
+	}{
+		{
+			name: "non-200 response skipped",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{},
+			},
+			ctx:       newResponseContext(500, []byte(`{"answer":"x"}`), map[string]interface{}{}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "empty body skipped",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{},
+			},
+			ctx:       newResponseContext(200, nil, map[string]interface{}{}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "missing embedding metadata skipped",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{},
+			},
+			ctx:       newResponseContext(200, []byte(`{"answer":"x"}`), map[string]interface{}{}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "invalid embedding metadata skipped",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{},
+			},
+			ctx:       newResponseContext(200, []byte(`{"answer":"x"}`), map[string]interface{}{MetadataKeyEmbedding: "not-json"}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "invalid response body json skipped",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{},
+			},
+			ctx:       newResponseContext(200, []byte("not-json"), map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "store error still no-op",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+					return errors.New("store failed")
+				}},
+			},
+			ctx:       newResponseContext(200, []byte(`{"answer":"x"}`), map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}),
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "store success with api fallback",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+					if !reflect.DeepEqual(embeddings, []float32{0.1, 0.2}) {
+						t.Fatalf("unexpected embeddings: %v", embeddings)
+					}
+					if response.ResponsePayload["answer"] != "x" {
+						t.Fatalf("unexpected response payload: %v", response.ResponsePayload)
+					}
+					if filter["api_id"] != "req-1" {
+						t.Fatalf("expected fallback api_id=req-1, got %v", filter["api_id"])
+					}
+					if _, ok := filter["ctx"].(context.Context); !ok {
+						t.Fatalf("expected context in store filter")
+					}
+					if response.RequestHash == "" {
+						t.Fatalf("expected generated request hash")
+					}
+					if time.Since(response.ResponseFetchedTime) > 2*time.Second {
+						t.Fatalf("response timestamp too old: %v", response.ResponseFetchedTime)
+					}
+					return nil
+				}},
+			},
+			ctx: &policy.ResponseContext{
+				SharedContext:  &policy.SharedContext{RequestID: "req-1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
+				ResponseStatus: 200,
+				ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+			},
+			assertion: assertUpstreamResponseMods,
+		},
+		{
+			name: "store success with api name/version",
+			policy: &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+					if filter["api_id"] != "Books:v2" {
+						t.Fatalf("unexpected api_id: %v", filter["api_id"])
+					}
+					return nil
+				}},
+			},
+			ctx: &policy.ResponseContext{
+				SharedContext:  &policy.SharedContext{RequestID: "req-2", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}, APIName: "Books", APIVersion: "v2"},
+				ResponseStatus: 200,
+				ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+			},
+			assertion: assertUpstreamResponseMods,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := tt.policy.OnResponse(tt.ctx, nil)
+			tt.assertion(t, action)
+		})
+	}
+}
+
+func TestBuildErrorResponse(t *testing.T) {
+	p := &SemanticCachePolicy{}
+	action := p.buildErrorResponse("jsonpath failed", errors.New("bad path"))
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 400 {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	if resp.Headers["Content-Type"] != "application/json" {
+		t.Fatalf("unexpected content type: %q", resp.Headers["Content-Type"])
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("invalid json body: %v", err)
+	}
+	if body["type"] != "SEMANTIC_CACHE" {
+		t.Fatalf("unexpected type: %v", body["type"])
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "jsonpath failed") || !strings.Contains(msg, "bad path") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func TestCreateProviderHelpers_UnsupportedTypes(t *testing.T) {
+	_, err := createEmbeddingProvider(embeddingproviders.EmbeddingProviderConfig{EmbeddingProvider: "UNKNOWN"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported embedding provider") {
+		t.Fatalf("expected unsupported embedding provider error, got %v", err)
+	}
+
+	_, err = createVectorDBProvider(vectordbproviders.VectorDBProviderConfig{VectorStoreProvider: "UNKNOWN"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported vector store provider") {
+		t.Fatalf("expected unsupported vector store provider error, got %v", err)
+	}
+}
+
+func newResponseContext(status int, body []byte, metadata map[string]interface{}) *policy.ResponseContext {
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	return &policy.ResponseContext{
+		SharedContext:  &policy.SharedContext{RequestID: "req-1", Metadata: metadata, APIName: "Books", APIVersion: "v1"},
+		ResponseStatus: status,
+		ResponseBody:   &policy.Body{Content: body, Present: len(body) > 0},
+	}
+}
+
+func assertUpstreamResponseMods(t *testing.T, action policy.ResponseAction) {
+	t.Helper()
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}

--- a/policies/semantic-prompt-guard/policy-definition.yaml
+++ b/policies/semantic-prompt-guard/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-prompt-guard
-version: v0.2.2
+version: v0.3.0
 description: |
   Evaluates request prompts using embedding similarity against configured allow
   and deny phrases. Blocks prompts that match denied phrases or fail allow

--- a/policies/semantic-prompt-guard/semanticpromptguard_test.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard_test.go
@@ -1,0 +1,676 @@
+package semanticpromptguard
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
+)
+
+type mockEmbeddingProvider struct {
+	getEmbeddingFn  func(input string) ([]float32, error)
+	getEmbeddingsFn func(inputs []string) ([][]float32, error)
+}
+
+func (m *mockEmbeddingProvider) Init(config embeddingproviders.EmbeddingProviderConfig) error {
+	return nil
+}
+
+func (m *mockEmbeddingProvider) GetType() string {
+	return "MOCK"
+}
+
+func (m *mockEmbeddingProvider) GetEmbedding(input string) ([]float32, error) {
+	if m.getEmbeddingFn != nil {
+		return m.getEmbeddingFn(input)
+	}
+	return []float32{1, 0}, nil
+}
+
+func (m *mockEmbeddingProvider) GetEmbeddings(inputs []string) ([][]float32, error) {
+	if m.getEmbeddingsFn != nil {
+		return m.getEmbeddingsFn(inputs)
+	}
+	result := make([][]float32, len(inputs))
+	for i := range inputs {
+		result[i] = []float32{float32(i + 1), 0}
+	}
+	return result, nil
+}
+
+func TestSemanticPromptGuardPolicy_Mode(t *testing.T) {
+	p := &SemanticPromptGuardPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
+func TestSemanticPromptGuardPolicy_OnResponse_NoOp(t *testing.T) {
+	p := &SemanticPromptGuardPolicy{}
+	action := p.OnResponse(&policy.ResponseContext{}, nil)
+	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	}
+}
+
+func TestGetPolicy_InvalidEmbeddingConfig(t *testing.T) {
+	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	if err == nil {
+		t.Fatalf("expected error for missing embedding config")
+	}
+	if !strings.Contains(err.Error(), "invalid embedding config") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseEmbeddingConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantHeader     string
+		wantModel      string
+		wantErrContain string
+	}{
+		{
+			name: "openai success",
+			params: map[string]interface{}{
+				"embeddingProvider": "OPENAI",
+				"embeddingEndpoint": "http://example.com",
+				"embeddingModel":    "text-embedding-3-small",
+				"apiKey":            "secret",
+			},
+			wantHeader: "Authorization",
+			wantModel:  "text-embedding-3-small",
+		},
+		{
+			name: "azure openai without model",
+			params: map[string]interface{}{
+				"embeddingProvider": "AZURE_OPENAI",
+				"embeddingEndpoint": "http://example.com",
+				"apiKey":            "secret",
+			},
+			wantHeader: "api-key",
+			wantModel:  "",
+		},
+		{
+			name: "missing provider",
+			params: map[string]interface{}{
+				"embeddingEndpoint": "http://example.com",
+				"embeddingModel":    "m",
+				"apiKey":            "secret",
+			},
+			wantErrContain: "'embeddingProvider' is required",
+		},
+		{
+			name: "openai missing model",
+			params: map[string]interface{}{
+				"embeddingProvider": "OPENAI",
+				"embeddingEndpoint": "http://example.com",
+				"apiKey":            "secret",
+			},
+			wantErrContain: "'embeddingModel' is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &SemanticPromptGuardPolicy{}
+			err := parseEmbeddingConfig(tt.params, p)
+			if tt.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseEmbeddingConfig failed: %v", err)
+			}
+			if p.embeddingConfig.AuthHeaderName != tt.wantHeader {
+				t.Fatalf("unexpected auth header: got %q, want %q", p.embeddingConfig.AuthHeaderName, tt.wantHeader)
+			}
+			if p.embeddingConfig.EmbeddingModel != tt.wantModel {
+				t.Fatalf("unexpected embedding model: got %q, want %q", p.embeddingConfig.EmbeddingModel, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestParseParams(t *testing.T) {
+	basePolicy := &SemanticPromptGuardPolicy{
+		embeddingProvider: &mockEmbeddingProvider{},
+	}
+
+	tests := []struct {
+		name           string
+		params         map[string]interface{}
+		wantErrContain string
+	}{
+		{
+			name: "valid allowed and denied phrases",
+			params: map[string]interface{}{
+				"jsonPath":                 "$.prompt",
+				"allowSimilarityThreshold": 0.7,
+				"denySimilarityThreshold":  0.8,
+				"showAssessment":           true,
+				"allowedPhrases":           []interface{}{"safe"},
+				"deniedPhrases":            []interface{}{"attack"},
+			},
+		},
+		{
+			name: "invalid jsonPath type",
+			params: map[string]interface{}{
+				"jsonPath":       true,
+				"allowedPhrases": []interface{}{"safe"},
+			},
+			wantErrContain: "'jsonPath' must be a string",
+		},
+		{
+			name: "invalid allow threshold",
+			params: map[string]interface{}{
+				"allowSimilarityThreshold": 2.0,
+				"allowedPhrases":           []interface{}{"safe"},
+			},
+			wantErrContain: "'allowSimilarityThreshold' must be between 0.0 and 1.0",
+		},
+		{
+			name: "invalid deny threshold",
+			params: map[string]interface{}{
+				"denySimilarityThreshold": -1.0,
+				"allowedPhrases":          []interface{}{"safe"},
+			},
+			wantErrContain: "'denySimilarityThreshold' must be between 0.0 and 1.0",
+		},
+		{
+			name: "invalid showAssessment type",
+			params: map[string]interface{}{
+				"showAssessment": "true",
+				"allowedPhrases": []interface{}{"safe"},
+			},
+			wantErrContain: "'showAssessment' must be a boolean",
+		},
+		{
+			name: "invalid allowed phrases type",
+			params: map[string]interface{}{
+				"allowedPhrases": "safe",
+			},
+			wantErrContain: "error parsing allowedPhrases",
+		},
+		{
+			name:           "no allowed or denied phrases",
+			params:         map[string]interface{}{},
+			wantErrContain: "at least one allowedPhrases or deniedPhrases entry is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &SemanticPromptGuardPolicy{embeddingProvider: basePolicy.embeddingProvider}
+			got, err := parseParams(tt.params, p)
+			if tt.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseParams failed: %v", err)
+			}
+			if got.JsonPath != "$.prompt" {
+				t.Fatalf("unexpected jsonPath: %q", got.JsonPath)
+			}
+			if !got.ShowAssessment {
+				t.Fatalf("expected showAssessment=true")
+			}
+			if len(got.AllowedPhrases) != 1 || len(got.DeniedPhrases) != 1 {
+				t.Fatalf("unexpected phrase counts: allowed=%d denied=%d", len(got.AllowedPhrases), len(got.DeniedPhrases))
+			}
+			if got.AllowedPhrases[0].Embedding == nil || got.DeniedPhrases[0].Embedding == nil {
+				t.Fatalf("expected embeddings to be populated")
+			}
+		})
+	}
+}
+
+func TestEnsureEmbeddings(t *testing.T) {
+	tests := []struct {
+		name           string
+		provider       *mockEmbeddingProvider
+		phrases        []PhraseEmbedding
+		wantErrContain string
+	}{
+		{
+			name: "success",
+			provider: &mockEmbeddingProvider{
+				getEmbeddingsFn: func(inputs []string) ([][]float32, error) {
+					return [][]float32{{1, 0}, {0, 1}}, nil
+				},
+			},
+			phrases: []PhraseEmbedding{{Phrase: "a"}, {Phrase: "b"}},
+		},
+		{
+			name: "provider error",
+			provider: &mockEmbeddingProvider{
+				getEmbeddingsFn: func(inputs []string) ([][]float32, error) {
+					return nil, errors.New("provider failed")
+				},
+			},
+			phrases:        []PhraseEmbedding{{Phrase: "a"}},
+			wantErrContain: "failed to get embeddings",
+		},
+		{
+			name: "count mismatch",
+			provider: &mockEmbeddingProvider{
+				getEmbeddingsFn: func(inputs []string) ([][]float32, error) {
+					return [][]float32{{1, 0}}, nil
+				},
+			},
+			phrases:        []PhraseEmbedding{{Phrase: "a"}, {Phrase: "b"}},
+			wantErrContain: "expected 2 embeddings but got 1",
+		},
+		{
+			name:           "empty phrase",
+			provider:       &mockEmbeddingProvider{},
+			phrases:        []PhraseEmbedding{{Phrase: ""}},
+			wantErrContain: "phrase at index 0 is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &SemanticPromptGuardPolicy{embeddingProvider: tt.provider}
+			got, err := p.ensureEmbeddings(tt.phrases)
+			if tt.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ensureEmbeddings failed: %v", err)
+			}
+			if len(got) != len(tt.phrases) {
+				t.Fatalf("unexpected count: got %d, want %d", len(got), len(tt.phrases))
+			}
+			for _, phrase := range got {
+				if len(phrase.Embedding) == 0 {
+					t.Fatalf("expected embedding for phrase %q", phrase.Phrase)
+				}
+			}
+		})
+	}
+}
+
+func TestParsePhraseEmbeddings(t *testing.T) {
+	tests := []struct {
+		name           string
+		raw            interface{}
+		wantCount      int
+		wantErrContain string
+	}{
+		{name: "nil raw", raw: nil, wantCount: 0},
+		{name: "valid array", raw: []interface{}{"a", "b"}, wantCount: 2},
+		{name: "not array", raw: "a", wantErrContain: "must be an array"},
+		{name: "non string entry", raw: []interface{}{1}, wantErrContain: "must be a string"},
+		{name: "empty entry", raw: []interface{}{""}, wantErrContain: "cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePhraseEmbeddings(tt.raw, "allowedPhrases")
+			if tt.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error mismatch: got %q, want contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parsePhraseEmbeddings failed: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Fatalf("unexpected count: got %d, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestParseFloatParam(t *testing.T) {
+	params := map[string]interface{}{
+		"float64": float64(0.1),
+		"float32": float32(0.2),
+		"int":     int(3),
+		"int64":   int64(4),
+		"string":  "0.5",
+		"bad":     "x",
+	}
+
+	if got := parseFloatParam(params, "float64", 1); got != 0.1 {
+		t.Fatalf("unexpected float64 parse: %v", got)
+	}
+	if got := parseFloatParam(params, "float32", 1); math.Abs(got-0.2) > 1e-6 {
+		t.Fatalf("unexpected float32 parse: %v", got)
+	}
+	if got := parseFloatParam(params, "int", 1); got != 3 {
+		t.Fatalf("unexpected int parse: %v", got)
+	}
+	if got := parseFloatParam(params, "int64", 1); got != 4 {
+		t.Fatalf("unexpected int64 parse: %v", got)
+	}
+	if got := parseFloatParam(params, "string", 1); got != 0.5 {
+		t.Fatalf("unexpected string parse: %v", got)
+	}
+	if got := parseFloatParam(params, "bad", 1); got != 1 {
+		t.Fatalf("expected default for bad string, got %v", got)
+	}
+	if got := parseFloatParam(params, "missing", 1); got != 1 {
+		t.Fatalf("expected default for missing key, got %v", got)
+	}
+}
+
+func TestSemanticPromptGuardPolicy_OnRequestAndValidatePayload(t *testing.T) {
+	tests := []struct {
+		name               string
+		payload            string
+		params             SemanticPromptGuardPolicyParams
+		provider           *mockEmbeddingProvider
+		wantImmediate      bool
+		wantStatus         int
+		wantAssessment     bool
+		wantAssessmentText string
+	}{
+		{
+			name:    "jsonpath extraction error",
+			payload: `{"message":"hi"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:       "$.prompt",
+				ShowAssessment: true,
+			},
+			provider:       &mockEmbeddingProvider{},
+			wantImmediate:  true,
+			wantStatus:     GuardrailErrorCode,
+			wantAssessment: true,
+		},
+		{
+			name:    "empty extracted prompt",
+			payload: `{"prompt":""}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:       "$.prompt",
+				ShowAssessment: true,
+			},
+			provider:       &mockEmbeddingProvider{},
+			wantImmediate:  true,
+			wantStatus:     GuardrailErrorCode,
+			wantAssessment: true,
+		},
+		{
+			name:    "embedding provider error",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:       "$.prompt",
+				DeniedPhrases:  []PhraseEmbedding{{Phrase: "ban", Embedding: []float32{1, 0}}},
+				ShowAssessment: true,
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return nil, errors.New("boom")
+				},
+			},
+			wantImmediate:  true,
+			wantStatus:     GuardrailErrorCode,
+			wantAssessment: true,
+		},
+		{
+			name:    "deny list blocks",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:                "$.prompt",
+				DenySimilarityThreshold: 0.8,
+				DeniedPhrases:           []PhraseEmbedding{{Phrase: "ban", Embedding: []float32{1, 0}}},
+				ShowAssessment:          true,
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate:      true,
+			wantStatus:         GuardrailErrorCode,
+			wantAssessment:     true,
+			wantAssessmentText: "denied phrase",
+		},
+		{
+			name:    "deny list allows",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:                "$.prompt",
+				DenySimilarityThreshold: 0.9,
+				DeniedPhrases:           []PhraseEmbedding{{Phrase: "ban", Embedding: []float32{0, 1}}},
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate: false,
+		},
+		{
+			name:    "allow list allows",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:                 "$.prompt",
+				AllowSimilarityThreshold: 0.8,
+				AllowedPhrases:           []PhraseEmbedding{{Phrase: "safe", Embedding: []float32{1, 0}}},
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate: false,
+		},
+		{
+			name:    "allow list blocks",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:                 "$.prompt",
+				AllowSimilarityThreshold: 0.8,
+				AllowedPhrases:           []PhraseEmbedding{{Phrase: "safe", Embedding: []float32{0, 1}}},
+				ShowAssessment:           true,
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate:      true,
+			wantStatus:         GuardrailErrorCode,
+			wantAssessment:     true,
+			wantAssessmentText: "not similar enough",
+		},
+		{
+			name:    "both lists deny takes precedence",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:                 "$.prompt",
+				AllowSimilarityThreshold: 0.5,
+				DenySimilarityThreshold:  0.5,
+				AllowedPhrases:           []PhraseEmbedding{{Phrase: "safe", Embedding: []float32{1, 0}}},
+				DeniedPhrases:            []PhraseEmbedding{{Phrase: "ban", Embedding: []float32{1, 0}}},
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate: true,
+			wantStatus:    GuardrailErrorCode,
+		},
+		{
+			name:    "similarity error due to dimension mismatch",
+			payload: `{"prompt":"hello"}`,
+			params: SemanticPromptGuardPolicyParams{
+				JsonPath:      "$.prompt",
+				DeniedPhrases: []PhraseEmbedding{{Phrase: "ban", Embedding: []float32{1, 0, 1}}},
+			},
+			provider: &mockEmbeddingProvider{
+				getEmbeddingFn: func(input string) ([]float32, error) {
+					return []float32{1, 0}, nil
+				},
+			},
+			wantImmediate: true,
+			wantStatus:    GuardrailErrorCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &SemanticPromptGuardPolicy{
+				embeddingProvider: tt.provider,
+				params:            tt.params,
+			}
+
+			ctx := &policy.RequestContext{
+				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policy.Body{Content: []byte(tt.payload), Present: true, EndOfStream: true},
+			}
+
+			action := p.OnRequest(ctx, nil)
+			if !tt.wantImmediate {
+				if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+					t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+				}
+				return
+			}
+
+			resp, ok := action.(policy.ImmediateResponse)
+			if !ok {
+				t.Fatalf("expected ImmediateResponse, got %T", action)
+			}
+			if resp.StatusCode != tt.wantStatus {
+				t.Fatalf("unexpected status: got %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			message := decodeSemanticPromptGuardMessage(t, resp.Body)
+			if tt.wantAssessment {
+				if _, ok := message["assessments"]; !ok {
+					t.Fatalf("expected assessments in error message")
+				}
+			}
+			if tt.wantAssessmentText != "" {
+				assessments := ""
+				if v, ok := message["assessments"].(string); ok {
+					assessments = v
+				}
+				if !strings.Contains(assessments, tt.wantAssessmentText) {
+					t.Fatalf("assessment mismatch: got %q, want contain %q", assessments, tt.wantAssessmentText)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAssessmentObject(t *testing.T) {
+	p := &SemanticPromptGuardPolicy{}
+
+	withErrNoAssessment := p.buildAssessmentObject("reason", errors.New("err details"), false)
+	if withErrNoAssessment["actionReason"] != "reason" {
+		t.Fatalf("expected custom reason with validation error, got %v", withErrNoAssessment["actionReason"])
+	}
+	if _, ok := withErrNoAssessment["assessments"]; ok {
+		t.Fatalf("did not expect assessments when showAssessment=false")
+	}
+
+	withoutErrWithAssessment := p.buildAssessmentObject("friendly reason", nil, true)
+	if withoutErrWithAssessment["actionReason"] != "Violation of applied semantic prompt guard constraints detected." {
+		t.Fatalf("unexpected actionReason: %v", withoutErrWithAssessment["actionReason"])
+	}
+	if withoutErrWithAssessment["assessments"] != "friendly reason" {
+		t.Fatalf("unexpected assessments: %v", withoutErrWithAssessment["assessments"])
+	}
+}
+
+func TestMaxSimilarityAndCosineSimilarity(t *testing.T) {
+	t.Run("maxSimilarity picks closest", func(t *testing.T) {
+		target := []float32{1, 0}
+		phrases := []PhraseEmbedding{
+			{Phrase: "first", Embedding: []float32{0, 1}},
+			{Phrase: "second", Embedding: []float32{1, 0}},
+		}
+
+		sim, closest, err := maxSimilarity(target, phrases)
+		if err != nil {
+			t.Fatalf("maxSimilarity failed: %v", err)
+		}
+		if sim < 0.99 {
+			t.Fatalf("expected high similarity, got %f", sim)
+		}
+		if closest.Phrase != "second" {
+			t.Fatalf("unexpected closest phrase: %q", closest.Phrase)
+		}
+	})
+
+	t.Run("cosineSimilarity errors", func(t *testing.T) {
+		if _, err := cosineSimilarity(nil, []float32{1}); err == nil {
+			t.Fatalf("expected error for empty vector")
+		}
+		if _, err := cosineSimilarity([]float32{1}, []float32{1, 2}); err == nil {
+			t.Fatalf("expected error for dimension mismatch")
+		}
+		if _, err := cosineSimilarity([]float32{0, 0}, []float32{1, 0}); err == nil {
+			t.Fatalf("expected error for zero norm")
+		}
+	})
+
+	t.Run("maxSimilarity empty phrases", func(t *testing.T) {
+		sim, closest, err := maxSimilarity([]float32{1, 0}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sim != 0 {
+			t.Fatalf("expected similarity 0, got %f", sim)
+		}
+		if !reflect.DeepEqual(closest, PhraseEmbedding{}) {
+			t.Fatalf("expected zero closest phrase, got %+v", closest)
+		}
+	})
+}
+
+func decodeSemanticPromptGuardMessage(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var outer map[string]interface{}
+	if err := json.Unmarshal(body, &outer); err != nil {
+		t.Fatalf("failed to unmarshal response body: %v", err)
+	}
+	message, ok := outer["message"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected message object, got %T", outer["message"])
+	}
+	return message
+}

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -26,7 +26,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean
@@ -60,7 +60,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v0.2.2
+version: v0.3.0
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the
@@ -11,55 +11,67 @@ parameters:
   properties:
     promptTokenLimits:
       type: array
+      x-wso2-policy-advanced-param: false
       description: Specifies rate limits for prompt (input) tokens.
       default: []
       items:
         type: object
+        x-wso2-policy-advanced-param: false
         required: ["count", "duration"]
         properties:
           count:
             type: integer
+            x-wso2-policy-advanced-param: false
             description: Specifies the maximum number of tokens allowed in the
               configured duration.
             minimum: 1
           duration:
             type: string
+            x-wso2-policy-advanced-param: false
             description: Specifies the duration window for the limit, for
               example "1m", "1h", or "24h".
             pattern: "^[-+]?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
     completionTokenLimits:
       type: array
+      x-wso2-policy-advanced-param: false
       description: Specifies rate limits for completion (output) tokens.
       default: []
       items:
         type: object
+        x-wso2-policy-advanced-param: false
         required: ["count", "duration"]
         properties:
           count:
             type: integer
+            x-wso2-policy-advanced-param: false
             description: Specifies the maximum number of tokens allowed in the
               configured duration.
             minimum: 1
           duration:
             type: string
+            x-wso2-policy-advanced-param: false
             description: Specifies the duration window for the limit, for
               example "1m", "1h", or "24h".
             pattern: "^[-+]?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
     totalTokenLimits:
       type: array
+      x-wso2-policy-advanced-param: false
       description: Specifies rate limits for total tokens (prompt + completion).
       default: []
       items:
         type: object
+        x-wso2-policy-advanced-param: false
         required: ["count", "duration"]
         properties:
           count:
             type: integer
+            x-wso2-policy-advanced-param: false
             description: Specifies the maximum number of tokens allowed in the
               configured duration.
             minimum: 1
           duration:
             type: string
+            x-wso2-policy-advanced-param: false
             description: Specifies the duration window for the limit, for
               example "1m", "1h", or "24h".
             pattern: "^[-+]?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -19,7 +19,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         onlyDNS:
           type: boolean
@@ -52,7 +52,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         onlyDNS:
           type: boolean

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -15,6 +15,7 @@ parameters:
       properties:
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
@@ -22,18 +23,21 @@ parameters:
           default: ""
         onlyDNS:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, validates URLs only via DNS resolution (faster, less reliable).
             If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
           default: false
         timeout:
           type: integer
+          x-wso2-policy-advanced-param: true
           description: |
             Timeout in milliseconds for DNS lookup or HTTP HEAD request.
             Default is 3000ms (3 seconds).
           default: 3000
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, includes detailed assessment information including invalid URLs in error responses.
             If false, returns minimal error information.
@@ -44,6 +48,7 @@ parameters:
       properties:
         jsonPath:
           type: string
+          x-wso2-policy-advanced-param: true
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
@@ -51,22 +56,28 @@ parameters:
           default: ""
         onlyDNS:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, validates URLs only via DNS resolution (faster, less reliable).
             If false (default), validates URLs via HTTP HEAD request (slower, more reliable).
           default: false
         timeout:
           type: integer
+          x-wso2-policy-advanced-param: true
           description: |
             Timeout in milliseconds for DNS lookup or HTTP HEAD request.
             Default is 3000ms (3 seconds).
           default: 3000
         showAssessment:
           type: boolean
+          x-wso2-policy-advanced-param: true
           description: |
             If true, includes detailed assessment information including invalid URLs in error responses.
             If false, returns minimal error information.
           default: false
+  anyOf:
+    - required: [ request ]
+    - required: [ response ]
 
 systemParameters:
   type: object

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -26,7 +26,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean
@@ -60,7 +60,7 @@ parameters:
           description: |
             JSONPath expression to extract a specific value from JSON payload.
             If empty, validates the entire payload as a string.
-            Examples: "$.message", "$.data.content", "$.items[0].text"
+            Examples: "$.messages", "$.data.content", "$.items[0].text"
           default: ""
         invert:
           type: boolean


### PR DESCRIPTION
## Summary
- Applied policy parameter standardization and metadata updates across auth, rate limit, headers, guardrail, and AI policy sets.
- Added/updated defaults, advanced parameter annotations, naming consistency, and version/doc updates (including v0.3 docs where relevant).
- Added extensive unit test coverage for policies that were missing or needed stronger regression coverage.

## Key Changes
- Updated policy definitions and docs for:
  - `api-key-auth`, `jwt-auth`, `cors`, `basic-ratelimit`, `set-headers`, `remove-headers`
  - `semantic-prompt-guard`, `semantic-cache`, `prompt-template`, `prompt-decorator`
  - `pii-masking-regex`, `model-round-robin`, `model-weighted-round-robin`
  - `azure-content-safety-content-moderation`, `token-based-ratelimit`, `regex-guardrail`, `url-guardrail`
- Parameter/modeling improvements include:
  - renamed/structured user params (e.g. nested request/response/header shapes)
  - advanced param annotations (`x-wso2-policy-advanced-param`) alignment from validation sheet
  - required `anyOf` behavior where request/response at least one is required
  - refined defaults for system/user params and policy version bumps to `v0.3.0` where requested
- Docs updates include metadata consistency and v0.3 doc sections aligned with updated definitions/logic.

## Tests
Added comprehensive unit tests for:
- `prompt-template`
- `prompt-decorator`
- `regex-guardrail`
- `azure-content-safety-content-moderation`
- `model-round-robin`
- `model-weighted-round-robin`
- `pii-masking-regex`
- `api-key-auth`
- `cors`
- `semantic-prompt-guard`
- `semantic-cache`

Validated with targeted `go test ./...` and `go test -race ./...` runs on updated policy modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in PII detectors (Email, Phone, SSN); Prompt Decorator supports text or messages; Prompt Template supports multiple templates; Semantic Cache and Token-Based Ratelimit policies added; Model Round-Robin providers introduced.

* **Improvements**
  * Azure Content Safety moved to severity-thresholds; many policies annotated with advanced-parameter metadata; JSONPath examples standardized to use $.messages.

* **Documentation**
  * New docs and metadata for multiple policies (PII masking, prompt decorator/template, semantic cache, token ratelimit, model round-robin).

* **Tests**
  * Extensive new unit test suites across many policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->