### PR TITLE
Refactor subscription-validation policy

### DIFF
--- a/docs/subscription-validation/v0.2/docs/subscription-validation.md
+++ b/docs/subscription-validation/v0.2/docs/subscription-validation.md
@@ -24,18 +24,16 @@ These parameters are configured per API or route by the API developer:
 
 | Parameter               | Type    | Required | Default            | Description |
 |-------------------------|---------|----------|--------------------|-------------|
-| `enabled`               | boolean | No       | `true`             | Enables or disables subscription validation for the route. When `false`, the policy acts as a no-op and always lets the request pass. |
 | `subscriptionKeyHeader` | string  | No       | `Subscription-Key` | Name of the HTTP request header that carries the subscription token. This is the primary source and is checked before cookie fallback. |
 | `subscriptionKeyCookie` | string  | No       | `""`               | Optional cookie name that can carry the subscription token. When non-empty, the cookie value is checked only if the header does not contain a token. |
 
 At runtime the policy behaves as follows:
 
-1. If `enabled` is `false`, the policy immediately allows the request without further checks.
-2. If `enabled` is `true`, it first attempts to read the subscription token from `subscriptionKeyHeader`.
-3. If no header token is present and `subscriptionKeyCookie` is non-empty, it attempts to read the token from the named cookie.
-4. If a token is found, it is validated against the subscription store for the target API.
-5. If a matching active subscription is not found, the request is rejected.
-6. When the matched subscription plan includes throttle limits, the policy enforces per-subscription rate limits and can block requests when the quota is exceeded.
+1. It first attempts to read the subscription token from `subscriptionKeyHeader`.
+2. If no header token is present and `subscriptionKeyCookie` is non-empty, it attempts to read the token from the named cookie.
+3. If a token is found, it is validated against the subscription store for the target API.
+4. If a matching active subscription is not found, the request is rejected.
+5. When the matched subscription plan includes throttle limits, the policy enforces per-subscription rate limits and can block requests when the quota is exceeded.
 
 ### System Parameters
 
@@ -97,7 +95,6 @@ spec:
     - name: subscription-validation
       version: v0
       params:
-        enabled: true
   operations:
     - method: GET
       path: /{country_code}/{city}

--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v0.2.0
+version: v0.3.0
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,
@@ -12,13 +12,6 @@ parameters:
   type: object
   additionalProperties: false
   properties:
