### PR TITLE
Fix advanced ratelimit decompression and consume limit in the response phase when concume > remaining

### DIFF
--- a/policies/advanced-ratelimit/algorithms/fixedwindow/fixedwindow.lua
+++ b/policies/advanced-ratelimit/algorithms/fixedwindow/fixedwindow.lua
@@ -1,0 +1,58 @@
+-- Fixed Window clamp script
+-- KEYS[1]: rate limit key
+-- ARGV[1]: limit
+-- ARGV[2]: requested cost
+-- ARGV[3]: ttl_millis
+-- ARGV[4]: clamp (1 = clamp consumption, 0 = consume only if fully allowed)
+
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local requested = tonumber(ARGV[2]) or 0
+local ttl_millis = tonumber(ARGV[3])
+local clamp = tonumber(ARGV[4]) == 1
+
+if requested < 0 then
+    requested = 0
+end
+
+local current = redis.call('GET', key)
+if current == false then
+    current = 0
+else
+    current = tonumber(current)
+end
+
+local remaining_before = limit - current
+if remaining_before < 0 then
+    remaining_before = 0
+end
+
+local consumed = 0
+local allowed = 0
+
+if requested <= remaining_before then
+    consumed = requested
+    allowed = 1
+elseif clamp then
+    consumed = remaining_before
+    allowed = 0
+end
+
+if consumed > 0 then
+    if current == 0 then
+        redis.call('SET', key, current + consumed, 'PX', ttl_millis)
+    else
+        redis.call('INCRBY', key, consumed)
+    end
+end
+
+local new_count = current + consumed
+local remaining = limit - new_count
+if remaining < 0 then
+    remaining = 0
+end
+
+local overflow = requested - consumed
+
+-- Return: {allowed, remaining, new_count, consumed, overflow}
+return {allowed, remaining, new_count, consumed, overflow}

--- a/policies/advanced-ratelimit/algorithms/gcra/gcra.lua
+++ b/policies/advanced-ratelimit/algorithms/gcra/gcra.lua
@@ -5,7 +5,8 @@
 -- ARGV[3]: burst_allowance (nanoseconds)
 -- ARGV[4]: burst_capacity
 -- ARGV[5]: expiration (seconds)
--- ARGV[6]: count (number of requests) - NEW!
+-- ARGV[6]: count (number of requests)
+-- ARGV[7]: clamp mode (1 = consume remaining on overflow, 0 = deny without consumption)
 
 local key = KEYS[1]
 local now = tonumber(ARGV[1])
@@ -13,7 +14,8 @@ local emission_interval = tonumber(ARGV[2])
 local burst_allowance = tonumber(ARGV[3])
 local burst_capacity = tonumber(ARGV[4])
 local expiration = tonumber(ARGV[5])
-local count = tonumber(ARGV[6]) or 1  -- NEW: default to 1 if not provided
+local count = tonumber(ARGV[6]) or 1
+local clamp = tonumber(ARGV[7]) == 1
 
 -- Get current TAT (Theoretical Arrival Time)
 local tat = redis.call('GET', key)
@@ -37,6 +39,7 @@ local allow_at = tat - burst_allowance
 local allowed = 0
 local new_tat = tat
 local retry_after_nanos = 0
+local consumed = 0
 
 -- Calculate remaining capacity BEFORE consuming
 local remaining = burst_capacity
@@ -48,13 +51,25 @@ if used_burst > 0 and used_burst <= burst_allowance then
     end
 end
 
-if now >= allow_at and count <= remaining then
-    -- Request allowed (time check AND capacity check)
-    allowed = 1
-    new_tat = tat + (emission_interval * count)  -- MODIFIED: multiply by count
+if now >= allow_at then
+    consumed = count
+    if consumed > remaining then
+        if clamp then
+            consumed = remaining
+        else
+            consumed = 0
+        end
+    end
+
+    if consumed == count then
+        -- Request fully allowed
+        allowed = 1
+    end
+
+    new_tat = tat + (emission_interval * consumed)
 
     -- Update TAT in Redis with expiration (skip for peek operations where count=0)
-    if count > 0 then
+    if consumed > 0 then
         redis.call('SET', key, new_tat, 'EX', expiration)
     end
 
@@ -73,12 +88,19 @@ if now >= allow_at and count <= remaining then
         end
     end
 else
