### PR TITLE
Fix/llm cost calculator

### DIFF
--- a/policies/llm-cost/calculator_openai.go
+++ b/policies/llm-cost/calculator_openai.go
@@ -18,7 +18,7 @@ package llmcost
 
 import "encoding/json"
 
-// OpenAICalculator handles models with provider "openai" and "text-completion-openai".
+// OpenAICalculator handles models with provider "openai".
 type OpenAICalculator struct{}
 
 func (c *OpenAICalculator) Normalize(responseBody []byte, requestBody []byte) (Usage, error) {

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -130,6 +130,10 @@ func (p *LLMCostPolicy) OnResponse(ctx *policy.ResponseContext, _ map[string]int
 
 	// Select provider calculator.
 	calc := selectCalculator(pricing.Provider)
+	if calc == nil {
+		slog.Warn("llm-cost: unsupported provider, skipping cost calculation", "provider", pricing.Provider, "model", modelName)
+		return setCostMetadata(ctx, 0.0, costStatusNotCalculated)
+	}
 
 	// Get buffered request body (may be nil for providers that don't need it).
 	var requestBody []byte

--- a/policies/llm-cost/pricing.go
+++ b/policies/llm-cost/pricing.go
@@ -248,9 +248,12 @@ type providerCalculator interface {
 	Adjust(baseCost float64, usage Usage, pricing ModelPricing) float64
 }
 
-// selectCalculator returns the appropriate calculator for a given provider value.
+// selectCalculator returns the appropriate calculator for a given provider value,
+// or nil if the provider is not supported.
 func selectCalculator(provider string) providerCalculator {
 	switch provider {
+	case "openai":
+		return &OpenAICalculator{}
 	case "anthropic":
 		return &AnthropicCalculator{}
 	case "gemini",
@@ -263,8 +266,8 @@ func selectCalculator(provider string) providerCalculator {
 		return &GeminiCalculator{}
 	case "mistral":
 		return &MistralCalculator{}
-	default: // "openai", "text-completion-openai"
-		return &OpenAICalculator{}
+	default:
+		return nil
 	}
 }
 

--- a/policies/llm-cost/testdata/model_prices.json
+++ b/policies/llm-cost/testdata/model_prices.json
@@ -2032,7 +2032,7 @@
     "max_output_tokens": 4096,
     "max_tokens": 4096,
     "output_cost_per_token": 4e-07,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "chat-bison": {
     "input_cost_per_character": 2.5e-07,
@@ -2596,7 +2596,7 @@
     "max_output_tokens": 4096,
     "max_tokens": 4096,
     "output_cost_per_token": 2e-06,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "deep-research-pro-preview-12-2025": {
     "input_cost_per_image": 0.0011,
@@ -2619,7 +2619,7 @@
     "max_tokens": 4096,
     "output_cost_per_token": 1.6e-06,
     "output_cost_per_token_batches": 2e-07,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "ft:davinci-002": {
     "input_cost_per_token": 1.2e-05,
@@ -2629,7 +2629,7 @@
     "max_tokens": 4096,
     "output_cost_per_token": 1.2e-05,
     "output_cost_per_token_batches": 1e-06,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "ft:gpt-3.5-turbo": {
     "input_cost_per_token": 3e-06,
@@ -4518,7 +4518,7 @@
     "max_output_tokens": 4096,
     "max_tokens": 4096,
     "output_cost_per_token": 2e-06,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "gpt-3.5-turbo-instruct-0914": {
     "input_cost_per_token": 1.5e-06,
@@ -4526,7 +4526,7 @@
     "max_output_tokens": 4097,
     "max_tokens": 4097,
     "output_cost_per_token": 2e-06,
-    "provider": "text-completion-openai"
+    "provider": "openai"
   },
   "gpt-4": {
     "input_cost_per_token": 3e-05,


### PR DESCRIPTION
## Purpose                                                                                                                                                         
The `selectCalculator` function implicitly defaulted to `OpenAICalculator` for any unrecognized provider, meaning unknown providers would silently produce incorrect cost calculations instead of being flagged. Additionally, the pricing data used the  `"text-completion-openai"` for legacy OpenAI text completion models, which was an unnecessary distinction since both use the same calculator and response format.                                                    
                                                                                                                                                                     
  ## Goals        
  - Consolidate `"text-completion-openai"` into `"openai"` in the pricing data so there is a single, consistent provider name for all OpenAI models.
  - Make `"openai"` an explicit case in `selectCalculator` and return `nil` for unknown providers, causing cost calculation to be skipped with a warning log rather than silently falling back to the wrong calculator.                                                                                                                
                                                                                                                                                                     
  ## Approach                                                                                                                                                        
  - Replaced all occurrences of `"text-completion-openai"` with `"openai"` in `testdata/model_prices.json`.
  - Refactored `selectCalculator` in `pricing.go` to include `"openai"` as an explicit case and return `nil` from the `default` branch.                              
  - Added a `nil` guard in `llm_cost.go` that logs a warning and returns `costStatusNotCalculated` when the provider is unsupported.
                                                                                                                                                                     
  ## User stories 
  As an API gateway operator, I want cost calculation to fail explicitly for unknown providers rather than silently produce incorrect results using the wrong calculator.                                                                                                                                                        
   
  ## Release note                                                                                                                                                    
  Fixed an implicit fallback to the OpenAI cost calculator for unrecognized LLM providers. Unknown providers now skip cost calculation and emit a warning log. The`"text-completion-openai"` provider name in pricing data has been normalized to `"openai"`.                                                                        
   
  ## Documentation                                                                                                                                                   
  N/A — internal cost calculation behaviour, no user-facing documentation impact.

  ## Training
  N/A

  ## Certification
  N/A — no impact on certification exams.
                                                                                                                                                                     
  ## Marketing
  N/A                                                                                                                                                                
                  
  ## Automation tests
  - Unit tests
    > All existing unit tests pass. The `selectCalculator` logic is exercised through the existing pricing and cost calculation test suite in `llm_cost_test.go`.
  - Integration tests                                                                                                                                                
    > N/A — no integration test changes required for this fix.
                                                                                                                                                                     
  ## Security checks
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
  - Ran FindSecurityBugs plugin and verified report? N/A (Go project)                                                                                                
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
                                                                                                                                                                     
  ## Samples      
  N/A
                                                                                                                                                                     
  ## Related PRs
  N/A                                                                                                                                                                
                  
  ## Migrations (if applicable)
  Users supplying a custom pricing JSON file should rename any `"text-completion-openai"` provider entries to `"openai"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported LLM providers by explicitly returning a "not_calculated" status instead of potentially applying incorrect cost calculations.

* **Chores**
  * Standardized LLM provider naming conventions in cost calculation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->