-    enabled:
-      type: boolean
-      default: true
-      x-wso2-policy-advanced-param: false
-      description: >
-        When false, the subscription validation check is disabled and the
-        policy is effectively a no-op.
     subscriptionKeyHeader:
       type: string
       default: Subscription-Key

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,7 +27,6 @@ const (
 
 // PolicyConfig holds the resolved configuration for the subscriptionValidation policy.
 type PolicyConfig struct {
-	Enabled                bool
 	SubscriptionKeyHeader  string
 	SubscriptionKeyCookie  string
 }
@@ -52,7 +52,6 @@ var (
 	sharedRateLimitMu = &sync.Mutex{}
 	ins               = &SubscriptionValidationPolicy{
 		cfg: PolicyConfig{
-			Enabled:               true,
 			SubscriptionKeyHeader: defaultSubscriptionKeyHeader,
 			SubscriptionKeyCookie: defaultSubscriptionKeyCookie,
 		},
@@ -133,15 +132,6 @@ func mergeConfig(base PolicyConfig, params map[string]interface{}) PolicyConfig 
 		return cfg
 	}
 
-	if raw, ok := params["enabled"]; ok {
-		if b, ok := raw.(bool); ok {
-			cfg.Enabled = b
-		} else if s, ok := raw.(string); ok {
-			lower := strings.ToLower(strings.TrimSpace(s))
-			cfg.Enabled = lower == "true" || lower == "1" || lower == "yes"
-		}
-	}
-
 	if raw, ok := params["subscriptionKeyHeader"]; ok {
 		if s, ok := raw.(string); ok && strings.TrimSpace(s) != "" {
 			cfg.SubscriptionKeyHeader = strings.TrimSpace(s)
@@ -170,9 +160,6 @@ func (p *SubscriptionValidationPolicy) Mode() policy.ProcessingMode {
 // OnRequest validates the subscription (token-first, appId-fallback)
 // and enforces plan-based rate limiting when applicable.
 func (p *SubscriptionValidationPolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
-	if !p.cfg.Enabled {
-		return nil
-	}
 	if ctx == nil || ctx.SharedContext == nil {
 		return p.forbiddenResponse("request context is missing")
 	}
@@ -281,11 +268,17 @@ func (p *SubscriptionValidationPolicy) checkRateLimit(apiID, token string, entry
 	rl.count++
 	rl.lastSeen = now
 	exceeded := rl.count > entry.ThrottleLimitCount
+	resetAt := rl.windowStart.Add(window)
+	limit := entry.ThrottleLimitCount
+	remaining := limit - rl.count
+	if remaining < 0 {
+		remaining = 0
+	}
 	p.rateLimitMu.Unlock()
 
 	if exceeded {
 		if entry.StopOnQuotaReach {
-			return p.rateLimitResponse(entry.ThrottleLimitCount, entry.ThrottleLimitUnit)
+			return p.rateLimitResponse(limit, remaining, resetAt, window)
 		}
 		slog.Warn("subscriptionValidation: quota exceeded but stopOnQuotaReach is false, allowing",
 			"apiId", apiID)
@@ -341,21 +334,64 @@ func (p *SubscriptionValidationPolicy) forbiddenResponse(detail string) policy.R
 }
 
 // rateLimitResponse constructs a 429 Too Many Requests response.
-func (p *SubscriptionValidationPolicy) rateLimitResponse(limit int, unit string) policy.RequestAction {
+func (p *SubscriptionValidationPolicy) rateLimitResponse(limit, remaining int, resetAt time.Time, window time.Duration) policy.RequestAction {
 	payload := map[string]interface{}{
 		"error":   "rate_limit_exceeded",
-		"message": fmt.Sprintf("Subscription quota exceeded: %d requests per %s", limit, unit),
+		"message": fmt.Sprintf("Subscription quota exceeded: %d requests per %s", limit, entryThrottleUnitString(window)),
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		body = []byte(`{"error":"rate_limit_exceeded","message":"subscription quota exceeded"}`)
 	}
 
+	resetUnix := resetAt.Unix()
+	resetSeconds := int64(time.Until(resetAt).Seconds())
+	if resetSeconds < 0 {
+		resetSeconds = 0
+	}
+	retryAfterSeconds := resetSeconds
+	if retryAfterSeconds < 1 {
+		retryAfterSeconds = 1
+	}
+	windowSeconds := int64(window.Seconds())
+	if windowSeconds < 1 {
+		windowSeconds = 1
+	}
+	policyValue := fmt.Sprintf("%d;w=%d", limit, windowSeconds)
+
 	return policy.ImmediateResponse{
 		StatusCode: 429,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
+			// X-RateLimit-* (de facto standard)
+			"X-RateLimit-Limit":            strconv.Itoa(limit),
+			"X-RateLimit-Remaining":       strconv.Itoa(remaining),
+			"X-RateLimit-Reset":           strconv.FormatInt(resetUnix, 10),
+			"X-RateLimit-Full-Quota-Reset": strconv.FormatInt(resetUnix, 10),
+			// RateLimit-* (IETF draft)
+			"RateLimit-Limit":              strconv.Itoa(limit),
+			"RateLimit-Remaining":         strconv.Itoa(remaining),
+			"RateLimit-Reset":             strconv.FormatInt(resetSeconds, 10),
+			"RateLimit-Full-Quota-Reset":  strconv.FormatInt(resetSeconds, 10),
+			"RateLimit-Policy":            policyValue,
+			// RFC 7231
+			"Retry-After": strconv.FormatInt(retryAfterSeconds, 10),
 		},
 		Body: body,
+	}
+}
+
+// entryThrottleUnitString returns a human-friendly unit string for the throttling window.
+// We avoid exposing the exact unit parsing logic externally.
+func entryThrottleUnitString(window time.Duration) string {
+	switch window {
+	case time.Minute:
+		return "Min"
+	case time.Hour:
+		return "Hour"
+	case 24 * time.Hour:
+		return "Day"
+	default:
+		return window.String()
 	}
 }

--- a/policies/subscription-validation/subscriptionvalidation_test.go
+++ b/policies/subscription-validation/subscriptionvalidation_test.go
@@ -2,6 +2,7 @@ package subscriptionvalidation
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
@@ -27,7 +28,6 @@ func newPolicy(cfg PolicyConfig, store *policyenginev1.SubscriptionStore) *Subsc
 
 func defaultCfg() PolicyConfig {
 	return PolicyConfig{
-		Enabled:               true,
 		SubscriptionKeyHeader: defaultSubscriptionKeyHeader,
 		SubscriptionKeyCookie: defaultSubscriptionKeyCookie,
 	}
@@ -85,13 +85,73 @@ func assertImmediate(t *testing.T, action policy.RequestAction, wantStatus int, 
 	}
 }
 
+func assertRateLimitHeaders(t *testing.T, resp policy.ImmediateResponse, wantLimit, wantRemaining int) {
+	t.Helper()
+	if resp.Headers == nil {
+		t.Fatalf("expected headers to be set")
+	}
+	assertIntHeader := func(key string, want int) {
+		gotRaw, ok := resp.Headers[key]
+		if !ok {
+			t.Fatalf("missing rate-limit header %q", key)
+		}
+		got, err := strconv.Atoi(gotRaw)
+		if err != nil {
+			t.Fatalf("rate-limit header %q value %q is not an int: %v", key, gotRaw, err)
+		}
+		if got != want {
+			t.Fatalf("rate-limit header %q expected %d, got %d", key, want, got)
+		}
+	}
+
+	if ct, ok := resp.Headers["Content-Type"]; !ok || ct != "application/json" {
+		t.Fatalf("expected Content-Type=application/json, got %q (ok=%v)", ct, ok)
+	}
+
+	assertIntHeader("X-RateLimit-Limit", wantLimit)
+	assertIntHeader("X-RateLimit-Remaining", wantRemaining)
+	assertIntHeader("RateLimit-Limit", wantLimit)
+	assertIntHeader("RateLimit-Remaining", wantRemaining)
+
+	// Reset-related headers can be time-sensitive; assert they are present and parse.
+	parseInt64Header := func(key string) int64 {
+		gotRaw, ok := resp.Headers[key]
+		if !ok {
+			t.Fatalf("missing rate-limit header %q", key)
+		}
+		got, err := strconv.ParseInt(gotRaw, 10, 64)
+		if err != nil {
+			t.Fatalf("rate-limit header %q value %q is not an int64: %v", key, gotRaw, err)
+		}
+		return got
+	}
+
+	xResetUnix := parseInt64Header("X-RateLimit-Reset")
+	if xResetUnix < 0 {
+		t.Fatalf("expected X-RateLimit-Reset >= 0, got %d", xResetUnix)
+	}
+	_ = parseInt64Header("X-RateLimit-Full-Quota-Reset")
+
+	rResetSeconds := parseInt64Header("RateLimit-Reset")
+	if rResetSeconds < 0 {
+		t.Fatalf("expected RateLimit-Reset >= 0, got %d", rResetSeconds)
+	}
+	_ = parseInt64Header("RateLimit-Full-Quota-Reset")
+
+	if policyValue, ok := resp.Headers["RateLimit-Policy"]; !ok || policyValue == "" {
+		t.Fatalf("missing/empty rate-limit header %q", "RateLimit-Policy")
+	}
+
+	retryAfter := parseInt64Header("Retry-After")
+	if retryAfter < 1 {
+		t.Fatalf("expected Retry-After >= 1, got %d", retryAfter)
+	}
+}
+
 // --- mergeConfig tests -------------------------------------------------------
 
 func TestMergeConfig_Defaults(t *testing.T) {
 	cfg := mergeConfig(defaultCfg(), nil)
-	if !cfg.Enabled {
-		t.Fatal("expected Enabled=true by default")
-	}
 	if cfg.SubscriptionKeyHeader != defaultSubscriptionKeyHeader {
 		t.Fatalf("expected default header=%q, got %q", defaultSubscriptionKeyHeader, cfg.SubscriptionKeyHeader)
 	}
@@ -99,29 +159,15 @@ func TestMergeConfig_Defaults(t *testing.T) {
 
 func TestMergeConfig_Overrides(t *testing.T) {
 	cfg := mergeConfig(defaultCfg(), map[string]interface{}{
-		"enabled":               false,
 		"subscriptionKeyHeader": "X-My-Key",
 		"subscriptionKeyCookie": "sub-key",
 	})
-	if cfg.Enabled {
-		t.Fatal("expected Enabled=false after override")
-	}
 	if cfg.SubscriptionKeyHeader != "X-My-Key" {
 		t.Fatalf("expected header=X-My-Key, got %q", cfg.SubscriptionKeyHeader)
 	}
 	if cfg.SubscriptionKeyCookie != "sub-key" {
 		t.Fatalf("expected cookie=sub-key, got %q", cfg.SubscriptionKeyCookie)
 	}
-}
-
-// --- disabled ----------------------------------------------------------------
-
-func TestOnRequest_SkipsWhenDisabled(t *testing.T) {
-	cfg := defaultCfg()
-	cfg.Enabled = false
-	p := newPolicy(cfg, nil)
-	ctx := ctxWithToken("api-1", "tok-1", "")
-	assertNil(t, p.OnRequest(ctx, nil))
 }
 
 // --- token path (primary) ----------------------------------------------------
@@ -331,7 +377,22 @@ func TestOnRequest_RateLimitEnforced(t *testing.T) {
 	}
 
 	ctx := ctxWithToken("api-1", "tok-1", "")
-	assertImmediate(t, p.OnRequest(ctx, nil), 429, "rate_limit_exceeded")
+	action := p.OnRequest(ctx, nil)
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if resp.StatusCode != 429 {
+		t.Fatalf("expected status 429, got %d", resp.StatusCode)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if body["error"] != "rate_limit_exceeded" {
+		t.Fatalf("expected error=%q, got %q", "rate_limit_exceeded", body["error"])
+	}
+	assertRateLimitHeaders(t, resp, 3, 0)
 }
 
 func TestOnRequest_RateLimitNotEnforcedWhenStopOnQuotaFalse(t *testing.T) {


### PR DESCRIPTION
## Purpose
Refactor subscription-validation policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed the `enabled` parameter from the subscription-validation policy; the policy is now always active.

* **Improvements**
  * Enhanced rate-limit responses with richer HTTP headers including `Retry-After`, `X-RateLimit-*`, and `RateLimit-*` headers with precise reset timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->