-    -- Request denied
-    retry_after_nanos = allow_at - now
+    -- Request denied by timing
+    consumed = 0
+end
+
+if allowed == 0 then
+    local next_allow_at = new_tat - burst_allowance
+    retry_after_nanos = next_allow_at - now
     if retry_after_nanos < 0 then
         retry_after_nanos = 0
     end
 end
+
+local overflow = count - consumed
 
 -- Calculate full quota available time
 -- Full quota is available when TAT <= now (all tokens regenerated)
@@ -87,5 +109,5 @@ if new_tat < now then
     full_quota_at_nanos = now
 end
 
--- Return: {allowed, remaining, reset_nanos, retry_after_nanos, full_quota_at_nanos}
-return {allowed, remaining, new_tat, retry_after_nanos, full_quota_at_nanos}
+-- Return: {allowed, remaining, reset_nanos, retry_after_nanos, full_quota_at_nanos, consumed, overflow}
+return {allowed, remaining, new_tat, retry_after_nanos, full_quota_at_nanos, consumed, overflow}

--- a/policies/advanced-ratelimit/cost_extractor_test.go
+++ b/policies/advanced-ratelimit/cost_extractor_test.go
@@ -1,0 +1,90 @@
+package ratelimit
+
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+)
+
+func TestCostExtractor_ExtractResponseCost_GzipEncodedBody(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.prompt_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	body := gzipBytes(t, []byte(`{"usage":{"prompt_tokens":42}}`))
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-encoding": {"gzip"},
+			"content-type":     {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: body,
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from gzip response body to succeed")
+	}
+	if cost != 42 {
+		t.Fatalf("expected extracted cost to be 42, got %v", cost)
+	}
+}
+
+func TestCostExtractor_ExtractResponseCost_InvalidGzipBodyFallsBackToDefault(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 7,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.prompt_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-encoding": {"gzip"},
+			"content-type":     {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"usage":{"prompt_tokens":42}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if extracted {
+		t.Fatal("expected extraction to fail for invalid gzip payload")
+	}
+	if cost != 7 {
+		t.Fatalf("expected default cost 7, got %v", cost)
+	}
+}
+
+func gzipBytes(t *testing.T, input []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(input); err != nil {
+		t.Fatalf("failed to gzip test input: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/policies/advanced-ratelimit/limiter/interface.go
+++ b/policies/advanced-ratelimit/limiter/interface.go
@@ -31,6 +31,11 @@ type Limiter interface {
 	// AllowN checks if N requests are allowed for the given key
 	AllowN(ctx context.Context, key string, n int64) (*Result, error)
 
+	// ConsumeOrClampN consumes up to N tokens atomically.
+	// If N exceeds available capacity, it consumes the available remainder (clamps to zero)
+	// and returns a denied result with overflow details in Result.
+	ConsumeOrClampN(ctx context.Context, key string, n int64) (*Result, error)
+
 	// GetAvailable returns the available tokens for the given key without consuming
 	// This is useful for checking remaining capacity before making a request
 	GetAvailable(ctx context.Context, key string) (int64, error)

--- a/policies/advanced-ratelimit/limiter/result.go
+++ b/policies/advanced-ratelimit/limiter/result.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package limiter
 
 import (
@@ -28,6 +28,17 @@ import (
 type Result struct {
 	// Allowed indicates whether the request is allowed
 	Allowed bool
+
+	// Requested is the number of tokens/requests requested for this operation.
+	Requested int64
+
+	// Consumed is the number of tokens/requests actually consumed.
+	// For normal allow operations this matches Requested when allowed.
+	// For clamp operations this may be lower than Requested.
+	Consumed int64
+
+	// Overflow is the amount that exceeded available quota.
+	Overflow int64
 
 	// Limit is the maximum number of requests allowed in the time window
 	Limit int64

--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v0.2.0
+version: v0.8.0
 description: |
   Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas,
   weighted rate limiting, flexible key extraction, and both in-memory and Redis backends. Supports


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clamping mode for rate limiting: requests can now consume available tokens up to quota limits instead of simple allow/deny decisions.
  * Enhanced cost extraction with support for gzip and deflate compressed response payloads.
  * Extended rate limit results with detailed accounting: requested tokens, consumed tokens, and overflow amounts.

* **Chores**
  * Version bumped from v0.2.0 to v0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->