### PR TITLE
Update policy versions to v0.9.0 and refactor policies to utilize v1alpha2 interfaces

### DIFF
--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v0.3.2
+version: v0.9.0
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.

--- a/policies/analytics-header-filter/analyticsheaderfilter_test.go
+++ b/policies/analytics-header-filter/analyticsheaderfilter_test.go
@@ -21,19 +21,19 @@ package analyticsheaderfilter
 import (
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestGetPolicy(t *testing.T) {
-	p, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, nil)
 	if err != nil {
-		t.Errorf("GetPolicy returned error: %v", err)
+		t.Errorf("GetPolicyV2 returned error: %v", err)
 	}
 	if p == nil {
-		t.Error("GetPolicy returned nil policy")
+		t.Error("GetPolicyV2 returned nil policy")
 	}
 	if _, ok := p.(*AnalyticsHeaderFilterPolicy); !ok {
-		t.Error("GetPolicy returned wrong policy type")
+		t.Error("GetPolicyV2 returned wrong policy type")
 	}
 }
 
@@ -41,16 +41,16 @@ func TestMode(t *testing.T) {
 	p := &AnalyticsHeaderFilterPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeProcess {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeProcess {
 		t.Errorf("Expected RequestHeaderMode to be HeaderModeProcess, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeSkip {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Errorf("Expected RequestBodyMode to be BodyModeSkip, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeProcess {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeProcess {
 		t.Errorf("Expected ResponseHeaderMode to be HeaderModeProcess, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeSkip {
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Errorf("Expected ResponseBodyMode to be BodyModeSkip, got %v", mode.ResponseBodyMode)
 	}
 }
@@ -316,13 +316,13 @@ func TestParseHeaderFilterConfig(t *testing.T) {
 	}
 }
 
-func TestOnRequest(t *testing.T) {
+func TestOnRequestHeaders(t *testing.T) {
 	p := &AnalyticsHeaderFilterPolicy{}
 
 	tests := []struct {
 		name                    string
 		params                  map[string]interface{}
-		expectedDropAction      *policy.DropHeaderAction
+		expectedDropAction      *policyv1alpha2.DropHeaderAction
 		expectDropActionPresent bool
 	}{
 		{
@@ -347,7 +347,7 @@ func TestOnRequest(t *testing.T) {
 					"headers": []interface{}{"Authorization", "Content-Type"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "allow",
 				Headers: []string{"authorization", "content-type"},
 			},
@@ -361,7 +361,7 @@ func TestOnRequest(t *testing.T) {
 					"headers": []interface{}{"X-Debug", "X-Internal"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "deny",
 				Headers: []string{"x-debug", "x-internal"},
 			},
@@ -390,7 +390,7 @@ func TestOnRequest(t *testing.T) {
 					"headers": []interface{}{"X-Debug"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "allow",
 				Headers: []string{"authorization"},
 			},
@@ -400,42 +400,42 @@ func TestOnRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := createMockRequestContext(nil)
-			result := p.OnRequest(ctx, tt.params)
+			ctx := createMockRequestHeaderContext(nil)
+			result := p.OnRequestHeaders(ctx, tt.params)
 
-			if modifications, ok := result.(policy.UpstreamRequestModifications); ok {
+			if modifications, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications); ok {
 				if tt.expectDropActionPresent {
-					if modifications.DropHeadersFromAnalytics.Action != tt.expectedDropAction.Action {
-						t.Errorf("Expected action %s, got %s", tt.expectedDropAction.Action, modifications.DropHeadersFromAnalytics.Action)
+					if modifications.AnalyticsHeaderFilter.Action != tt.expectedDropAction.Action {
+						t.Errorf("Expected action %s, got %s", tt.expectedDropAction.Action, modifications.AnalyticsHeaderFilter.Action)
 					}
-					if len(modifications.DropHeadersFromAnalytics.Headers) != len(tt.expectedDropAction.Headers) {
-						t.Errorf("Expected %d headers, got %d", len(tt.expectedDropAction.Headers), len(modifications.DropHeadersFromAnalytics.Headers))
+					if len(modifications.AnalyticsHeaderFilter.Headers) != len(tt.expectedDropAction.Headers) {
+						t.Errorf("Expected %d headers, got %d", len(tt.expectedDropAction.Headers), len(modifications.AnalyticsHeaderFilter.Headers))
 						return
 					}
 					for i, expected := range tt.expectedDropAction.Headers {
-						if modifications.DropHeadersFromAnalytics.Headers[i] != expected {
-							t.Errorf("Expected header[%d] to be %s, got %s", i, expected, modifications.DropHeadersFromAnalytics.Headers[i])
+						if modifications.AnalyticsHeaderFilter.Headers[i] != expected {
+							t.Errorf("Expected header[%d] to be %s, got %s", i, expected, modifications.AnalyticsHeaderFilter.Headers[i])
 						}
 					}
 				} else {
-					if modifications.DropHeadersFromAnalytics.Action != "" || len(modifications.DropHeadersFromAnalytics.Headers) > 0 {
+					if modifications.AnalyticsHeaderFilter.Action != "" || len(modifications.AnalyticsHeaderFilter.Headers) > 0 {
 						t.Error("Expected no drop action but got one")
 					}
 				}
 			} else {
-				t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+				t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 			}
 		})
 	}
 }
 
-func TestOnResponse(t *testing.T) {
+func TestOnResponseHeaders(t *testing.T) {
 	p := &AnalyticsHeaderFilterPolicy{}
 
 	tests := []struct {
 		name                    string
 		params                  map[string]interface{}
-		expectedDropAction      *policy.DropHeaderAction
+		expectedDropAction      *policyv1alpha2.DropHeaderAction
 		expectDropActionPresent bool
 	}{
 		{
@@ -460,7 +460,7 @@ func TestOnResponse(t *testing.T) {
 					"headers": []interface{}{"Content-Type", "X-Custom"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "allow",
 				Headers: []string{"content-type", "x-custom"},
 			},
@@ -474,7 +474,7 @@ func TestOnResponse(t *testing.T) {
 					"headers": []interface{}{"X-Debug", "X-Internal"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "deny",
 				Headers: []string{"x-debug", "x-internal"},
 			},
@@ -503,7 +503,7 @@ func TestOnResponse(t *testing.T) {
 					"headers": []interface{}{"X-Debug"},
 				},
 			},
-			expectedDropAction: &policy.DropHeaderAction{
+			expectedDropAction: &policyv1alpha2.DropHeaderAction{
 				Action:  "deny",
 				Headers: []string{"x-debug"},
 			},
@@ -513,59 +513,53 @@ func TestOnResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := createMockResponseContext(nil, nil)
-			result := p.OnResponse(ctx, tt.params)
+			ctx := createMockResponseHeaderContext(nil)
+			result := p.OnResponseHeaders(ctx, tt.params)
 
-			if modifications, ok := result.(policy.UpstreamResponseModifications); ok {
+			if modifications, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications); ok {
 				if tt.expectDropActionPresent {
-					if modifications.DropHeadersFromAnalytics.Action != tt.expectedDropAction.Action {
-						t.Errorf("Expected action %s, got %s", tt.expectedDropAction.Action, modifications.DropHeadersFromAnalytics.Action)
+					if modifications.AnalyticsHeaderFilter.Action != tt.expectedDropAction.Action {
+						t.Errorf("Expected action %s, got %s", tt.expectedDropAction.Action, modifications.AnalyticsHeaderFilter.Action)
 					}
-					if len(modifications.DropHeadersFromAnalytics.Headers) != len(tt.expectedDropAction.Headers) {
-						t.Errorf("Expected %d headers, got %d", len(tt.expectedDropAction.Headers), len(modifications.DropHeadersFromAnalytics.Headers))
+					if len(modifications.AnalyticsHeaderFilter.Headers) != len(tt.expectedDropAction.Headers) {
+						t.Errorf("Expected %d headers, got %d", len(tt.expectedDropAction.Headers), len(modifications.AnalyticsHeaderFilter.Headers))
 						return
 					}
 					for i, expected := range tt.expectedDropAction.Headers {
-						if modifications.DropHeadersFromAnalytics.Headers[i] != expected {
-							t.Errorf("Expected header[%d] to be %s, got %s", i, expected, modifications.DropHeadersFromAnalytics.Headers[i])
+						if modifications.AnalyticsHeaderFilter.Headers[i] != expected {
+							t.Errorf("Expected header[%d] to be %s, got %s", i, expected, modifications.AnalyticsHeaderFilter.Headers[i])
 						}
 					}
 				} else {
-					if modifications.DropHeadersFromAnalytics.Action != "" || len(modifications.DropHeadersFromAnalytics.Headers) > 0 {
+					if modifications.AnalyticsHeaderFilter.Action != "" || len(modifications.AnalyticsHeaderFilter.Headers) > 0 {
 						t.Error("Expected no drop action but got one")
 					}
 				}
 			} else {
-				t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+				t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 			}
 		})
 	}
 }
 
-// Helper functions for creating mock contexts
-func createMockRequestContext(headers map[string][]string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func createMockRequestHeaderContext(headers map[string][]string) *policyv1alpha2.RequestHeaderContext {
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  make(map[string]any),
 		},
-		Headers: policy.NewHeaders(headers),
-		Body:    nil,
+		Headers: policyv1alpha2.NewHeaders(headers),
 		Path:    "/api/test",
 		Method:  "GET",
-		Scheme:  "http",
 	}
 }
 
-func createMockResponseContext(requestHeaders, responseHeaders map[string][]string) *policy.ResponseContext {
-	return &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+func createMockResponseHeaderContext(responseHeaders map[string][]string) *policyv1alpha2.ResponseHeaderContext {
+	return &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  make(map[string]any),
 		},
-		RequestHeaders:  policy.NewHeaders(requestHeaders),
-		ResponseHeaders: policy.NewHeaders(responseHeaders),
-		RequestBody:     nil,
-		ResponseBody:    nil,
+		ResponseHeaders: policyv1alpha2.NewHeaders(responseHeaders),
 	}
 }

--- a/policies/analytics-header-filter/policy-definition.yaml
+++ b/policies/analytics-header-filter/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: analytics-header-filter
-version: v0.2.1
+version: v0.9.0
 description: |
   Filters request and response headers from analytics data using configurable allow or deny lists.
 

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -349,12 +349,7 @@ func (p *APIKeyPolicy) authenticate(
 			"missing or invalid 'in' configuration")
 	}
 
-	issuer, ok := params["issuer"].(string)
-	if !ok || issuer == "" {
-		slog.Debug("API Key Auth Policy: Missing or invalid 'issuer' configuration")
-		return p.failAuthV2(shared, 401, "json", "Valid API key required",
-			"missing or invalid 'issuer' configuration")
-	}
+	issuer, _ := params["issuer"].(string)
 
 	slog.Debug("API Key Auth Policy: Configuration loaded", "keyName", keyName, "location", location)
 

--- a/policies/api-key-auth/apikey_test.go
+++ b/policies/api-key-auth/apikey_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	apikeycommon "github.com/wso2/api-platform/common/apikey"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
@@ -13,11 +14,11 @@ import (
 func TestAPIKeyPolicy_Mode(t *testing.T) {
 	p := &APIKeyPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if got != want {
@@ -26,29 +27,29 @@ func TestAPIKeyPolicy_Mode(t *testing.T) {
 }
 
 func TestGetPolicy_ReturnsSingleton(t *testing.T) {
-	p1, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	p1, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
-	p2, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	p2, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 	if p1 != p2 {
 		t.Fatalf("expected singleton policy instance")
 	}
 }
 
-func TestAPIKeyPolicy_OnRequest_SuccessFromHeader(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_SuccessFromHeader(t *testing.T) {
 	resetAPIKeyStore(t)
 	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
 
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
 		http.CanonicalHeaderKey("x-api-key"): {"header-secret"},
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x-api-key",
 		"in":  "header",
 	})
@@ -59,19 +60,19 @@ func TestAPIKeyPolicy_OnRequest_SuccessFromHeader(t *testing.T) {
 	if ctx.SharedContext.AuthContext.AuthType != "apikey" {
 		t.Fatalf("expected AuthType='apikey', got %q", ctx.SharedContext.AuthContext.AuthType)
 	}
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
-func TestAPIKeyPolicy_OnRequest_SuccessFromQuery(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_SuccessFromQuery(t *testing.T) {
 	resetAPIKeyStore(t)
 	seedExternalAPIKey(t, "api-2", "query-secret", `["GET /orders"]`)
 
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders?x_api_key=query-secret", nil, "api-2", "OrdersAPI", "v1", "/orders")
+	ctx := newRequestHeaderContext(t, "GET", "/orders?x_api_key=query-secret", nil, "api-2", "OrdersAPI", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x_api_key",
 		"in":  "query",
 	})
@@ -79,12 +80,12 @@ func TestAPIKeyPolicy_OnRequest_SuccessFromQuery(t *testing.T) {
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("expected AuthContext.Authenticated=true")
 	}
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
-func TestAPIKeyPolicy_OnRequest_MissingOrInvalidConfig(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_MissingOrInvalidConfig(t *testing.T) {
 	tests := []struct {
 		name   string
 		params map[string]interface{}
@@ -114,11 +115,11 @@ func TestAPIKeyPolicy_OnRequest_MissingOrInvalidConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetAPIKeyStore(t)
 			p := &APIKeyPolicy{}
-			ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+			ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
 				"x-api-key": {"header-secret"},
 			}, "api-1", "OrdersAPI", "v1", "/orders")
 
-			action := p.OnRequest(ctx, tt.params)
+			action := p.OnRequestHeaders(ctx, tt.params)
 			assertUnauthorizedJSON(t, action)
 
 			if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
@@ -128,12 +129,12 @@ func TestAPIKeyPolicy_OnRequest_MissingOrInvalidConfig(t *testing.T) {
 	}
 }
 
-func TestAPIKeyPolicy_OnRequest_FailsWhenAPIKeyMissing(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenAPIKeyMissing(t *testing.T) {
 	resetAPIKeyStore(t)
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders?foo=bar", nil, "api-1", "OrdersAPI", "v1", "/orders")
+	ctx := newRequestHeaderContext(t, "GET", "/orders?foo=bar", nil, "api-1", "OrdersAPI", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x_api_key",
 		"in":  "query",
 	})
@@ -141,14 +142,14 @@ func TestAPIKeyPolicy_OnRequest_FailsWhenAPIKeyMissing(t *testing.T) {
 	assertUnauthorizedJSON(t, action)
 }
 
-func TestAPIKeyPolicy_OnRequest_FailsWhenAPIDetailsMissing(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenAPIDetailsMissing(t *testing.T) {
 	resetAPIKeyStore(t)
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
 		"x-api-key": {"header-secret"},
 	}, "api-1", "", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x-api-key",
 		"in":  "header",
 	})
@@ -156,16 +157,16 @@ func TestAPIKeyPolicy_OnRequest_FailsWhenAPIDetailsMissing(t *testing.T) {
 	assertUnauthorizedJSON(t, action)
 }
 
-func TestAPIKeyPolicy_OnRequest_FailsWhenValidationReturnsFalse(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenValidationReturnsFalse(t *testing.T) {
 	resetAPIKeyStore(t)
 	seedExternalAPIKey(t, "api-1", "different-secret", `["GET /orders"]`)
 
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
 		"x-api-key": {"wrong-secret"},
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x-api-key",
 		"in":  "header",
 	})
@@ -173,16 +174,16 @@ func TestAPIKeyPolicy_OnRequest_FailsWhenValidationReturnsFalse(t *testing.T) {
 	assertUnauthorizedJSON(t, action)
 }
 
-func TestAPIKeyPolicy_OnRequest_FailsWhenValidationErrors(t *testing.T) {
+func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenValidationErrors(t *testing.T) {
 	resetAPIKeyStore(t)
 	seedExternalAPIKey(t, "api-1", "bad-ops-secret", `not-json`)
 
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders", map[string][]string{
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
 		"x-api-key": {"bad-ops-secret"},
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
-	action := p.OnRequest(ctx, map[string]interface{}{
+	action := p.OnRequestHeaders(ctx, map[string]interface{}{
 		"key": "x-api-key",
 		"in":  "header",
 	})
@@ -190,17 +191,20 @@ func TestAPIKeyPolicy_OnRequest_FailsWhenValidationErrors(t *testing.T) {
 	assertUnauthorizedJSON(t, action)
 }
 
-func TestAPIKeyPolicy_OnResponse_NoOp(t *testing.T) {
-	p := &APIKeyPolicy{}
-	action := p.OnResponse(&policy.ResponseContext{}, nil)
-	if action != nil {
-		t.Fatalf("expected nil response action, got %T", action)
-	}
-}
-
 func TestAPIKeyPolicy_HandleAuthFailure_PlainFormat(t *testing.T) {
 	p := &APIKeyPolicy{}
-	ctx := newRequestContext(t, "GET", "/orders", nil, "api-1", "OrdersAPI", "v1", "/orders")
+	// handleAuthFailure uses v1alpha RequestContext
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+			APIId:     "api-1",
+			APIName:   "OrdersAPI",
+		},
+		Headers: policy.NewHeaders(nil),
+		Method:  "GET",
+		Path:    "/orders",
+	}
 
 	action := p.handleAuthFailure(ctx, 401, "plain", "Auth failed", "test failure")
 	resp, ok := action.(policy.ImmediateResponse)
@@ -264,13 +268,13 @@ func TestExtractQueryParam(t *testing.T) {
 	}
 }
 
-func newRequestContext(t *testing.T, method, path string, headers map[string][]string, apiID, apiName, apiVersion, opPath string) *policy.RequestContext {
+func newRequestHeaderContext(t *testing.T, method, path string, headers map[string][]string, apiID, apiName, apiVersion, opPath string) *policyv1alpha2.RequestHeaderContext {
 	t.Helper()
 	if headers == nil {
 		headers = map[string][]string{}
 	}
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID:     "req-1",
 			Metadata:      map[string]interface{}{},
 			APIId:         apiID,
@@ -278,15 +282,15 @@ func newRequestContext(t *testing.T, method, path string, headers map[string][]s
 			APIVersion:    apiVersion,
 			OperationPath: opPath,
 		},
-		Headers: policy.NewHeaders(headers),
+		Headers: policyv1alpha2.NewHeaders(headers),
 		Method:  method,
 		Path:    path,
 	}
 }
 
-func assertUnauthorizedJSON(t *testing.T, action policy.RequestAction) {
+func assertUnauthorizedJSON(t *testing.T, action policyv1alpha2.RequestHeaderAction) {
 	t.Helper()
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -343,7 +347,20 @@ func sanitizeTestName(v string) string {
 func TestAPIKeyPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	p := &APIKeyPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}
-	ctx := newRequestContext(t, "GET", "/orders", nil, "api-1", "OrdersAPI", "v1", "/orders")
+	// handleAuthSuccess uses v1alpha RequestContext
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:     "req-1",
+			Metadata:      map[string]interface{}{},
+			APIId:         "api-1",
+			APIName:       "OrdersAPI",
+			APIVersion:    "v1",
+			OperationPath: "/orders",
+		},
+		Headers: policy.NewHeaders(nil),
+		Method:  "GET",
+		Path:    "/orders",
+	}
 	ctx.SharedContext.AuthContext = prior
 
 	p.handleAuthSuccess(ctx)
@@ -359,7 +376,20 @@ func TestAPIKeyPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 func TestAPIKeyPolicy_AuthContext_PreviousPreserved_OnFailure(t *testing.T) {
 	p := &APIKeyPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}
-	ctx := newRequestContext(t, "GET", "/orders", nil, "api-1", "OrdersAPI", "v1", "/orders")
+	// handleAuthFailure uses v1alpha RequestContext
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:     "req-1",
+			Metadata:      map[string]interface{}{},
+			APIId:         "api-1",
+			APIName:       "OrdersAPI",
+			APIVersion:    "v1",
+			OperationPath: "/orders",
+		},
+		Headers: policy.NewHeaders(nil),
+		Method:  "GET",
+		Path:    "/orders",
+	}
 	ctx.SharedContext.AuthContext = prior
 
 	p.handleAuthFailure(ctx, 401, "json", "Valid API key required", "invalid API key")

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v0.8.2
+version: v0.9.0
 description: |
   Secures APIs by validating API keys in incoming requests. API keys can be
   provided through a configured HTTP header or query parameter.

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -1051,6 +1051,10 @@ func (p *AWSBedrockGuardrailPolicy) OnRequestBody(ctx *policyv1alpha2.RequestCon
 		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
+	if ctx.Metadata == nil {
+		ctx.Metadata = make(map[string]interface{})
+	}
+
 	var content []byte
 	if ctx.Body != nil {
 		content = ctx.Body.Content

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 type mockBedrockClient struct {
@@ -53,13 +53,13 @@ func makePIIIntervenedOutput(match string) *bedrockruntime.ApplyGuardrailOutput 
 }
 
 func TestGetPolicy_ValidatesRequiredAndPhaseParams(t *testing.T) {
-	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err == nil || !strings.Contains(err.Error(), "'region' parameter is required") {
 		t.Fatalf("expected missing region error, got: %v", err)
 	}
 
 	params := baseParams()
-	_, err = GetPolicy(policy.PolicyMetadata{}, params)
+	_, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err == nil || !strings.Contains(err.Error(), "at least one of 'request' or 'response' parameters must be provided") {
 		t.Fatalf("expected missing phase params error, got: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestGetPolicy_ValidatesRequiredAndPhaseParams(t *testing.T) {
 	params["request"] = map[string]interface{}{
 		"jsonPath": 1, // invalid type
 	}
-	_, err = GetPolicy(policy.PolicyMetadata{}, params)
+	_, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err == nil || !strings.Contains(err.Error(), "invalid request parameters") {
 		t.Fatalf("expected invalid request params error, got: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestGetPolicy_RequestRedactForcesResponseRedact(t *testing.T) {
 		"redactPII": false,
 	}
 
-	pRaw, err := GetPolicy(policy.PolicyMetadata{}, params)
+	pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("GetPolicy returned error: %v", err)
 	}
@@ -293,10 +293,10 @@ func TestValidatePayload_EarlyAndErrorPaths(t *testing.T) {
 			"alice@example.com": "EMAIL_0000",
 		},
 	}
-	restored := p.validatePayload([]byte(`{"msg":"EMAIL_0000"}`), AWSBedrockGuardrailPolicyParams{
+	restored := p.validatePayloadV2([]byte(`{"msg":"EMAIL_0000"}`), AWSBedrockGuardrailPolicyParams{
 		RedactPII: false,
 	}, true, metadata)
-	respMod, ok := restored.(policy.UpstreamResponseModifications)
+	respMod, ok := restored.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", restored)
 	}
@@ -305,12 +305,12 @@ func TestValidatePayload_EarlyAndErrorPaths(t *testing.T) {
 	}
 
 	// JSONPath extraction error with passthrough disabled should block.
-	blocked := p.validatePayload([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
+	blocked := p.validatePayloadV2([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
 		JsonPath:           "$.msg",
 		PassthroughOnError: false,
 		ShowAssessment:     false,
 	}, false, map[string]interface{}{})
-	immResp, ok := blocked.(policy.ImmediateResponse)
+	immResp, ok := blocked.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse for request block, got %T", blocked)
 	}
@@ -319,20 +319,20 @@ func TestValidatePayload_EarlyAndErrorPaths(t *testing.T) {
 	}
 
 	// JSONPath extraction error with passthrough enabled should continue.
-	passthrough := p.validatePayload([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
+	passthrough := p.validatePayloadV2([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
 		JsonPath:           "$.msg",
 		PassthroughOnError: true,
 	}, false, map[string]interface{}{})
-	if _, ok := passthrough.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := passthrough.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on passthrough, got %T", passthrough)
 	}
 
 	// Response block path uses UpstreamResponseModifications + status code.
-	respBlocked := p.validatePayload([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
+	respBlocked := p.validatePayloadV2([]byte(`not-json`), AWSBedrockGuardrailPolicyParams{
 		JsonPath:           "$.msg",
 		PassthroughOnError: false,
 	}, true, map[string]interface{}{})
-	respBlockedMod, ok := respBlocked.(policy.UpstreamResponseModifications)
+	respBlockedMod, ok := respBlocked.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications for response block, got %T", respBlocked)
 	}
@@ -344,8 +344,8 @@ func TestValidatePayload_EarlyAndErrorPaths(t *testing.T) {
 func TestBuildErrorResponse_RequestAndResponse(t *testing.T) {
 	p := &AWSBedrockGuardrailPolicy{}
 
-	reqResp := p.buildErrorResponse("reason", nil, false, false, nil)
-	imm, ok := reqResp.(policy.ImmediateResponse)
+	reqResp := p.buildErrorResponseV2("reason", nil, false, false, nil)
+	imm, ok := reqResp.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", reqResp)
 	}
@@ -356,8 +356,8 @@ func TestBuildErrorResponse_RequestAndResponse(t *testing.T) {
 		t.Fatalf("expected Content-Type application/json, got %q", ct)
 	}
 
-	respResp := p.buildErrorResponse("reason", nil, true, false, nil)
-	upResp, ok := respResp.(policy.UpstreamResponseModifications)
+	respResp := p.buildErrorResponseV2("reason", nil, true, false, nil)
+	upResp, ok := respResp.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", respResp)
 	}
@@ -371,17 +371,17 @@ func TestOnRequest_NoRequestParams_ReturnsNoOp(t *testing.T) {
 		hasRequestParams: false,
 	}
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"hello"}`),
 		},
 	}
 
-	result := p.OnRequest(ctx, map[string]interface{}{})
-	mod, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestBody(ctx, map[string]interface{}{})
+	mod, ok := result.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
@@ -398,27 +398,27 @@ func TestOnRequest_DisabledRequestFlow_ReturnsNoOp(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"hello"}`),
 		},
 	}
 
-	result := p.OnRequest(ctx, map[string]interface{}{})
-	if _, ok := result.(policy.UpstreamRequestModifications); !ok {
+	result := p.OnRequestBody(ctx, map[string]interface{}{})
+	if _, ok := result.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
 }
 
 func TestOnRequest_BlockAndPassthroughOnJSONPathError(t *testing.T) {
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`not-json`),
 		},
 	}
@@ -431,8 +431,8 @@ func TestOnRequest_BlockAndPassthroughOnJSONPathError(t *testing.T) {
 			PassthroughOnError: false,
 		},
 	}
-	blockResult := blockPolicy.OnRequest(ctx, map[string]interface{}{})
-	imm, ok := blockResult.(policy.ImmediateResponse)
+	blockResult := blockPolicy.OnRequestBody(ctx, map[string]interface{}{})
+	imm, ok := blockResult.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", blockResult)
 	}
@@ -448,8 +448,8 @@ func TestOnRequest_BlockAndPassthroughOnJSONPathError(t *testing.T) {
 			PassthroughOnError: true,
 		},
 	}
-	passthroughResult := passthroughPolicy.OnRequest(ctx, map[string]interface{}{})
-	if _, ok := passthroughResult.(policy.UpstreamRequestModifications); !ok {
+	passthroughResult := passthroughPolicy.OnRequestBody(ctx, map[string]interface{}{})
+	if _, ok := passthroughResult.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", passthroughResult)
 	}
 }
@@ -459,17 +459,17 @@ func TestOnResponse_NoResponseParams_ReturnsNoOp(t *testing.T) {
 		hasResponseParams: false,
 	}
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"hello"}`),
 		},
 	}
 
-	result := p.OnResponse(ctx, map[string]interface{}{})
-	mod, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseBody(ctx, map[string]interface{}{})
+	mod, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
 	}
@@ -486,17 +486,17 @@ func TestOnResponse_DisabledResponseFlow_ReturnsNoOp(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"hello"}`),
 		},
 	}
 
-	result := p.OnResponse(ctx, map[string]interface{}{})
-	if _, ok := result.(policy.UpstreamResponseModifications); !ok {
+	result := p.OnResponseBody(ctx, map[string]interface{}{})
+	if _, ok := result.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
 	}
 }
@@ -510,21 +510,21 @@ func TestOnResponse_RestoreAndBlockPaths(t *testing.T) {
 		},
 	}
 
-	restoreCtx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	restoreCtx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{
 				MetadataKeyPIIEntities: map[string]string{
 					"alice@example.com": "EMAIL_0000",
 				},
 			},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"EMAIL_0000"}`),
 		},
 	}
 
-	restoreResult := restorePolicy.OnResponse(restoreCtx, map[string]interface{}{})
-	restoreMod, ok := restoreResult.(policy.UpstreamResponseModifications)
+	restoreResult := restorePolicy.OnResponseBody(restoreCtx, map[string]interface{}{})
+	restoreMod, ok := restoreResult.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", restoreResult)
 	}
@@ -541,17 +541,17 @@ func TestOnResponse_RestoreAndBlockPaths(t *testing.T) {
 		},
 	}
 
-	blockCtx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	blockCtx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`not-json`),
 		},
 	}
 
-	blockResult := blockPolicy.OnResponse(blockCtx, map[string]interface{}{})
-	blockMod, ok := blockResult.(policy.UpstreamResponseModifications)
+	blockResult := blockPolicy.OnResponseBody(blockCtx, map[string]interface{}{})
+	blockMod, ok := blockResult.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", blockResult)
 	}
@@ -585,17 +585,17 @@ func TestOnRequest_WithMockedBedrockNoViolation(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"hello from request"}`),
 		},
 	}
 
-	result := p.OnRequest(ctx, map[string]interface{}{})
-	mod, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestBody(ctx, map[string]interface{}{})
+	mod, ok := result.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
@@ -635,17 +635,17 @@ func TestOnRequest_WithMockedBedrockViolation(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`hello`),
 		},
 	}
 
-	result := p.OnRequest(ctx, map[string]interface{}{})
-	imm, ok := result.(policy.ImmediateResponse)
+	result := p.OnRequestBody(ctx, map[string]interface{}{})
+	imm, ok := result.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", result)
 	}
@@ -676,17 +676,17 @@ func TestOnRequest_WithMockedBedrockErrorPassthrough(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(`hello`),
 		},
 	}
 
-	result := p.OnRequest(ctx, map[string]interface{}{})
-	if _, ok := result.(policy.UpstreamRequestModifications); !ok {
+	result := p.OnRequestBody(ctx, map[string]interface{}{})
+	if _, ok := result.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on passthrough, got %T", result)
 	}
 }
@@ -714,17 +714,17 @@ func TestOnResponse_WithMockedBedrockPIIRedaction(t *testing.T) {
 		},
 	}
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"msg":"john@example.com"}`),
 		},
 	}
 
-	result := p.OnResponse(ctx, map[string]interface{}{})
-	mod, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseBody(ctx, map[string]interface{}{})
+	mod, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
 	}

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: aws-bedrock-guardrail
-version: v0.2.1
+version: v0.9.0
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
@@ -7,17 +7,17 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestAzureContentSafetyPolicy_Mode(t *testing.T) {
 	p := &AzureContentSafetyContentModerationPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeStream,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -134,7 +134,7 @@ func TestAzureContentSafetyPolicy_GetPolicy_Errors(t *testing.T) {
 		"azureContentSafetyKey":      "k",
 	}
 
-	_, err := GetPolicy(policy.PolicyMetadata{}, base)
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, base)
 	if err == nil || !strings.Contains(err.Error(), "at least one of 'request' or 'response' parameters must be provided") {
 		t.Fatalf("expected request/response presence error, got %v", err)
 	}
@@ -146,7 +146,7 @@ func TestAzureContentSafetyPolicy_GetPolicy_Errors(t *testing.T) {
 			"showAssessment": "true",
 		},
 	}
-	_, err = GetPolicy(policy.PolicyMetadata{}, badReq)
+	_, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, badReq)
 	if err == nil || !strings.Contains(err.Error(), "invalid request parameters") {
 		t.Fatalf("expected invalid request parameters error, got %v", err)
 	}
@@ -161,8 +161,8 @@ func TestAzureContentSafetyPolicy_OnRequest_NoRequestConfig_NoOp(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
@@ -176,8 +176,8 @@ func TestAzureContentSafetyPolicy_OnResponse_NoResponseConfig_NoOp(t *testing.T)
 		},
 	})
 
-	action := p.OnResponse(azureResponseContext(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+	action := p.OnResponseBody(azureResponseContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
 	}
 }
@@ -194,8 +194,8 @@ func TestAzureContentSafetyPolicy_NoValidCategories_PassThrough(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass-through when no valid categories, got %T", action)
 	}
 }
@@ -209,8 +209,8 @@ func TestAzureContentSafetyPolicy_JSONPathError_PassthroughBehavior(t *testing.T
 			"passthroughOnError": true,
 		},
 	})
-	a1 := pPass.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
-	if _, ok := a1.(policy.UpstreamRequestModifications); !ok {
+	a1 := pPass.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := a1.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass-through for jsonPath error when passthrough enabled, got %T", a1)
 	}
 
@@ -223,7 +223,7 @@ func TestAzureContentSafetyPolicy_JSONPathError_PassthroughBehavior(t *testing.T
 			"showAssessment":     true,
 		},
 	})
-	a2 := pFail.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	a2 := pFail.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
 	body := assertAzureRequestError(t, a2, true, "REQUEST")
 	msg := extractAzureMessage(t, body)
 	if _, ok := msg["assessments"]; !ok {
@@ -246,8 +246,8 @@ func TestAzureContentSafetyPolicy_APICallError_PassthroughBehavior(t *testing.T)
 			"passthroughOnError": true,
 		},
 	})
-	a1 := pPass.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
-	if _, ok := a1.(policy.UpstreamRequestModifications); !ok {
+	a1 := pPass.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
+	if _, ok := a1.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass-through on API error when passthrough enabled, got %T", a1)
 	}
 
@@ -259,7 +259,7 @@ func TestAzureContentSafetyPolicy_APICallError_PassthroughBehavior(t *testing.T)
 			"passthroughOnError": false,
 		},
 	})
-	a2 := pFail.OnRequest(azureRequestContext(`{"message":"hello"}`), nil)
+	a2 := pFail.OnRequestBody(azureRequestContext(`{"message":"hello"}`), nil)
 	assertAzureRequestError(t, a2, false, "REQUEST")
 }
 
@@ -281,8 +281,8 @@ func TestAzureContentSafetyPolicy_APISuccess_NoViolation(t *testing.T) {
 			"hateSeverityThreshold": 4,
 		},
 	})
-	action := p.OnRequest(azureRequestContext(`{"messages":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(azureRequestContext(`{"messages":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on non-violation, got %T", action)
 	}
 }
@@ -309,7 +309,7 @@ func TestAzureContentSafetyPolicy_APIViolation_RequestAndResponse(t *testing.T) 
 		},
 	})
 
-	reqAction := p.OnRequest(azureRequestContext(`{"messages":"blocked text"}`), nil)
+	reqAction := p.OnRequestBody(azureRequestContext(`{"messages":"blocked text"}`), nil)
 	reqBody := assertAzureRequestError(t, reqAction, true, "REQUEST")
 	reqMsg := extractAzureMessage(t, reqBody)
 	assessment, ok := reqMsg["assessments"].(map[string]interface{})
@@ -320,7 +320,7 @@ func TestAzureContentSafetyPolicy_APIViolation_RequestAndResponse(t *testing.T) 
 		t.Fatalf("expected assessments.categories on violation")
 	}
 
-	respAction := p.OnResponse(azureResponseContext(`{"messages":"blocked response"}`), nil)
+	respAction := p.OnResponseBody(azureResponseContext(`{"messages":"blocked response"}`), nil)
 	respBody := assertAzureResponseError(t, respAction, true, "RESPONSE")
 	respMsg := extractAzureMessage(t, respBody)
 	if _, ok := respMsg["assessments"]; !ok {
@@ -330,7 +330,7 @@ func TestAzureContentSafetyPolicy_APIViolation_RequestAndResponse(t *testing.T) 
 
 func mustGetAzurePolicy(t *testing.T, params map[string]interface{}) *AzureContentSafetyContentModerationPolicy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -357,35 +357,35 @@ func azureMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	}))
 }
 
-func azureRequestContext(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func azureRequestContext(body string) *policyv1alpha2.RequestContext {
+	return &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},
 	}
 }
 
-func azureResponseContext(body string) *policy.ResponseContext {
-	return &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+func azureResponseContext(body string) *policyv1alpha2.ResponseContext {
+	return &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata:  map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},
 	}
 }
 
-func assertAzureRequestError(t *testing.T, action policy.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+func assertAzureRequestError(t *testing.T, action policyv1alpha2.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
 	t.Helper()
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -397,9 +397,9 @@ func assertAzureRequestError(t *testing.T, action policy.RequestAction, expectAs
 	return body
 }
 
-func assertAzureResponseError(t *testing.T, action policy.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+func assertAzureResponseError(t *testing.T, action policyv1alpha2.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
 	t.Helper()
-	resp, ok := action.(policy.UpstreamResponseModifications)
+	resp, ok := action.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
 	}

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: azure-content-safety-content-moderation
-version: v0.8.1
+version: v0.9.0
 description: |
   Validates request and response content with Azure Content Safety moderation
   checks.

--- a/policies/basic-auth/basicauth_test.go
+++ b/policies/basic-auth/basicauth_test.go
@@ -6,19 +6,20 @@ import (
 	"fmt"
 	"testing"
 
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
 
-func newBasicRequestContext(headers map[string][]string) *policy.RequestContext {
+func newBasicRequestHeaderContext(headers map[string][]string) *policyv1alpha2.RequestHeaderContext {
 	if headers == nil {
 		headers = map[string][]string{}
 	}
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-1",
 			Metadata:  map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(headers),
+		Headers: policyv1alpha2.NewHeaders(headers),
 		Method:  "GET",
 		Path:    "/api/resource",
 	}
@@ -39,11 +40,11 @@ func defaultParams() map[string]interface{} {
 func TestBasicAuthPolicy_Mode(t *testing.T) {
 	p := &BasicAuthPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -51,26 +52,26 @@ func TestBasicAuthPolicy_Mode(t *testing.T) {
 }
 
 func TestGetPolicy_ReturnsSingleton(t *testing.T) {
-	p1, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	p1, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, nil)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
-	p2, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	p2, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, nil)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 	if p1 != p2 {
 		t.Fatalf("expected singleton policy instance")
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_ValidCredentials(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_ValidCredentials(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(map[string][]string{
+	ctx := newBasicRequestHeaderContext(map[string][]string{
 		"authorization": {basicAuthHeader("admin", "secret")},
 	})
 
-	action := p.OnRequest(ctx, defaultParams())
+	action := p.OnRequestHeaders(ctx, defaultParams())
 
 	if ctx.SharedContext.AuthContext == nil {
 		t.Fatal("expected AuthContext to be set")
@@ -84,18 +85,18 @@ func TestBasicAuthPolicy_OnRequest_ValidCredentials(t *testing.T) {
 	if ctx.SharedContext.AuthContext.Subject != "admin" {
 		t.Errorf("expected Subject='admin', got %q", ctx.SharedContext.AuthContext.Subject)
 	}
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_WrongPassword(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_WrongPassword(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(map[string][]string{
+	ctx := newBasicRequestHeaderContext(map[string][]string{
 		"authorization": {basicAuthHeader("admin", "wrong-password")},
 	})
 
-	action := p.OnRequest(ctx, defaultParams())
+	action := p.OnRequestHeaders(ctx, defaultParams())
 
 	if ctx.SharedContext.AuthContext == nil {
 		t.Fatal("expected AuthContext to be set")
@@ -107,7 +108,7 @@ func TestBasicAuthPolicy_OnRequest_WrongPassword(t *testing.T) {
 		t.Errorf("expected AuthType='basic', got %q", ctx.SharedContext.AuthContext.AuthType)
 	}
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -116,13 +117,13 @@ func TestBasicAuthPolicy_OnRequest_WrongPassword(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_MissingAuthorizationHeader(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_MissingAuthorizationHeader(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(nil)
+	ctx := newBasicRequestHeaderContext(nil)
 
-	action := p.OnRequest(ctx, defaultParams())
+	action := p.OnRequestHeaders(ctx, defaultParams())
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -132,7 +133,7 @@ func TestBasicAuthPolicy_OnRequest_MissingAuthorizationHeader(t *testing.T) {
 	assertJSONError(t, resp.Body)
 }
 
-func TestBasicAuthPolicy_OnRequest_MalformedAuthorizationHeader(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_MalformedAuthorizationHeader(t *testing.T) {
 	tests := []struct {
 		name   string
 		header string
@@ -146,11 +147,11 @@ func TestBasicAuthPolicy_OnRequest_MalformedAuthorizationHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &BasicAuthPolicy{}
-			ctx := newBasicRequestContext(map[string][]string{
+			ctx := newBasicRequestHeaderContext(map[string][]string{
 				"authorization": {tt.header},
 			})
 
-			action := p.OnRequest(ctx, defaultParams())
+			action := p.OnRequestHeaders(ctx, defaultParams())
 
 			if ctx.SharedContext.AuthContext == nil {
 				t.Fatal("expected AuthContext to be set on failure")
@@ -159,7 +160,7 @@ func TestBasicAuthPolicy_OnRequest_MalformedAuthorizationHeader(t *testing.T) {
 				t.Error("expected Authenticated=false")
 			}
 
-			resp, ok := action.(policy.ImmediateResponse)
+			resp, ok := action.(policyv1alpha2.ImmediateResponse)
 			if !ok {
 				t.Fatalf("expected ImmediateResponse, got %T", action)
 			}
@@ -170,9 +171,9 @@ func TestBasicAuthPolicy_OnRequest_MalformedAuthorizationHeader(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_AllowUnauthenticated(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_AllowUnauthenticated(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(nil) // no authorization header
+	ctx := newBasicRequestHeaderContext(nil) // no authorization header
 
 	params := map[string]interface{}{
 		"username":             "admin",
@@ -180,11 +181,11 @@ func TestBasicAuthPolicy_OnRequest_AllowUnauthenticated(t *testing.T) {
 		"allowUnauthenticated": true,
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.OnRequestHeaders(ctx, params)
 
 	// Should allow through even without credentials
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications (allow through), got %T", action)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications (allow through), got %T", action)
 	}
 	// AuthContext should still reflect the failure
 	if ctx.SharedContext.AuthContext == nil {
@@ -195,9 +196,9 @@ func TestBasicAuthPolicy_OnRequest_AllowUnauthenticated(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_CustomRealm(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_CustomRealm(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(nil)
+	ctx := newBasicRequestHeaderContext(nil)
 
 	params := map[string]interface{}{
 		"username": "admin",
@@ -205,9 +206,9 @@ func TestBasicAuthPolicy_OnRequest_CustomRealm(t *testing.T) {
 		"realm":    "My API",
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.OnRequestHeaders(ctx, params)
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -218,17 +219,17 @@ func TestBasicAuthPolicy_OnRequest_CustomRealm(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_InvalidConfig_NoUsername(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_InvalidConfig_NoUsername(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(nil)
+	ctx := newBasicRequestHeaderContext(nil)
 
 	params := map[string]interface{}{
 		"password": "secret",
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.OnRequestHeaders(ctx, params)
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -237,17 +238,17 @@ func TestBasicAuthPolicy_OnRequest_InvalidConfig_NoUsername(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnRequest_InvalidConfig_NoPassword(t *testing.T) {
+func TestBasicAuthPolicy_OnRequestHeaders_InvalidConfig_NoPassword(t *testing.T) {
 	p := &BasicAuthPolicy{}
-	ctx := newBasicRequestContext(nil)
+	ctx := newBasicRequestHeaderContext(nil)
 
 	params := map[string]interface{}{
 		"username": "admin",
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.OnRequestHeaders(ctx, params)
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -256,18 +257,20 @@ func TestBasicAuthPolicy_OnRequest_InvalidConfig_NoPassword(t *testing.T) {
 	}
 }
 
-func TestBasicAuthPolicy_OnResponse_NoOp(t *testing.T) {
-	p := &BasicAuthPolicy{}
-	action := p.OnResponse(&policy.ResponseContext{}, nil)
-	if action != nil {
-		t.Fatalf("expected nil response action, got %T", action)
-	}
-}
-
+// TestBasicAuthPolicy_AuthContext_PreviousPreserved_OnSuccess tests the v1alpha helper
+// that chains AuthContext entries.
 func TestBasicAuthPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	p := &BasicAuthPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}
-	ctx := newBasicRequestContext(nil)
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: policy.NewHeaders(nil),
+		Method:  "GET",
+		Path:    "/api/resource",
+	}
 	ctx.SharedContext.AuthContext = prior
 
 	p.handleAuthSuccess(ctx, "alice")
@@ -280,10 +283,20 @@ func TestBasicAuthPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	}
 }
 
+// TestBasicAuthPolicy_AuthContext_PreviousPreserved_OnFailure tests the v1alpha helper
+// that chains AuthContext entries on failure.
 func TestBasicAuthPolicy_AuthContext_PreviousPreserved_OnFailure(t *testing.T) {
 	p := &BasicAuthPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}
-	ctx := newBasicRequestContext(nil)
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: policy.NewHeaders(nil),
+		Method:  "GET",
+		Path:    "/api/resource",
+	}
 	ctx.SharedContext.AuthContext = prior
 
 	p.handleAuthFailure(ctx, false, "Restricted", "invalid credentials")

--- a/policies/basic-auth/policy-definition.yaml
+++ b/policies/basic-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-auth
-version: v0.8.1
+version: v0.9.0
 description: |
   Protects APIs using Basic Authentication by validating username and password credentials.
 

--- a/policies/basic-ratelimit/basic_ratelimit_test.go
+++ b/policies/basic-ratelimit/basic_ratelimit_test.go
@@ -5,24 +5,25 @@ import (
 	"strings"
 	"testing"
 
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
 
 type stubDelegatePolicy struct {
-	mode policy.ProcessingMode
+	mode policyv1alpha2.ProcessingMode
 
-	onRequestAction policy.RequestAction
-	onRequestCtx    *policy.RequestContext
-	onRequestParams map[string]interface{}
-	onRequestCalls  int
+	onRequestHeadersAction policyv1alpha2.RequestHeaderAction
+	onRequestHeadersCtx    *policyv1alpha2.RequestHeaderContext
+	onRequestHeadersParams map[string]interface{}
+	onRequestHeadersCalls  int
 
-	onResponseAction policy.ResponseAction
-	onResponseCtx    *policy.ResponseContext
-	onResponseParams map[string]interface{}
-	onResponseCalls  int
+	onResponseHeadersAction policyv1alpha2.ResponseHeaderAction
+	onResponseHeadersCtx    *policyv1alpha2.ResponseHeaderContext
+	onResponseHeadersParams map[string]interface{}
+	onResponseHeadersCalls  int
 }
 
-func (s *stubDelegatePolicy) Mode() policy.ProcessingMode {
+func (s *stubDelegatePolicy) Mode() policyv1alpha2.ProcessingMode {
 	return s.mode
 }
 
@@ -30,20 +31,34 @@ func (s *stubDelegatePolicy) OnRequest(
 	ctx *policy.RequestContext,
 	params map[string]interface{},
 ) policy.RequestAction {
-	s.onRequestCalls++
-	s.onRequestCtx = ctx
-	s.onRequestParams = params
-	return s.onRequestAction
+	return nil
 }
 
 func (s *stubDelegatePolicy) OnResponse(
 	ctx *policy.ResponseContext,
 	params map[string]interface{},
 ) policy.ResponseAction {
-	s.onResponseCalls++
-	s.onResponseCtx = ctx
-	s.onResponseParams = params
-	return s.onResponseAction
+	return nil
+}
+
+func (s *stubDelegatePolicy) OnRequestHeaders(
+	ctx *policyv1alpha2.RequestHeaderContext,
+	params map[string]interface{},
+) policyv1alpha2.RequestHeaderAction {
+	s.onRequestHeadersCalls++
+	s.onRequestHeadersCtx = ctx
+	s.onRequestHeadersParams = params
+	return s.onRequestHeadersAction
+}
+
+func (s *stubDelegatePolicy) OnResponseHeaders(
+	ctx *policyv1alpha2.ResponseHeaderContext,
+	params map[string]interface{},
+) policyv1alpha2.ResponseHeaderAction {
+	s.onResponseHeadersCalls++
+	s.onResponseHeadersCtx = ctx
+	s.onResponseHeadersParams = params
+	return s.onResponseHeadersAction
 }
 
 func getSingleQuota(t *testing.T, rlParams map[string]interface{}) map[string]interface{} {
@@ -96,10 +111,6 @@ func getFirstKeyExtractionType(t *testing.T, quota map[string]interface{}) strin
 	}
 
 	return extractorType
-}
-
-func intPtr(v int) *int {
-	return &v
 }
 
 func TestTransformToRatelimitParams_DefaultQuotaAndRouteNameKeyExtraction(t *testing.T) {
@@ -427,11 +438,11 @@ func TestBasicRateLimitPolicy_Mode_ProcessesHeadersAndSkipsBodies(t *testing.T) 
 	p := &BasicRateLimitPolicy{}
 	gotMode := p.Mode()
 
-	wantMode := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	wantMode := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if gotMode != wantMode {
@@ -439,18 +450,18 @@ func TestBasicRateLimitPolicy_Mode_ProcessesHeadersAndSkipsBodies(t *testing.T) 
 	}
 }
 
-func TestBasicRateLimitPolicy_OnRequest_ForwardsContextParamsAndActionUnchanged(t *testing.T) {
-	sentinel := policy.ImmediateResponse{StatusCode: 429}
+func TestBasicRateLimitPolicy_OnRequestHeaders_ForwardsContextParamsAndActionUnchanged(t *testing.T) {
+	sentinel := policyv1alpha2.ImmediateResponse{StatusCode: 429}
 	delegate := &stubDelegatePolicy{
-		onRequestAction: sentinel,
+		onRequestHeadersAction: sentinel,
 	}
 	p := &BasicRateLimitPolicy{delegate: delegate}
 
-	ctx := &policy.RequestContext{
-		Headers: policy.NewHeaders(map[string][]string{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		Headers: policyv1alpha2.NewHeaders(map[string][]string{
 			"x-request-id": {"req-123"},
 		}),
-		SharedContext: &policy.SharedContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{
 				"user": "alice",
 			},
@@ -460,44 +471,43 @@ func TestBasicRateLimitPolicy_OnRequest_ForwardsContextParamsAndActionUnchanged(
 		"limits": "as-provided",
 	}
 
-	gotAction := p.OnRequest(ctx, params)
+	gotAction := p.OnRequestHeaders(ctx, params)
 
-	if delegate.onRequestCalls != 1 {
-		t.Fatalf("expected delegate OnRequest to be called once, got %d", delegate.onRequestCalls)
+	if delegate.onRequestHeadersCalls != 1 {
+		t.Fatalf("expected delegate OnRequestHeaders to be called once, got %d", delegate.onRequestHeadersCalls)
 	}
-	if delegate.onRequestCtx != ctx {
+	if delegate.onRequestHeadersCtx != ctx {
 		t.Fatalf("expected same request context pointer to be forwarded")
 	}
-	if !reflect.DeepEqual(delegate.onRequestParams, params) {
-		t.Fatalf("expected delegate to receive unchanged params map.\nwant=%v\ngot=%v", params, delegate.onRequestParams)
+	if !reflect.DeepEqual(delegate.onRequestHeadersParams, params) {
+		t.Fatalf("expected delegate to receive unchanged params map.\nwant=%v\ngot=%v", params, delegate.onRequestHeadersParams)
 	}
 	if !reflect.DeepEqual(gotAction, sentinel) {
 		t.Fatalf("expected returned request action to match delegate action.\nwant=%#v\ngot=%#v", sentinel, gotAction)
 	}
 
-	delegate.onRequestParams["after_call"] = "visible_in_caller"
+	delegate.onRequestHeadersParams["after_call"] = "visible_in_caller"
 	if params["after_call"] != "visible_in_caller" {
 		t.Fatalf("expected delegate and caller to observe the same params map reference")
 	}
 }
 
-func TestBasicRateLimitPolicy_OnResponse_ForwardsContextParamsAndActionUnchanged(t *testing.T) {
-	sentinel := policy.UpstreamResponseModifications{
-		SetHeaders: map[string]string{
+func TestBasicRateLimitPolicy_OnResponseHeaders_ForwardsContextParamsAndActionUnchanged(t *testing.T) {
+	sentinel := policyv1alpha2.DownstreamResponseHeaderModifications{
+		HeadersToSet: map[string]string{
 			"x-rate-limit": "ok",
 		},
-		StatusCode: intPtr(202),
 	}
 	delegate := &stubDelegatePolicy{
-		onResponseAction: sentinel,
+		onResponseHeadersAction: sentinel,
 	}
 	p := &BasicRateLimitPolicy{delegate: delegate}
 
-	ctx := &policy.ResponseContext{
-		ResponseHeaders: policy.NewHeaders(map[string][]string{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		ResponseHeaders: policyv1alpha2.NewHeaders(map[string][]string{
 			"x-response-id": {"res-123"},
 		}),
-		SharedContext: &policy.SharedContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			Metadata: map[string]interface{}{
 				"tenant": "foo",
 			},
@@ -507,29 +517,29 @@ func TestBasicRateLimitPolicy_OnResponse_ForwardsContextParamsAndActionUnchanged
 		"key": "value",
 	}
 
-	gotAction := p.OnResponse(ctx, params)
+	gotAction := p.OnResponseHeaders(ctx, params)
 
-	if delegate.onResponseCalls != 1 {
-		t.Fatalf("expected delegate OnResponse to be called once, got %d", delegate.onResponseCalls)
+	if delegate.onResponseHeadersCalls != 1 {
+		t.Fatalf("expected delegate OnResponseHeaders to be called once, got %d", delegate.onResponseHeadersCalls)
 	}
-	if delegate.onResponseCtx != ctx {
+	if delegate.onResponseHeadersCtx != ctx {
 		t.Fatalf("expected same response context pointer to be forwarded")
 	}
-	if !reflect.DeepEqual(delegate.onResponseParams, params) {
-		t.Fatalf("expected delegate to receive unchanged params map.\nwant=%v\ngot=%v", params, delegate.onResponseParams)
+	if !reflect.DeepEqual(delegate.onResponseHeadersParams, params) {
+		t.Fatalf("expected delegate to receive unchanged params map.\nwant=%v\ngot=%v", params, delegate.onResponseHeadersParams)
 	}
 	if !reflect.DeepEqual(gotAction, sentinel) {
 		t.Fatalf("expected returned response action to match delegate action.\nwant=%#v\ngot=%#v", sentinel, gotAction)
 	}
 
-	delegate.onResponseParams["after_call"] = "visible_in_caller"
+	delegate.onResponseHeadersParams["after_call"] = "visible_in_caller"
 	if params["after_call"] != "visible_in_caller" {
 		t.Fatalf("expected delegate and caller to observe the same params map reference")
 	}
 }
 
-func TestGetPolicy_ReturnsBasicRateLimitPolicy_WhenDelegateCreationSucceeds(t *testing.T) {
-	metadata := policy.PolicyMetadata{
+func TestGetPolicyV2_ReturnsBasicRateLimitPolicy_WhenDelegateCreationSucceeds(t *testing.T) {
+	metadata := policyv1alpha2.PolicyMetadata{
 		RouteName: "unit-test-basic-ratelimit-getpolicy-success",
 	}
 
@@ -544,20 +554,20 @@ func TestGetPolicy_ReturnsBasicRateLimitPolicy_WhenDelegateCreationSucceeds(t *t
 		"backend":   "memory",
 	}
 
-	p, err := GetPolicy(metadata, params)
+	p, err := GetPolicyV2(metadata, params)
 	if err != nil {
-		t.Fatalf("expected GetPolicy success, got error: %v", err)
+		t.Fatalf("expected GetPolicyV2 success, got error: %v", err)
 	}
 	if p == nil {
-		t.Fatalf("expected non-nil policy from GetPolicy")
+		t.Fatalf("expected non-nil policy from GetPolicyV2")
 	}
 	if _, ok := p.(*BasicRateLimitPolicy); !ok {
 		t.Fatalf("expected *BasicRateLimitPolicy, got %T", p)
 	}
 }
 
-func TestGetPolicy_PropagatesError_WhenDelegateCreationFails(t *testing.T) {
-	metadata := policy.PolicyMetadata{
+func TestGetPolicyV2_PropagatesError_WhenDelegateCreationFails(t *testing.T) {
+	metadata := policyv1alpha2.PolicyMetadata{
 		RouteName: "unit-test-basic-ratelimit-getpolicy-error",
 	}
 
@@ -571,20 +581,20 @@ func TestGetPolicy_PropagatesError_WhenDelegateCreationFails(t *testing.T) {
 		"backend": "memory",
 	}
 
-	p, err := GetPolicy(metadata, params)
+	p, err := GetPolicyV2(metadata, params)
 	if err == nil {
-		t.Fatalf("expected GetPolicy error for invalid limit value type, got nil")
+		t.Fatalf("expected GetPolicyV2 error for invalid limit value type, got nil")
 	}
 	if p != nil {
-		t.Fatalf("expected nil policy when GetPolicy fails, got %T", p)
+		t.Fatalf("expected nil policy when GetPolicyV2 fails, got %T", p)
 	}
 	if !strings.Contains(err.Error(), "limit must be a number") {
 		t.Fatalf("expected propagated delegate parse error to mention numeric limit, got: %v", err)
 	}
 }
 
-func TestGetPolicy_AcceptsLegacyLimitShape_ForDocsCompatibility(t *testing.T) {
-	metadata := policy.PolicyMetadata{
+func TestGetPolicyV2_AcceptsLegacyLimitShape_ForDocsCompatibility(t *testing.T) {
+	metadata := policyv1alpha2.PolicyMetadata{
 		RouteName: "unit-test-basic-ratelimit-getpolicy-legacy-limit",
 	}
 
@@ -599,9 +609,9 @@ func TestGetPolicy_AcceptsLegacyLimitShape_ForDocsCompatibility(t *testing.T) {
 		"backend":   "memory",
 	}
 
-	p, err := GetPolicy(metadata, params)
+	p, err := GetPolicyV2(metadata, params)
 	if err != nil {
-		t.Fatalf("expected GetPolicy to accept legacy limit shape, got error: %v", err)
+		t.Fatalf("expected GetPolicyV2 to accept legacy limit shape, got error: %v", err)
 	}
 	if p == nil {
 		t.Fatalf("expected non-nil policy for legacy limit shape")

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/wso2/api-platform/sdk v0.4.5
 	github.com/wso2/api-platform/sdk/core v0.1.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.1
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.1 // Upgrade
 )
 
 require (

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-ratelimit
-version: v0.8.3
+version: v0.9.0
 description: |
   Limits request rates by restricting the number of requests allowed within one
   or more defined time windows.

--- a/policies/content-length-guardrail/contentlengthguardrail_test.go
+++ b/policies/content-length-guardrail/contentlengthguardrail_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
@@ -130,10 +130,11 @@ func TestParseParams(t *testing.T) {
 				"max": 10,
 			},
 			expected: ContentLengthGuardrailPolicyParams{
-				Enabled:  RequestFlowEnabledByDefault,
-				Min:      1,
-				Max:      10,
-				JsonPath: DefaultJSONPath,
+				Enabled:          RequestFlowEnabledByDefault,
+				Min:              1,
+				Max:              10,
+				JsonPath:         DefaultJSONPath,
+				StreamingJsonPath: DefaultStreamingJsonPath,
 			},
 		},
 		{
@@ -146,12 +147,13 @@ func TestParseParams(t *testing.T) {
 				"showAssessment": true,
 			},
 			expected: ContentLengthGuardrailPolicyParams{
-				Enabled:        RequestFlowEnabledByDefault,
-				Min:            2,
-				Max:            20,
-				JsonPath:       "$.text",
-				Invert:         true,
-				ShowAssessment: true,
+				Enabled:          RequestFlowEnabledByDefault,
+				Min:              2,
+				Max:              20,
+				JsonPath:         "$.text",
+				StreamingJsonPath: DefaultStreamingJsonPath,
+				Invert:           true,
+				ShowAssessment:   true,
 			},
 		},
 	}
@@ -219,7 +221,7 @@ func TestParseParams_DisabledFlow_DoesNotRequireMinMax(t *testing.T) {
 
 func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	t.Run("request flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -233,16 +235,16 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected request params present and disabled, got hasRequest=%v enabled=%v", p.hasRequestParams, p.requestParams.Enabled)
 		}
 
-		action := p.OnRequest(&policy.RequestContext{
-			Body: &policy.Body{Content: []byte(`{"messages":[{"content":"hello"}]}`)},
+		action := p.OnRequestBody(&policyv1alpha2.RequestContext{
+			Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"hello"}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 			t.Fatalf("expected request no-op when request.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("response flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"response": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -256,10 +258,10 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected response params present and disabled, got hasResponse=%v enabled=%v", p.hasResponseParams, p.responseParams.Enabled)
 		}
 
-		action := p.OnResponse(&policy.ResponseContext{
-			ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"hello"}}]}`)},
+		action := p.OnResponseBody(&policyv1alpha2.ResponseContext{
+			ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"hello"}}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 			t.Fatalf("expected response no-op when response.enabled=false, got %T", action)
 		}
 	})
@@ -351,7 +353,7 @@ func TestGetPolicy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pRaw, err := GetPolicy(policy.PolicyMetadata{}, tc.params)
+			pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tc.params)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -381,16 +383,16 @@ func TestMode(t *testing.T) {
 	p := &ContentLengthGuardrailPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected RequestHeaderMode=Skip, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeBuffer {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected RequestBodyMode=Buffer, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode=Skip, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeBuffer {
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeStream {
 		t.Fatalf("expected ResponseBodyMode=Buffer, got %v", mode.ResponseBodyMode)
 	}
 }
@@ -398,13 +400,13 @@ func TestMode(t *testing.T) {
 func TestValidatePayload_RequestPaths(t *testing.T) {
 	p := &ContentLengthGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte("hello"), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	pass := p.validatePayloadV2([]byte("hello"), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10}, false)
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on valid payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(""), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10, ShowAssessment: true}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	fail := p.validatePayloadV2([]byte(""), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10, ShowAssessment: true}, false)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on invalid payload, got %T", fail)
 	}
@@ -426,21 +428,21 @@ func TestValidatePayload_RequestPaths(t *testing.T) {
 func TestValidatePayload_ResponsePaths(t *testing.T) {
 	p := &ContentLengthGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte("hello"), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10}, true)
-	if _, ok := pass.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications on valid response payload, got %T", pass)
+	pass := p.validatePayloadV2([]byte("hello"), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10}, true)
+	if _, ok := pass.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications on valid response payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(""), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10, ShowAssessment: false}, true)
-	resp, ok := fail.(policy.UpstreamResponseModifications)
+	fail := p.validatePayloadV2([]byte(""), ContentLengthGuardrailPolicyParams{Min: 1, Max: 10, ShowAssessment: false}, true)
+	resp, ok := fail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications on invalid response payload, got %T", fail)
+		t.Fatalf("expected DownstreamResponseModifications on invalid response payload, got %T", fail)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected response status %d, got %#v", GuardrailErrorCode, resp.StatusCode)
 	}
-	if resp.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("expected response content-type header, got %#v", resp.SetHeaders)
+	if resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("expected response content-type header, got %#v", resp.DownstreamResponseHeaderModifications.HeadersToSet)
 	}
 	msg := mustMessageMap(t, resp.Body)
 	if msg["direction"] != "RESPONSE" {
@@ -460,14 +462,14 @@ func TestValidatePayload_InvertMode(t *testing.T) {
 	}
 
 	// In invert mode, content within range should fail.
-	within := p.validatePayload([]byte("ab"), params, false)
-	if _, ok := within.(policy.ImmediateResponse); !ok {
+	within := p.validatePayloadV2([]byte("ab"), params, false)
+	if _, ok := within.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse when in-range payload is rejected in invert mode, got %T", within)
 	}
 
 	// In invert mode, content outside range should pass.
-	outside := p.validatePayload([]byte("abcd"), params, false)
-	if _, ok := outside.(policy.UpstreamRequestModifications); !ok {
+	outside := p.validatePayloadV2([]byte("abcd"), params, false)
+	if _, ok := outside.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications when out-of-range payload passes in invert mode, got %T", outside)
 	}
 }
@@ -476,22 +478,22 @@ func TestValidatePayload_JSONPathExtraction(t *testing.T) {
 	p := &ContentLengthGuardrailPolicy{}
 	payload := []byte(`{"data":{"text":"abc"}}`)
 
-	pass := p.validatePayload(payload, ContentLengthGuardrailPolicyParams{
+	pass := p.validatePayloadV2(payload, ContentLengthGuardrailPolicyParams{
 		Min:      3,
 		Max:      3,
 		JsonPath: "$.data.text",
 	}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass using jsonPath extraction, got %T", pass)
 	}
 
-	fail := p.validatePayload(payload, ContentLengthGuardrailPolicyParams{
+	fail := p.validatePayloadV2(payload, ContentLengthGuardrailPolicyParams{
 		Min:            1,
 		Max:            10,
 		JsonPath:       "$.missing",
 		ShowAssessment: true,
 	}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on jsonPath extraction failure, got %T", fail)
 	}
@@ -530,33 +532,33 @@ func TestBuildAssessmentObject(t *testing.T) {
 	}
 }
 
-func TestOnRequestAndOnResponse(t *testing.T) {
+func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	// No request params configured -> no-op.
 	p := &ContentLengthGuardrailPolicy{hasRequestParams: false, hasResponseParams: false}
-	reqNoOp := p.OnRequest(&policy.RequestContext{}, nil)
-	if _, ok := reqNoOp.(policy.UpstreamRequestModifications); !ok {
+	reqNoOp := p.OnRequestBody(&policyv1alpha2.RequestContext{}, nil)
+	if _, ok := reqNoOp.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op modifications, got %T", reqNoOp)
 	}
-	respNoOp := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := respNoOp.(policy.UpstreamResponseModifications); !ok {
+	respNoOp := p.OnResponseBody(&policyv1alpha2.ResponseContext{}, nil)
+	if _, ok := respNoOp.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op modifications, got %T", respNoOp)
 	}
 
 	// Request validation with nil body should fail when min > 0.
 	p.hasRequestParams = true
 	p.requestParams = ContentLengthGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10}
-	reqFail := p.OnRequest(&policy.RequestContext{Body: nil}, nil)
-	if _, ok := reqFail.(policy.ImmediateResponse); !ok {
+	reqFail := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: nil}, nil)
+	if _, ok := reqFail.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse for request nil-body validation failure, got %T", reqFail)
 	}
 
 	// Response validation with nil body should fail when min > 0.
 	p.hasResponseParams = true
 	p.responseParams = ContentLengthGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10}
-	respFail := p.OnResponse(&policy.ResponseContext{ResponseBody: nil}, nil)
-	respMod, ok := respFail.(policy.UpstreamResponseModifications)
+	respFail := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
+	respMod, ok := respFail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications for response nil-body validation failure, got %T", respFail)
+		t.Fatalf("expected DownstreamResponseModifications for response nil-body validation failure, got %T", respFail)
 	}
 	if respMod.StatusCode == nil || *respMod.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected status code %d, got %#v", GuardrailErrorCode, respMod.StatusCode)
@@ -564,15 +566,15 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 
 	// Explicitly disabled request flow should no-op.
 	p.requestParams.Enabled = false
-	reqDisabled := p.OnRequest(&policy.RequestContext{Body: &policy.Body{Content: []byte(`{"messages":[{"content":"hi"}]}`)}}, nil)
-	if _, ok := reqDisabled.(policy.UpstreamRequestModifications); !ok {
+	reqDisabled := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"hi"}]}`)}}, nil)
+	if _, ok := reqDisabled.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op when request.enabled=false, got %T", reqDisabled)
 	}
 
 	// Explicitly disabled response flow should no-op.
 	p.responseParams.Enabled = false
-	respDisabled := p.OnResponse(&policy.ResponseContext{ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"hi"}}]}`)}}, nil)
-	if _, ok := respDisabled.(policy.UpstreamResponseModifications); !ok {
+	respDisabled := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"hi"}}]}`)}}, nil)
+	if _, ok := respDisabled.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: content-length-guardrail
-version: v0.2.1
+version: v0.9.0
 description: |
   Validate content byte lengths in request or response payloads using min/max limits.
 

--- a/policies/cors/cors_test.go
+++ b/policies/cors/cors_test.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestCorsPolicy_Mode(t *testing.T) {
 	p := &CorsPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if got != want {
@@ -114,7 +114,7 @@ func TestCorsPolicy_GetPolicy_AllowCredentialsWildcardRejections(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -126,7 +126,7 @@ func TestCorsPolicy_GetPolicy_AllowCredentialsWildcardRejections(t *testing.T) {
 }
 
 func TestCorsPolicy_GetPolicy_InvalidOriginRegex(t *testing.T) {
-	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]any{
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]any{
 		"allowedOrigins": []any{"[invalid-regex"},
 	})
 	if err == nil {
@@ -149,7 +149,7 @@ func TestCorsPolicy_GetPolicy_MaxAgeFromFloatAndInt(t *testing.T) {
 	}
 }
 
-func TestCorsPolicy_OnRequest_PreflightSuccess(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_PreflightSuccess(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins":   []any{"*"},
 		"allowedMethods":   []any{"GET", "POST"},
@@ -158,7 +158,7 @@ func TestCorsPolicy_OnRequest_PreflightSuccess(t *testing.T) {
 		"maxAge":           3600,
 	})
 
-	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+	ctx := newCorsRequestHeaderContext("OPTIONS", map[string][]string{
 		"Origin":                        {"https://client.example.com"},
 		"Access-Control-Request-Method": {"GET"},
 		"Access-Control-Request-Headers": {
@@ -166,8 +166,8 @@ func TestCorsPolicy_OnRequest_PreflightSuccess(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -191,14 +191,14 @@ func TestCorsPolicy_OnRequest_PreflightSuccess(t *testing.T) {
 	}
 }
 
-func TestCorsPolicy_OnRequest_PreflightFailure_NotForwarded(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_PreflightFailure_NotForwarded(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins": []any{"https://allowed.example.com"},
 		"allowedMethods": []any{"GET"},
 		"allowedHeaders": []any{"x-api-key"},
 	})
 
-	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+	ctx := newCorsRequestHeaderContext("OPTIONS", map[string][]string{
 		"Origin":                        {"https://blocked.example.com"},
 		"Access-Control-Request-Method": {"DELETE"},
 		"Access-Control-Request-Headers": {
@@ -206,8 +206,8 @@ func TestCorsPolicy_OnRequest_PreflightFailure_NotForwarded(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -219,7 +219,7 @@ func TestCorsPolicy_OnRequest_PreflightFailure_NotForwarded(t *testing.T) {
 	}
 }
 
-func TestCorsPolicy_OnRequest_PreflightFailure_Forwarded(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_PreflightFailure_Forwarded(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins":   []any{"https://allowed.example.com"},
 		"allowedMethods":   []any{"GET"},
@@ -227,7 +227,7 @@ func TestCorsPolicy_OnRequest_PreflightFailure_Forwarded(t *testing.T) {
 		"forwardPreflight": true,
 	})
 
-	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+	ctx := newCorsRequestHeaderContext("OPTIONS", map[string][]string{
 		"Origin":                        {"https://blocked.example.com"},
 		"Access-Control-Request-Method": {"DELETE"},
 		"Access-Control-Request-Headers": {
@@ -235,26 +235,26 @@ func TestCorsPolicy_OnRequest_PreflightFailure_Forwarded(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	action := p.OnRequestHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
-func TestCorsPolicy_OnRequest_NonPreflightAllowedOrigin(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_NonPreflightAllowedOrigin(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins":   []any{"^https://allowed\\.example\\.com$"},
 		"exposedHeaders":   []any{"X-Trace-Id", "X-RateLimit-Remaining"},
 		"allowCredentials": true,
 	})
 
-	ctx := newCorsRequestContext("GET", map[string][]string{
+	ctx := newCorsRequestHeaderContext("GET", map[string][]string{
 		"Origin": {"https://allowed.example.com"},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	if action != nil {
-		t.Fatalf("expected nil action for non-preflight request, got %T", action)
+	action := p.OnRequestHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications for non-preflight request, got %T", action)
 	}
 
 	corsHeaders, ok := ctx.Metadata["cors_headers"].(map[string]string)
@@ -275,18 +275,18 @@ func TestCorsPolicy_OnRequest_NonPreflightAllowedOrigin(t *testing.T) {
 	}
 }
 
-func TestCorsPolicy_OnRequest_NonPreflightDisallowedOriginSetsStrip(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_NonPreflightDisallowedOriginSetsStrip(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins": []any{"^https://allowed\\.example\\.com$"},
 	})
 
-	ctx := newCorsRequestContext("GET", map[string][]string{
+	ctx := newCorsRequestHeaderContext("GET", map[string][]string{
 		"Origin": {"https://blocked.example.com"},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	if action != nil {
-		t.Fatalf("expected nil action for non-preflight request, got %T", action)
+	action := p.OnRequestHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications for non-preflight request, got %T", action)
 	}
 	if ctx.Metadata["cors_strip"] != true {
 		t.Fatalf("expected cors_strip=true, got %v", ctx.Metadata["cors_strip"])
@@ -296,13 +296,13 @@ func TestCorsPolicy_OnRequest_NonPreflightDisallowedOriginSetsStrip(t *testing.T
 	}
 }
 
-func TestCorsPolicy_OnRequest_NonPreflightWithoutOriginNoStrip(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_NonPreflightWithoutOriginNoStrip(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins": []any{"^https://allowed\\.example\\.com$"},
 	})
 
-	ctx := newCorsRequestContext("GET", nil)
-	_ = p.OnRequest(ctx, nil)
+	ctx := newCorsRequestHeaderContext("GET", nil)
+	_ = p.OnRequestHeaders(ctx, nil)
 
 	if _, ok := ctx.Metadata["cors_strip"]; ok {
 		t.Fatalf("did not expect cors_strip metadata when Origin is absent")
@@ -312,10 +312,10 @@ func TestCorsPolicy_OnRequest_NonPreflightWithoutOriginNoStrip(t *testing.T) {
 	}
 }
 
-func TestCorsPolicy_OnResponse_FromCorsHeadersMetadata(t *testing.T) {
+func TestCorsPolicy_OnResponseHeaders_FromCorsHeadersMetadata(t *testing.T) {
 	p := &CorsPolicy{}
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-1",
 			Metadata: map[string]interface{}{
 				"cors_headers": map[string]string{
@@ -325,20 +325,20 @@ func TestCorsPolicy_OnResponse_FromCorsHeadersMetadata(t *testing.T) {
 		},
 	}
 
-	action := p.OnResponse(ctx, nil)
-	mods, ok := action.(policy.UpstreamResponseModifications)
+	action := p.OnResponseHeaders(ctx, nil)
+	mods, ok := action.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
-	if mods.SetHeaders["Access-Control-Allow-Origin"] != "*" {
-		t.Fatalf("unexpected set headers: %v", mods.SetHeaders)
+	if mods.HeadersToSet["Access-Control-Allow-Origin"] != "*" {
+		t.Fatalf("unexpected set headers: %v", mods.HeadersToSet)
 	}
 }
 
-func TestCorsPolicy_OnResponse_FromCorsStripMetadata(t *testing.T) {
+func TestCorsPolicy_OnResponseHeaders_FromCorsStripMetadata(t *testing.T) {
 	p := &CorsPolicy{}
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-1",
 			Metadata: map[string]interface{}{
 				"cors_strip": true,
@@ -346,44 +346,44 @@ func TestCorsPolicy_OnResponse_FromCorsStripMetadata(t *testing.T) {
 		},
 	}
 
-	action := p.OnResponse(ctx, nil)
-	mods, ok := action.(policy.UpstreamResponseModifications)
+	action := p.OnResponseHeaders(ctx, nil)
+	mods, ok := action.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
 	want := []string{
 		"Access-Control-Allow-Origin",
 		"Access-Control-Allow-Credentials",
 		"Access-Control-Expose-Headers",
 	}
-	if !reflect.DeepEqual(mods.RemoveHeaders, want) {
-		t.Fatalf("unexpected remove headers: got %v, want %v", mods.RemoveHeaders, want)
+	if !reflect.DeepEqual(mods.HeadersToRemove, want) {
+		t.Fatalf("unexpected remove headers: got %v, want %v", mods.HeadersToRemove, want)
 	}
 }
 
-func TestCorsPolicy_OnResponse_NoMetadata(t *testing.T) {
+func TestCorsPolicy_OnResponseHeaders_NoMetadata(t *testing.T) {
 	p := &CorsPolicy{}
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-1",
 			Metadata:  map[string]interface{}{},
 		},
 	}
 
-	action := p.OnResponse(ctx, nil)
-	if action != nil {
-		t.Fatalf("expected nil, got %T", action)
+	action := p.OnResponseHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseHeaderModifications); !ok {
+		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
 }
 
-func TestCorsPolicy_OnRequest_PreflightSpecificAllowedHeadersCaseInsensitive(t *testing.T) {
+func TestCorsPolicy_OnRequestHeaders_PreflightSpecificAllowedHeadersCaseInsensitive(t *testing.T) {
 	p := mustGetCorsPolicy(t, map[string]any{
 		"allowedOrigins": []any{"*"},
 		"allowedMethods": []any{"GET"},
 		"allowedHeaders": []any{"X-Token", "X-Trace-Id"},
 	})
 
-	ctx := newCorsRequestContext("OPTIONS", map[string][]string{
+	ctx := newCorsRequestHeaderContext("OPTIONS", map[string][]string{
 		"Origin":                        {"https://client.example.com"},
 		"Access-Control-Request-Method": {"GET"},
 		"Access-Control-Request-Headers": {
@@ -391,8 +391,8 @@ func TestCorsPolicy_OnRequest_PreflightSpecificAllowedHeadersCaseInsensitive(t *
 		},
 	})
 
-	action := p.OnRequest(ctx, nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -403,9 +403,9 @@ func TestCorsPolicy_OnRequest_PreflightSpecificAllowedHeadersCaseInsensitive(t *
 
 func mustGetCorsPolicy(t *testing.T, params map[string]any) *CorsPolicy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 	cp, ok := p.(*CorsPolicy)
 	if !ok {
@@ -414,16 +414,16 @@ func mustGetCorsPolicy(t *testing.T, params map[string]any) *CorsPolicy {
 	return cp
 }
 
-func newCorsRequestContext(method string, headers map[string][]string) *policy.RequestContext {
+func newCorsRequestHeaderContext(method string, headers map[string][]string) *policyv1alpha2.RequestHeaderContext {
 	if headers == nil {
 		headers = map[string][]string{}
 	}
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-1",
 			Metadata:  map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(headers),
+		Headers: policyv1alpha2.NewHeaders(headers),
 		Method:  method,
 	}
 }

--- a/policies/cors/policy-definition.yaml
+++ b/policies/cors/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: cors
-version: v0.8.0
+version: v0.9.0
 description: |
   Applies Cross-Origin Resource Sharing (CORS) rules by handling preflight
   requests and adding CORS headers to responses. Controls cross-origin access

--- a/policies/dynamic-endpoint/policy-definition.yaml
+++ b/policies/dynamic-endpoint/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: dynamic-endpoint
-version: v0.2.0
+version: v0.9.0
 description: |
   Routes requests to a dynamically specified upstream definition.
   This policy reads an upstream name from parameters and routes the request to that upstream.

--- a/policies/json-schema-guardrail/jsonschemaguardrail_test.go
+++ b/policies/json-schema-guardrail/jsonschemaguardrail_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/xeipuuv/gojsonschema"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func decodeMessage(t *testing.T, body []byte) map[string]interface{} {
@@ -174,7 +174,7 @@ func TestParseParams_DisabledFlow_DoesNotRequireSchema(t *testing.T) {
 
 func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	t.Run("request flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -188,16 +188,16 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected request params present and disabled, got hasRequest=%v enabled=%v", p.hasRequestParams, p.requestParams.Enabled)
 		}
 
-		action := p.OnRequest(&policy.RequestContext{
-			Body: &policy.Body{Content: []byte(`{"name":"alice"}`)},
+		action := p.OnRequestBody(&policyv1alpha2.RequestContext{
+			Body: &policyv1alpha2.Body{Content: []byte(`{"name":"alice"}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 			t.Fatalf("expected request no-op when request.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("response flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"response": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -211,16 +211,16 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected response params present and disabled, got hasResponse=%v enabled=%v", p.hasResponseParams, p.responseParams.Enabled)
 		}
 
-		action := p.OnResponse(&policy.ResponseContext{
-			ResponseBody: &policy.Body{Content: []byte(`{"name":"alice"}`)},
+		action := p.OnResponseBody(&policyv1alpha2.ResponseContext{
+			ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"name":"alice"}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 			t.Fatalf("expected response no-op when response.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("disabled flow accepts empty schema", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{
 				"enabled": false,
 				"schema":  "",
@@ -239,27 +239,27 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	})
 }
 
-func TestGetPolicy(t *testing.T) {
-	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+func TestGetPolicyV2(t *testing.T) {
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err == nil || !strings.Contains(err.Error(), "at least one of 'request' or 'response' parameters must be provided") {
 		t.Fatalf("expected missing phase params error, got %v", err)
 	}
 
-	_, err = GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	_, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"request": map[string]interface{}{"schema": "{"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "invalid request parameters") {
 		t.Fatalf("expected invalid request params error, got %v", err)
 	}
 
-	_, err = GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	_, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"response": map[string]interface{}{"schema": "{"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "invalid response parameters") {
 		t.Fatalf("expected invalid response params error, got %v", err)
 	}
 
-	pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"request": map[string]interface{}{"schema": `{"type":"object"}`},
 	})
 	if err != nil {
@@ -279,7 +279,7 @@ func TestGetPolicy(t *testing.T) {
 		t.Fatalf("expected request disabled by default")
 	}
 
-	pRaw, err = GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	pRaw, err = GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"request":  map[string]interface{}{"schema": `{"type":"object"}`},
 		"response": map[string]interface{}{"schema": `{"type":"object"}`},
 	})
@@ -336,40 +336,40 @@ func TestMode(t *testing.T) {
 	p := &JSONSchemaGuardrailPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected RequestHeaderMode=Skip, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeBuffer {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected RequestBodyMode=Buffer, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode=Skip, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeBuffer {
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected ResponseBodyMode=Buffer, got %v", mode.ResponseBodyMode)
 	}
 }
 
-func TestValidatePayload_NormalAndInvert(t *testing.T) {
+func TestValidatePayloadV2_NormalAndInvert(t *testing.T) {
 	p := &JSONSchemaGuardrailPolicy{}
 	schema := `{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`
 	validPayload := []byte(`{"name":"alice"}`)
 	invalidPayload := []byte(`{"name":10}`)
 
 	// Normal mode valid -> pass
-	result := p.validatePayload(validPayload, JSONSchemaGuardrailPolicyParams{
+	result := p.validatePayloadV2(validPayload, JSONSchemaGuardrailPolicyParams{
 		Schema: schema,
 	}, false)
-	if _, ok := result.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := result.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
 
 	// Normal mode invalid -> fail
-	result = p.validatePayload(invalidPayload, JSONSchemaGuardrailPolicyParams{
+	result = p.validatePayloadV2(invalidPayload, JSONSchemaGuardrailPolicyParams{
 		Schema:         schema,
 		ShowAssessment: true,
 	}, false)
-	imm, ok := result.(policy.ImmediateResponse)
+	imm, ok := result.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", result)
 	}
@@ -388,34 +388,34 @@ func TestValidatePayload_NormalAndInvert(t *testing.T) {
 	}
 
 	// Invert mode valid -> fail
-	result = p.validatePayload(validPayload, JSONSchemaGuardrailPolicyParams{
+	result = p.validatePayloadV2(validPayload, JSONSchemaGuardrailPolicyParams{
 		Schema: schema,
 		Invert: true,
 	}, false)
-	if _, ok := result.(policy.ImmediateResponse); !ok {
+	if _, ok := result.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse for inverted-valid case, got %T", result)
 	}
 
 	// Invert mode invalid -> pass
-	result = p.validatePayload(invalidPayload, JSONSchemaGuardrailPolicyParams{
+	result = p.validatePayloadV2(invalidPayload, JSONSchemaGuardrailPolicyParams{
 		Schema: schema,
 		Invert: true,
 	}, false)
-	if _, ok := result.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := result.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications for inverted-invalid case, got %T", result)
 	}
 }
 
-func TestValidatePayload_JSONPathAndSchemaErrors(t *testing.T) {
+func TestValidatePayloadV2_JSONPathAndSchemaErrors(t *testing.T) {
 	p := &JSONSchemaGuardrailPolicy{}
 
 	// JSONPath extraction error
-	result := p.validatePayload([]byte(`{"name":"alice"}`), JSONSchemaGuardrailPolicyParams{
+	result := p.validatePayloadV2([]byte(`{"name":"alice"}`), JSONSchemaGuardrailPolicyParams{
 		Schema:         `{"type":"string"}`,
 		JsonPath:       "$.missing",
 		ShowAssessment: true,
 	}, false)
-	imm, ok := result.(policy.ImmediateResponse)
+	imm, ok := result.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on JSONPath error, got %T", result)
 	}
@@ -428,11 +428,11 @@ func TestValidatePayload_JSONPathAndSchemaErrors(t *testing.T) {
 	}
 
 	// Schema validation engine error (invalid schema keywords/types)
-	result = p.validatePayload([]byte(`{"name":"alice"}`), JSONSchemaGuardrailPolicyParams{
+	result = p.validatePayloadV2([]byte(`{"name":"alice"}`), JSONSchemaGuardrailPolicyParams{
 		Schema:         `{"type":"not-a-valid-jsonschema-type"}`,
 		ShowAssessment: true,
 	}, false)
-	imm, ok = result.(policy.ImmediateResponse)
+	imm, ok = result.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on schema validation engine error, got %T", result)
 	}
@@ -445,18 +445,18 @@ func TestValidatePayload_JSONPathAndSchemaErrors(t *testing.T) {
 	}
 }
 
-func TestBuildErrorResponseResponsePhase(t *testing.T) {
+func TestBuildErrorResponseV2_ResponsePhase(t *testing.T) {
 	p := &JSONSchemaGuardrailPolicy{}
-	res := p.buildErrorResponse("test reason", nil, true, false, nil)
-	mod, ok := res.(policy.UpstreamResponseModifications)
+	res := p.buildErrorResponseV2("test reason", nil, true, false, nil)
+	mod, ok := res.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", res)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", res)
 	}
 	if mod.StatusCode == nil || *mod.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected status %d, got %#v", GuardrailErrorCode, mod.StatusCode)
 	}
-	if mod.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("expected Content-Type header, got %#v", mod.SetHeaders)
+	if mod.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("expected Content-Type header, got %#v", mod.DownstreamResponseHeaderModifications.HeadersToSet)
 	}
 	msg := decodeMessage(t, mod.Body)
 	if msg["direction"] != "RESPONSE" {
@@ -495,16 +495,16 @@ func TestBuildAssessmentObject(t *testing.T) {
 	}
 }
 
-func TestOnRequestAndOnResponse(t *testing.T) {
+func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	// No configured phase params -> no-op
 	p := &JSONSchemaGuardrailPolicy{}
-	reqResult := p.OnRequest(&policy.RequestContext{}, nil)
-	if _, ok := reqResult.(policy.UpstreamRequestModifications); !ok {
+	reqResult := p.OnRequestBody(&policyv1alpha2.RequestContext{}, nil)
+	if _, ok := reqResult.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications no-op, got %T", reqResult)
 	}
-	respResult := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := respResult.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications no-op, got %T", respResult)
+	respResult := p.OnResponseBody(&policyv1alpha2.ResponseContext{}, nil)
+	if _, ok := respResult.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications no-op, got %T", respResult)
 	}
 
 	// Request phase configured, nil body -> validation failure
@@ -513,8 +513,8 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 		Enabled: true,
 		Schema:  `{"type":"object","required":["name"]}`,
 	}
-	reqResult = p.OnRequest(&policy.RequestContext{Body: nil}, nil)
-	if _, ok := reqResult.(policy.ImmediateResponse); !ok {
+	reqResult = p.OnRequestBody(&policyv1alpha2.RequestContext{Body: nil}, nil)
+	if _, ok := reqResult.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse on invalid request payload, got %T", reqResult)
 	}
 
@@ -524,24 +524,24 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 		Enabled: true,
 		Schema:  `{"type":"object","required":["name"]}`,
 	}
-	respResult = p.OnResponse(&policy.ResponseContext{ResponseBody: nil}, nil)
-	respMod, ok := respResult.(policy.UpstreamResponseModifications)
+	respResult = p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
+	respMod, ok := respResult.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications on invalid response payload, got %T", respResult)
+		t.Fatalf("expected DownstreamResponseModifications on invalid response payload, got %T", respResult)
 	}
 	if respMod.StatusCode == nil || *respMod.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected status %d, got %#v", GuardrailErrorCode, respMod.StatusCode)
 	}
 
 	p.requestParams.Enabled = false
-	reqDisabled := p.OnRequest(&policy.RequestContext{Body: &policy.Body{Content: []byte(`{"name":"alice"}`)}}, nil)
-	if _, ok := reqDisabled.(policy.UpstreamRequestModifications); !ok {
+	reqDisabled := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: &policyv1alpha2.Body{Content: []byte(`{"name":"alice"}`)}}, nil)
+	if _, ok := reqDisabled.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op when request.enabled=false, got %T", reqDisabled)
 	}
 
 	p.responseParams.Enabled = false
-	respDisabled := p.OnResponse(&policy.ResponseContext{ResponseBody: &policy.Body{Content: []byte(`{"name":"alice"}`)}}, nil)
-	if _, ok := respDisabled.(policy.UpstreamResponseModifications); !ok {
+	respDisabled := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"name":"alice"}`)}}, nil)
+	if _, ok := respDisabled.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }

--- a/policies/json-schema-guardrail/policy-definition.yaml
+++ b/policies/json-schema-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-schema-guardrail
-version: v0.2.2
+version: v0.9.0
 description: |
   Validate request or response content against a JSON Schema.
 

--- a/policies/json-xml-mediator/jsonxmlmediation_test.go
+++ b/policies/json-xml-mediator/jsonxmlmediation_test.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
-func createHeaders(key, value string) *policy.Headers {
+func createHeaders(key, value string) *policyv1alpha2.Headers {
 	h := map[string][]string{}
 	h[key] = []string{value}
-	return policy.NewHeaders(h)
+	return policyv1alpha2.NewHeaders(h)
 }
 
 func parseErrorJSON(t *testing.T, body []byte) map[string]interface{} {
@@ -26,7 +26,7 @@ func parseErrorJSON(t *testing.T, body []byte) map[string]interface{} {
 func newConfiguredPolicy(t *testing.T, params map[string]interface{}) *JSONXMLMediationPolicy {
 	t.Helper()
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestGetPolicy_InvalidUpstreamFormatConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tc.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tc.params)
 			if err == nil {
 				t.Fatalf("expected error for params %#v", tc.params)
 			}
@@ -140,11 +140,11 @@ func TestGetPolicy_InvalidUpstreamFormatConfig(t *testing.T) {
 func TestMode(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("xml", "json"))
 	mode := p.Mode()
-	expected := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	expected := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
 	}
 	if mode != expected {
 		t.Fatalf("unexpected mode: %+v", mode)
@@ -153,36 +153,36 @@ func TestMode(t *testing.T) {
 
 func TestOnRequest_JSONToXML_Success(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("xml", "json"))
-	ctx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`{"name":"John","age":30}`), Present: true},
+	ctx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`{"name":"John","age":30}`), Present: true},
 		Headers: createHeaders("content-type", "application/json"),
 	}
 
-	result := p.OnRequest(ctx, nil)
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestBody(ctx, nil)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
 	if mods.Body == nil || !strings.Contains(string(mods.Body), "<name>John</name>") {
 		t.Fatalf("expected transformed XML body, got: %s", string(mods.Body))
 	}
-	if mods.SetHeaders["content-type"] != "application/xml" {
-		t.Fatalf("unexpected content-type: %s", mods.SetHeaders["content-type"])
+	if mods.UpstreamRequestHeaderModifications.HeadersToSet["content-type"] != "application/xml" {
+		t.Fatalf("unexpected content-type: %s", mods.UpstreamRequestHeaderModifications.HeadersToSet["content-type"])
 	}
-	if mods.SetHeaders["content-length"] == "" {
+	if mods.UpstreamRequestHeaderModifications.HeadersToSet["content-length"] == "" {
 		t.Fatalf("expected content-length header")
 	}
 }
 
 func TestOnRequest_XMLToJSON_Success(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("json", "xml"))
-	ctx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`<root><name>John</name><age>30</age></root>`), Present: true},
+	ctx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`<root><name>John</name><age>30</age></root>`), Present: true},
 		Headers: createHeaders("content-type", "text/xml; charset=utf-8"),
 	}
 
-	result := p.OnRequest(ctx, nil)
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestBody(ctx, nil)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 	}
@@ -193,20 +193,20 @@ func TestOnRequest_XMLToJSON_Success(t *testing.T) {
 	if err := json.Unmarshal(mods.Body, &parsed); err != nil {
 		t.Fatalf("expected valid JSON output, got error: %v", err)
 	}
-	if mods.SetHeaders["content-type"] != "application/json" {
-		t.Fatalf("unexpected content-type: %s", mods.SetHeaders["content-type"])
+	if mods.UpstreamRequestHeaderModifications.HeadersToSet["content-type"] != "application/json" {
+		t.Fatalf("unexpected content-type: %s", mods.UpstreamRequestHeaderModifications.HeadersToSet["content-type"])
 	}
 }
 
 func TestOnResponse_XMLToJSON_Success(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("xml", "json"))
-	ctx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`<root><status>ok</status></root>`), Present: true},
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`<root><status>ok</status></root>`), Present: true},
 		ResponseHeaders: createHeaders("content-type", "application/xml"),
 	}
 
-	result := p.OnResponse(ctx, nil)
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseBody(ctx, nil)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
 	}
@@ -217,28 +217,28 @@ func TestOnResponse_XMLToJSON_Success(t *testing.T) {
 	if err := json.Unmarshal(mods.Body, &parsed); err != nil {
 		t.Fatalf("expected valid JSON output, got error: %v", err)
 	}
-	if mods.SetHeaders["content-type"] != "application/json" {
-		t.Fatalf("unexpected content-type: %s", mods.SetHeaders["content-type"])
+	if mods.DownstreamResponseHeaderModifications.HeadersToSet["content-type"] != "application/json" {
+		t.Fatalf("unexpected content-type: %s", mods.DownstreamResponseHeaderModifications.HeadersToSet["content-type"])
 	}
 }
 
 func TestOnResponse_JSONToXML_Success(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("json", "xml"))
-	ctx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`{"status":"ok"}`), Present: true},
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`{"status":"ok"}`), Present: true},
 		ResponseHeaders: createHeaders("content-type", "application/json; charset=utf-8"),
 	}
 
-	result := p.OnResponse(ctx, nil)
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseBody(ctx, nil)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
 	}
 	if mods.Body == nil || !strings.Contains(string(mods.Body), "<status>ok</status>") {
 		t.Fatalf("expected transformed XML response body, got: %s", string(mods.Body))
 	}
-	if mods.SetHeaders["content-type"] != "application/xml" {
-		t.Fatalf("unexpected content-type: %s", mods.SetHeaders["content-type"])
+	if mods.DownstreamResponseHeaderModifications.HeadersToSet["content-type"] != "application/xml" {
+		t.Fatalf("unexpected content-type: %s", mods.DownstreamResponseHeaderModifications.HeadersToSet["content-type"])
 	}
 }
 
@@ -246,32 +246,32 @@ func TestOnRequest_ContentTypeAndPayloadErrors(t *testing.T) {
 	pJSONToXML := newConfiguredPolicy(t, configuredParams("xml", "json"))
 	pXMLToJSON := newConfiguredPolicy(t, configuredParams("json", "xml"))
 
-	wrongTypeCtx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`{"name":"x"}`), Present: true},
+	wrongTypeCtx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`{"name":"x"}`), Present: true},
 		Headers: createHeaders("content-type", "application/xml"),
 	}
-	res := pJSONToXML.OnRequest(wrongTypeCtx, nil)
-	immediate, ok := res.(policy.ImmediateResponse)
+	res := pJSONToXML.OnRequestBody(wrongTypeCtx, nil)
+	immediate, ok := res.(policyv1alpha2.ImmediateResponse)
 	if !ok || immediate.StatusCode != 500 {
 		t.Fatalf("expected 500 ImmediateResponse for wrong content type, got %T %#v", res, res)
 	}
 
-	invalidJSONCtx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`{"name":`), Present: true},
+	invalidJSONCtx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`{"name":`), Present: true},
 		Headers: createHeaders("content-type", "application/json"),
 	}
-	res = pJSONToXML.OnRequest(invalidJSONCtx, nil)
-	immediate, ok = res.(policy.ImmediateResponse)
+	res = pJSONToXML.OnRequestBody(invalidJSONCtx, nil)
+	immediate, ok = res.(policyv1alpha2.ImmediateResponse)
 	if !ok || immediate.StatusCode != 500 {
 		t.Fatalf("expected 500 ImmediateResponse for invalid JSON, got %T %#v", res, res)
 	}
 
-	invalidXMLCtx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`<root><name>x</root>`), Present: true},
+	invalidXMLCtx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`<root><name>x</root>`), Present: true},
 		Headers: createHeaders("content-type", "application/xml"),
 	}
-	res = pXMLToJSON.OnRequest(invalidXMLCtx, nil)
-	immediate, ok = res.(policy.ImmediateResponse)
+	res = pXMLToJSON.OnRequestBody(invalidXMLCtx, nil)
+	immediate, ok = res.(policyv1alpha2.ImmediateResponse)
 	if !ok || immediate.StatusCode != 500 {
 		t.Fatalf("expected 500 ImmediateResponse for invalid XML, got %T %#v", res, res)
 	}
@@ -286,32 +286,32 @@ func TestOnResponse_ContentTypeAndPayloadErrors(t *testing.T) {
 	pXMLToJSON := newConfiguredPolicy(t, configuredParams("xml", "json"))
 	pJSONToXML := newConfiguredPolicy(t, configuredParams("json", "xml"))
 
-	wrongTypeCtx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`<root/>`), Present: true},
+	wrongTypeCtx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`<root/>`), Present: true},
 		ResponseHeaders: createHeaders("content-type", "application/json"),
 	}
-	res := pXMLToJSON.OnResponse(wrongTypeCtx, nil)
-	mods, ok := res.(policy.UpstreamResponseModifications)
+	res := pXMLToJSON.OnResponseBody(wrongTypeCtx, nil)
+	mods, ok := res.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok || mods.StatusCode == nil || *mods.StatusCode != 500 {
 		t.Fatalf("expected 500 UpstreamResponseModifications for wrong content type, got %T %#v", res, res)
 	}
 
-	invalidJSONCtx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`{"x":`), Present: true},
+	invalidJSONCtx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`{"x":`), Present: true},
 		ResponseHeaders: createHeaders("content-type", "application/json"),
 	}
-	res = pJSONToXML.OnResponse(invalidJSONCtx, nil)
-	mods, ok = res.(policy.UpstreamResponseModifications)
+	res = pJSONToXML.OnResponseBody(invalidJSONCtx, nil)
+	mods, ok = res.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok || mods.StatusCode == nil || *mods.StatusCode != 500 {
 		t.Fatalf("expected 500 UpstreamResponseModifications for invalid JSON, got %T %#v", res, res)
 	}
 
-	invalidXMLCtx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`<root><x></root>`), Present: true},
+	invalidXMLCtx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`<root><x></root>`), Present: true},
 		ResponseHeaders: createHeaders("content-type", "application/xml"),
 	}
-	res = pXMLToJSON.OnResponse(invalidXMLCtx, nil)
-	mods, ok = res.(policy.UpstreamResponseModifications)
+	res = pXMLToJSON.OnResponseBody(invalidXMLCtx, nil)
+	mods, ok = res.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok || mods.StatusCode == nil || *mods.StatusCode != 500 {
 		t.Fatalf("expected 500 UpstreamResponseModifications for invalid XML, got %T %#v", res, res)
 	}
@@ -325,12 +325,12 @@ func TestOnResponse_ContentTypeAndPayloadErrors(t *testing.T) {
 func TestNoBodyPassThrough(t *testing.T) {
 	p := newConfiguredPolicy(t, configuredParams("xml", "json"))
 
-	reqCtx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte{}, Present: false},
+	reqCtx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte{}, Present: false},
 		Headers: createHeaders("content-type", "application/json"),
 	}
-	reqResult := p.OnRequest(reqCtx, nil)
-	reqMods, ok := reqResult.(policy.UpstreamRequestModifications)
+	reqResult := p.OnRequestBody(reqCtx, nil)
+	reqMods, ok := reqResult.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", reqResult)
 	}
@@ -338,12 +338,12 @@ func TestNoBodyPassThrough(t *testing.T) {
 		t.Fatalf("expected nil body for request pass-through, got %s", string(reqMods.Body))
 	}
 
-	respCtx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte{}, Present: false},
+	respCtx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte{}, Present: false},
 		ResponseHeaders: createHeaders("content-type", "application/xml"),
 	}
-	respResult := p.OnResponse(respCtx, nil)
-	respMods, ok := respResult.(policy.UpstreamResponseModifications)
+	respResult := p.OnResponseBody(respCtx, nil)
+	respMods, ok := respResult.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", respResult)
 	}

--- a/policies/json-xml-mediator/jsonxmlmediation_test.go
+++ b/policies/json-xml-mediator/jsonxmlmediation_test.go
@@ -208,7 +208,7 @@ func TestOnResponse_XMLToJSON_Success(t *testing.T) {
 	result := p.OnResponseBody(ctx, nil)
 	mods, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", result)
 	}
 	if mods.Body == nil {
 		t.Fatalf("expected transformed JSON response body")
@@ -232,7 +232,7 @@ func TestOnResponse_JSONToXML_Success(t *testing.T) {
 	result := p.OnResponseBody(ctx, nil)
 	mods, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", result)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", result)
 	}
 	if mods.Body == nil || !strings.Contains(string(mods.Body), "<status>ok</status>") {
 		t.Fatalf("expected transformed XML response body, got: %s", string(mods.Body))
@@ -345,7 +345,7 @@ func TestNoBodyPassThrough(t *testing.T) {
 	respResult := p.OnResponseBody(respCtx, nil)
 	respMods, ok := respResult.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", respResult)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", respResult)
 	}
 	if respMods.Body != nil {
 		t.Fatalf("expected nil body for response pass-through, got %s", string(respMods.Body))

--- a/policies/json-xml-mediator/policy-definition.yaml
+++ b/policies/json-xml-mediator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-xml-mediator
-version: v0.8.0
+version: v0.9.0
 description: |
   Mediates request and response payloads between downstream and upstream JSON/XML formats
 

--- a/policies/jwt-auth/jwtauth_hardening_test.go
+++ b/policies/jwt-auth/jwtauth_hardening_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestJWTAuthPolicy_HappyPath_RemoteJWKS_IssuerNameAudienceScope(t *testing.T) {
@@ -38,7 +38,7 @@ func TestJWTAuthPolicy_HappyPath_RemoteJWKS_IssuerNameAudienceScope(t *testing.T
 	params["audiences"] = []interface{}{"api-audience"}
 	params["requiredScopes"] = []interface{}{"read"}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -60,7 +60,7 @@ func TestJWTAuthPolicy_HappyPath_AudienceArray_AndScpArray(t *testing.T) {
 	params["audiences"] = []interface{}{"api-audience"}
 	params["requiredScopes"] = []interface{}{"write"}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -80,7 +80,7 @@ func TestJWTAuthPolicy_HappyPath_CustomHeaderName_AndPrefix(t *testing.T) {
 	params["headerName"] = "X-Auth-Token"
 	params["authHeaderPrefix"] = "JWT"
 
-	ctx, action := executeOnRequest(t, params, authHeader("X-Auth-Token", "JWT", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("X-Auth-Token", "JWT", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -112,14 +112,14 @@ func TestJWTAuthPolicy_HappyPath_LocalCert_WithClaimMappings_AndUserIdClaim(t *t
 	}
 	params["userIdClaim"] = "username"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
-	if mods.SetHeaders["X-User-Email"] != "alice@example.com" {
+	if mods.HeadersToSet["X-User-Email"] != "alice@example.com" {
 		t.Fatalf("expected X-User-Email header to be set")
 	}
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Subject != "alice" {
@@ -135,10 +135,10 @@ func TestJWTAuthPolicy_Negative_MissingAuthorizationHeader(t *testing.T) {
 	params["errorMessageFormat"] = "plain"
 	params["errorMessage"] = "missing auth"
 
-	ctx, action := executeOnRequest(t, params, map[string][]string{})
+	ctx, action := executeOnRequestHeaders(t, params, map[string][]string{})
 	assertAuthFailure(t, ctx, action, 403)
 
-	resp := action.(policy.ImmediateResponse)
+	resp := action.(policyv1alpha2.ImmediateResponse)
 	if string(resp.Body) != "missing auth" {
 		t.Fatalf("expected plain error body")
 	}
@@ -159,7 +159,7 @@ func TestJWTAuthPolicy_Negative_WrongAuthorizationScheme(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["authHeaderScheme"] = "Bearer"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "JWT", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "JWT", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -167,7 +167,7 @@ func TestJWTAuthPolicy_Negative_MalformedJWT(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 
 	params := newRemoteParams("http://localhost:8080/jwks.json")
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", "not.a.jwt"))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", "not.a.jwt"))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -184,7 +184,7 @@ func TestJWTAuthPolicy_Negative_MissingAlgHeader(t *testing.T) {
 	}, "test-kid")
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -203,7 +203,7 @@ func TestJWTAuthPolicy_Negative_DisallowedAlgorithm(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["allowedAlgorithms"] = []interface{}{"ES256"}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -220,7 +220,7 @@ func TestJWTAuthPolicy_Negative_KidNotFoundInJWKS(t *testing.T) {
 	}, "missing-kid")
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -240,7 +240,7 @@ func TestJWTAuthPolicy_Edge_ExpWithinLeeway_Accepts(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["leeway"] = "30s"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -260,7 +260,7 @@ func TestJWTAuthPolicy_Edge_ExpBeyondLeeway_Rejects(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["leeway"] = "30s"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -280,7 +280,7 @@ func TestJWTAuthPolicy_Edge_NbfWithinLeeway_Accepts(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["leeway"] = "30s"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -300,7 +300,7 @@ func TestJWTAuthPolicy_Edge_NbfBeyondLeeway_Rejects(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["leeway"] = "30s"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -322,18 +322,18 @@ func TestJWTAuthPolicy_Edge_NegativeRetryCount_NoPanic(t *testing.T) {
 	params["jwksFetchRetryInterval"] = "1ms"
 
 	var (
-		ctx    *policy.RequestContext
-		action policy.RequestAction
+		ctx    *policyv1alpha2.RequestHeaderContext
+		action policyv1alpha2.RequestHeaderAction
 	)
 
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			t.Fatalf("OnRequest must not panic for invalid retry count: %v", recovered)
+			t.Fatalf("OnRequestHeaders must not panic for invalid retry count: %v", recovered)
 		}
 		assertAuthFailure(t, ctx, action, 401)
 	}()
 
-	ctx, action = executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action = executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 }
 
 func TestJWTAuthPolicy_Edge_RetryEventuallySucceeds(t *testing.T) {
@@ -367,7 +367,7 @@ func TestJWTAuthPolicy_Edge_RetryEventuallySucceeds(t *testing.T) {
 	params["jwksFetchRetryInterval"] = "1ms"
 	params["jwksFetchTimeout"] = "100ms"
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 
 	if got := atomic.LoadInt32(&requestCount); got != 3 {
@@ -401,12 +401,12 @@ func TestJWTAuthPolicy_Edge_JWKSCacheHit_SkipsRefetch(t *testing.T) {
 
 	p := mustGetPolicy(t, params)
 
-	ctx1 := createMockRequestContext(authHeader("Authorization", "Bearer", token))
-	action1 := p.OnRequest(ctx1, params)
+	ctx1 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action1 := p.(*JwtAuthPolicy).OnRequestHeaders(ctx1, params)
 	assertAuthSuccess(t, ctx1, action1)
 
-	ctx2 := createMockRequestContext(authHeader("Authorization", "Bearer", token))
-	action2 := p.OnRequest(ctx2, params)
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(ctx2, params)
 	assertAuthSuccess(t, ctx2, action2)
 
 	if got := atomic.LoadInt32(&requestCount); got != 1 {
@@ -440,14 +440,14 @@ func TestJWTAuthPolicy_Edge_JWKSCacheExpiry_Refetches(t *testing.T) {
 
 	p := mustGetPolicy(t, params)
 
-	ctx1 := createMockRequestContext(authHeader("Authorization", "Bearer", token))
-	action1 := p.OnRequest(ctx1, params)
+	ctx1 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action1 := p.(*JwtAuthPolicy).OnRequestHeaders(ctx1, params)
 	assertAuthSuccess(t, ctx1, action1)
 
 	time.Sleep(25 * time.Millisecond)
 
-	ctx2 := createMockRequestContext(authHeader("Authorization", "Bearer", token))
-	action2 := p.OnRequest(ctx2, params)
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(ctx2, params)
 	assertAuthSuccess(t, ctx2, action2)
 
 	if got := atomic.LoadInt32(&requestCount); got < 2 {
@@ -470,7 +470,7 @@ func TestJWTAuthPolicy_Security_AlgNoneRejected(t *testing.T) {
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["allowedAlgorithms"] = []interface{}{"RS256"}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -489,7 +489,7 @@ func TestJWTAuthPolicy_Security_ValidateIssuerTrue_RejectsUnknownIssuer(t *testi
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["validateIssuer"] = true
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -508,7 +508,7 @@ func TestJWTAuthPolicy_Security_ValidateIssuerFalse_AllowsIssuerMismatch_WithVal
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["validateIssuer"] = false
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -544,7 +544,7 @@ func TestJWTAuthPolicy_Security_UserIssuers_MultipleManagers_TriesFallbackManage
 	}
 	params["issuers"] = []interface{}{"km-bad", "km-good"}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -576,7 +576,7 @@ func TestJWTAuthPolicy_Security_MissingIss_ValidateIssuerToggle(t *testing.T) {
 			params := newRemoteParams(jwksServer.URL + "/jwks.json")
 			params["validateIssuer"] = tc.validate
 
-			ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+			ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 			if tc.expectPass {
 				assertAuthSuccess(t, ctx, action)
 			} else {
@@ -599,7 +599,7 @@ func TestJWTAuthPolicy_Security_AuthorizationSchemeCaseInsensitive(t *testing.T)
 	})
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "bearer", token))
 	assertAuthSuccess(t, ctx, action)
 }
 
@@ -641,10 +641,10 @@ func TestJWTAuthPolicy_Regression_ErrorFormats_JsonPlainMinimal(t *testing.T) {
 			params["errorMessage"] = "custom error message"
 			params["onFailureStatusCode"] = 401
 
-			ctx, action := executeOnRequest(t, params, map[string][]string{})
+			ctx, action := executeOnRequestHeaders(t, params, map[string][]string{})
 			assertAuthFailure(t, ctx, action, 401)
 
-			resp := action.(policy.ImmediateResponse)
+			resp := action.(policyv1alpha2.ImmediateResponse)
 			if resp.Headers["content-type"] != tc.expectedType {
 				t.Fatalf("expected content-type %s, got %s", tc.expectedType, resp.Headers["content-type"])
 			}
@@ -665,7 +665,7 @@ func TestJWTAuthPolicy_Regression_OnFailureStatusCodeHonored(t *testing.T) {
 
 	params := newRemoteParams("http://localhost:8080/jwks.json")
 	params["onFailureStatusCode"] = 403
-	ctx, action := executeOnRequest(t, params, map[string][]string{})
+	ctx, action := executeOnRequestHeaders(t, params, map[string][]string{})
 	assertAuthFailure(t, ctx, action, 403)
 }
 
@@ -685,7 +685,7 @@ func TestJWTAuthPolicy_Regression_MetadataSetOnSuccessAndFailure(t *testing.T) {
 		})
 		params := newRemoteParams(jwksServer.URL + "/jwks.json")
 
-		ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+		ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 		assertAuthSuccess(t, ctx, action)
 
 		if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.AuthType != "jwt" {
@@ -697,7 +697,7 @@ func TestJWTAuthPolicy_Regression_MetadataSetOnSuccessAndFailure(t *testing.T) {
 		resetJWTAuthSingletonCache(t)
 
 		params := newRemoteParams("http://localhost:8080/jwks.json")
-		ctx, action := executeOnRequest(t, params, map[string][]string{})
+		ctx, action := executeOnRequestHeaders(t, params, map[string][]string{})
 		assertAuthFailure(t, ctx, action, 401)
 
 		// On failure, AuthContext should indicate not authenticated
@@ -707,7 +707,7 @@ func TestJWTAuthPolicy_Regression_MetadataSetOnSuccessAndFailure(t *testing.T) {
 	})
 }
 
-func TestJWTAuthPolicy_Regression_ModeAndOnResponseContract(t *testing.T) {
+func TestJWTAuthPolicy_Regression_ModeContract(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 
 	p := mustGetPolicy(t, map[string]interface{}{})
@@ -717,21 +717,17 @@ func TestJWTAuthPolicy_Regression_ModeAndOnResponseContract(t *testing.T) {
 	}
 
 	mode := jwtPolicy.Mode()
-	if mode.RequestHeaderMode != policy.HeaderModeProcess {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeProcess {
 		t.Fatalf("expected RequestHeaderMode to be process")
 	}
-	if mode.RequestBodyMode != policy.BodyModeSkip {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Fatalf("expected RequestBodyMode to be skip")
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode to be skip")
 	}
-	if mode.ResponseBodyMode != policy.BodyModeSkip {
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Fatalf("expected ResponseBodyMode to be skip")
-	}
-
-	if action := jwtPolicy.OnResponse(&policy.ResponseContext{}, map[string]interface{}{}); action != nil {
-		t.Fatalf("expected nil response action, got %T", action)
 	}
 }
 
@@ -753,7 +749,7 @@ func TestJWTAuthPolicy_Regression_RequiredClaimsTypeMismatch(t *testing.T) {
 		"role": "admin",
 	}
 
-	ctx, action := executeOnRequest(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -866,18 +862,18 @@ func resetJWTAuthSingletonCache(t *testing.T) {
 	})
 }
 
-func executeOnRequest(t *testing.T, params map[string]interface{}, headers map[string][]string) (*policy.RequestContext, policy.RequestAction) {
+func executeOnRequestHeaders(t *testing.T, params map[string]interface{}, headers map[string][]string) (*policyv1alpha2.RequestHeaderContext, policyv1alpha2.RequestHeaderAction) {
 	t.Helper()
 	p := mustGetPolicy(t, params)
-	ctx := createMockRequestContext(headers)
-	return ctx, p.OnRequest(ctx, params)
+	ctx := createMockRequestHeaderContext(headers)
+	return ctx, p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 }
 
-func mustGetPolicy(t *testing.T, params map[string]interface{}) policy.Policy {
+func mustGetPolicy(t *testing.T, params map[string]interface{}) policyv1alpha2.Policy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 	return p
 }
@@ -917,7 +913,7 @@ func authHeader(headerName, scheme, token string) map[string][]string {
 	}
 }
 
-func assertAuthSuccess(t *testing.T, ctx *policy.RequestContext, action policy.RequestAction) {
+func assertAuthSuccess(t *testing.T, ctx *policyv1alpha2.RequestHeaderContext, action policyv1alpha2.RequestHeaderAction) {
 	t.Helper()
 
 	if ctx == nil {
@@ -926,12 +922,12 @@ func assertAuthSuccess(t *testing.T, ctx *policy.RequestContext, action policy.R
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("expected auth success, got unauthenticated context")
 	}
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
-func assertAuthFailure(t *testing.T, ctx *policy.RequestContext, action policy.RequestAction, statusCode int) {
+func assertAuthFailure(t *testing.T, ctx *policyv1alpha2.RequestHeaderContext, action policyv1alpha2.RequestHeaderAction, statusCode int) {
 	t.Helper()
 
 	if ctx == nil {
@@ -941,7 +937,7 @@ func assertAuthFailure(t *testing.T, ctx *policy.RequestContext, action policy.R
 		t.Fatalf("expected auth failure, got authenticated context")
 	}
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -952,12 +948,10 @@ func assertAuthFailure(t *testing.T, ctx *policy.RequestContext, action policy.R
 
 func createRS256TokenWithKid(t *testing.T, privateKey *rsa.PrivateKey, claims map[string]interface{}, kid string) string {
 	t.Helper()
+	claims = normalizeClaims(claims)
 
-	normalizedClaims := normalizeClaims(claims)
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(normalizedClaims))
-	if kid != "" {
-		token.Header["kid"] = kid
-	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
+	token.Header["kid"] = kid
 
 	tokenString, err := token.SignedString(privateKey)
 	if err != nil {
@@ -968,78 +962,65 @@ func createRS256TokenWithKid(t *testing.T, privateKey *rsa.PrivateKey, claims ma
 
 func createUnsignedNoneToken(t *testing.T, claims map[string]interface{}) string {
 	t.Helper()
+	claims = normalizeClaims(claims)
 
-	normalizedClaims := normalizeClaims(claims)
-	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims(normalizedClaims))
-	token.Header["kid"] = "none-kid"
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims(claims))
 
 	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	if err != nil {
-		t.Fatalf("failed to sign none token: %v", err)
+		t.Fatalf("failed to create unsigned token: %v", err)
 	}
 	return tokenString
 }
 
 func createTokenWithoutAlgHeader(t *testing.T, privateKey *rsa.PrivateKey, claims map[string]interface{}, kid string) string {
 	t.Helper()
+	claims = normalizeClaims(claims)
 
-	normalizedClaims := normalizeClaims(claims)
-	header := map[string]interface{}{
-		"typ": "JWT",
-	}
-	if kid != "" {
-		header["kid"] = kid
-	}
-
-	headerJSON, err := json.Marshal(header)
+	headerJSON, err := json.Marshal(map[string]string{"typ": "JWT", "kid": kid})
 	if err != nil {
 		t.Fatalf("failed to marshal header: %v", err)
 	}
-	payloadJSON, err := json.Marshal(normalizedClaims)
+	payloadJSON, err := json.Marshal(claims)
 	if err != nil {
 		t.Fatalf("failed to marshal claims: %v", err)
 	}
 
-	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
-	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
-	signingInput := headerEncoded + "." + payloadEncoded
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := header + "." + payload
 
-	digest := sha256.Sum256([]byte(signingInput))
-	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hashed[:])
 	if err != nil {
-		t.Fatalf("failed to create signature: %v", err)
+		t.Fatalf("failed to sign token: %v", err)
 	}
 
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
 }
 
 func normalizeClaims(claims map[string]interface{}) map[string]interface{} {
-	normalized := make(map[string]interface{}, len(claims)+2)
-	for k, v := range claims {
-		normalized[k] = v
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
 	}
-	if _, ok := normalized["exp"]; !ok {
-		normalized["exp"] = time.Now().Add(time.Hour).Unix()
+	if _, ok := claims["iat"]; !ok {
+		claims["iat"] = time.Now().Unix()
 	}
-	if _, ok := normalized["iat"]; !ok {
-		normalized["iat"] = time.Now().Unix()
-	}
-	return normalized
+	return claims
 }
 
 func writeJWKSResponse(t *testing.T, w http.ResponseWriter, publicKey *rsa.PublicKey, kid string) {
 	t.Helper()
+	nBytes := publicKey.N.Bytes()
+	nB64 := base64.RawURLEncoding.EncodeToString(nBytes)
 
-	nB64 := base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes())
-
-	e := publicKey.E
-	eBytes := make([]byte, 0, 4)
-	for e > 0 {
-		eBytes = append([]byte{byte(e & 0xFF)}, eBytes...)
-		e >>= 8
-	}
-	if len(eBytes) == 0 {
-		eBytes = []byte{0}
+	eBytes := make([]byte, 4)
+	eBytes[0] = byte((publicKey.E >> 24) & 0xFF)
+	eBytes[1] = byte((publicKey.E >> 16) & 0xFF)
+	eBytes[2] = byte((publicKey.E >> 8) & 0xFF)
+	eBytes[3] = byte(publicKey.E & 0xFF)
+	for len(eBytes) > 1 && eBytes[0] == 0 {
+		eBytes = eBytes[1:]
 	}
 	eB64 := base64.RawURLEncoding.EncodeToString(eBytes)
 
@@ -1058,6 +1039,6 @@ func writeJWKSResponse(t *testing.T, w http.ResponseWriter, publicKey *rsa.Publi
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(jwks); err != nil {
-		t.Fatalf("failed to encode JWKS response: %v", err)
+		t.Logf("Failed to encode JWKS: %v", err)
 	}
 }

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package jwtauth
 
 import (
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 )
 
@@ -60,7 +61,7 @@ func TestJWTAuthPolicy_ValidToken(t *testing.T) {
 	})
 
 	// Create request context with Authorization header
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -95,13 +96,13 @@ func TestJWTAuthPolicy_ValidToken(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify successful authentication
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
@@ -111,26 +112,26 @@ func TestJWTAuthPolicy_ValidToken(t *testing.T) {
 		t.Errorf("Expected AuthType='jwt', got %q", ctx.SharedContext.AuthContext.AuthType)
 	}
 
-	// Verify it's an UpstreamRequestModifications action
-	modifications, ok := action.(policy.UpstreamRequestModifications)
+	// Verify it's an UpstreamRequestHeaderModifications action
+	modifications, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 
 	// Verify claim mappings were applied as headers
-	if modifications.SetHeaders["X-User-ID"] != "user123" {
-		t.Errorf("Expected X-User-ID header to be 'user123', got %s", modifications.SetHeaders["X-User-ID"])
+	if modifications.HeadersToSet["X-User-ID"] != "user123" {
+		t.Errorf("Expected X-User-ID header to be 'user123', got %s", modifications.HeadersToSet["X-User-ID"])
 	}
 
-	if modifications.SetHeaders["X-User-Name"] != "John Doe" {
-		t.Errorf("Expected X-User-Name header to be 'John Doe', got %s", modifications.SetHeaders["X-User-Name"])
+	if modifications.HeadersToSet["X-User-Name"] != "John Doe" {
+		t.Errorf("Expected X-User-Name header to be 'John Doe', got %s", modifications.HeadersToSet["X-User-Name"])
 	}
 }
 
 // TestJWTAuthPolicy_MissingToken tests authentication failure when Authorization header is missing
 func TestJWTAuthPolicy_MissingToken(t *testing.T) {
 	// Create request context without Authorization header
-	ctx := createMockRequestContext(map[string][]string{})
+	ctx := createMockRequestHeaderContext(map[string][]string{})
 
 	params := map[string]interface{}{
 		"headerName":          "Authorization",
@@ -151,12 +152,12 @@ func TestJWTAuthPolicy_MissingToken(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify authentication failed
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
@@ -164,7 +165,7 @@ func TestJWTAuthPolicy_MissingToken(t *testing.T) {
 	}
 
 	// Verify it's an ImmediateResponse
-	response, ok := action.(policy.ImmediateResponse)
+	response, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse, got %T", action)
 	}
@@ -176,7 +177,7 @@ func TestJWTAuthPolicy_MissingToken(t *testing.T) {
 
 // TestJWTAuthPolicy_InvalidTokenFormat tests with malformed token
 func TestJWTAuthPolicy_InvalidTokenFormat(t *testing.T) {
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {"Bearer invalid.token"},
 	})
 
@@ -196,18 +197,18 @@ func TestJWTAuthPolicy_InvalidTokenFormat(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=false for invalid token format")
 	}
 
-	_, ok := action.(policy.ImmediateResponse)
+	_, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for invalid token, got %T", action)
 	}
@@ -226,7 +227,7 @@ func TestJWTAuthPolicy_ExpiredToken(t *testing.T) {
 		"iss": "https://issuer.example.com",
 	}, expiredTime)
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -245,18 +246,18 @@ func TestJWTAuthPolicy_ExpiredToken(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=false for expired token")
 	}
 
-	_, ok := action.(policy.ImmediateResponse)
+	_, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for expired token")
 	}
@@ -274,7 +275,7 @@ func TestJWTAuthPolicy_InvalidAudience(t *testing.T) {
 		"iss": "https://issuer.example.com",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -293,18 +294,18 @@ func TestJWTAuthPolicy_InvalidAudience(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=false for invalid audience")
 	}
 
-	_, ok := action.(policy.ImmediateResponse)
+	_, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for invalid audience")
 	}
@@ -322,7 +323,7 @@ func TestJWTAuthPolicy_CustomClaims(t *testing.T) {
 		"iss":  "https://issuer.example.com",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -343,20 +344,20 @@ func TestJWTAuthPolicy_CustomClaims(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true when required claims match")
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications for valid token with matching claims")
+		t.Fatalf("Expected UpstreamRequestHeaderModifications for valid token with matching claims")
 	}
 }
 
@@ -372,7 +373,7 @@ func TestJWTAuthPolicy_InvalidCustomClaims(t *testing.T) {
 		"iss":  "https://issuer.example.com",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -393,18 +394,18 @@ func TestJWTAuthPolicy_InvalidCustomClaims(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=false for mismatched required claims")
 	}
 
-	_, ok := action.(policy.ImmediateResponse)
+	_, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for invalid claims")
 	}
@@ -426,7 +427,7 @@ func TestJWTAuthPolicy_InvalidSignature(t *testing.T) {
 		"iss": "https://issuer.example.com",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -444,19 +445,19 @@ func TestJWTAuthPolicy_InvalidSignature(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Should fail because signature doesn't match the JWKS public key
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=false for token signed with invalid key")
 	}
 
-	response, ok := action.(policy.ImmediateResponse)
+	response, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for invalid signature, got %T", action)
 	}
@@ -477,7 +478,7 @@ func TestJWTAuthPolicy_CustomHeaderPrefix(t *testing.T) {
 		"iss": "https://issuer.example.com",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("JWT %s", token)},
 	})
 
@@ -496,26 +497,26 @@ func TestJWTAuthPolicy_CustomHeaderPrefix(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true with custom prefix override")
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications with custom header prefix")
+		t.Fatalf("Expected UpstreamRequestHeaderModifications with custom header prefix")
 	}
 }
 
 // TestJWTAuthPolicy_ErrorResponseFormat tests different error response formats
 func TestJWTAuthPolicy_ErrorResponseFormatJSON(t *testing.T) {
-	ctx := createMockRequestContext(map[string][]string{})
+	ctx := createMockRequestHeaderContext(map[string][]string{})
 
 	params := map[string]interface{}{
 		"errorMessageFormat":  "json",
@@ -531,14 +532,14 @@ func TestJWTAuthPolicy_ErrorResponseFormatJSON(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
-	response := action.(policy.ImmediateResponse)
+	response := action.(policyv1alpha2.ImmediateResponse)
 	if response.Headers["content-type"] != "application/json" {
 		t.Errorf("Expected content-type to be application/json")
 	}
@@ -550,7 +551,7 @@ func TestJWTAuthPolicy_ErrorResponseFormatJSON(t *testing.T) {
 }
 
 func TestJWTAuthPolicy_ErrorResponseFormatPlain(t *testing.T) {
-	ctx := createMockRequestContext(map[string][]string{})
+	ctx := createMockRequestHeaderContext(map[string][]string{})
 
 	params := map[string]interface{}{
 		"errorMessageFormat":  "plain",
@@ -566,14 +567,14 @@ func TestJWTAuthPolicy_ErrorResponseFormatPlain(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
-	response := action.(policy.ImmediateResponse)
+	response := action.(policyv1alpha2.ImmediateResponse)
 	if response.Headers["content-type"] != "text/plain" {
 		t.Errorf("Expected content-type to be text/plain")
 	}
@@ -626,7 +627,7 @@ func TestJWTAuthPolicy_RemoteWithSelfSignedCert(t *testing.T) {
 	})
 
 	// Create request context
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -653,22 +654,22 @@ func TestJWTAuthPolicy_RemoteWithSelfSignedCert(t *testing.T) {
 		"audiences": []interface{}{"api-audience"},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify successful authentication - token validated against self-signed JWKS
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true with self-signed certificate")
 	}
 
-	// Verify it's an UpstreamRequestModifications action
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+	// Verify it's an UpstreamRequestHeaderModifications action
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -719,7 +720,7 @@ func TestJWTAuthPolicy_SkipTlsVerify_Success(t *testing.T) {
 	})
 
 	// Create request context
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -746,22 +747,22 @@ func TestJWTAuthPolicy_SkipTlsVerify_Success(t *testing.T) {
 		"audiences": []interface{}{"api-audience"},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify successful authentication - TLS verification was skipped
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true with skipTlsVerify=true")
 	}
 
-	// Verify it's an UpstreamRequestModifications action
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+	// Verify it's an UpstreamRequestHeaderModifications action
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -812,7 +813,7 @@ func TestJWTAuthPolicy_SkipTlsVerify_False_Fails(t *testing.T) {
 	})
 
 	// Create request context
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -840,13 +841,13 @@ func TestJWTAuthPolicy_SkipTlsVerify_False_Fails(t *testing.T) {
 		"jwksFetchRetryCount": 0,
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify authentication failed - TLS verification should fail for self-signed cert
 	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
@@ -854,7 +855,7 @@ func TestJWTAuthPolicy_SkipTlsVerify_False_Fails(t *testing.T) {
 	}
 
 	// Verify it's an ImmediateResponse (error)
-	response, ok := action.(policy.ImmediateResponse)
+	response, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse for TLS verification failure, got %T", action)
 	}
@@ -880,7 +881,7 @@ func TestJWTAuthPolicy_LocalInlineCertificate(t *testing.T) {
 	pubKeyPEM := publicKeyToPEM(t, publicKey)
 
 	// Create request context
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -906,22 +907,22 @@ func TestJWTAuthPolicy_LocalInlineCertificate(t *testing.T) {
 		"audiences": []interface{}{"api-audience"},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify successful authentication
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true with inline certificate")
 	}
 
-	// Verify it's an UpstreamRequestModifications action
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+	// Verify it's an UpstreamRequestHeaderModifications action
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -942,7 +943,7 @@ func TestJWTAuthPolicy_LocalCertificateFile(t *testing.T) {
 	defer os.Remove(certPath)
 
 	// Create request context
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -968,22 +969,22 @@ func TestJWTAuthPolicy_LocalCertificateFile(t *testing.T) {
 		"audiences": []interface{}{"api-audience"},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("Failed to create policy: %v", err)
 	}
 
 	// Execute policy
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Verify successful authentication
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Errorf("Expected AuthContext.Authenticated=true with certificate file")
 	}
 
-	// Verify it's an UpstreamRequestModifications action
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+	// Verify it's an UpstreamRequestHeaderModifications action
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1066,6 +1067,8 @@ func createJWKSServer(t *testing.T, publicKey *rsa.PublicKey, kid string) *httpt
 	return server
 }
 
+// createMockRequestContext creates a v1alpha RequestContext for private helper tests
+// (handleAuthSuccess, handleAuthFailure) which still use the v1alpha interface.
 func createMockRequestContext(headers map[string][]string) *policy.RequestContext {
 	return &policy.RequestContext{
 		SharedContext: &policy.SharedContext{
@@ -1079,7 +1082,18 @@ func createMockRequestContext(headers map[string][]string) *policy.RequestContex
 	}
 }
 
-// createTestHeaders is no longer needed with NewHeaders
+// createMockRequestHeaderContext creates a v1alpha2 RequestHeaderContext for OnRequestHeaders tests.
+func createMockRequestHeaderContext(headers map[string][]string) *policyv1alpha2.RequestHeaderContext {
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  make(map[string]interface{}),
+		},
+		Headers: policyv1alpha2.NewHeaders(headers),
+		Path:    "/api/test",
+		Method:  "GET",
+	}
+}
 
 // createHTTPSJWKSServerUnstarted creates an unstarted HTTPS server for initial hostname detection
 func createHTTPSJWKSServerUnstarted(t *testing.T, publicKey *rsa.PublicKey, kid string) *httptest.Server {
@@ -1216,89 +1230,6 @@ func createSelfSignedCertForHost(t *testing.T, hostURL string) (string, []byte, 
 	return certFile.Name() + ":" + keyFile.Name(), certPEM, caFile.Name()
 }
 
-// // createSelfSignedCert creates a self-signed certificate for testing HTTPS endpoints
-// func createSelfSignedCert(t *testing.T) (string, []byte, string) {
-// 	// Generate RSA key
-// 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-// 	if err != nil {
-// 		t.Fatalf("Failed to generate private key: %v", err)
-// 	}
-
-// 	// Create certificate template
-// 	template := &x509.Certificate{
-// 		SerialNumber: big.NewInt(1),
-// 		Subject: pkix.Name{
-// 			Organization: []string{"Test"},
-// 			CommonName:   "localhost",
-// 		},
-// 		NotBefore:             time.Now(),
-// 		NotAfter:              time.Now().Add(24 * time.Hour),
-// 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-// 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-// 		BasicConstraintsValid: true,
-// 		IsCA:                  true,
-// 		DNSNames:              []string{"localhost", "127.0.0.1"},
-// 	}
-
-// 	// Create self-signed certificate
-// 	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
-// 	if err != nil {
-// 		t.Fatalf("Failed to create certificate: %v", err)
-// 	}
-
-// 	// Encode certificate to PEM
-// 	certPEM := pem.EncodeToMemory(&pem.Block{
-// 		Type:  "CERTIFICATE",
-// 		Bytes: certBytes,
-// 	})
-
-// 	// Encode private key to PEM
-// 	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-// 	if err != nil {
-// 		t.Fatalf("Failed to marshal private key: %v", err)
-// 	}
-
-// 	keyPEM := pem.EncodeToMemory(&pem.Block{
-// 		Type:  "PRIVATE KEY",
-// 		Bytes: privKeyBytes,
-// 	})
-
-// 	// Write certificate to temporary file
-// 	certFile, err := os.CreateTemp("", "test-cert-*.pem")
-// 	if err != nil {
-// 		t.Fatalf("Failed to create cert temporary file: %v", err)
-// 	}
-// 	defer certFile.Close()
-
-// 	if _, err := certFile.Write(certPEM); err != nil {
-// 		t.Fatalf("Failed to write certificate to file: %v", err)
-// 	}
-
-// 	// Write private key to temporary file
-// 	keyFile, err := os.CreateTemp("", "test-key-*.pem")
-// 	if err != nil {
-// 		t.Fatalf("Failed to create key temporary file: %v", err)
-// 	}
-// 	defer keyFile.Close()
-
-// 	if _, err := keyFile.Write(keyPEM); err != nil {
-// 		t.Fatalf("Failed to write key to file: %v", err)
-// 	}
-
-// 	// Write CA cert to separate temporary file (for client validation)
-// 	caFile, err := os.CreateTemp("", "test-ca-*.pem")
-// 	if err != nil {
-// 		t.Fatalf("Failed to create CA temp file: %v", err)
-// 	}
-// 	defer caFile.Close()
-
-// 	if _, err := caFile.Write(certPEM); err != nil {
-// 		t.Fatalf("Failed to write CA cert to file: %v", err)
-// 	}
-
-// 	return certFile.Name() + ":" + keyFile.Name(), certPEM, caFile.Name()
-// }
-
 // createHTTPSJWKSServer creates an HTTPS JWKS endpoint with self-signed certificate
 func createHTTPSJWKSServer(t *testing.T, publicKey *rsa.PublicKey, kid string, certKeyPath string) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1407,7 +1338,7 @@ func TestJWTAuthPolicy_UserIdClaim_DefaultSub(t *testing.T) {
 		"aud": "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1427,12 +1358,12 @@ func TestJWTAuthPolicy_UserIdClaim_DefaultSub(t *testing.T) {
 		// userIdClaim not specified, should default to "sub"
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1443,9 +1374,9 @@ func TestJWTAuthPolicy_UserIdClaim_DefaultSub(t *testing.T) {
 		t.Errorf("Expected Subject='user-12345', got %q", ctx.SharedContext.AuthContext.Subject)
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1464,7 +1395,7 @@ func TestJWTAuthPolicy_UserIdClaim_CustomClaim(t *testing.T) {
 		"aud":     "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1484,12 +1415,12 @@ func TestJWTAuthPolicy_UserIdClaim_CustomClaim(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1503,9 +1434,9 @@ func TestJWTAuthPolicy_UserIdClaim_CustomClaim(t *testing.T) {
 		t.Errorf("Expected Properties[\"user_id\"]='custom-user-9999', got %q", ctx.SharedContext.AuthContext.Properties["user_id"])
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1523,7 +1454,7 @@ func TestJWTAuthPolicy_UserIdClaim_EmailClaim(t *testing.T) {
 		"aud":   "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1543,12 +1474,12 @@ func TestJWTAuthPolicy_UserIdClaim_EmailClaim(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1562,9 +1493,9 @@ func TestJWTAuthPolicy_UserIdClaim_EmailClaim(t *testing.T) {
 		t.Errorf("Expected Properties[\"email\"]='alice@example.com', got %q", ctx.SharedContext.AuthContext.Properties["email"])
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1582,7 +1513,7 @@ func TestJWTAuthPolicy_UserIdClaim_MissingClaim(t *testing.T) {
 		// Note: no 'preferred_username' claim
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1602,12 +1533,12 @@ func TestJWTAuthPolicy_UserIdClaim_MissingClaim(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	// Authentication should still succeed even if a custom claim doesn't exist
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
@@ -1619,9 +1550,9 @@ func TestJWTAuthPolicy_UserIdClaim_MissingClaim(t *testing.T) {
 		t.Errorf("Expected Subject='user-12345' (from sub), got %q", ctx.SharedContext.AuthContext.Subject)
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1639,7 +1570,7 @@ func TestJWTAuthPolicy_UserIdClaim_NumericValue(t *testing.T) {
 		"aud":        "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1659,12 +1590,12 @@ func TestJWTAuthPolicy_UserIdClaim_NumericValue(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1678,9 +1609,9 @@ func TestJWTAuthPolicy_UserIdClaim_NumericValue(t *testing.T) {
 		t.Errorf("Expected Properties[\"account_id\"]='987654321', got %q", ctx.SharedContext.AuthContext.Properties["account_id"])
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1697,7 +1628,7 @@ func TestJWTAuthPolicy_UserIdClaim_EmptyString(t *testing.T) {
 		"aud": "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1717,12 +1648,12 @@ func TestJWTAuthPolicy_UserIdClaim_EmptyString(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1733,9 +1664,9 @@ func TestJWTAuthPolicy_UserIdClaim_EmptyString(t *testing.T) {
 		t.Errorf("Expected Subject='user-12345' (from sub), got %q", ctx.SharedContext.AuthContext.Subject)
 	}
 
-	_, ok := action.(policy.UpstreamRequestModifications)
+	_, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 }
 
@@ -1755,7 +1686,7 @@ func TestJWTAuthPolicy_UserIdClaim_WithClaimMappings(t *testing.T) {
 		"aud":      "api-audience",
 	})
 
-	ctx := createMockRequestContext(map[string][]string{
+	ctx := createMockRequestHeaderContext(map[string][]string{
 		"authorization": {fmt.Sprintf("Bearer %s", token)},
 	})
 
@@ -1779,12 +1710,12 @@ func TestJWTAuthPolicy_UserIdClaim_WithClaimMappings(t *testing.T) {
 		},
 	}
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
-	action := p.OnRequest(ctx, params)
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(ctx, params)
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
 		t.Fatalf("Expected AuthContext.Authenticated=true")
@@ -1796,20 +1727,22 @@ func TestJWTAuthPolicy_UserIdClaim_WithClaimMappings(t *testing.T) {
 	}
 
 	// Verify claim mappings were also applied
-	modifications, ok := action.(policy.UpstreamRequestModifications)
+	modifications, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Fatalf("Expected UpstreamRequestModifications, got %T", action)
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
 	}
 
-	if modifications.SetHeaders["X-User-Email"] != "john@example.com" {
-		t.Errorf("Expected X-User-Email='john@example.com', got '%v'", modifications.SetHeaders["X-User-Email"])
+	if modifications.HeadersToSet["X-User-Email"] != "john@example.com" {
+		t.Errorf("Expected X-User-Email='john@example.com', got '%v'", modifications.HeadersToSet["X-User-Email"])
 	}
 
-	if modifications.SetHeaders["X-User-Role"] != "admin" {
-		t.Errorf("Expected X-User-Role='admin', got '%v'", modifications.SetHeaders["X-User-Role"])
+	if modifications.HeadersToSet["X-User-Role"] != "admin" {
+		t.Errorf("Expected X-User-Role='admin', got '%v'", modifications.HeadersToSet["X-User-Role"])
 	}
 }
 
+// TestJWTAuthPolicy_AuthContext_PreviousPreserved_OnSuccess tests that the v1alpha helper
+// chains AuthContext entries on success.
 func TestJWTAuthPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	p := &JwtAuthPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}
@@ -1827,6 +1760,8 @@ func TestJWTAuthPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	}
 }
 
+// TestJWTAuthPolicy_AuthContext_PreviousPreserved_OnFailure tests that the v1alpha helper
+// chains AuthContext entries on failure.
 func TestJWTAuthPolicy_AuthContext_PreviousPreserved_OnFailure(t *testing.T) {
 	p := &JwtAuthPolicy{}
 	prior := &policy.AuthContext{Authenticated: true, AuthType: "other"}

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v0.8.3
+version: v0.9.0
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/wso2/api-platform/sdk v0.3.8
 	github.com/wso2/api-platform/sdk/core v0.1.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2 // upgrade
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/wso2/api-platform/sdk v0.3.8
 	github.com/wso2/api-platform/sdk/core v0.1.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2 // upgrade
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v0.1.0
+version: v0.9.0
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v0.1.1
+version: v0.9.0
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").

--- a/policies/log-message/logmessage_test.go
+++ b/policies/log-message/logmessage_test.go
@@ -26,25 +26,25 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 var slogMessagePattern = regexp.MustCompile(`msg="((?:\\.|[^"])*)"`)
 
-func createTestHeaders(headers map[string]string) *policy.Headers {
+func createTestHeaders(headers map[string]string) *policyv1alpha2.Headers {
 	headerMap := make(map[string][]string)
 	for key, value := range headers {
 		headerMap[key] = []string{value}
 	}
-	return policy.NewHeaders(headerMap)
+	return policyv1alpha2.NewHeaders(headerMap)
 }
 
-func createTestHeadersMulti(headers map[string][]string) *policy.Headers {
+func createTestHeadersMulti(headers map[string][]string) *policyv1alpha2.Headers {
 	headerMap := make(map[string][]string)
 	for key, values := range headers {
 		headerMap[key] = values
 	}
-	return policy.NewHeaders(headerMap)
+	return policyv1alpha2.NewHeaders(headerMap)
 }
 
 func toInterfaceSlice(items []string) []interface{} {
@@ -106,11 +106,11 @@ func TestLogMessagePolicy_Mode(t *testing.T) {
 	p := &LogMessagePolicy{}
 	mode := p.Mode()
 
-	expectedMode := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	expectedMode := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeStream,
 	}
 
 	if mode != expectedMode {
@@ -118,10 +118,10 @@ func TestLogMessagePolicy_Mode(t *testing.T) {
 	}
 }
 
-func TestGetPolicy(t *testing.T) {
-	policyInstance, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+func TestGetPolicyV2(t *testing.T) {
+	policyInstance, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 
 	if _, ok := policyInstance.(*LogMessagePolicy); !ok {
@@ -213,7 +213,7 @@ func TestParseExcludedHeaders(t *testing.T) {
 	})
 }
 
-func TestBuildHeadersMap_MasksAuthorizationAndExcludes(t *testing.T) {
+func TestBuildHeadersMapV2_MasksAuthorizationAndExcludes(t *testing.T) {
 	p := &LogMessagePolicy{}
 	headers := createTestHeadersMulti(map[string][]string{
 		"Content-Type":  {"application/json"},
@@ -222,7 +222,7 @@ func TestBuildHeadersMap_MasksAuthorizationAndExcludes(t *testing.T) {
 		"X-Multi":       {"one", "two"},
 	})
 
-	result := p.buildHeadersMap(headers, map[string]struct{}{"x-api-key": {}})
+	result := p.buildHeadersMapV2(headers, map[string]struct{}{"x-api-key": {}})
 
 	authValue, ok := getHeaderValue(result, "authorization")
 	if !ok {
@@ -249,42 +249,41 @@ func TestBuildHeadersMap_MasksAuthorizationAndExcludes(t *testing.T) {
 	}
 }
 
-func TestBuildHeadersMap_NilHeaders(t *testing.T) {
+func TestBuildHeadersMapV2_NilHeaders(t *testing.T) {
 	p := &LogMessagePolicy{}
-	result := p.buildHeadersMap(nil, map[string]struct{}{})
+	result := p.buildHeadersMapV2(nil, map[string]struct{}{})
 	if len(result) != 0 {
 		t.Fatalf("expected empty map for nil headers, got %v", result)
 	}
 }
 
-func TestGetRequestID(t *testing.T) {
+func TestGetRequestIDV2(t *testing.T) {
 	p := &LogMessagePolicy{}
 
 	t.Run("present", func(t *testing.T) {
 		headers := createTestHeaders(map[string]string{"x-request-id": "req-123"})
-		if requestID := p.getRequestID(headers); requestID != "req-123" {
+		if requestID := p.getRequestIDV2(headers); requestID != "req-123" {
 			t.Fatalf("expected req-123, got %s", requestID)
 		}
 	})
 
 	t.Run("missing", func(t *testing.T) {
 		headers := createTestHeaders(map[string]string{"content-type": "application/json"})
-		if requestID := p.getRequestID(headers); requestID != ErrMsgMissingReqID {
+		if requestID := p.getRequestIDV2(headers); requestID != ErrMsgMissingReqID {
 			t.Fatalf("expected %s, got %s", ErrMsgMissingReqID, requestID)
 		}
 	})
 
 	t.Run("nil headers", func(t *testing.T) {
-		if requestID := p.getRequestID(nil); requestID != ErrMsgMissingReqID {
+		if requestID := p.getRequestIDV2(nil); requestID != ErrMsgMissingReqID {
 			t.Fatalf("expected %s, got %s", ErrMsgMissingReqID, requestID)
 		}
 	})
 }
 
-func TestOnRequest_NoRequestConfig_DoesNotLog(t *testing.T) {
+func TestOnRequestHeaders_NoRequestConfig_DoesNotLog(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.RequestContext{
-		Body: &policy.Body{Content: []byte(`{"hello":"world"}`), Present: true},
+	ctx := &policyv1alpha2.RequestHeaderContext{
 		Headers: createTestHeaders(map[string]string{
 			"x-request-id": "req-001",
 		}),
@@ -293,11 +292,11 @@ func TestOnRequest_NoRequestConfig_DoesNotLog(t *testing.T) {
 	}
 
 	records := captureLogRecords(t, func() {
-		result := p.OnRequest(ctx, map[string]interface{}{
-			"response": map[string]interface{}{"payload": true},
+		result := p.OnRequestHeaders(ctx, map[string]interface{}{
+			"response": map[string]interface{}{"headers": true},
 		})
-		if _, ok := result.(policy.UpstreamRequestModifications); !ok {
-			t.Fatalf("expected UpstreamRequestModifications, got %T", result)
+		if _, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+			t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
 		}
 	})
 
@@ -306,10 +305,9 @@ func TestOnRequest_NoRequestConfig_DoesNotLog(t *testing.T) {
 	}
 }
 
-func TestOnRequest_LogsPayloadAndHeaders(t *testing.T) {
+func TestOnRequestHeaders_LogsHeaders(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.RequestContext{
-		Body: &policy.Body{Content: []byte(`{"action":"login"}`), Present: true},
+	ctx := &policyv1alpha2.RequestHeaderContext{
 		Headers: createTestHeaders(map[string]string{
 			"x-request-id":   "req-123",
 			"authorization":  "Bearer secret",
@@ -321,14 +319,104 @@ func TestOnRequest_LogsPayloadAndHeaders(t *testing.T) {
 	}
 
 	records := captureLogRecords(t, func() {
-		result := p.OnRequest(ctx, map[string]interface{}{
+		result := p.OnRequestHeaders(ctx, map[string]interface{}{
 			"request": map[string]interface{}{
-				"payload":        true,
 				"headers":        true,
 				"excludeHeaders": toInterfaceSlice([]string{"x-api-key"}),
 			},
 		})
-		mods, ok := result.(policy.UpstreamRequestModifications)
+		if _, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+			t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+		}
+	})
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 request log record, got %d", len(records))
+	}
+
+	record := records[0]
+	if record.MediationFlow != MediationFlowRequest {
+		t.Fatalf("expected mediation flow %s, got %s", MediationFlowRequest, record.MediationFlow)
+	}
+	if record.RequestID != "req-123" {
+		t.Fatalf("expected request id req-123, got %s", record.RequestID)
+	}
+	if record.Payload != "" {
+		t.Fatalf("expected no payload in header phase log, got %q", record.Payload)
+	}
+
+	auth, ok := getHeaderValue(record.Headers, "authorization")
+	if !ok || auth != "***" {
+		t.Fatalf("expected masked authorization header, got %v", auth)
+	}
+	if _, ok := getHeaderValue(record.Headers, "x-api-key"); ok {
+		t.Fatalf("expected x-api-key to be excluded")
+	}
+	if traceValue, ok := getHeaderValue(record.Headers, "x-trace-header"); !ok || traceValue != "trace-abc" {
+		t.Fatalf("expected x-trace-header to be logged, got %v", traceValue)
+	}
+}
+
+func TestOnRequestHeaders_InvalidRequestConfigType_DoesNotLog(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		Headers: createTestHeaders(map[string]string{"x-request-id": "req-002"}),
+		Method:  "POST",
+		Path:    "/resource",
+	}
+
+	records := captureLogRecords(t, func() {
+		p.OnRequestHeaders(ctx, map[string]interface{}{"request": true})
+	})
+
+	if len(records) != 0 {
+		t.Fatalf("expected no logs for invalid request config type, got %d", len(records))
+	}
+}
+
+func TestOnRequestBody_NoRequestConfig_DoesNotLog(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.RequestContext{
+		Body: &policyv1alpha2.Body{Content: []byte(`{"hello":"world"}`), Present: true},
+		Headers: createTestHeaders(map[string]string{
+			"x-request-id": "req-001",
+		}),
+		Method: "POST",
+		Path:   "/resource",
+	}
+
+	records := captureLogRecords(t, func() {
+		result := p.OnRequestBody(ctx, map[string]interface{}{
+			"response": map[string]interface{}{"payload": true},
+		})
+		if _, ok := result.(policyv1alpha2.UpstreamRequestModifications); !ok {
+			t.Fatalf("expected UpstreamRequestModifications, got %T", result)
+		}
+	})
+
+	if len(records) != 0 {
+		t.Fatalf("expected no request logs, got %d", len(records))
+	}
+}
+
+func TestOnRequestBody_LogsPayload(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.RequestContext{
+		Body: &policyv1alpha2.Body{Content: []byte(`{"action":"login"}`), Present: true},
+		Headers: createTestHeaders(map[string]string{
+			"x-request-id": "req-123",
+		}),
+		Method: "POST",
+		Path:   "/login",
+	}
+
+	records := captureLogRecords(t, func() {
+		result := p.OnRequestBody(ctx, map[string]interface{}{
+			"request": map[string]interface{}{
+				"payload": true,
+			},
+		})
+		mods, ok := result.(policyv1alpha2.UpstreamRequestModifications)
 		if !ok {
 			t.Fatalf("expected UpstreamRequestModifications, got %T", result)
 		}
@@ -351,30 +439,19 @@ func TestOnRequest_LogsPayloadAndHeaders(t *testing.T) {
 	if record.Payload != `{"action":"login"}` {
 		t.Fatalf("unexpected payload: %s", record.Payload)
 	}
-
-	auth, ok := getHeaderValue(record.Headers, "authorization")
-	if !ok || auth != "***" {
-		t.Fatalf("expected masked authorization header, got %v", auth)
-	}
-	if _, ok := getHeaderValue(record.Headers, "x-api-key"); ok {
-		t.Fatalf("expected x-api-key to be excluded")
-	}
-	if traceValue, ok := getHeaderValue(record.Headers, "x-trace-header"); !ok || traceValue != "trace-abc" {
-		t.Fatalf("expected x-trace-header to be logged, got %v", traceValue)
-	}
 }
 
-func TestOnRequest_InvalidRequestConfigType_DoesNotLog(t *testing.T) {
+func TestOnRequestBody_InvalidRequestConfigType_DoesNotLog(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.RequestContext{
-		Body:    &policy.Body{Content: []byte(`{"hello":"world"}`), Present: true},
+	ctx := &policyv1alpha2.RequestContext{
+		Body:    &policyv1alpha2.Body{Content: []byte(`{"hello":"world"}`), Present: true},
 		Headers: createTestHeaders(map[string]string{"x-request-id": "req-002"}),
 		Method:  "POST",
 		Path:    "/resource",
 	}
 
 	records := captureLogRecords(t, func() {
-		p.OnRequest(ctx, map[string]interface{}{"request": true})
+		p.OnRequestBody(ctx, map[string]interface{}{"request": true})
 	})
 
 	if len(records) != 0 {
@@ -382,21 +459,20 @@ func TestOnRequest_InvalidRequestConfigType_DoesNotLog(t *testing.T) {
 	}
 }
 
-func TestOnResponse_NoResponseConfig_DoesNotLog(t *testing.T) {
+func TestOnResponseHeaders_NoResponseConfig_DoesNotLog(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`{"ok":true}`), Present: true},
+	ctx := &policyv1alpha2.ResponseHeaderContext{
 		ResponseHeaders: createTestHeaders(map[string]string{"x-request-id": "resp-001"}),
 		RequestMethod:   "GET",
 		RequestPath:     "/status",
 	}
 
 	records := captureLogRecords(t, func() {
-		result := p.OnResponse(ctx, map[string]interface{}{
-			"request": map[string]interface{}{"payload": true},
+		result := p.OnResponseHeaders(ctx, map[string]interface{}{
+			"request": map[string]interface{}{"headers": true},
 		})
-		if _, ok := result.(policy.UpstreamResponseModifications); !ok {
-			t.Fatalf("expected UpstreamResponseModifications, got %T", result)
+		if _, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications); !ok {
+			t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", result)
 		}
 	})
 
@@ -405,10 +481,9 @@ func TestOnResponse_NoResponseConfig_DoesNotLog(t *testing.T) {
 	}
 }
 
-func TestOnResponse_LogsPayloadAndHeaders(t *testing.T) {
+func TestOnResponseHeaders_LogsHeaders(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.ResponseContext{
-		ResponseBody: &policy.Body{Content: []byte(`{"status":"success"}`), Present: true},
+	ctx := &policyv1alpha2.ResponseHeaderContext{
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"x-request-id":     "resp-123",
 			"set-cookie":       "session=abc",
@@ -419,16 +494,100 @@ func TestOnResponse_LogsPayloadAndHeaders(t *testing.T) {
 	}
 
 	records := captureLogRecords(t, func() {
-		result := p.OnResponse(ctx, map[string]interface{}{
+		result := p.OnResponseHeaders(ctx, map[string]interface{}{
 			"response": map[string]interface{}{
-				"payload":        true,
 				"headers":        true,
 				"excludeHeaders": toInterfaceSlice([]string{"set-cookie"}),
 			},
 		})
-		mods, ok := result.(policy.UpstreamResponseModifications)
+		if _, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications); !ok {
+			t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", result)
+		}
+	})
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 response log record, got %d", len(records))
+	}
+
+	record := records[0]
+	if record.MediationFlow != MediationFlowResponse {
+		t.Fatalf("expected mediation flow %s, got %s", MediationFlowResponse, record.MediationFlow)
+	}
+	if record.RequestID != "resp-123" {
+		t.Fatalf("expected request id resp-123, got %s", record.RequestID)
+	}
+	if record.Payload != "" {
+		t.Fatalf("expected no payload in header phase log, got %q", record.Payload)
+	}
+
+	if _, ok := getHeaderValue(record.Headers, "set-cookie"); ok {
+		t.Fatalf("expected set-cookie to be excluded")
+	}
+	if token, ok := getHeaderValue(record.Headers, "x-internal-token"); !ok || token != "token-1" {
+		t.Fatalf("expected x-internal-token to be logged, got %v", token)
+	}
+}
+
+func TestOnResponseHeaders_InvalidResponseConfigType_DoesNotLog(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		ResponseHeaders: createTestHeaders(map[string]string{"x-request-id": "resp-002"}),
+		RequestMethod:   "GET",
+		RequestPath:     "/status",
+	}
+
+	records := captureLogRecords(t, func() {
+		p.OnResponseHeaders(ctx, map[string]interface{}{"response": "invalid"})
+	})
+
+	if len(records) != 0 {
+		t.Fatalf("expected no logs for invalid response config type, got %d", len(records))
+	}
+}
+
+func TestOnResponseBody_NoResponseConfig_DoesNotLog(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`{"ok":true}`), Present: true},
+		ResponseHeaders: createTestHeaders(map[string]string{"x-request-id": "resp-001"}),
+		RequestMethod:   "GET",
+		RequestPath:     "/status",
+	}
+
+	records := captureLogRecords(t, func() {
+		result := p.OnResponseBody(ctx, map[string]interface{}{
+			"request": map[string]interface{}{"payload": true},
+		})
+		if _, ok := result.(policyv1alpha2.DownstreamResponseModifications); !ok {
+			t.Fatalf("expected DownstreamResponseModifications, got %T", result)
+		}
+	})
+
+	if len(records) != 0 {
+		t.Fatalf("expected no response logs, got %d", len(records))
+	}
+}
+
+func TestOnResponseBody_LogsPayload(t *testing.T) {
+	p := &LogMessagePolicy{}
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"status":"success"}`), Present: true},
+		ResponseHeaders: createTestHeaders(map[string]string{
+			"x-request-id": "resp-123",
+		}),
+		RequestMethod: "GET",
+		RequestPath:   "/users",
+	}
+
+	records := captureLogRecords(t, func() {
+		result := p.OnResponseBody(ctx, map[string]interface{}{
+			"response": map[string]interface{}{
+				"payload": true,
+			},
+		})
+		mods, ok := result.(policyv1alpha2.DownstreamResponseModifications)
 		if !ok {
-			t.Fatalf("expected UpstreamResponseModifications, got %T", result)
+			t.Fatalf("expected DownstreamResponseModifications, got %T", result)
 		}
 		if mods.Body != nil {
 			t.Fatalf("expected no body modification, got %s", string(mods.Body))
@@ -449,26 +608,19 @@ func TestOnResponse_LogsPayloadAndHeaders(t *testing.T) {
 	if record.Payload != `{"status":"success"}` {
 		t.Fatalf("unexpected payload: %s", record.Payload)
 	}
-
-	if _, ok := getHeaderValue(record.Headers, "set-cookie"); ok {
-		t.Fatalf("expected set-cookie to be excluded")
-	}
-	if token, ok := getHeaderValue(record.Headers, "x-internal-token"); !ok || token != "token-1" {
-		t.Fatalf("expected x-internal-token to be logged, got %v", token)
-	}
 }
 
-func TestOnResponse_InvalidResponseConfigType_DoesNotLog(t *testing.T) {
+func TestOnResponseBody_InvalidResponseConfigType_DoesNotLog(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`{"ok":true}`), Present: true},
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`{"ok":true}`), Present: true},
 		ResponseHeaders: createTestHeaders(map[string]string{"x-request-id": "resp-002"}),
 		RequestMethod:   "GET",
 		RequestPath:     "/status",
 	}
 
 	records := captureLogRecords(t, func() {
-		p.OnResponse(ctx, map[string]interface{}{"response": "invalid"})
+		p.OnResponseBody(ctx, map[string]interface{}{"response": "invalid"})
 	})
 
 	if len(records) != 0 {
@@ -476,17 +628,17 @@ func TestOnResponse_InvalidResponseConfigType_DoesNotLog(t *testing.T) {
 	}
 }
 
-func TestOnResponse_LogsWithMissingRequestID(t *testing.T) {
+func TestOnResponseBody_LogsWithMissingRequestID(t *testing.T) {
 	p := &LogMessagePolicy{}
-	ctx := &policy.ResponseContext{
-		ResponseBody:    &policy.Body{Content: []byte(`{"ok":true}`), Present: true},
+	ctx := &policyv1alpha2.ResponseContext{
+		ResponseBody:    &policyv1alpha2.Body{Content: []byte(`{"ok":true}`), Present: true},
 		ResponseHeaders: createTestHeaders(map[string]string{"content-type": "application/json"}),
 		RequestMethod:   "GET",
 		RequestPath:     "/status",
 	}
 
 	records := captureLogRecords(t, func() {
-		p.OnResponse(ctx, map[string]interface{}{
+		p.OnResponseBody(ctx, map[string]interface{}{
 			"response": map[string]interface{}{"payload": true},
 		})
 	})

--- a/policies/log-message/policy-definition.yaml
+++ b/policies/log-message/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: log-message
-version: v0.2.1
+version: v0.9.0
 description: |
   Log request and response payloads and headers for observability without changing traffic.
 

--- a/policies/mcp-acl-list/mcp-acl-list.go
+++ b/policies/mcp-acl-list/mcp-acl-list.go
@@ -736,6 +736,128 @@ func (p *McpAclListPolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, _ m
 	return policyv1alpha2.UpstreamRequestModifications{}
 }
 
+// OnResponseBody enforces ACL rules on the MCP response body.
+func (p *McpAclListPolicy) OnResponseBody(ctx *policyv1alpha2.ResponseContext, _ map[string]any) policyv1alpha2.ResponseAction {
+	if !isMcpPostRequest(ctx.RequestMethod, ctx.OperationPath) {
+		return nil
+	}
+	slog.Debug("MCP ACL List Policy: OnResponseBody started")
+
+	if ctx.Metadata == nil {
+		return nil
+	}
+
+	capabilityType, _ := ctx.Metadata[metadataMcpCapabilityType].(string)
+	action, _ := ctx.Metadata[metadataMcpAction].(string)
+	if capabilityType == "" || action != "list" {
+		slog.Debug("MCP ACL List Policy: OnResponseBody skipped, action is not list", "capabilityType", capabilityType, "action", action)
+		return nil
+	}
+
+	config := p.getAclConfig(capabilityType)
+	if !config.Enabled {
+		return nil
+	}
+
+	if ctx.ResponseBody == nil || !ctx.ResponseBody.Present {
+		return nil
+	}
+
+	if isEventStreamV2(ctx.ResponseHeaders) {
+		events := parseEventStream(ctx.ResponseBody.Content)
+		updated := false
+		for i, event := range events {
+			if strings.TrimSpace(event.data) == "" {
+				continue
+			}
+			var responsePayload map[string]any
+			if err := json.Unmarshal([]byte(event.data), &responsePayload); err != nil {
+				continue
+			}
+			if _, hasError := responsePayload["error"]; hasError {
+				slog.Debug("MCP ACL List Policy: Upstream response contains error", "capabilityType", capabilityType)
+				continue
+			}
+			resultRaw, ok := responsePayload["result"].(map[string]any)
+			if !ok {
+				slog.Debug("MCP ACL List Policy: Invalid MCP response result", "capabilityType", capabilityType, "error", "result not an object")
+				continue
+			}
+
+			listKey := capabilityType
+			existing, ok := resultRaw[listKey].([]any)
+			if !ok {
+				continue
+			}
+			filtered, changed := filterListItems(existing, capabilityType, config)
+			if !changed {
+				slog.Debug("MCP ACL List Policy: No changes in list items", "capabilityType", capabilityType)
+				continue
+			}
+
+			resultRaw[listKey] = filtered
+			responsePayload["result"] = resultRaw
+
+			updatedPayload, err := json.Marshal(responsePayload)
+			if err != nil {
+				slog.Debug("MCP ACL List Policy: Failed to marshal updated response", "capabilityType", capabilityType, "error", err)
+				continue
+			}
+			events[i].data = string(updatedPayload)
+			updated = true
+		}
+
+		if !updated {
+			return nil
+		}
+		return policyv1alpha2.DownstreamResponseModifications{
+			Body: buildEventStream(events),
+		}
+	}
+
+	var responsePayload map[string]any
+	if err := json.Unmarshal(ctx.ResponseBody.Content, &responsePayload); err != nil {
+		slog.Debug("MCP ACL List Policy: Failed to parse MCP response", "capabilityType", capabilityType, "error", err)
+		return nil
+	}
+
+	if _, hasError := responsePayload["error"]; hasError {
+		slog.Debug("MCP ACL List Policy: Upstream response contains error", "capabilityType", capabilityType)
+		return nil
+	}
+
+	resultRaw, ok := responsePayload["result"].(map[string]any)
+	if !ok {
+		slog.Debug("MCP ACL List Policy: Invalid MCP response result", "capabilityType", capabilityType, "error", "result not an object")
+		return nil
+	}
+
+	listKey := capabilityType
+	existing, ok := resultRaw[listKey].([]any)
+	if !ok {
+		return nil
+	}
+
+	filtered, changed := filterListItems(existing, capabilityType, config)
+	if !changed {
+		slog.Debug("MCP ACL List Policy: No changes in list items", "capabilityType", capabilityType)
+		return nil
+	}
+
+	resultRaw[listKey] = filtered
+	responsePayload["result"] = resultRaw
+
+	updatedPayload, err := json.Marshal(responsePayload)
+	if err != nil {
+		slog.Debug("MCP ACL List Policy: Failed to marshal updated response", "capabilityType", capabilityType, "error", err)
+		return nil
+	}
+
+	return policyv1alpha2.DownstreamResponseModifications{
+		Body: updatedPayload,
+	}
+}
+
 // getSessionIDV2 extracts the MCP session ID from v1alpha2 headers.
 func getSessionIDV2(headers *policyv1alpha2.Headers) string {
 	if headers == nil {

--- a/policies/mcp-acl-list/policy-definition.yaml
+++ b/policies/mcp-acl-list/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-acl-list
-version: v0.2.2
+version: v0.9.0
 description: |
   Control MCP tool, resource, and prompt access with allow/deny mode plus exceptions, apply the same rules to requests and list responses, and avoid rewriting capability names or entry fields.
 

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -6,6 +6,6 @@ require github.com/wso2/api-platform/sdk v0.4.5
 
 require github.com/wso2/api-platform/sdk/core v0.1.0
 
-require github.com/wso2/gateway-controllers/policies/jwt-auth v0.8.2
+require github.com/wso2/gateway-controllers/policies/jwt-auth v0.8.2 //update
 
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v0.2.3
+version: v0.9.0
 description: |
   Secure Model Context Protocol traffic by validating bearer access tokens for MCP resources using the underlying JWT authentication runtime.
 

--- a/policies/mcp-authz/mcp-authz.go
+++ b/policies/mcp-authz/mcp-authz.go
@@ -311,7 +311,7 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, _ map
 		slog.Debug("MCP Authorization Policy: Processing MCP request for authorization")
 	} else {
 		slog.Debug("MCP Authorization Policy: Skipping authz...")
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return nil
 	}
 
 	// Check AuthContext populated by an upstream auth policy
@@ -337,7 +337,7 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, _ map
 	attributeType, ok := p.getAttributeTypeFromMethod(mcpReq.Method)
 	if !ok {
 		slog.Debug("MCP Authorization Policy: Skipping since the method is not one of tools, resources, or prompts", "method", mcpReq.Method)
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return nil
 	}
 
 	// Extract attribute name/identifier based on method type
@@ -365,7 +365,7 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, _ map
 	if authCtx.AuthType == McpOAuthAuthType {
 		authCtx.AuthType = McpOAuthzAuthType
 	}
-	return policyv1alpha2.UpstreamRequestModifications{}
+	return nil
 }
 
 func (p *McpAuthzPolicy) handleAuthFailureV2(ctx *policyv1alpha2.RequestContext, errorMessage string, scopeMap map[string]struct{}) policyv1alpha2.RequestAction {

--- a/policies/mcp-authz/policy-definition.yaml
+++ b/policies/mcp-authz/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-authz
-version: v0.2.3
+version: v0.9.0
 description: |
   Authorize MCP tools, resources, prompts, and methods using claim/scope rules after `mcp-auth`; evaluate rules by specificity, require all matching rules to pass, and allow access when no rule matches.
 

--- a/policies/mcp-rewrite/mcp-rewrite.go
+++ b/policies/mcp-rewrite/mcp-rewrite.go
@@ -941,6 +941,127 @@ func (p *McpRewritePolicy) buildEventStreamErrorResponseV2(statusCode int, jsonR
 	}
 }
 
+// OnResponseBody applies rewrite rules to the MCP response body.
+func (p *McpRewritePolicy) OnResponseBody(ctx *policyv1alpha2.ResponseContext, _ map[string]any) policyv1alpha2.ResponseAction {
+	if !isMcpPostRequest(ctx.RequestMethod, ctx.RequestPath) {
+		return nil
+	}
+	slog.Debug("MCP Rewrite Policy: OnResponseBody started")
+
+	if ctx.Metadata == nil {
+		return nil
+	}
+
+	capabilityType, _ := ctx.Metadata[metadataMcpCapabilityType].(string)
+	action, _ := ctx.Metadata[metadataMcpAction].(string)
+	if action != "list" {
+		slog.Debug("MCP Rewrite Policy: OnResponseBody skipped, action is not list", "capabilityType", capabilityType, "action", action)
+		return nil
+	}
+
+	config := p.getCapabilityConfig(capabilityType)
+	if !config.Enabled {
+		return nil
+	}
+
+	if ctx.ResponseBody == nil || !ctx.ResponseBody.Present {
+		return nil
+	}
+
+	if isEventStreamV2(ctx.ResponseHeaders) {
+		events := parseEventStream(ctx.ResponseBody.Content)
+		updated := false
+		for i, event := range events {
+			if strings.TrimSpace(event.data) == "" {
+				continue
+			}
+			var responsePayload map[string]any
+			if err := json.Unmarshal([]byte(event.data), &responsePayload); err != nil {
+				continue
+			}
+			if _, hasError := responsePayload["error"]; hasError {
+				slog.Debug("MCP Rewrite Policy: Upstream response contains error", "capabilityType", capabilityType)
+				continue
+			}
+			resultRaw, ok := responsePayload["result"].(map[string]any)
+			if !ok {
+				slog.Debug("MCP Rewrite Policy: Invalid MCP response result", "capabilityType", capabilityType, "error", "result not an object")
+				continue
+			}
+
+			listKey := capabilityType
+			existing, ok := resultRaw[listKey].([]any)
+			if !ok {
+				continue
+			}
+
+			filtered, changed := rewriteListItems(existing, capabilityType, config)
+			if !changed {
+				continue
+			}
+
+			resultRaw[listKey] = filtered
+			responsePayload["result"] = resultRaw
+
+			updatedPayload, err := json.Marshal(responsePayload)
+			if err != nil {
+				slog.Debug("MCP Rewrite Policy: Failed to marshal updated response", "capabilityType", capabilityType, "error", err)
+				continue
+			}
+			events[i].data = string(updatedPayload)
+			updated = true
+		}
+
+		if !updated {
+			return nil
+		}
+		return policyv1alpha2.DownstreamResponseModifications{
+			Body: buildEventStream(events),
+		}
+	}
+
+	var responsePayload map[string]any
+	if err := json.Unmarshal(ctx.ResponseBody.Content, &responsePayload); err != nil {
+		slog.Debug("MCP Rewrite Policy: Failed to parse MCP response", "capabilityType", capabilityType, "error", err)
+		return nil
+	}
+
+	if _, hasError := responsePayload["error"]; hasError {
+		slog.Debug("MCP Rewrite Policy: Upstream response contains error", "capabilityType", capabilityType)
+		return nil
+	}
+
+	resultRaw, ok := responsePayload["result"].(map[string]any)
+	if !ok {
+		slog.Debug("MCP Rewrite Policy: Invalid MCP response result", "capabilityType", capabilityType, "error", "result not an object")
+		return nil
+	}
+
+	listKey := capabilityType
+	existing, ok := resultRaw[listKey].([]any)
+	if !ok {
+		return nil
+	}
+
+	filtered, changed := rewriteListItems(existing, capabilityType, config)
+	if !changed {
+		return nil
+	}
+
+	resultRaw[listKey] = filtered
+	responsePayload["result"] = resultRaw
+
+	updatedPayload, err := json.Marshal(responsePayload)
+	if err != nil {
+		slog.Debug("MCP Rewrite Policy: Failed to marshal updated response", "capabilityType", capabilityType, "error", err)
+		return nil
+	}
+
+	return policyv1alpha2.DownstreamResponseModifications{
+		Body: updatedPayload,
+	}
+}
+
 // buildErrorResponseV2 builds a v1alpha2 JSON error response.
 func (p *McpRewritePolicy) buildErrorResponseV2(statusCode int, jsonRpcCode int, reason string, requestID any, sessionID string) policyv1alpha2.RequestAction {
 	responseBody := map[string]any{

--- a/policies/mcp-rewrite/policy-definition.yaml
+++ b/policies/mcp-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-rewrite
-version: v0.2.1
+version: v0.9.0
 description: |
   Rewrite MCP tool, resource, and prompt names between client-facing and backend values, and optionally filter list responses to configured entries (omit to allow all, set `[]` to deny all).
 

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v0.8.1
+version: v0.9.0
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.

--- a/policies/model-round-robin/roundrobin_test.go
+++ b/policies/model-round-robin/roundrobin_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 	"time"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestModelRoundRobinPolicy_Mode(t *testing.T) {
 	p := &ModelRoundRobinPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -155,7 +155,7 @@ func TestModelRoundRobinPolicy_GetPolicy_ParseErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -183,7 +183,7 @@ func TestModelRoundRobinPolicy_GetPolicy_SuccessAndDefaults(t *testing.T) {
 	}
 }
 
-func TestModelRoundRobinPolicy_OnRequest_PayloadRoundRobin(t *testing.T) {
+func TestModelRoundRobinPolicy_OnRequestBody_PayloadRoundRobin(t *testing.T) {
 	p := mustGetRRPolicy(t, map[string]interface{}{
 		"models": baseRRModels(),
 		"requestModel": map[string]interface{}{
@@ -192,22 +192,35 @@ func TestModelRoundRobinPolicy_OnRequest_PayloadRoundRobin(t *testing.T) {
 		},
 	})
 
-	ctx1 := rrRequestContextWithBody(`{"model":"original","x":"y"}`)
-	action1 := p.OnRequest(ctx1, nil)
+	// Phase 1: headers — selects model and stores in metadata
+	shared1 := rrSharedContext()
+	headerCtx1 := &policyv1alpha2.RequestHeaderContext{SharedContext: shared1}
+	p.OnRequestHeaders(headerCtx1, nil)
+
+	// Phase 2: body — substitutes selected model into payload
+	bodyCtx1 := &policyv1alpha2.RequestContext{
+		SharedContext: shared1,
+		Body:          &policyv1alpha2.Body{Content: []byte(`{"model":"original","x":"y"}`), Present: true},
+	}
+	action1 := p.OnRequestBody(bodyCtx1, nil)
 	mods1 := mustRRRequestMods(t, action1)
 	got1 := decodeJSONMapRR(t, mods1.Body)
 	if got1["model"] != "gpt-4" {
 		t.Fatalf("expected first selected model gpt-4, got %v", got1["model"])
 	}
-	if ctx1.Metadata[MetadataKeyOriginalModel] != "original" {
-		t.Fatalf("expected original model metadata to be set")
-	}
-	if ctx1.Metadata[MetadataKeySelectedModel] != "gpt-4" {
+	if shared1.Metadata[MetadataKeySelectedModel] != "gpt-4" {
 		t.Fatalf("expected selected model metadata to be set")
 	}
 
-	ctx2 := rrRequestContextWithBody(`{"model":"original2"}`)
-	action2 := p.OnRequest(ctx2, nil)
+	shared2 := rrSharedContext()
+	headerCtx2 := &policyv1alpha2.RequestHeaderContext{SharedContext: shared2}
+	p.OnRequestHeaders(headerCtx2, nil)
+
+	bodyCtx2 := &policyv1alpha2.RequestContext{
+		SharedContext: shared2,
+		Body:          &policyv1alpha2.Body{Content: []byte(`{"model":"original2"}`), Present: true},
+	}
+	action2 := p.OnRequestBody(bodyCtx2, nil)
 	mods2 := mustRRRequestMods(t, action2)
 	got2 := decodeJSONMapRR(t, mods2.Body)
 	if got2["model"] != "gpt-35" {
@@ -215,7 +228,7 @@ func TestModelRoundRobinPolicy_OnRequest_PayloadRoundRobin(t *testing.T) {
 	}
 }
 
-func TestModelRoundRobinPolicy_OnRequest_QueryParamAndPathParamMutation(t *testing.T) {
+func TestModelRoundRobinPolicy_OnRequestHeaders_QueryParamAndPathParamMutation(t *testing.T) {
 	pQuery := mustGetRRPolicy(t, map[string]interface{}{
 		"models": baseRRModels(),
 		"requestModel": map[string]interface{}{
@@ -223,10 +236,13 @@ func TestModelRoundRobinPolicy_OnRequest_QueryParamAndPathParamMutation(t *testi
 			"identifier": "model",
 		},
 	})
-	queryCtx := rrRequestContextWithPath("/v1/chat?model=old&x=1")
-	queryAction := pQuery.OnRequest(queryCtx, nil)
-	queryMods := mustRRRequestMods(t, queryAction)
-	if got := queryMods.SetHeaders[":path"]; !strings.Contains(got, "model=gpt-4") {
+	queryCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: rrSharedContext(),
+		Path:          "/v1/chat?model=old&x=1",
+	}
+	queryAction := pQuery.OnRequestHeaders(queryCtx, nil)
+	queryMods := mustRRRequestHeaderMods(t, queryAction)
+	if got := queryMods.HeadersToSet[":path"]; !strings.Contains(got, "model=gpt-4") {
 		t.Fatalf("expected query path to include new model, got %q", got)
 	}
 
@@ -237,15 +253,18 @@ func TestModelRoundRobinPolicy_OnRequest_QueryParamAndPathParamMutation(t *testi
 			"identifier": `/models/([^/]+)`,
 		},
 	})
-	pathCtx := rrRequestContextWithPath("/v1/models/old/completions?x=1")
-	pathAction := pPath.OnRequest(pathCtx, nil)
-	pathMods := mustRRRequestMods(t, pathAction)
-	if got := pathMods.SetHeaders[":path"]; !strings.Contains(got, "/models/gpt-4/") {
+	pathCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: rrSharedContext(),
+		Path:          "/v1/models/old/completions?x=1",
+	}
+	pathAction := pPath.OnRequestHeaders(pathCtx, nil)
+	pathMods := mustRRRequestHeaderMods(t, pathAction)
+	if got := pathMods.HeadersToSet[":path"]; !strings.Contains(got, "/models/gpt-4/") {
 		t.Fatalf("expected path to include new model, got %q", got)
 	}
 }
 
-func TestModelRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
+func TestModelRoundRobinPolicy_OnRequestHeaders_AllModelsSuspended(t *testing.T) {
 	p := mustGetRRPolicy(t, map[string]interface{}{
 		"models": baseRRModels(),
 		"requestModel": map[string]interface{}{
@@ -258,8 +277,12 @@ func TestModelRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
 	p.suspendedModels["gpt-4"] = until
 	p.suspendedModels["gpt-35"] = until
 
-	action := p.OnRequest(rrRequestContextWithHeaders(map[string][]string{"x-model": {"orig"}}), nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: rrSharedContext(),
+		Headers:       policyv1alpha2.NewHeaders(map[string][]string{"x-model": {"orig"}}),
+	}
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse when all models suspended, got %T", action)
 	}
@@ -268,7 +291,7 @@ func TestModelRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
 	}
 }
 
-func TestModelRoundRobinPolicy_OnResponse_SuspendsModelOnError(t *testing.T) {
+func TestModelRoundRobinPolicy_OnResponseHeaders_SuspendsModelOnError(t *testing.T) {
 	p := mustGetRRPolicy(t, map[string]interface{}{
 		"models":          baseRRModels(),
 		"suspendDuration": 60,
@@ -278,19 +301,20 @@ func TestModelRoundRobinPolicy_OnResponse_SuspendsModelOnError(t *testing.T) {
 		},
 	})
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "test-id",
-			Metadata: map[string]interface{}{
-				MetadataKeySelectedModel: "gpt-4",
-			},
+	sharedCtx := &policyv1alpha2.SharedContext{
+		RequestID: "test-id",
+		Metadata: map[string]interface{}{
+			MetadataKeySelectedModel: "gpt-4",
 		},
+	}
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext:  sharedCtx,
 		ResponseStatus: 500,
 	}
 
-	action := p.OnResponse(ctx, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseHeaderModifications); !ok {
+		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
 	until, exists := p.suspendedModels["gpt-4"]
 	if !exists {
@@ -334,7 +358,7 @@ func TestModelRoundRobinPolicy_ExtractInt(t *testing.T) {
 
 func mustGetRRPolicy(t *testing.T, params map[string]interface{}) *ModelRoundRobinPolicy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -345,9 +369,18 @@ func mustGetRRPolicy(t *testing.T, params map[string]interface{}) *ModelRoundRob
 	return rp
 }
 
-func mustRRRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+func mustRRRequestHeaderMods(t *testing.T, action policyv1alpha2.RequestHeaderAction) policyv1alpha2.UpstreamRequestHeaderModifications {
 	t.Helper()
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+	return mods
+}
+
+func mustRRRequestMods(t *testing.T, action policyv1alpha2.RequestAction) policyv1alpha2.UpstreamRequestModifications {
+	t.Helper()
+	mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
@@ -363,36 +396,10 @@ func decodeJSONMapRR(t *testing.T, body []byte) map[string]interface{} {
 	return m
 }
 
-func rrRequestContextWithBody(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Body: &policy.Body{
-			Content: []byte(body),
-			Present: body != "",
-		},
-	}
-}
-
-func rrRequestContextWithPath(path string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Path: path,
-	}
-}
-
-func rrRequestContextWithHeaders(headers map[string][]string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Headers: policy.NewHeaders(headers),
+func rrSharedContext() *policyv1alpha2.SharedContext {
+	return &policyv1alpha2.SharedContext{
+		RequestID: "req-id",
+		Metadata:  map[string]interface{}{},
 	}
 }
 

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-weighted-round-robin
-version: v0.2.2
+version: v0.9.0
 description: |
   Distribute requests across models using weighted round-robin so higher-weight models receive proportionally more traffic.
 

--- a/policies/model-weighted-round-robin/weightedroundrobin_test.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 	"time"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestModelWeightedRoundRobinPolicy_Mode(t *testing.T) {
 	p := &ModelWeightedRoundRobinPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -105,7 +105,7 @@ func TestModelWeightedRoundRobinPolicy_GetPolicy_ParseErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -152,7 +152,7 @@ func TestModelWeightedRoundRobinPolicy_BuildWeightedSequence(t *testing.T) {
 	}
 }
 
-func TestModelWeightedRoundRobinPolicy_OnRequest_PayloadWeightedSelection(t *testing.T) {
+func TestModelWeightedRoundRobinPolicy_OnRequestBody_PayloadWeightedSelection(t *testing.T) {
 	p := mustGetWeightedPolicy(t, map[string]interface{}{
 		"models": baseWeightedModels(),
 		"requestModel": map[string]interface{}{
@@ -162,24 +162,48 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_PayloadWeightedSelection(t *tes
 	})
 
 	// weight distribution: gpt-4, gpt-4, gpt-35, ...
-	ctx1 := weightedRequestContextWithBody(`{"model":"orig"}`)
-	a1 := p.OnRequest(ctx1, nil)
+	// Request 1
+	shared1 := weightedSharedContext()
+	headerCtx1 := &policyv1alpha2.RequestHeaderContext{SharedContext: shared1}
+	p.OnRequestHeaders(headerCtx1, nil)
+
+	bodyCtx1 := &policyv1alpha2.RequestContext{
+		SharedContext: shared1,
+		Body:          &policyv1alpha2.Body{Content: []byte(`{"model":"orig"}`), Present: true},
+	}
+	a1 := p.OnRequestBody(bodyCtx1, nil)
 	m1 := mustWeightedRequestMods(t, a1)
 	j1 := decodeJSONMapWeighted(t, m1.Body)
 	if j1["model"] != "gpt-4" {
 		t.Fatalf("expected first model gpt-4, got %v", j1["model"])
 	}
 
-	ctx2 := weightedRequestContextWithBody(`{"model":"orig2"}`)
-	a2 := p.OnRequest(ctx2, nil)
+	// Request 2
+	shared2 := weightedSharedContext()
+	headerCtx2 := &policyv1alpha2.RequestHeaderContext{SharedContext: shared2}
+	p.OnRequestHeaders(headerCtx2, nil)
+
+	bodyCtx2 := &policyv1alpha2.RequestContext{
+		SharedContext: shared2,
+		Body:          &policyv1alpha2.Body{Content: []byte(`{"model":"orig2"}`), Present: true},
+	}
+	a2 := p.OnRequestBody(bodyCtx2, nil)
 	m2 := mustWeightedRequestMods(t, a2)
 	j2 := decodeJSONMapWeighted(t, m2.Body)
 	if j2["model"] != "gpt-4" {
 		t.Fatalf("expected second model gpt-4, got %v", j2["model"])
 	}
 
-	ctx3 := weightedRequestContextWithBody(`{"model":"orig3"}`)
-	a3 := p.OnRequest(ctx3, nil)
+	// Request 3
+	shared3 := weightedSharedContext()
+	headerCtx3 := &policyv1alpha2.RequestHeaderContext{SharedContext: shared3}
+	p.OnRequestHeaders(headerCtx3, nil)
+
+	bodyCtx3 := &policyv1alpha2.RequestContext{
+		SharedContext: shared3,
+		Body:          &policyv1alpha2.Body{Content: []byte(`{"model":"orig3"}`), Present: true},
+	}
+	a3 := p.OnRequestBody(bodyCtx3, nil)
 	m3 := mustWeightedRequestMods(t, a3)
 	j3 := decodeJSONMapWeighted(t, m3.Body)
 	if j3["model"] != "gpt-35" {
@@ -187,7 +211,7 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_PayloadWeightedSelection(t *tes
 	}
 }
 
-func TestModelWeightedRoundRobinPolicy_OnRequest_QueryAndPathMutation(t *testing.T) {
+func TestModelWeightedRoundRobinPolicy_OnRequestHeaders_QueryAndPathMutation(t *testing.T) {
 	pQuery := mustGetWeightedPolicy(t, map[string]interface{}{
 		"models": baseWeightedModels(),
 		"requestModel": map[string]interface{}{
@@ -195,10 +219,13 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_QueryAndPathMutation(t *testing
 			"identifier": "model",
 		},
 	})
-	queryCtx := weightedRequestContextWithPath("/v1/chat?model=old")
-	queryAction := pQuery.OnRequest(queryCtx, nil)
-	queryMods := mustWeightedRequestMods(t, queryAction)
-	if got := queryMods.SetHeaders[":path"]; !strings.Contains(got, "model=gpt-4") {
+	queryCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: weightedSharedContext(),
+		Path:          "/v1/chat?model=old",
+	}
+	queryAction := pQuery.OnRequestHeaders(queryCtx, nil)
+	queryMods := mustWeightedRequestHeaderMods(t, queryAction)
+	if got := queryMods.HeadersToSet[":path"]; !strings.Contains(got, "model=gpt-4") {
 		t.Fatalf("expected query path to include new model, got %q", got)
 	}
 
@@ -209,15 +236,18 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_QueryAndPathMutation(t *testing
 			"identifier": `/models/([^/]+)`,
 		},
 	})
-	pathCtx := weightedRequestContextWithPath("/v1/models/old/completions")
-	pathAction := pPath.OnRequest(pathCtx, nil)
-	pathMods := mustWeightedRequestMods(t, pathAction)
-	if got := pathMods.SetHeaders[":path"]; !strings.Contains(got, "/models/gpt-4/") {
+	pathCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: weightedSharedContext(),
+		Path:          "/v1/models/old/completions",
+	}
+	pathAction := pPath.OnRequestHeaders(pathCtx, nil)
+	pathMods := mustWeightedRequestHeaderMods(t, pathAction)
+	if got := pathMods.HeadersToSet[":path"]; !strings.Contains(got, "/models/gpt-4/") {
 		t.Fatalf("expected path to include new model, got %q", got)
 	}
 }
 
-func TestModelWeightedRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T) {
+func TestModelWeightedRoundRobinPolicy_OnRequestHeaders_AllModelsSuspended(t *testing.T) {
 	p := mustGetWeightedPolicy(t, map[string]interface{}{
 		"models": baseWeightedModels(),
 		"requestModel": map[string]interface{}{
@@ -230,8 +260,12 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T
 	p.suspendedModels["gpt-4"] = until
 	p.suspendedModels["gpt-35"] = until
 
-	action := p.OnRequest(weightedRequestContextWithHeaders(map[string][]string{"x-model": {"orig"}}), nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: weightedSharedContext(),
+		Headers:       policyv1alpha2.NewHeaders(map[string][]string{"x-model": {"orig"}}),
+	}
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse when all models suspended, got %T", action)
 	}
@@ -240,7 +274,7 @@ func TestModelWeightedRoundRobinPolicy_OnRequest_AllModelsSuspended(t *testing.T
 	}
 }
 
-func TestModelWeightedRoundRobinPolicy_OnResponse_SuspendsSelectedModel(t *testing.T) {
+func TestModelWeightedRoundRobinPolicy_OnResponseHeaders_SuspendsSelectedModel(t *testing.T) {
 	p := mustGetWeightedPolicy(t, map[string]interface{}{
 		"models":          baseWeightedModels(),
 		"suspendDuration": 30,
@@ -250,18 +284,19 @@ func TestModelWeightedRoundRobinPolicy_OnResponse_SuspendsSelectedModel(t *testi
 		},
 	})
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "id",
-			Metadata: map[string]interface{}{
-				MetadataKeySelectedModel: "gpt-4",
-			},
+	sharedCtx := &policyv1alpha2.SharedContext{
+		RequestID: "id",
+		Metadata: map[string]interface{}{
+			MetadataKeySelectedModel: "gpt-4",
 		},
+	}
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext:  sharedCtx,
 		ResponseStatus: 429,
 	}
-	action := p.OnResponse(ctx, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseHeaders(ctx, nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseHeaderModifications); !ok {
+		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
 	if until, exists := p.suspendedModels["gpt-4"]; !exists || !until.After(time.Now()) {
 		t.Fatalf("expected selected model to be suspended")
@@ -287,7 +322,7 @@ func TestModelWeightedRoundRobinPolicy_SelectNextAvailable_SkipsSuspended(t *tes
 
 func mustGetWeightedPolicy(t *testing.T, params map[string]interface{}) *ModelWeightedRoundRobinPolicy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -298,9 +333,18 @@ func mustGetWeightedPolicy(t *testing.T, params map[string]interface{}) *ModelWe
 	return wp
 }
 
-func mustWeightedRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+func mustWeightedRequestHeaderMods(t *testing.T, action policyv1alpha2.RequestHeaderAction) policyv1alpha2.UpstreamRequestHeaderModifications {
 	t.Helper()
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+	return mods
+}
+
+func mustWeightedRequestMods(t *testing.T, action policyv1alpha2.RequestAction) policyv1alpha2.UpstreamRequestModifications {
+	t.Helper()
+	mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
@@ -316,36 +360,10 @@ func decodeJSONMapWeighted(t *testing.T, body []byte) map[string]interface{} {
 	return m
 }
 
-func weightedRequestContextWithBody(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Body: &policy.Body{
-			Content: []byte(body),
-			Present: body != "",
-		},
-	}
-}
-
-func weightedRequestContextWithPath(path string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Path: path,
-	}
-}
-
-func weightedRequestContextWithHeaders(headers map[string][]string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "req-id",
-			Metadata:  map[string]interface{}{},
-		},
-		Headers: policy.NewHeaders(headers),
+func weightedSharedContext() *policyv1alpha2.SharedContext {
+	return &policyv1alpha2.SharedContext{
+		RequestID: "req-id",
+		Metadata:  map[string]interface{}{},
 	}
 }
 

--- a/policies/pii-masking-regex/piimaskingregex.go
+++ b/policies/pii-masking-regex/piimaskingregex.go
@@ -503,6 +503,9 @@ func (p *PIIMaskingRegexPolicy) processRequestBody(ctx *policyv1alpha2.RequestCo
 	if p.params.RedactPII {
 		modifiedContent = p.redactPIIFromContent(extractedValue, p.params.PIIEntities)
 	} else {
+		if ctx.Metadata == nil {
+			ctx.Metadata = make(map[string]interface{})
+		}
 		modifiedContent, err = p.maskPIIFromContent(extractedValue, p.params.PIIEntities, ctx.Metadata)
 		if err != nil {
 			return p.buildErrorResponseV2(fmt.Sprintf("error masking PII: %v", err)).(policyv1alpha2.RequestAction)

--- a/policies/pii-masking-regex/piimaskingregex_test.go
+++ b/policies/pii-masking-regex/piimaskingregex_test.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestPIIMaskingRegexPolicy_Mode(t *testing.T) {
 	p := &PIIMaskingRegexPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeStream,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -120,7 +120,7 @@ func TestPIIMaskingRegexPolicy_GetPolicy_ParseErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -185,7 +185,7 @@ func TestPIIMaskingRegexPolicy_OnRequest_MaskAndStoreMetadata(t *testing.T) {
 	})
 
 	ctx := piiRequestContext(`{"messages":[{"content":"Contact me at a.user@example.com please"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustPIIRequestMods(t, action)
 	if len(mods.Body) == 0 {
 		t.Fatalf("expected modified body")
@@ -218,7 +218,7 @@ func TestPIIMaskingRegexPolicy_OnRequest_RedactMode(t *testing.T) {
 	})
 
 	ctx := piiRequestContext(`{"messages":[{"content":"email a.user@example.com"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustPIIRequestMods(t, action)
 	out := decodeJSONMapPII(t, mods.Body)
 	msg := mustGetLastMessageContent(t, out)
@@ -236,7 +236,7 @@ func TestPIIMaskingRegexPolicy_OnRequest_NoMatch_NoOp(t *testing.T) {
 	})
 
 	ctx := piiRequestContext(`{"messages":[{"content":"no pii here"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustPIIRequestMods(t, action)
 	if mods.Body != nil {
 		t.Fatalf("expected no modifications when no pii match, got body=%s", string(mods.Body))
@@ -250,8 +250,8 @@ func TestPIIMaskingRegexPolicy_OnRequest_JSONPathError(t *testing.T) {
 	})
 
 	ctx := piiRequestContext(`{"messages":"a.user@example.com"}`)
-	action := p.OnRequest(ctx, nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	action := p.OnRequestBody(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse for extraction error, got %T", action)
 	}
@@ -265,8 +265,8 @@ func TestPIIMaskingRegexPolicy_OnResponse_RestoreMaskedPII(t *testing.T) {
 		"email": true,
 	})
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata: map[string]interface{}{
 				MetadataKeyPIIEntities: map[string]string{
@@ -274,13 +274,13 @@ func TestPIIMaskingRegexPolicy_OnResponse_RestoreMaskedPII(t *testing.T) {
 				},
 			},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"answer":"Found [EMAIL_0000]"}`),
 			Present: true,
 		},
 	}
-	action := p.OnResponse(ctx, nil)
-	mods, ok := action.(policy.UpstreamResponseModifications)
+	action := p.OnResponseBody(ctx, nil)
+	mods, ok := action.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
 	}
@@ -295,18 +295,18 @@ func TestPIIMaskingRegexPolicy_OnResponse_NoOpCases(t *testing.T) {
 	})
 
 	// No metadata
-	ctx1 := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx1 := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata:  map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"x":"y"}`),
 			Present: true,
 		},
 	}
-	a1 := p.OnResponse(ctx1, nil)
-	if _, ok := a1.(policy.UpstreamResponseModifications); !ok {
+	a1 := p.OnResponseBody(ctx1, nil)
+	if _, ok := a1.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", a1)
 	}
 
@@ -315,27 +315,27 @@ func TestPIIMaskingRegexPolicy_OnResponse_NoOpCases(t *testing.T) {
 		"email":     true,
 		"redactPII": true,
 	})
-	ctx2 := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx2 := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata: map[string]interface{}{
 				MetadataKeyPIIEntities: map[string]string{"a.user@example.com": "[EMAIL_0000]"},
 			},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(`{"x":"[EMAIL_0000]"}`),
 			Present: true,
 		},
 	}
-	a2 := pRedact.OnResponse(ctx2, nil)
-	if _, ok := a2.(policy.UpstreamResponseModifications); !ok {
+	a2 := pRedact.OnResponseBody(ctx2, nil)
+	if _, ok := a2.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications, got %T", a2)
 	}
 }
 
 func mustGetPIIPolicy(t *testing.T, params map[string]interface{}) *PIIMaskingRegexPolicy {
 	t.Helper()
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -346,22 +346,22 @@ func mustGetPIIPolicy(t *testing.T, params map[string]interface{}) *PIIMaskingRe
 	return pp
 }
 
-func mustPIIRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+func mustPIIRequestMods(t *testing.T, action policyv1alpha2.RequestAction) policyv1alpha2.UpstreamRequestModifications {
 	t.Helper()
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 	return mods
 }
 
-func piiRequestContext(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func piiRequestContext(body string) *policyv1alpha2.RequestContext {
+	return &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "req-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},

--- a/policies/pii-masking-regex/piimaskingregex_test.go
+++ b/policies/pii-masking-regex/piimaskingregex_test.go
@@ -282,7 +282,7 @@ func TestPIIMaskingRegexPolicy_OnResponse_RestoreMaskedPII(t *testing.T) {
 	action := p.OnResponseBody(ctx, nil)
 	mods, ok := action.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 	if !strings.Contains(string(mods.Body), "a.user@example.com") {
 		t.Fatalf("expected placeholder to be restored, got %s", string(mods.Body))
@@ -307,7 +307,7 @@ func TestPIIMaskingRegexPolicy_OnResponse_NoOpCases(t *testing.T) {
 	}
 	a1 := p.OnResponseBody(ctx1, nil)
 	if _, ok := a1.(policyv1alpha2.DownstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", a1)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", a1)
 	}
 
 	// Redact mode always no-op for response restoration
@@ -329,7 +329,7 @@ func TestPIIMaskingRegexPolicy_OnResponse_NoOpCases(t *testing.T) {
 	}
 	a2 := pRedact.OnResponseBody(ctx2, nil)
 	if _, ok := a2.(policyv1alpha2.DownstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", a2)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", a2)
 	}
 }
 

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: pii-masking-regex
-version: v0.8.2
+version: v0.9.0
 description: |
   Masks or redacts Personally Identifiable Information (PII) in request and
   response payloads.

--- a/policies/prompt-decorator/go.mod
+++ b/policies/prompt-decorator/go.mod
@@ -4,4 +4,4 @@ go 1.25.7
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.0 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.0

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-decorator
-version: v0.8.1
+version: v0.9.0
 description: |
   Applies configured prompt decorations to request payloads before upstream processing.
 

--- a/policies/prompt-decorator/promptdecorator.go
+++ b/policies/prompt-decorator/promptdecorator.go
@@ -287,7 +287,7 @@ func (p *PromptDecoratorPolicy) OnRequest(ctx *policy.RequestContext, params map
 		// If malformed entries found, return error without modifying the slice
 		if len(malformedEntries) > 0 {
 			errorDetails := fmt.Sprintf("malformed entries at %s", strings.Join(malformedEntries, "; "))
-			return p.buildErrorResponse("Array contains non-map elements", fmt.Errorf(errorDetails))
+			return p.buildErrorResponse("Array contains non-map elements", fmt.Errorf("%s", errorDetails))
 		}
 
 		// Create decoration messages from decoration config

--- a/policies/prompt-decorator/promptdecorator_test.go
+++ b/policies/prompt-decorator/promptdecorator_test.go
@@ -7,37 +7,22 @@ import (
 	"sync"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestPromptDecoratorPolicy_Mode(t *testing.T) {
 	p := &PromptDecoratorPolicy{}
 
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
-	}
-}
-
-func TestPromptDecoratorPolicy_OnResponse_NoOp(t *testing.T) {
-	p := &PromptDecoratorPolicy{}
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "test-request-id",
-			Metadata:  map[string]interface{}{},
-		},
-	}
-
-	action := p.OnResponse(ctx, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
 	}
 }
 
@@ -212,7 +197,7 @@ func TestPromptDecoratorPolicy_GetPolicy_InvalidParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -236,7 +221,7 @@ func TestPromptDecoratorPolicy_OnRequest_TextDefaultPath_Prepend(t *testing.T) {
 			{"role":"user","content":"Summarize this text"}
 		]
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -256,7 +241,7 @@ func TestPromptDecoratorPolicy_OnRequest_TextDefaultPath_Append(t *testing.T) {
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"Explain TCP"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -278,7 +263,7 @@ func TestPromptDecoratorPolicy_OnRequest_TextCustomPath(t *testing.T) {
 		"input":{"prompt":"Create a plan"},
 		"messages":[{"role":"user","content":"unchanged"}]
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -307,7 +292,7 @@ func TestPromptDecoratorPolicy_OnRequest_MessagesDefaultPath_Prepend(t *testing.
 			{"role":"assistant","content":"Hi"}
 		]
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -337,7 +322,7 @@ func TestPromptDecoratorPolicy_OnRequest_MessagesDefaultPath_Append(t *testing.T
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -367,7 +352,7 @@ func TestPromptDecoratorPolicy_OnRequest_MessagesCustomPath(t *testing.T) {
 		"conversation":{"history":[{"role":"user","content":"hello"}]},
 		"messages":[{"role":"user","content":"keep me"}]
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -394,12 +379,12 @@ func TestPromptDecoratorPolicy_OnRequest_EmptyBodyReturnsError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		ctx  *policy.RequestContext
+		ctx  *policyv1alpha2.RequestContext
 	}{
 		{
 			name: "nil body",
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{
 					RequestID: "test-request-id",
 					Metadata:  map[string]interface{}{},
 				},
@@ -408,12 +393,12 @@ func TestPromptDecoratorPolicy_OnRequest_EmptyBodyReturnsError(t *testing.T) {
 		},
 		{
 			name: "empty body content",
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{
 					RequestID: "test-request-id",
 					Metadata:  map[string]interface{}{},
 				},
-				Body: &policy.Body{
+				Body: &policyv1alpha2.Body{
 					Content: []byte{},
 					Present: false,
 				},
@@ -423,7 +408,7 @@ func TestPromptDecoratorPolicy_OnRequest_EmptyBodyReturnsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := p.OnRequest(tt.ctx, nil)
+			action := p.OnRequestBody(tt.ctx, nil)
 			assertDecoratorError(t, action, "Empty request body")
 		})
 	}
@@ -437,7 +422,7 @@ func TestPromptDecoratorPolicy_OnRequest_InvalidJSONReturnsError(t *testing.T) {
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Error parsing JSON payload")
 }
 
@@ -450,7 +435,7 @@ func TestPromptDecoratorPolicy_OnRequest_JSONPathNotFoundReturnsError(t *testing
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Error extracting value from JSONPath")
 }
 
@@ -465,7 +450,7 @@ func TestPromptDecoratorPolicy_OnRequest_TargetTypeMismatch_StringPathWithMessag
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Invalid configuration for string target")
 }
 
@@ -478,7 +463,7 @@ func TestPromptDecoratorPolicy_OnRequest_TargetTypeMismatch_ArrayPathWithTextCon
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[{"role":"user","content":"hello"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Invalid configuration for messages target")
 }
 
@@ -493,7 +478,7 @@ func TestPromptDecoratorPolicy_OnRequest_ArrayContainsNonMapElementReturnsError(
 	})
 
 	ctx := newRequestContextWithBody(`{"messages":[1,{"role":"user","content":"hello"}]}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Array contains non-map elements")
 }
 
@@ -506,7 +491,7 @@ func TestPromptDecoratorPolicy_OnRequest_ExtractedValueWrongTypeReturnsError(t *
 	})
 
 	ctx := newRequestContextWithBody(`{"temperature":0.7}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Extracted value must be a string or an array of message objects")
 }
 
@@ -524,7 +509,7 @@ func TestPromptDecoratorPolicy_OnRequest_JSONPathWithArrayIndex_TextTarget(t *te
 			{"role":"assistant","content":"second"}
 		]
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	payload := decodeJSONMap(t, mods.Body)
@@ -550,7 +535,7 @@ func TestPromptDecoratorPolicy_OnRequest_JSONPathNavigationFailure(t *testing.T)
 	ctx := newRequestContextWithBody(`{
 		"messages":{"0":{"content":"hello"}}
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertDecoratorError(t, action, "Error extracting value from JSONPath")
 }
 
@@ -595,8 +580,8 @@ func TestPromptDecoratorPolicy_OnRequest_ConcurrentAccess(t *testing.T) {
 			msg := fmt.Sprintf("prompt-%d", i)
 			ctx := newRequestContextWithBody(fmt.Sprintf(`{"messages":[{"role":"user","content":"%s"}]}`, msg))
 
-			action := p.OnRequest(ctx, nil)
-			mods, ok := action.(policy.UpstreamRequestModifications)
+			action := p.OnRequestBody(ctx, nil)
+			mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 			if !ok {
 				errCh <- fmt.Errorf("expected UpstreamRequestModifications, got %T", action)
 				return
@@ -629,7 +614,7 @@ func TestPromptDecoratorPolicy_OnRequest_ConcurrentAccess(t *testing.T) {
 func mustGetPromptDecoratorPolicy(t *testing.T, params map[string]interface{}) *PromptDecoratorPolicy {
 	t.Helper()
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -640,20 +625,20 @@ func mustGetPromptDecoratorPolicy(t *testing.T, params map[string]interface{}) *
 	return policyImpl
 }
 
-func mustRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+func mustRequestMods(t *testing.T, action policyv1alpha2.RequestAction) policyv1alpha2.UpstreamRequestModifications {
 	t.Helper()
 
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 	return mods
 }
 
-func assertDecoratorError(t *testing.T, action policy.RequestAction, wantMessagePrefix string) policy.ImmediateResponse {
+func assertDecoratorError(t *testing.T, action policyv1alpha2.RequestAction, wantMessagePrefix string) policyv1alpha2.ImmediateResponse {
 	t.Helper()
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -721,13 +706,13 @@ func mustMessagesNoFail(v interface{}) []map[string]interface{} {
 	return out
 }
 
-func newRequestContextWithBody(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func newRequestContextWithBody(body string) *policyv1alpha2.RequestContext {
+	return &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},

--- a/policies/prompt-template/policy-definition.yaml
+++ b/policies/prompt-template/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-template
-version: v0.8.1
+version: v0.9.0
 description: |
   Applies configured prompt templates to request payloads to transform prompts
   before upstream processing.

--- a/policies/prompt-template/prompttemplate_test.go
+++ b/policies/prompt-template/prompttemplate_test.go
@@ -7,37 +7,22 @@ import (
 	"sync"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestPromptTemplatePolicy_Mode(t *testing.T) {
 	p := &PromptTemplatePolicy{}
 
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
-	}
-}
-
-func TestPromptTemplatePolicy_OnResponse_NoOp(t *testing.T) {
-	p := &PromptTemplatePolicy{}
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
-			RequestID: "test-request-id",
-			Metadata:  map[string]interface{}{},
-		},
-	}
-
-	action := p.OnResponse(ctx, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
 	}
 }
 
@@ -184,7 +169,7 @@ func TestPromptTemplatePolicy_GetPolicy_InvalidParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -202,7 +187,7 @@ func TestPromptTemplatePolicy_GetPolicy_TemplatesJSONStringWorks(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Sam"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	if len(mods.Body) == 0 {
@@ -214,17 +199,17 @@ func TestPromptTemplatePolicy_GetPolicy_TemplatesJSONStringWorks(t *testing.T) {
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_NoBodyOrEmptyBody(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_NoBodyOrEmptyBody(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, baseParams())
 
 	tests := []struct {
 		name string
-		ctx  *policy.RequestContext
+		ctx  *policyv1alpha2.RequestContext
 	}{
 		{
 			name: "nil body",
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{
 					RequestID: "test-request-id",
 					Metadata:  map[string]interface{}{},
 				},
@@ -233,12 +218,12 @@ func TestPromptTemplatePolicy_OnRequest_NoBodyOrEmptyBody(t *testing.T) {
 		},
 		{
 			name: "empty body",
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{
 					RequestID: "test-request-id",
 					Metadata:  map[string]interface{}{},
 				},
-				Body: &policy.Body{
+				Body: &policyv1alpha2.Body{
 					Content: []byte{},
 					Present: false,
 				},
@@ -248,7 +233,7 @@ func TestPromptTemplatePolicy_OnRequest_NoBodyOrEmptyBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := p.OnRequest(tt.ctx, nil)
+			action := p.OnRequestBody(tt.ctx, nil)
 			mods := mustRequestMods(t, action)
 			if mods.Body != nil {
 				t.Fatalf("expected no body modifications, got %s", string(mods.Body))
@@ -257,11 +242,11 @@ func TestPromptTemplatePolicy_OnRequest_NoBodyOrEmptyBody(t *testing.T) {
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_FullPayloadSingleReplacement(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_FullPayloadSingleReplacement(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, baseParams())
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	body := decodeJSONMap(t, mods.Body)
@@ -270,11 +255,11 @@ func TestPromptTemplatePolicy_OnRequest_FullPayloadSingleReplacement(t *testing.
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_NoTemplateReferences_NoChanges(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_NoTemplateReferences_NoChanges(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, baseParams())
 
 	ctx := newRequestContextWithBody(`{"prompt":"plain prompt text"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 
 	if mods.Body != nil {
@@ -282,7 +267,7 @@ func TestPromptTemplatePolicy_OnRequest_NoTemplateReferences_NoChanges(t *testin
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_FullPayloadMultipleReplacements(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_FullPayloadMultipleReplacements(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -296,7 +281,7 @@ func TestPromptTemplatePolicy_OnRequest_FullPayloadMultipleReplacements(t *testi
 		"b":"template://greet?name=Bob",
 		"c":"template://bye?name=Ann"
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -311,7 +296,7 @@ func TestPromptTemplatePolicy_OnRequest_FullPayloadMultipleReplacements(t *testi
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_URLQueryDecoding(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_URLQueryDecoding(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "intro", "template": "Hello [[name]] from [[city]]"},
@@ -320,7 +305,7 @@ func TestPromptTemplatePolicy_OnRequest_URLQueryDecoding(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://intro?name=John+Doe&city=New%20York"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -329,7 +314,7 @@ func TestPromptTemplatePolicy_OnRequest_URLQueryDecoding(t *testing.T) {
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_EscapesQuotesAndNewlines(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_EscapesQuotesAndNewlines(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{
@@ -341,7 +326,7 @@ func TestPromptTemplatePolicy_OnRequest_EscapesQuotesAndNewlines(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://multi?text=hello%20world"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -351,15 +336,15 @@ func TestPromptTemplatePolicy_OnRequest_EscapesQuotesAndNewlines(t *testing.T) {
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_MissingTemplate_DefaultError(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_MissingTemplate_DefaultError(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, baseParams())
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://unknown?name=Ann"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertTemplateError(t, action, "Error resolving templates")
 }
 
-func TestPromptTemplatePolicy_OnRequest_MissingTemplate_Passthrough(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_MissingTemplate_Passthrough(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -372,7 +357,7 @@ func TestPromptTemplatePolicy_OnRequest_MissingTemplate_Passthrough(t *testing.T
 		"a":"template://greet?name=Ann",
 		"b":"template://unknown?name=Bob"
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -384,7 +369,7 @@ func TestPromptTemplatePolicy_OnRequest_MissingTemplate_Passthrough(t *testing.T
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_DefaultKeep(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_UnresolvedPlaceholder_DefaultKeep(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hi [[name]] from [[city]]"},
@@ -393,7 +378,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_DefaultKeep(t *tes
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -402,7 +387,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_DefaultKeep(t *tes
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_Empty(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_UnresolvedPlaceholder_Empty(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hi [[name]] from [[city]]"},
@@ -412,7 +397,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_Empty(t *testing.T
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://greet?name=Ann"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -421,7 +406,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_Empty(t *testing.T
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_ErrorDeterministic(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_UnresolvedPlaceholder_ErrorDeterministic(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "[[x]] [[x]] [[y]]"},
@@ -431,7 +416,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_ErrorDeterministic
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"prompt":"template://greet"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	resp := assertTemplateError(t, action, "Error resolving templates")
 
 	var body map[string]interface{}
@@ -444,7 +429,7 @@ func TestPromptTemplatePolicy_OnRequest_UnresolvedPlaceholder_ErrorDeterministic
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_JSONPath_UpdatesOnlyTarget(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_JSONPath_UpdatesOnlyTarget(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -458,7 +443,7 @@ func TestPromptTemplatePolicy_OnRequest_JSONPath_UpdatesOnlyTarget(t *testing.T)
 		"other":"template://greet?name=Bob",
 		"nested":{"value":"template://greet?name=Cat"}
 	}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -477,7 +462,7 @@ func TestPromptTemplatePolicy_OnRequest_JSONPath_UpdatesOnlyTarget(t *testing.T)
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidPathReturnsError(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_JSONPath_InvalidPathReturnsError(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -487,11 +472,11 @@ func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidPathReturnsError(t *test
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"target":"template://greet?name=Ann"}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertTemplateError(t, action, "Error extracting value from JSONPath")
 }
 
-func TestPromptTemplatePolicy_OnRequest_JSONPath_NonStringTargetReturnsError(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_JSONPath_NonStringTargetReturnsError(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -501,11 +486,11 @@ func TestPromptTemplatePolicy_OnRequest_JSONPath_NonStringTargetReturnsError(t *
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"target":{"value":"template://greet?name=Ann"}}`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertTemplateError(t, action, "Error extracting value from JSONPath")
 }
 
-func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidJSONReturnsError(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_JSONPath_InvalidJSONReturnsError(t *testing.T) {
 	params := map[string]interface{}{
 		"templates": []interface{}{
 			map[string]interface{}{"name": "greet", "template": "Hello [[name]]"},
@@ -515,11 +500,11 @@ func TestPromptTemplatePolicy_OnRequest_JSONPath_InvalidJSONReturnsError(t *test
 	p := mustGetPromptTemplatePolicy(t, params)
 
 	ctx := newRequestContextWithBody(`{"target":"template://greet?name=Ann"`)
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	assertTemplateError(t, action, "Error parsing JSON payload")
 }
 
-func TestPromptTemplatePolicy_OnRequest_StressManyTemplatesAndReferences(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_StressManyTemplatesAndReferences(t *testing.T) {
 	templateCount := 25
 	templates := make([]interface{}, 0, templateCount)
 	payloadMap := make(map[string]interface{}, templateCount)
@@ -543,7 +528,7 @@ func TestPromptTemplatePolicy_OnRequest_StressManyTemplatesAndReferences(t *test
 	})
 
 	ctx := newRequestContextWithBody(string(payload))
-	action := p.OnRequest(ctx, nil)
+	action := p.OnRequestBody(ctx, nil)
 	mods := mustRequestMods(t, action)
 	body := decodeJSONMap(t, mods.Body)
 
@@ -568,7 +553,7 @@ func TestPromptTemplatePolicy_ResolveTemplateReference_MalformedURI(t *testing.T
 	}
 }
 
-func TestPromptTemplatePolicy_OnRequest_ConcurrentAccess(t *testing.T) {
+func TestPromptTemplatePolicy_OnRequestBody_ConcurrentAccess(t *testing.T) {
 	p := mustGetPromptTemplatePolicy(t, baseParams())
 
 	const workers = 50
@@ -583,8 +568,8 @@ func TestPromptTemplatePolicy_OnRequest_ConcurrentAccess(t *testing.T) {
 			name := fmt.Sprintf("User%d", i)
 			ctx := newRequestContextWithBody(fmt.Sprintf(`{"prompt":"template://greet?name=%s"}`, name))
 
-			action := p.OnRequest(ctx, nil)
-			mods, ok := action.(policy.UpstreamRequestModifications)
+			action := p.OnRequestBody(ctx, nil)
+			mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 			if !ok {
 				errCh <- fmt.Errorf("expected UpstreamRequestModifications, got %T", action)
 				return
@@ -614,7 +599,7 @@ func TestPromptTemplatePolicy_OnRequest_ConcurrentAccess(t *testing.T) {
 func mustGetPromptTemplatePolicy(t *testing.T, params map[string]interface{}) *PromptTemplatePolicy {
 	t.Helper()
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -625,20 +610,20 @@ func mustGetPromptTemplatePolicy(t *testing.T, params map[string]interface{}) *P
 	return policyImpl
 }
 
-func mustRequestMods(t *testing.T, action policy.RequestAction) policy.UpstreamRequestModifications {
+func mustRequestMods(t *testing.T, action policyv1alpha2.RequestAction) policyv1alpha2.UpstreamRequestModifications {
 	t.Helper()
 
-	mods, ok := action.(policy.UpstreamRequestModifications)
+	mods, ok := action.(policyv1alpha2.UpstreamRequestModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 	return mods
 }
 
-func assertTemplateError(t *testing.T, action policy.RequestAction, wantMessagePrefix string) policy.ImmediateResponse {
+func assertTemplateError(t *testing.T, action policyv1alpha2.RequestAction, wantMessagePrefix string) policyv1alpha2.ImmediateResponse {
 	t.Helper()
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -682,13 +667,13 @@ func decodeJSONMapNoFail(payload []byte) map[string]interface{} {
 	return result
 }
 
-func newRequestContextWithBody(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func newRequestContextWithBody(body string) *policyv1alpha2.RequestContext {
+	return &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: regex-guardrail
-version: v0.2.1
+version: v0.9.0
 description: |
   Validate request or response content against regex patterns using optional JSONPath extraction and optional inverted matching.
 

--- a/policies/regex-guardrail/regexguardrail_test.go
+++ b/policies/regex-guardrail/regexguardrail_test.go
@@ -5,18 +5,18 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func TestRegexGuardrailPolicy_Mode(t *testing.T) {
 	p := &RegexGuardrailPolicy{}
 
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeStream,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -204,7 +204,7 @@ func TestRegexGuardrailPolicy_GetPolicy_Errors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetPolicy(policy.PolicyMetadata{}, tt.params)
+			_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tt.params)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -248,7 +248,7 @@ func TestRegexGuardrailPolicy_ParseParams_DisabledFlow_DoesNotRequireRegex(t *te
 
 func TestRegexGuardrailPolicy_DisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	t.Run("request flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -262,14 +262,14 @@ func TestRegexGuardrailPolicy_DisabledFlow_GetPolicyAndHandlers_NoRequiredParams
 			t.Fatalf("expected request params present and disabled, got hasRequest=%v enabled=%v", p.hasRequestParams, p.requestParams.Enabled)
 		}
 
-		action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"hello"}]}`), nil)
-		if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		action := p.OnRequestBody(newRequestContextWithBody(`{"messages":[{"content":"hello"}]}`), nil)
+		if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 			t.Fatalf("expected request no-op when request.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("response flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"response": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -283,27 +283,27 @@ func TestRegexGuardrailPolicy_DisabledFlow_GetPolicyAndHandlers_NoRequiredParams
 			t.Fatalf("expected response params present and disabled, got hasResponse=%v enabled=%v", p.hasResponseParams, p.responseParams.Enabled)
 		}
 
-		action := p.OnResponse(newResponseContextWithBody(`{"status":"ok"}`), nil)
-		if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		action := p.OnResponseBody(newResponseContextWithBody(`{"status":"ok"}`), nil)
+		if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 			t.Fatalf("expected response no-op when response.enabled=false, got %T", action)
 		}
 	})
 }
 
-func TestRegexGuardrailPolicy_OnRequest_NoRequestConfig_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_NoRequestConfig_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"regex": "hello",
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(newRequestContextWithBody(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_Disabled_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_Disabled_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":   "hello",
@@ -311,26 +311,26 @@ func TestRegexGuardrailPolicy_OnRequest_Disabled_NoOp(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"hello"}]}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":[{"content":"hello"}]}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnResponse_NoResponseConfig_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_NoResponseConfig_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex": "hello",
 		},
 	})
 
-	action := p.OnResponse(newResponseContextWithBody(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseBody(newResponseContextWithBody(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnResponse_Disabled_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_Disabled_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"regex":   "hello",
@@ -338,72 +338,72 @@ func TestRegexGuardrailPolicy_OnResponse_Disabled_NoOp(t *testing.T) {
 		},
 	})
 
-	action := p.OnResponse(newResponseContextWithBody(`{"message":"hello"}`), nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseBody(newResponseContextWithBody(`{"message":"hello"}`), nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_EmptyBody_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_EmptyBody_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex": "hello",
 		},
 	})
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte{},
 			Present: false,
 		},
 	}
-	action := p.OnRequest(ctx, nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(ctx, nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnResponse_EmptyBody_NoOp(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_EmptyBody_NoOp(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"regex": "hello",
 		},
 	})
 
-	ctx := &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-id",
 			Metadata:  map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte{},
 			Present: false,
 		},
 	}
-	action := p.OnResponse(ctx, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseBody(ctx, nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_DefaultJSONPath_Success(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_DefaultJSONPath_Success(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex": "hello",
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"hello world"}]}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":[{"content":"hello world"}]}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_CustomJSONPath_Success(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_CustomJSONPath_Success(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":    "secret",
@@ -411,13 +411,13 @@ func TestRegexGuardrailPolicy_OnRequest_CustomJSONPath_Success(t *testing.T) {
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":[{"content":"my secret token"}]}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":[{"content":"my secret token"}]}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_EmptyJSONPath_UsesWholePayload(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_EmptyJSONPath_UsesWholePayload(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":    "sam",
@@ -425,13 +425,13 @@ func TestRegexGuardrailPolicy_OnRequest_EmptyJSONPath_UsesWholePayload(t *testin
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"name":"sam"}`), nil)
-	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+	action := p.OnRequestBody(newRequestContextWithBody(`{"name":"sam"}`), nil)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_InvertBehavior(t *testing.T) {
 	passPolicy := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":    "forbidden",
@@ -439,8 +439,8 @@ func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
 			"invert":   true,
 		},
 	})
-	passAction := passPolicy.OnRequest(newRequestContextWithBody(`{"messages":"allowed content"}`), nil)
-	if _, ok := passAction.(policy.UpstreamRequestModifications); !ok {
+	passAction := passPolicy.OnRequestBody(newRequestContextWithBody(`{"messages":"allowed content"}`), nil)
+	if _, ok := passAction.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass with invert=true on non-match, got %T", passAction)
 	}
 
@@ -451,11 +451,11 @@ func TestRegexGuardrailPolicy_OnRequest_InvertBehavior(t *testing.T) {
 			"invert":   true,
 		},
 	})
-	failAction := failPolicy.OnRequest(newRequestContextWithBody(`{"messages":"contains forbidden term"}`), nil)
+	failAction := failPolicy.OnRequestBody(newRequestContextWithBody(`{"messages":"contains forbidden term"}`), nil)
 	assertRequestErrorResponse(t, failAction, false, "REQUEST")
 }
 
-func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentFalse(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_RegexViolation_ShowAssessmentFalse(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "abc",
@@ -464,7 +464,7 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentFalse(t *te
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
 	body := assertRequestErrorResponse(t, action, false, "REQUEST")
 
 	message := extractMessageAssessment(t, body)
@@ -473,7 +473,7 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentFalse(t *te
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentTrue(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_RegexViolation_ShowAssessmentTrue(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "abc",
@@ -482,7 +482,7 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentTrue(t *tes
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":"does not match"}`), nil)
 	body := assertRequestErrorResponse(t, action, true, "REQUEST")
 
 	message := extractMessageAssessment(t, body)
@@ -492,7 +492,7 @@ func TestRegexGuardrailPolicy_OnRequest_RegexViolation_ShowAssessmentTrue(t *tes
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_ExtractionError_ShowAssessmentTrue(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_ExtractionError_ShowAssessmentTrue(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex":          "abc",
@@ -501,7 +501,7 @@ func TestRegexGuardrailPolicy_OnRequest_ExtractionError_ShowAssessmentTrue(t *te
 		},
 	})
 
-	action := p.OnRequest(newRequestContextWithBody(`{"message":"abc"}`), nil)
+	action := p.OnRequestBody(newRequestContextWithBody(`{"message":"abc"}`), nil)
 	body := assertRequestErrorResponse(t, action, true, "REQUEST")
 	message := extractMessageAssessment(t, body)
 
@@ -511,7 +511,7 @@ func TestRegexGuardrailPolicy_OnRequest_ExtractionError_ShowAssessmentTrue(t *te
 	}
 }
 
-func TestRegexGuardrailPolicy_OnRequest_DefaultJSONPath_ArrayPayload_ExtractionError(t *testing.T) {
+func TestRegexGuardrailPolicy_OnRequestBody_DefaultJSONPath_ArrayPayload_ExtractionError(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"request": map[string]interface{}{
 			"regex": "hello",
@@ -520,11 +520,11 @@ func TestRegexGuardrailPolicy_OnRequest_DefaultJSONPath_ArrayPayload_ExtractionE
 
 	// Default jsonPath is $.messages[-1].content; this payload has messages as a string,
 	// so indexed extraction fails.
-	action := p.OnRequest(newRequestContextWithBody(`{"messages":"hello"}`), nil)
+	action := p.OnRequestBody(newRequestContextWithBody(`{"messages":"hello"}`), nil)
 	assertRequestErrorResponse(t, action, false, "REQUEST")
 }
 
-func TestRegexGuardrailPolicy_OnResponse_Success(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_Success(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"enabled":  true,
@@ -533,13 +533,13 @@ func TestRegexGuardrailPolicy_OnResponse_Success(t *testing.T) {
 		},
 	})
 
-	action := p.OnResponse(newResponseContextWithBody(`{"status":"ok"}`), nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	action := p.OnResponseBody(newResponseContextWithBody(`{"status":"ok"}`), nil)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 }
 
-func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentFalse(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_RegexViolation_ShowAssessmentFalse(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"enabled":        true,
@@ -549,7 +549,7 @@ func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentFalse(t *t
 		},
 	})
 
-	action := p.OnResponse(newResponseContextWithBody(`{"status":"failed"}`), nil)
+	action := p.OnResponseBody(newResponseContextWithBody(`{"status":"failed"}`), nil)
 	body := assertResponseErrorResponse(t, action, false, "RESPONSE")
 	message := extractMessageAssessment(t, body)
 	if _, exists := message["assessments"]; exists {
@@ -557,7 +557,7 @@ func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentFalse(t *t
 	}
 }
 
-func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentTrue(t *testing.T) {
+func TestRegexGuardrailPolicy_OnResponseBody_RegexViolation_ShowAssessmentTrue(t *testing.T) {
 	p := mustGetRegexPolicy(t, map[string]interface{}{
 		"response": map[string]interface{}{
 			"enabled":        true,
@@ -567,7 +567,7 @@ func TestRegexGuardrailPolicy_OnResponse_RegexViolation_ShowAssessmentTrue(t *te
 		},
 	})
 
-	action := p.OnResponse(newResponseContextWithBody(`{"status":"failed"}`), nil)
+	action := p.OnResponseBody(newResponseContextWithBody(`{"status":"failed"}`), nil)
 	body := assertResponseErrorResponse(t, action, true, "RESPONSE")
 	message := extractMessageAssessment(t, body)
 	if _, exists := message["assessments"]; !exists {
@@ -601,7 +601,7 @@ func TestRegexGuardrailPolicy_BuildAssessmentObject(t *testing.T) {
 func mustGetRegexPolicy(t *testing.T, params map[string]interface{}) *RegexGuardrailPolicy {
 	t.Helper()
 
-	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	p, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, params)
 	if err != nil {
 		t.Fatalf("failed to create policy: %v", err)
 	}
@@ -612,10 +612,10 @@ func mustGetRegexPolicy(t *testing.T, params map[string]interface{}) *RegexGuard
 	return rp
 }
 
-func assertRequestErrorResponse(t *testing.T, action policy.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+func assertRequestErrorResponse(t *testing.T, action policyv1alpha2.RequestAction, expectAssessments bool, wantDirection string) map[string]interface{} {
 	t.Helper()
 
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -635,18 +635,18 @@ func assertRequestErrorResponse(t *testing.T, action policy.RequestAction, expec
 	return body
 }
 
-func assertResponseErrorResponse(t *testing.T, action policy.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
+func assertResponseErrorResponse(t *testing.T, action policyv1alpha2.ResponseAction, expectAssessments bool, wantDirection string) map[string]interface{} {
 	t.Helper()
 
-	resp, ok := action.(policy.UpstreamResponseModifications)
+	resp, ok := action.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("unexpected status code: got %v, want %d", resp.StatusCode, GuardrailErrorCode)
 	}
-	if resp.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("unexpected content type header: %v", resp.SetHeaders["Content-Type"])
+	if resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("unexpected content type header: %v", resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"])
 	}
 
 	body := decodeJSONMap(t, resp.Body)
@@ -697,26 +697,26 @@ func decodeJSONMap(t *testing.T, payload []byte) map[string]interface{} {
 	return result
 }
 
-func newRequestContextWithBody(body string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func newRequestContextWithBody(body string) *policyv1alpha2.RequestContext {
+	return &policyv1alpha2.RequestContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  map[string]interface{}{},
 		},
-		Body: &policy.Body{
+		Body: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},
 	}
 }
 
-func newResponseContextWithBody(body string) *policy.ResponseContext {
-	return &policy.ResponseContext{
-		SharedContext: &policy.SharedContext{
+func newResponseContextWithBody(body string) *policyv1alpha2.ResponseContext {
+	return &policyv1alpha2.ResponseContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			RequestID: "test-request-id",
 			Metadata:  map[string]interface{}{},
 		},
-		ResponseBody: &policy.Body{
+		ResponseBody: &policyv1alpha2.Body{
 			Content: []byte(body),
 			Present: body != "",
 		},

--- a/policies/remove-headers/policy-definition.yaml
+++ b/policies/remove-headers/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: remove-headers
-version: v0.8.0
+version: v0.9.0
 description: |
   Removes configured headers from requests and/or responses. Header matching is
   case-insensitive, and removing a non-existent header is ignored.

--- a/policies/remove-headers/removeheaders_test.go
+++ b/policies/remove-headers/removeheaders_test.go
@@ -21,27 +21,27 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 // Helper function to create test headers
-func createTestHeaders(headers map[string]string) *policy.Headers {
+func createTestHeaders(headers map[string]string) *policyv1alpha2.Headers {
 	headerMap := make(map[string][]string)
 	for k, v := range headers {
 		headerMap[k] = []string{v}
 	}
-	return policy.NewHeaders(headerMap)
+	return policyv1alpha2.NewHeaders(headerMap)
 }
 
 func TestRemoveHeadersPolicy_Mode(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
 	mode := p.Mode()
 
-	expectedMode := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	expectedMode := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if mode != expectedMode {
@@ -50,10 +50,10 @@ func TestRemoveHeadersPolicy_Mode(t *testing.T) {
 }
 
 func TestGetPolicy(t *testing.T) {
-	metadata := policy.PolicyMetadata{}
+	metadata := policyv1alpha2.PolicyMetadata{}
 	params := map[string]interface{}{}
 
-	p, err := GetPolicy(metadata, params)
+	p, err := GetPolicyV2(metadata, params)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -67,9 +67,13 @@ func TestGetPolicy(t *testing.T) {
 	}
 }
 
-func TestRemoveHeadersPolicy_OnRequest_NoHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnRequestHeaders_NoHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type":  "application/json",
 			"authorization": "Bearer token123",
@@ -78,22 +82,26 @@ func TestRemoveHeadersPolicy_OnRequest_NoHeaders(t *testing.T) {
 
 	// No requestHeaders parameter
 	params := map[string]interface{}{}
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
 	// Should return empty modifications
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 0 {
-		t.Errorf("Expected no headers to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 0 {
+		t.Errorf("Expected no headers to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 }
 
-func TestRemoveHeadersPolicy_OnRequest_SingleHeader(t *testing.T) {
+func TestRemoveHeadersPolicy_OnRequestHeaders_SingleHeader(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type":    "application/json",
 			"authorization":   "Bearer token123",
@@ -109,27 +117,31 @@ func TestRemoveHeadersPolicy_OnRequest_SingleHeader(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 1 {
-		t.Errorf("Expected 1 header to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 1 {
+		t.Errorf("Expected 1 header to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 
 	expectedHeaderName := "x-custom-header" // Should be normalized to lowercase
-	if mods.RemoveHeaders[0] != expectedHeaderName {
+	if mods.HeadersToRemove[0] != expectedHeaderName {
 		t.Errorf("Expected header '%s' to be removed, got '%s'",
-			expectedHeaderName, mods.RemoveHeaders[0])
+			expectedHeaderName, mods.HeadersToRemove[0])
 	}
 }
 
-func TestRemoveHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnRequestHeaders_MultipleHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type":  "application/json",
 			"authorization": "Bearer token123",
@@ -153,15 +165,15 @@ func TestRemoveHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 3 {
-		t.Errorf("Expected 3 headers to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 3 {
+		t.Errorf("Expected 3 headers to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 
 	expectedHeaders := []string{"authorization", "x-api-key", "x-debug-info"}
@@ -169,7 +181,7 @@ func TestRemoveHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
 	// Check that all expected headers are in the removal list
 	for _, expectedHeader := range expectedHeaders {
 		found := false
-		for _, actualHeader := range mods.RemoveHeaders {
+		for _, actualHeader := range mods.HeadersToRemove {
 			if actualHeader == expectedHeader {
 				found = true
 				break
@@ -177,14 +189,18 @@ func TestRemoveHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("Expected header '%s' to be in removal list, got %v",
-				expectedHeader, mods.RemoveHeaders)
+				expectedHeader, mods.HeadersToRemove)
 		}
 	}
 }
 
-func TestRemoveHeadersPolicy_OnRequest_HeaderNameNormalization(t *testing.T) {
+func TestRemoveHeadersPolicy_OnRequestHeaders_HeaderNameNormalization(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"x-upper-case": "test-value",
 		}),
@@ -198,23 +214,27 @@ func TestRemoveHeadersPolicy_OnRequest_HeaderNameNormalization(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	expectedHeaderName := "x-upper-case" // Should be trimmed and lowercase
-	if len(mods.RemoveHeaders) != 1 || mods.RemoveHeaders[0] != expectedHeaderName {
+	if len(mods.HeadersToRemove) != 1 || mods.HeadersToRemove[0] != expectedHeaderName {
 		t.Errorf("Expected header '%s' to be normalized and removed, got %v",
-			expectedHeaderName, mods.RemoveHeaders)
+			expectedHeaderName, mods.HeadersToRemove)
 	}
 }
 
-func TestRemoveHeadersPolicy_OnResponse_NoHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnResponseHeaders_NoHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 			"server":       "nginx/1.21.0",
@@ -223,22 +243,26 @@ func TestRemoveHeadersPolicy_OnResponse_NoHeaders(t *testing.T) {
 
 	// No responseHeaders parameter
 	params := map[string]interface{}{}
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
 	// Should return empty modifications
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 0 {
-		t.Errorf("Expected no headers to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 0 {
+		t.Errorf("Expected no headers to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 }
 
-func TestRemoveHeadersPolicy_OnResponse_SingleHeader(t *testing.T) {
+func TestRemoveHeadersPolicy_OnResponseHeaders_SingleHeader(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 			"server":       "nginx/1.21.0",
@@ -254,27 +278,31 @@ func TestRemoveHeadersPolicy_OnResponse_SingleHeader(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 1 {
-		t.Errorf("Expected 1 header to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 1 {
+		t.Errorf("Expected 1 header to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 
 	expectedHeaderName := "x-powered-by" // Should be normalized to lowercase
-	if mods.RemoveHeaders[0] != expectedHeaderName {
+	if mods.HeadersToRemove[0] != expectedHeaderName {
 		t.Errorf("Expected header '%s' to be removed, got '%s'",
-			expectedHeaderName, mods.RemoveHeaders[0])
+			expectedHeaderName, mods.HeadersToRemove[0])
 	}
 }
 
-func TestRemoveHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnResponseHeaders_MultipleHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type":    "application/json",
 			"server":          "nginx/1.21.0",
@@ -298,15 +326,15 @@ func TestRemoveHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 3 {
-		t.Errorf("Expected 3 headers to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 3 {
+		t.Errorf("Expected 3 headers to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 
 	expectedHeaders := []string{"server", "x-powered-by", "x-debug-trace"}
@@ -314,7 +342,7 @@ func TestRemoveHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
 	// Check that all expected headers are in the removal list
 	for _, expectedHeader := range expectedHeaders {
 		found := false
-		for _, actualHeader := range mods.RemoveHeaders {
+		for _, actualHeader := range mods.HeadersToRemove {
 			if actualHeader == expectedHeader {
 				found = true
 				break
@@ -322,7 +350,7 @@ func TestRemoveHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("Expected header '%s' to be in removal list, got %v",
-				expectedHeader, mods.RemoveHeaders)
+				expectedHeader, mods.HeadersToRemove)
 		}
 	}
 }
@@ -331,7 +359,11 @@ func TestRemoveHeadersPolicy_BothRequestAndResponse(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
 
 	// Test request phase
-	reqCtx := &policy.RequestContext{
+	reqCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"authorization": "Bearer token123",
 		}),
@@ -350,37 +382,45 @@ func TestRemoveHeadersPolicy_BothRequestAndResponse(t *testing.T) {
 		},
 	}
 
-	reqResult := p.OnRequest(reqCtx, params)
-	reqMods, ok := reqResult.(policy.UpstreamRequestModifications)
+	reqResult := p.OnRequestHeaders(reqCtx, params)
+	reqMods, ok := reqResult.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", reqResult)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", reqResult)
 	}
 
-	if len(reqMods.RemoveHeaders) != 1 || reqMods.RemoveHeaders[0] != "authorization" {
-		t.Errorf("Expected request header 'authorization' to be removed, got %v", reqMods.RemoveHeaders)
+	if len(reqMods.HeadersToRemove) != 1 || reqMods.HeadersToRemove[0] != "authorization" {
+		t.Errorf("Expected request header 'authorization' to be removed, got %v", reqMods.HeadersToRemove)
 	}
 
 	// Test response phase
-	respCtx := &policy.ResponseContext{
+	respCtx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"server": "nginx/1.21.0",
 		}),
 	}
 
-	respResult := p.OnResponse(respCtx, params)
-	respMods, ok := respResult.(policy.UpstreamResponseModifications)
+	respResult := p.OnResponseHeaders(respCtx, params)
+	respMods, ok := respResult.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", respResult)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", respResult)
 	}
 
-	if len(respMods.RemoveHeaders) != 1 || respMods.RemoveHeaders[0] != "server" {
-		t.Errorf("Expected response header 'server' to be removed, got %v", respMods.RemoveHeaders)
+	if len(respMods.HeadersToRemove) != 1 || respMods.HeadersToRemove[0] != "server" {
+		t.Errorf("Expected response header 'server' to be removed, got %v", respMods.HeadersToRemove)
 	}
 }
 
 func TestRemoveHeadersPolicy_EmptyHeadersList(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -388,21 +428,25 @@ func TestRemoveHeadersPolicy_EmptyHeadersList(t *testing.T) {
 		"requestHeaders": []interface{}{}, // Empty array
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 0 {
-		t.Errorf("Expected no headers to be removed for empty array, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 0 {
+		t.Errorf("Expected no headers to be removed for empty array, got %d headers", len(mods.HeadersToRemove))
 	}
 }
 
 func TestRemoveHeadersPolicy_InvalidHeadersType(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -410,21 +454,25 @@ func TestRemoveHeadersPolicy_InvalidHeadersType(t *testing.T) {
 		"requestHeaders": "not-an-array", // Invalid type
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 0 {
-		t.Errorf("Expected no headers to be removed for invalid type, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 0 {
+		t.Errorf("Expected no headers to be removed for invalid type, got %d headers", len(mods.HeadersToRemove))
 	}
 }
 
 func TestRemoveHeadersPolicy_InvalidHeaderEntry(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -437,26 +485,30 @@ func TestRemoveHeadersPolicy_InvalidHeaderEntry(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	// Should only process valid entries
-	if len(mods.RemoveHeaders) != 1 {
-		t.Errorf("Expected 1 valid header to be removed, got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 1 {
+		t.Errorf("Expected 1 valid header to be removed, got %d headers", len(mods.HeadersToRemove))
 	}
 
-	if mods.RemoveHeaders[0] != "valid-header" {
-		t.Errorf("Expected valid header to be processed correctly, got '%s'", mods.RemoveHeaders[0])
+	if mods.HeadersToRemove[0] != "valid-header" {
+		t.Errorf("Expected valid header to be processed correctly, got '%s'", mods.HeadersToRemove[0])
 	}
 }
 
 func TestRemoveHeadersPolicy_DuplicateHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -474,22 +526,22 @@ func TestRemoveHeadersPolicy_DuplicateHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 3 {
-		t.Errorf("Expected 3 headers in removal list (including duplicates), got %d headers", len(mods.RemoveHeaders))
+	if len(mods.HeadersToRemove) != 3 {
+		t.Errorf("Expected 3 headers in removal list (including duplicates), got %d headers", len(mods.HeadersToRemove))
 	}
 
 	// Check that duplicates are preserved in the removal list
 	expectedHeaders := []string{"x-custom-header", "x-custom-header", "authorization"}
 	for i, expected := range expectedHeaders {
-		if i < len(mods.RemoveHeaders) && mods.RemoveHeaders[i] != expected {
-			t.Errorf("Expected header at index %d to be '%s', got '%s'", i, expected, mods.RemoveHeaders[i])
+		if i < len(mods.HeadersToRemove) && mods.HeadersToRemove[i] != expected {
+			t.Errorf("Expected header at index %d to be '%s', got '%s'", i, expected, mods.HeadersToRemove[i])
 		}
 	}
 }
@@ -643,9 +695,13 @@ func TestRemoveHeadersPolicy_Validate_MissingNameField(t *testing.T) {
 	}
 }
 
-func TestRemoveHeadersPolicy_OnRequest_NestedHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnRequestHeaders_NestedHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"x-nested-request": "remove-me",
 		}),
@@ -661,20 +717,24 @@ func TestRemoveHeadersPolicy_OnRequest_NestedHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestHeaders(ctx, params)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 1 || mods.RemoveHeaders[0] != "x-nested-request" {
-		t.Errorf("Expected nested request header to be removed, got %v", mods.RemoveHeaders)
+	if len(mods.HeadersToRemove) != 1 || mods.HeadersToRemove[0] != "x-nested-request" {
+		t.Errorf("Expected nested request header to be removed, got %v", mods.HeadersToRemove)
 	}
 }
 
-func TestRemoveHeadersPolicy_OnResponse_NestedHeaders(t *testing.T) {
+func TestRemoveHeadersPolicy_OnResponseHeaders_NestedHeaders(t *testing.T) {
 	p := &RemoveHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"x-nested-response": "remove-me",
 		}),
@@ -690,14 +750,14 @@ func TestRemoveHeadersPolicy_OnResponse_NestedHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseHeaders(ctx, params)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.RemoveHeaders) != 1 || mods.RemoveHeaders[0] != "x-nested-response" {
-		t.Errorf("Expected nested response header to be removed, got %v", mods.RemoveHeaders)
+	if len(mods.HeadersToRemove) != 1 || mods.HeadersToRemove[0] != "x-nested-response" {
+		t.Errorf("Expected nested response header to be removed, got %v", mods.HeadersToRemove)
 	}
 }
 

--- a/policies/request-rewrite/policy-definition.yaml
+++ b/policies/request-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: request-rewrite
-version: v0.2.3
+version: v0.9.0
 description: |
   Rewrite request paths, query parameters, and HTTP methods before forwarding upstream, with optional header and query match conditions to apply rewrites only when criteria are met.
 

--- a/policies/respond/policy-definition.yaml
+++ b/policies/respond/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: respond
-version: v0.2.1
+version: v0.9.0
 description: |
   Return a response directly to the client without forwarding the request to the upstream.
 

--- a/policies/respond/respond_test.go
+++ b/policies/respond/respond_test.go
@@ -5,19 +5,19 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
-func mustImmediateResponse(t *testing.T, action policy.RequestAction) policy.ImmediateResponse {
+func mustImmediateResponse(t *testing.T, action policyv1alpha2.RequestHeaderAction) policyv1alpha2.ImmediateResponse {
 	t.Helper()
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
 	return resp
 }
 
-func assertConfigError(t *testing.T, resp policy.ImmediateResponse) {
+func assertConfigError(t *testing.T, resp policyv1alpha2.ImmediateResponse) {
 	t.Helper()
 	if resp.StatusCode != 500 {
 		t.Fatalf("expected status code 500, got %d", resp.StatusCode)
@@ -39,13 +39,13 @@ func assertConfigError(t *testing.T, resp policy.ImmediateResponse) {
 }
 
 func TestGetPolicyReturnsSingleton(t *testing.T) {
-	first, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	first, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
-	second, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	second, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err != nil {
-		t.Fatalf("GetPolicy failed: %v", err)
+		t.Fatalf("GetPolicyV2 failed: %v", err)
 	}
 	if first != second {
 		t.Fatalf("expected singleton policy instance")
@@ -55,30 +55,23 @@ func TestGetPolicyReturnsSingleton(t *testing.T) {
 func TestMode(t *testing.T) {
 	p := &RespondPolicy{}
 	mode := p.Mode()
-	if mode.RequestHeaderMode != policy.HeaderModeProcess {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeProcess {
 		t.Fatalf("unexpected request header mode: %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeSkip {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Fatalf("unexpected request body mode: %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("unexpected response header mode: %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeSkip {
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeSkip {
 		t.Fatalf("unexpected response body mode: %v", mode.ResponseBodyMode)
 	}
 }
 
-func TestOnResponseReturnsNil(t *testing.T) {
+func TestOnRequestHeadersDefaults(t *testing.T) {
 	p := &RespondPolicy{}
-	if got := p.OnResponse(&policy.ResponseContext{}, map[string]interface{}{}); got != nil {
-		t.Fatalf("expected nil response action, got %T", got)
-	}
-}
-
-func TestOnRequestDefaults(t *testing.T) {
-	p := &RespondPolicy{}
-	resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, map[string]interface{}{}))
+	resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, map[string]interface{}{}))
 
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected default status 200, got %d", resp.StatusCode)
@@ -91,9 +84,9 @@ func TestOnRequestDefaults(t *testing.T) {
 	}
 }
 
-func TestOnRequestValidConfig(t *testing.T) {
+func TestOnRequestHeadersValidConfig(t *testing.T) {
 	p := &RespondPolicy{}
-	resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, map[string]interface{}{
+	resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, map[string]interface{}{
 		"statusCode": 201,
 		"body":       `{"ok":true}`,
 		"headers": []interface{}{
@@ -116,7 +109,7 @@ func TestOnRequestValidConfig(t *testing.T) {
 	}
 }
 
-func TestOnRequestStatusCodeValidation(t *testing.T) {
+func TestOnRequestHeadersStatusCodeValidation(t *testing.T) {
 	p := &RespondPolicy{}
 	tests := []map[string]interface{}{
 		{"statusCode": 99},
@@ -126,28 +119,28 @@ func TestOnRequestStatusCodeValidation(t *testing.T) {
 	}
 
 	for _, params := range tests {
-		resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, params))
+		resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, params))
 		assertConfigError(t, resp)
 	}
 }
 
-func TestOnRequestBodyTypeValidation(t *testing.T) {
+func TestOnRequestHeadersBodyTypeValidation(t *testing.T) {
 	p := &RespondPolicy{}
-	resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, map[string]interface{}{
+	resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, map[string]interface{}{
 		"body": 42,
 	}))
 	assertConfigError(t, resp)
 }
 
-func TestOnRequestHeadersTypeValidation(t *testing.T) {
+func TestOnRequestHeadersHeadersTypeValidation(t *testing.T) {
 	p := &RespondPolicy{}
-	resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, map[string]interface{}{
+	resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, map[string]interface{}{
 		"headers": "not-an-array",
 	}))
 	assertConfigError(t, resp)
 }
 
-func TestOnRequestHeaderObjectValidation(t *testing.T) {
+func TestOnRequestHeadersHeaderObjectValidation(t *testing.T) {
 	p := &RespondPolicy{}
 
 	tests := []struct {
@@ -186,7 +179,7 @@ func TestOnRequestHeaderObjectValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := mustImmediateResponse(t, p.OnRequest(&policy.RequestContext{}, map[string]interface{}{
+			resp := mustImmediateResponse(t, p.OnRequestHeaders(&policyv1alpha2.RequestHeaderContext{}, map[string]interface{}{
 				"headers": tt.headers,
 			}))
 			assertConfigError(t, resp)

--- a/policies/semantic-cache/policy-definition.yaml
+++ b/policies/semantic-cache/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-cache
-version: v0.8.1
+version: v0.9.0
 description: |
   Caches LLM responses using semantic similarity over request embeddings to
   reduce repeated upstream calls. Returns cached responses on similarity hits

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/uuid"
 	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 	utils "github.com/wso2/api-platform/sdk/utils"
 	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
 	vectordbproviders "github.com/wso2/api-platform/sdk/utils/vectordbproviders"
@@ -55,9 +54,9 @@ type SemanticCachePolicy struct {
 // (StreamingResponsePolicy, RequestPolicy, ResponsePolicy), so v1alpha2 kernels
 // can discover those capabilities via type assertions even when using this factory.
 func GetPolicy(
-	metadata policy.PolicyMetadata,
+	metadata policyv1alpha2.PolicyMetadata,
 	params map[string]interface{},
-) (policy.Policy, error) {
+) (policyv1alpha2.Policy, error) {
 	p := &SemanticCachePolicy{}
 
 	// Parse and validate parameters
@@ -94,12 +93,12 @@ func GetPolicyV2(
 	metadata policyv1alpha2.PolicyMetadata,
 	params map[string]interface{},
 ) (policyv1alpha2.Policy, error) {
-	return GetPolicy(policy.PolicyMetadata{
+	return GetPolicy(policyv1alpha2.PolicyMetadata{
 		RouteName:  metadata.RouteName,
 		APIId:      metadata.APIId,
 		APIName:    metadata.APIName,
 		APIVersion: metadata.APIVersion,
-		AttachedTo: policy.Level(metadata.AttachedTo),
+		AttachedTo: policyv1alpha2.Level(metadata.AttachedTo),
 	}, params)
 }
 
@@ -316,17 +315,17 @@ func createVectorDBProvider(config vectordbproviders.VectorDBProviderConfig) (ve
 }
 
 // Mode returns the processing mode for this policy
-func (p *SemanticCachePolicy) Mode() policy.ProcessingMode {
-	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+func (p *SemanticCachePolicy) Mode() policyv1alpha2.ProcessingMode {
+	return policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
 	}
 }
 
 // OnRequest handles request body processing for semantic caching
-func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, params map[string]interface{}) policyv1alpha2.RequestAction {
 	var content []byte
 	if ctx.Body != nil {
 		content = ctx.Body.Content
@@ -345,7 +344,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[s
 
 	// If no content to embed, continue to upstream
 	if len(textToEmbed) == 0 {
-		return policy.UpstreamRequestModifications{}
+		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
 	// Generate embedding
@@ -353,7 +352,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[s
 	if err != nil {
 		slog.Debug("SemanticCache: Error generating embedding", "error", err)
 		// Log error but don't block request
-		return policy.UpstreamRequestModifications{}
+		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
 	// Store embedding in metadata for response phase
@@ -380,7 +379,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[s
 	if err != nil {
 		slog.Debug("SemanticCache: Cache retrieval error", "error", err, "apiID", apiID)
 		// Cache miss or error - continue to upstream
-		return policy.UpstreamRequestModifications{}
+		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
 	// Check if we got a valid cache response
@@ -388,17 +387,100 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[s
 	if cacheResponse.ResponsePayload == nil || len(cacheResponse.ResponsePayload) == 0 {
 		slog.Debug("SemanticCache: Cache miss", "apiID", apiID, "threshold", p.threshold)
 		// Cache miss - continue to upstream
-		return policy.UpstreamRequestModifications{}
+		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
 	// Cache hit - return cached response immediately
 	slog.Debug("SemanticCache: Cache hit", "apiID", apiID)
 	responseBytes, err := json.Marshal(cacheResponse.ResponsePayload)
 	if err != nil {
-		return policy.UpstreamRequestModifications{}
+		return policyv1alpha2.UpstreamRequestModifications{}
 	}
 
-	return policy.ImmediateResponse{
+	return policyv1alpha2.ImmediateResponse{
+		StatusCode: 200,
+		Headers: map[string]string{
+			"Content-Type":   "application/json",
+			"X-Cache-Status": "HIT",
+		},
+		Body: responseBytes,
+	}
+}
+
+// OnRequestBody implements the v1alpha2 body-phase request handler.
+func (p *SemanticCachePolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, params map[string]interface{}) policyv1alpha2.RequestAction {
+	var content []byte
+	if ctx.Body != nil {
+		content = ctx.Body.Content
+	}
+
+	// Extract text from request body using JSONPath if specified
+	textToEmbed := string(content)
+	if p.jsonPath != "" && len(content) > 0 {
+		extracted, err := utils.ExtractStringValueFromJsonpath(content, p.jsonPath)
+		if err != nil {
+			// JSONPath extraction failed - return error response
+			return p.buildErrorResponseV2("Error extracting value from JSONPath", err)
+		}
+		textToEmbed = extracted
+	}
+
+	// If no content to embed, continue to upstream
+	if len(textToEmbed) == 0 {
+		return policyv1alpha2.UpstreamRequestModifications{}
+	}
+
+	// Generate embedding
+	embedding, err := p.embeddingProvider.GetEmbedding(textToEmbed)
+	if err != nil {
+		slog.Debug("SemanticCache: Error generating embedding", "error", err)
+		// Log error but don't block request
+		return policyv1alpha2.UpstreamRequestModifications{}
+	}
+
+	// Store embedding in metadata for response phase
+	if ctx.Metadata == nil {
+		ctx.Metadata = make(map[string]interface{})
+	}
+	embeddingBytes, err := json.Marshal(embedding)
+	if err == nil {
+		ctx.Metadata[MetadataKeyEmbedding] = string(embeddingBytes)
+	}
+
+	// Get API ID from context (use APIName and APIVersion to create unique ID)
+	apiID := fmt.Sprintf("%s:%s", ctx.APIName, ctx.APIVersion)
+
+	// Check cache for similar response
+	// Threshold needs to be a string for the vector DB provider
+	cacheFilter := map[string]interface{}{
+		"threshold": fmt.Sprintf("%.2f", p.threshold),
+		"api_id":    apiID,
+		"ctx":       context.Background(), // Vector DB providers need context
+	}
+
+	cacheResponse, err := p.vectorStoreProvider.Retrieve(embedding, cacheFilter)
+	if err != nil {
+		slog.Debug("SemanticCache: Cache retrieval error", "error", err, "apiID", apiID)
+		// Cache miss or error - continue to upstream
+		return policyv1alpha2.UpstreamRequestModifications{}
+	}
+
+	// Check if we got a valid cache response
+	// Retrieve returns empty CacheResponse on no match or threshold not met
+	if cacheResponse.ResponsePayload == nil || len(cacheResponse.ResponsePayload) == 0 {
+		slog.Debug("SemanticCache: Cache miss", "apiID", apiID, "threshold", p.threshold)
+		// Cache miss - continue to upstream
+		return policyv1alpha2.UpstreamRequestModifications{}
+	}
+
+	// Cache hit - return cached response immediately
+	slog.Debug("SemanticCache: Cache hit", "apiID", apiID)
+	responseBytes, err := json.Marshal(cacheResponse.ResponsePayload)
+	if err != nil {
+		return policyv1alpha2.UpstreamRequestModifications{}
+	}
+
+	return policyv1alpha2.ImmediateResponse{
 		StatusCode: 200,
 		Headers: map[string]string{
 			"Content-Type":   "application/json",
@@ -409,11 +491,11 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[s
 }
 
 // OnResponse handles response body processing for semantic caching
-func (p *SemanticCachePolicy) OnResponse(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+func (p *SemanticCachePolicy) OnResponse(ctx *policyv1alpha2.ResponseContext, params map[string]interface{}) policyv1alpha2.ResponseAction {
 	// Only cache successful responses (200 status code)
 	if ctx.ResponseStatus != 200 {
 		slog.Debug("SemanticCache: Skipping cache for non-200 response", "statusCode", ctx.ResponseStatus)
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	var content []byte
@@ -422,26 +504,26 @@ func (p *SemanticCachePolicy) OnResponse(ctx *policy.ResponseContext, params map
 	}
 
 	if len(content) == 0 {
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	// Retrieve embedding from metadata (stored in request phase)
 	embeddingStr, ok := ctx.Metadata[MetadataKeyEmbedding].(string)
 	if !ok || embeddingStr == "" {
 		slog.Debug("SemanticCache: No embedding found in metadata, skipping cache storage")
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	// Deserialize embedding
 	var embedding []float32
 	if err := json.Unmarshal([]byte(embeddingStr), &embedding); err != nil {
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	// Parse response body
 	var responseData map[string]interface{}
 	if err := json.Unmarshal(content, &responseData); err != nil {
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	// Get API ID from context (use APIName and APIVersion to create unique ID)
@@ -466,15 +548,16 @@ func (p *SemanticCachePolicy) OnResponse(ctx *policy.ResponseContext, params map
 	if err := p.vectorStoreProvider.Store(embedding, cacheResponse, cacheFilter); err != nil {
 		slog.Debug("SemanticCache: Error storing in cache", "error", err, "apiID", apiID)
 		// Log error but don't modify response
-		return policy.UpstreamResponseModifications{}
+		return policyv1alpha2.DownstreamResponseModifications{}
 	}
 
 	slog.Debug("SemanticCache: Response cached successfully", "apiID", apiID)
-	return policy.UpstreamResponseModifications{}
+	return policyv1alpha2.DownstreamResponseModifications{}
 }
 
 // buildErrorResponse builds an error response for JSONPath extraction failures
-func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) policy.RequestAction {
+
+func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) policyv1alpha2.RequestAction {
 	errorMsg := message
 	if err != nil {
 		errorMsg = fmt.Sprintf("%s: %v", message, err)
@@ -490,7 +573,7 @@ func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) poli
 		bodyBytes = []byte(`{"type":"SEMANTIC_CACHE","message":"Internal error"}`)
 	}
 
-	return policy.ImmediateResponse{
+	return policyv1alpha2.ImmediateResponse{
 		StatusCode: 400,
 		Headers: map[string]string{
 			"Content-Type": "application/json",

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -94,13 +94,17 @@ func GetPolicyV2(
 	metadata policyv1alpha2.PolicyMetadata,
 	params map[string]interface{},
 ) (policyv1alpha2.Policy, error) {
-	return GetPolicy(policy.PolicyMetadata{
+	p, err := GetPolicy(policy.PolicyMetadata{
 		RouteName:  metadata.RouteName,
 		APIId:      metadata.APIId,
 		APIName:    metadata.APIName,
 		APIVersion: metadata.APIVersion,
 		AttachedTo: policy.Level(metadata.AttachedTo),
 	}, params)
+	if err != nil {
+		return nil, err
+	}
+	return p.(*SemanticCachePolicy), nil
 }
 
 // parseParams parses and validates parameters from the params map
@@ -316,17 +320,17 @@ func createVectorDBProvider(config vectordbproviders.VectorDBProviderConfig) (ve
 }
 
 // Mode returns the processing mode for this policy
-func (p *SemanticCachePolicy) Mode() policyv1alpha2.ProcessingMode {
-	return policyv1alpha2.ProcessingMode{
-		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
-		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
-		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
-		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
+func (p *SemanticCachePolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
 	}
 }
 
-// OnRequest handles request body processing for semantic caching
-func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, params map[string]interface{}) policyv1alpha2.RequestAction {
+// OnRequest handles request body processing for semantic caching (v1alpha interface)
+func (p *SemanticCachePolicy) OnRequest(ctx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
 	var content []byte
 	if ctx.Body != nil {
 		content = ctx.Body.Content
@@ -345,7 +349,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, para
 
 	// If no content to embed, continue to upstream
 	if len(textToEmbed) == 0 {
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return policy.UpstreamRequestModifications{}
 	}
 
 	// Generate embedding
@@ -353,7 +357,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, para
 	if err != nil {
 		slog.Debug("SemanticCache: Error generating embedding", "error", err)
 		// Log error but don't block request
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return policy.UpstreamRequestModifications{}
 	}
 
 	// Store embedding in metadata for response phase
@@ -380,7 +384,7 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, para
 	if err != nil {
 		slog.Debug("SemanticCache: Cache retrieval error", "error", err, "apiID", apiID)
 		// Cache miss or error - continue to upstream
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return policy.UpstreamRequestModifications{}
 	}
 
 	// Check if we got a valid cache response
@@ -388,17 +392,17 @@ func (p *SemanticCachePolicy) OnRequest(ctx *policyv1alpha2.RequestContext, para
 	if cacheResponse.ResponsePayload == nil || len(cacheResponse.ResponsePayload) == 0 {
 		slog.Debug("SemanticCache: Cache miss", "apiID", apiID, "threshold", p.threshold)
 		// Cache miss - continue to upstream
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return policy.UpstreamRequestModifications{}
 	}
 
 	// Cache hit - return cached response immediately
 	slog.Debug("SemanticCache: Cache hit", "apiID", apiID)
 	responseBytes, err := json.Marshal(cacheResponse.ResponsePayload)
 	if err != nil {
-		return policyv1alpha2.UpstreamRequestModifications{}
+		return policy.UpstreamRequestModifications{}
 	}
 
-	return policyv1alpha2.ImmediateResponse{
+	return policy.ImmediateResponse{
 		StatusCode: 200,
 		Headers: map[string]string{
 			"Content-Type":   "application/json",
@@ -491,12 +495,12 @@ func (p *SemanticCachePolicy) OnRequestBody(ctx *policyv1alpha2.RequestContext, 
 	}
 }
 
-// OnResponse handles response body processing for semantic caching
-func (p *SemanticCachePolicy) OnResponse(ctx *policyv1alpha2.ResponseContext, params map[string]interface{}) policyv1alpha2.ResponseAction {
+// OnResponse handles response body processing for semantic caching (v1alpha interface)
+func (p *SemanticCachePolicy) OnResponse(ctx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
 	// Only cache successful responses (200 status code)
 	if ctx.ResponseStatus != 200 {
 		slog.Debug("SemanticCache: Skipping cache for non-200 response", "statusCode", ctx.ResponseStatus)
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	var content []byte
@@ -505,26 +509,26 @@ func (p *SemanticCachePolicy) OnResponse(ctx *policyv1alpha2.ResponseContext, pa
 	}
 
 	if len(content) == 0 {
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	// Retrieve embedding from metadata (stored in request phase)
 	embeddingStr, ok := ctx.Metadata[MetadataKeyEmbedding].(string)
 	if !ok || embeddingStr == "" {
 		slog.Debug("SemanticCache: No embedding found in metadata, skipping cache storage")
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	// Deserialize embedding
 	var embedding []float32
 	if err := json.Unmarshal([]byte(embeddingStr), &embedding); err != nil {
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	// Parse response body
 	var responseData map[string]interface{}
 	if err := json.Unmarshal(content, &responseData); err != nil {
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	// Get API ID from context (use APIName and APIVersion to create unique ID)
@@ -549,16 +553,15 @@ func (p *SemanticCachePolicy) OnResponse(ctx *policyv1alpha2.ResponseContext, pa
 	if err := p.vectorStoreProvider.Store(embedding, cacheResponse, cacheFilter); err != nil {
 		slog.Debug("SemanticCache: Error storing in cache", "error", err, "apiID", apiID)
 		// Log error but don't modify response
-		return policyv1alpha2.DownstreamResponseModifications{}
+		return policy.UpstreamResponseModifications{}
 	}
 
 	slog.Debug("SemanticCache: Response cached successfully", "apiID", apiID)
-	return policyv1alpha2.DownstreamResponseModifications{}
+	return policy.UpstreamResponseModifications{}
 }
 
-// buildErrorResponse builds an error response for JSONPath extraction failures
-
-func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) policyv1alpha2.RequestAction {
+// buildErrorResponse builds an error response for JSONPath extraction failures (v1alpha)
+func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) policy.RequestAction {
 	errorMsg := message
 	if err != nil {
 		errorMsg = fmt.Sprintf("%s: %v", message, err)
@@ -574,7 +577,7 @@ func (p *SemanticCachePolicy) buildErrorResponse(message string, err error) poli
 		bodyBytes = []byte(`{"type":"SEMANTIC_CACHE","message":"Internal error"}`)
 	}
 
-	return policyv1alpha2.ImmediateResponse{
+	return policy.ImmediateResponse{
 		StatusCode: 400,
 		Headers: map[string]string{
 			"Content-Type": "application/json",

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 	utils "github.com/wso2/api-platform/sdk/utils"
 	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
 	vectordbproviders "github.com/wso2/api-platform/sdk/utils/vectordbproviders"
@@ -54,9 +55,9 @@ type SemanticCachePolicy struct {
 // (StreamingResponsePolicy, RequestPolicy, ResponsePolicy), so v1alpha2 kernels
 // can discover those capabilities via type assertions even when using this factory.
 func GetPolicy(
-	metadata policyv1alpha2.PolicyMetadata,
+	metadata policy.PolicyMetadata,
 	params map[string]interface{},
-) (policyv1alpha2.Policy, error) {
+) (policy.Policy, error) {
 	p := &SemanticCachePolicy{}
 
 	// Parse and validate parameters
@@ -93,12 +94,12 @@ func GetPolicyV2(
 	metadata policyv1alpha2.PolicyMetadata,
 	params map[string]interface{},
 ) (policyv1alpha2.Policy, error) {
-	return GetPolicy(policyv1alpha2.PolicyMetadata{
+	return GetPolicy(policy.PolicyMetadata{
 		RouteName:  metadata.RouteName,
 		APIId:      metadata.APIId,
 		APIName:    metadata.APIName,
 		APIVersion: metadata.APIVersion,
-		AttachedTo: policyv1alpha2.Level(metadata.AttachedTo),
+		AttachedTo: policy.Level(metadata.AttachedTo),
 	}, params)
 }
 

--- a/policies/semantic-cache/semanticcache_test.go
+++ b/policies/semantic-cache/semanticcache_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
 	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
 	vectordbproviders "github.com/wso2/api-platform/sdk/utils/vectordbproviders"
 )
@@ -79,11 +80,11 @@ func (m *mockVectorDBProvider) Close() error {
 func TestSemanticCachePolicy_Mode(t *testing.T) {
 	p := &SemanticCachePolicy{}
 	got := p.Mode()
-	want := policyv1alpha2.ProcessingMode{
-		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
-		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
-		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
-		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -593,7 +594,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 func TestBuildErrorResponse(t *testing.T) {
 	p := &SemanticCachePolicy{}
 	action := p.buildErrorResponse("jsonpath failed", errors.New("bad path"))
-	resp, ok := action.(policyv1alpha2.ImmediateResponse)
+	resp, ok := action.(policy.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}

--- a/policies/semantic-cache/semanticcache_test.go
+++ b/policies/semantic-cache/semanticcache_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
 	vectordbproviders "github.com/wso2/api-platform/sdk/utils/vectordbproviders"
 )
@@ -79,11 +79,11 @@ func (m *mockVectorDBProvider) Close() error {
 func TestSemanticCachePolicy_Mode(t *testing.T) {
 	p := &SemanticCachePolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeBuffer,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
@@ -91,7 +91,7 @@ func TestSemanticCachePolicy_Mode(t *testing.T) {
 }
 
 func TestGetPolicy_InvalidParams(t *testing.T) {
-	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -323,7 +323,7 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 	tests := []struct {
 		name             string
 		policy           *SemanticCachePolicy
-		ctx              *policy.RequestContext
+		ctx              *policyv1alpha2.RequestContext
 		wantImmediate    bool
 		wantStatus       int
 		wantCacheStatus  string
@@ -336,9 +336,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				vectorStoreProvider: &mockVectorDBProvider{},
 				threshold:           0.5,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
-				Body:          &policy.Body{Content: nil, Present: false},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policyv1alpha2.Body{Content: nil, Present: false},
 			},
 			wantImmediate: false,
 		},
@@ -350,9 +350,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				jsonPath:            "$.missing",
 				threshold:           0.5,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
-				Body:          &policy.Body{Content: []byte(`{"prompt":"hello"}`), Present: true},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policyv1alpha2.Body{Content: []byte(`{"prompt":"hello"}`), Present: true},
 			},
 			wantImmediate: true,
 			wantStatus:    400,
@@ -366,9 +366,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				vectorStoreProvider: &mockVectorDBProvider{},
 				threshold:           0.5,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
-				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policyv1alpha2.Body{Content: []byte("hello"), Present: true},
 			},
 			wantImmediate: false,
 		},
@@ -392,9 +392,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				}},
 				threshold: 0.7,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
-				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policyv1alpha2.Body{Content: []byte("hello"), Present: true},
 			},
 			wantImmediate:    false,
 			wantMetadataSave: true,
@@ -410,9 +410,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				}},
 				threshold: 0.5,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
-				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policyv1alpha2.Body{Content: []byte("hello"), Present: true},
 			},
 			wantImmediate:   true,
 			wantStatus:      200,
@@ -427,9 +427,9 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				}},
 				threshold: 0.5,
 			},
-			ctx: &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
-				Body:          &policy.Body{Content: []byte("hello"), Present: true},
+			ctx: &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
+				Body:          &policyv1alpha2.Body{Content: []byte("hello"), Present: true},
 			},
 			wantImmediate: false,
 		},
@@ -437,10 +437,10 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := tt.policy.OnRequest(tt.ctx, nil)
+			action := tt.policy.OnRequestBody(tt.ctx, nil)
 
 			if !tt.wantImmediate {
-				if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+				if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 					t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 				}
 				if tt.wantMetadataSave {
@@ -451,7 +451,7 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				return
 			}
 
-			resp, ok := action.(policy.ImmediateResponse)
+			resp, ok := action.(policyv1alpha2.ImmediateResponse)
 			if !ok {
 				t.Fatalf("expected ImmediateResponse, got %T", action)
 			}
@@ -478,8 +478,8 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 	tests := []struct {
 		name      string
 		policy    *SemanticCachePolicy
-		ctx       *policy.ResponseContext
-		assertion func(t *testing.T, action policy.ResponseAction)
+		ctx       *policyv1alpha2.ResponseContext
+		assertion func(t *testing.T, action policyv1alpha2.ResponseAction)
 	}{
 		{
 			name: "non-200 response skipped",
@@ -556,10 +556,10 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 					return nil
 				}},
 			},
-			ctx: &policy.ResponseContext{
-				SharedContext:  &policy.SharedContext{RequestID: "req-1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
+			ctx: &policyv1alpha2.ResponseContext{
+				SharedContext:  &policyv1alpha2.SharedContext{RequestID: "req-1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
 				ResponseStatus: 200,
-				ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+				ResponseBody:   &policyv1alpha2.Body{Content: []byte(`{"answer":"x"}`), Present: true},
 			},
 			assertion: assertUpstreamResponseMods,
 		},
@@ -573,10 +573,10 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 					return nil
 				}},
 			},
-			ctx: &policy.ResponseContext{
-				SharedContext:  &policy.SharedContext{RequestID: "req-2", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}, APIName: "Books", APIVersion: "v2"},
+			ctx: &policyv1alpha2.ResponseContext{
+				SharedContext:  &policyv1alpha2.SharedContext{RequestID: "req-2", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}, APIName: "Books", APIVersion: "v2"},
 				ResponseStatus: 200,
-				ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+				ResponseBody:   &policyv1alpha2.Body{Content: []byte(`{"answer":"x"}`), Present: true},
 			},
 			assertion: assertUpstreamResponseMods,
 		},
@@ -584,7 +584,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action := tt.policy.OnResponse(tt.ctx, nil)
+			action := tt.policy.OnResponseBody(tt.ctx, nil)
 			tt.assertion(t, action)
 		})
 	}
@@ -593,7 +593,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 func TestBuildErrorResponse(t *testing.T) {
 	p := &SemanticCachePolicy{}
 	action := p.buildErrorResponse("jsonpath failed", errors.New("bad path"))
-	resp, ok := action.(policy.ImmediateResponse)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -628,20 +628,20 @@ func TestCreateProviderHelpers_UnsupportedTypes(t *testing.T) {
 	}
 }
 
-func newResponseContext(status int, body []byte, metadata map[string]interface{}) *policy.ResponseContext {
+func newResponseContext(status int, body []byte, metadata map[string]interface{}) *policyv1alpha2.ResponseContext {
 	if metadata == nil {
 		metadata = map[string]interface{}{}
 	}
-	return &policy.ResponseContext{
-		SharedContext:  &policy.SharedContext{RequestID: "req-1", Metadata: metadata, APIName: "Books", APIVersion: "v1"},
+	return &policyv1alpha2.ResponseContext{
+		SharedContext:  &policyv1alpha2.SharedContext{RequestID: "req-1", Metadata: metadata, APIName: "Books", APIVersion: "v1"},
 		ResponseStatus: status,
-		ResponseBody:   &policy.Body{Content: body, Present: len(body) > 0},
+		ResponseBody:   &policyv1alpha2.Body{Content: body, Present: len(body) > 0},
 	}
 }
 
-func assertUpstreamResponseMods(t *testing.T, action policy.ResponseAction) {
+func assertUpstreamResponseMods(t *testing.T, action policyv1alpha2.ResponseAction) {
 	t.Helper()
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
+	if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
 	}
 }

--- a/policies/semantic-prompt-guard/policy-definition.yaml
+++ b/policies/semantic-prompt-guard/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-prompt-guard
-version: v0.8.1
+version: v0.9.0
 description: |
   Evaluates request prompts using embedding similarity against configured allow
   and deny phrases. Blocks prompts that match denied phrases or fail allow

--- a/policies/semantic-prompt-guard/semanticpromptguard_test.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	embeddingproviders "github.com/wso2/api-platform/sdk/utils/embeddingproviders"
 )
 
@@ -46,27 +46,19 @@ func (m *mockEmbeddingProvider) GetEmbeddings(inputs []string) ([][]float32, err
 func TestSemanticPromptGuardPolicy_Mode(t *testing.T) {
 	p := &SemanticPromptGuardPolicy{}
 	got := p.Mode()
-	want := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
-		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	want := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeSkip,
+		RequestBodyMode:    policyv1alpha2.BodyModeBuffer,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeSkip,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
 	}
 }
 
-func TestSemanticPromptGuardPolicy_OnResponse_NoOp(t *testing.T) {
-	p := &SemanticPromptGuardPolicy{}
-	action := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := action.(policy.UpstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications, got %T", action)
-	}
-}
-
 func TestGetPolicy_InvalidEmbeddingConfig(t *testing.T) {
-	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{})
 	if err == nil {
 		t.Fatalf("expected error for missing embedding config")
 	}
@@ -578,20 +570,20 @@ func TestSemanticPromptGuardPolicy_OnRequestAndValidatePayload(t *testing.T) {
 				params:            tt.params,
 			}
 
-			ctx := &policy.RequestContext{
-				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
-				Body:          &policy.Body{Content: []byte(tt.payload), Present: true, EndOfStream: true},
+			ctx := &policyv1alpha2.RequestContext{
+				SharedContext: &policyv1alpha2.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}},
+				Body:          &policyv1alpha2.Body{Content: []byte(tt.payload), Present: true, EndOfStream: true},
 			}
 
-			action := p.OnRequest(ctx, nil)
+			action := p.OnRequestBody(ctx, nil)
 			if !tt.wantImmediate {
-				if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+				if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 					t.Fatalf("expected UpstreamRequestModifications, got %T", action)
 				}
 				return
 			}
 
-			resp, ok := action.(policy.ImmediateResponse)
+			resp, ok := action.(policyv1alpha2.ImmediateResponse)
 			if !ok {
 				t.Fatalf("expected ImmediateResponse, got %T", action)
 			}

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: sentence-count-guardrail
-version: v0.2.3
+version: v0.9.0
 description: |
   Validate sentence counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -690,6 +690,9 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx *policyv1alpha2.R
 		return policyv1alpha2.ResponseChunkAction{}
 	}
 	chunkStr := string(chunk.Chunk)
+	if ctx.Metadata == nil {
+		ctx.Metadata = make(map[string]interface{})
+	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.

--- a/policies/sentence-count-guardrail/sentencecountguardrail_test.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
@@ -130,10 +130,11 @@ func TestParseParams(t *testing.T) {
 				"max": 10,
 			},
 			expected: SentenceCountGuardrailPolicyParams{
-				Enabled:  RequestFlowEnabledByDefault,
-				Min:      1,
-				Max:      10,
-				JsonPath: DefaultJSONPath,
+				Enabled:          RequestFlowEnabledByDefault,
+				Min:              1,
+				Max:              10,
+				JsonPath:         DefaultJSONPath,
+				StreamingJsonPath: DefaultStreamingJsonPath,
 			},
 		},
 		{
@@ -146,12 +147,13 @@ func TestParseParams(t *testing.T) {
 				"showAssessment": true,
 			},
 			expected: SentenceCountGuardrailPolicyParams{
-				Enabled:        RequestFlowEnabledByDefault,
-				Min:            2,
-				Max:            20,
-				JsonPath:       "",
-				Invert:         true,
-				ShowAssessment: true,
+				Enabled:          RequestFlowEnabledByDefault,
+				Min:              2,
+				Max:              20,
+				JsonPath:         "",
+				StreamingJsonPath: DefaultStreamingJsonPath,
+				Invert:           true,
+				ShowAssessment:   true,
 			},
 		},
 	}
@@ -219,7 +221,7 @@ func TestParseParams_DisabledFlow_DoesNotRequireMinMax(t *testing.T) {
 
 func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	t.Run("request flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -233,16 +235,16 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected request params present and disabled, got hasRequest=%v enabled=%v", p.hasRequestParams, p.requestParams.Enabled)
 		}
 
-		action := p.OnRequest(&policy.RequestContext{
-			Body: &policy.Body{Content: []byte(`{"messages":[{"content":"Hi."}]}`)},
+		action := p.OnRequestBody(&policyv1alpha2.RequestContext{
+			Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"Hi."}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 			t.Fatalf("expected request no-op when request.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("response flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"response": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -256,10 +258,10 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected response params present and disabled, got hasResponse=%v enabled=%v", p.hasResponseParams, p.responseParams.Enabled)
 		}
 
-		action := p.OnResponse(&policy.ResponseContext{
-			ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"Hi."}}]}`)},
+		action := p.OnResponseBody(&policyv1alpha2.ResponseContext{
+			ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"Hi."}}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 			t.Fatalf("expected response no-op when response.enabled=false, got %T", action)
 		}
 	})
@@ -285,7 +287,7 @@ func TestParseParams_DisabledFlow_IgnoresProvidedMinMax(t *testing.T) {
 
 func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	t.Run("request configured with empty response object", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{"min": 1, "max": 10},
 			"response": map[string]interface{}{},
 		})
@@ -306,7 +308,7 @@ func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	})
 
 	t.Run("response configured with empty request object", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{},
 			"response": map[string]interface{}{"enabled": true, "min": 1, "max": 10},
 		})
@@ -327,7 +329,7 @@ func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	})
 
 	t.Run("both empty objects still fail", func(t *testing.T) {
-		_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{},
 			"response": map[string]interface{}{},
 		})
@@ -442,7 +444,7 @@ func TestGetPolicy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pRaw, err := GetPolicy(policy.PolicyMetadata{}, tc.params)
+			pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tc.params)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -472,30 +474,30 @@ func TestMode(t *testing.T) {
 	p := &SentenceCountGuardrailPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected RequestHeaderMode=Skip, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeBuffer {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected RequestBodyMode=Buffer, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode=Skip, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeBuffer {
-		t.Fatalf("expected ResponseBodyMode=Buffer, got %v", mode.ResponseBodyMode)
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeStream {
+		t.Fatalf("expected ResponseBodyMode=Stream, got %v", mode.ResponseBodyMode)
 	}
 }
 
 func TestValidatePayload_RequestPaths(t *testing.T) {
 	p := &SentenceCountGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"messages":"Hello."}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"messages":"Hello."}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, false)
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on valid payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"messages":""}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: true}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	fail := p.validatePayloadV2([]byte(`{"messages":""}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: true}, false)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on invalid payload, got %T", fail)
 	}
@@ -517,21 +519,21 @@ func TestValidatePayload_RequestPaths(t *testing.T) {
 func TestValidatePayload_ResponsePaths(t *testing.T) {
 	p := &SentenceCountGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"messages":"Hello."}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, true)
-	if _, ok := pass.(policy.UpstreamResponseModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"messages":"Hello."}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, true)
+	if _, ok := pass.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications on valid response payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"messages":""}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: false}, true)
-	resp, ok := fail.(policy.UpstreamResponseModifications)
+	fail := p.validatePayloadV2([]byte(`{"messages":""}`), SentenceCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: false}, true)
+	resp, ok := fail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications on invalid response payload, got %T", fail)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected response status %d, got %#v", GuardrailErrorCode, resp.StatusCode)
 	}
-	if resp.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("expected response content-type header, got %#v", resp.SetHeaders)
+	if resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("expected response content-type header, got %#v", resp.DownstreamResponseHeaderModifications.HeadersToSet)
 	}
 	msg := mustMessageMap(t, resp.Body)
 	if msg["direction"] != "RESPONSE" {
@@ -552,14 +554,14 @@ func TestValidatePayload_InvertMode(t *testing.T) {
 	}
 
 	// In invert mode, content within range should fail.
-	within := p.validatePayload([]byte(`{"messages":"One."}`), params, false)
-	if _, ok := within.(policy.ImmediateResponse); !ok {
+	within := p.validatePayloadV2([]byte(`{"messages":"One."}`), params, false)
+	if _, ok := within.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse when in-range payload is rejected in invert mode, got %T", within)
 	}
 
 	// In invert mode, content outside range should pass.
-	outside := p.validatePayload([]byte(`{"messages":"One. Two. Three. Four."}`), params, false)
-	if _, ok := outside.(policy.UpstreamRequestModifications); !ok {
+	outside := p.validatePayloadV2([]byte(`{"messages":"One. Two. Three. Four."}`), params, false)
+	if _, ok := outside.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications when out-of-range payload passes in invert mode, got %T", outside)
 	}
 }
@@ -568,22 +570,22 @@ func TestValidatePayload_JSONPathExtraction(t *testing.T) {
 	p := &SentenceCountGuardrailPolicy{}
 	payload := []byte(`{"data":{"text":"First. Second."}}`)
 
-	pass := p.validatePayload(payload, SentenceCountGuardrailPolicyParams{
+	pass := p.validatePayloadV2(payload, SentenceCountGuardrailPolicyParams{
 		Min:      2,
 		Max:      2,
 		JsonPath: "$.data.text",
 	}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass using jsonPath extraction, got %T", pass)
 	}
 
-	fail := p.validatePayload(payload, SentenceCountGuardrailPolicyParams{
+	fail := p.validatePayloadV2(payload, SentenceCountGuardrailPolicyParams{
 		Min:            1,
 		Max:            10,
 		JsonPath:       "$.missing",
 		ShowAssessment: true,
 	}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on jsonPath extraction failure, got %T", fail)
 	}
@@ -622,31 +624,31 @@ func TestBuildAssessmentObject(t *testing.T) {
 	}
 }
 
-func TestOnRequestAndOnResponse(t *testing.T) {
+func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	// No request params configured -> no-op.
 	p := &SentenceCountGuardrailPolicy{hasRequestParams: false, hasResponseParams: false}
-	reqNoOp := p.OnRequest(&policy.RequestContext{}, nil)
-	if _, ok := reqNoOp.(policy.UpstreamRequestModifications); !ok {
+	reqNoOp := p.OnRequestBody(&policyv1alpha2.RequestContext{}, nil)
+	if _, ok := reqNoOp.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op modifications, got %T", reqNoOp)
 	}
-	respNoOp := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := respNoOp.(policy.UpstreamResponseModifications); !ok {
+	respNoOp := p.OnResponseBody(&policyv1alpha2.ResponseContext{}, nil)
+	if _, ok := respNoOp.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op modifications, got %T", respNoOp)
 	}
 
 	// Request validation with nil body should fail when min > 0.
 	p.hasRequestParams = true
 	p.requestParams = SentenceCountGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10, JsonPath: ""}
-	reqFail := p.OnRequest(&policy.RequestContext{Body: nil}, nil)
-	if _, ok := reqFail.(policy.ImmediateResponse); !ok {
+	reqFail := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: nil}, nil)
+	if _, ok := reqFail.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse for request nil-body validation failure, got %T", reqFail)
 	}
 
 	// Response validation with nil body should fail when min > 0.
 	p.hasResponseParams = true
 	p.responseParams = SentenceCountGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10, JsonPath: ""}
-	respFail := p.OnResponse(&policy.ResponseContext{ResponseBody: nil}, nil)
-	respMod, ok := respFail.(policy.UpstreamResponseModifications)
+	respFail := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
+	respMod, ok := respFail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications for response nil-body validation failure, got %T", respFail)
 	}
@@ -655,14 +657,14 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 	}
 
 	p.requestParams.Enabled = false
-	reqDisabled := p.OnRequest(&policy.RequestContext{Body: &policy.Body{Content: []byte(`{"messages":[{"content":"Hi."}]}`)}}, nil)
-	if _, ok := reqDisabled.(policy.UpstreamRequestModifications); !ok {
+	reqDisabled := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"Hi."}]}`)}}, nil)
+	if _, ok := reqDisabled.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op when request.enabled=false, got %T", reqDisabled)
 	}
 
 	p.responseParams.Enabled = false
-	respDisabled := p.OnResponse(&policy.ResponseContext{ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"Hi."}}]}`)}}, nil)
-	if _, ok := respDisabled.(policy.UpstreamResponseModifications); !ok {
+	respDisabled := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"Hi."}}]}`)}}, nil)
+	if _, ok := respDisabled.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }

--- a/policies/set-headers/policy-definition.yaml
+++ b/policies/set-headers/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: set-headers
-version: v0.8.0
+version: v0.9.0
 description: |
   Sets configured headers on requests and/or responses. If the same header is set
   multiple times, the latest configured value overwrites earlier values.

--- a/policies/set-headers/setheaders_test.go
+++ b/policies/set-headers/setheaders_test.go
@@ -21,27 +21,27 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 // Helper function to create test headers
-func createTestHeaders(headers map[string]string) *policy.Headers {
+func createTestHeaders(headers map[string]string) *policyv1alpha2.Headers {
 	headerMap := make(map[string][]string)
 	for k, v := range headers {
 		headerMap[k] = []string{v}
 	}
-	return policy.NewHeaders(headerMap)
+	return policyv1alpha2.NewHeaders(headerMap)
 }
 
 func TestSetHeadersPolicy_Mode(t *testing.T) {
 	p := &SetHeadersPolicy{}
 	mode := p.Mode()
 
-	expectedMode := policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
-		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeSkip,
+	expectedMode := policyv1alpha2.ProcessingMode{
+		RequestHeaderMode:  policyv1alpha2.HeaderModeProcess,
+		RequestBodyMode:    policyv1alpha2.BodyModeSkip,
+		ResponseHeaderMode: policyv1alpha2.HeaderModeProcess,
+		ResponseBodyMode:   policyv1alpha2.BodyModeSkip,
 	}
 
 	if mode != expectedMode {
@@ -50,10 +50,10 @@ func TestSetHeadersPolicy_Mode(t *testing.T) {
 }
 
 func TestGetPolicy(t *testing.T) {
-	metadata := policy.PolicyMetadata{}
+	metadata := policyv1alpha2.PolicyMetadata{}
 	params := map[string]interface{}{}
 
-	p, err := GetPolicy(metadata, params)
+	p, err := GetPolicyV2(metadata, params)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -67,9 +67,13 @@ func TestGetPolicy(t *testing.T) {
 	}
 }
 
-func TestSetHeadersPolicy_OnRequest_NoHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnRequestHeaders_NoHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -77,22 +81,26 @@ func TestSetHeadersPolicy_OnRequest_NoHeaders(t *testing.T) {
 
 	// No requestHeaders parameter
 	params := map[string]interface{}{}
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
 	// Should return empty modifications
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 0 {
-		t.Errorf("Expected no headers to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers to be set, got %d headers", len(mods.HeadersToSet))
 	}
 }
 
-func TestSetHeadersPolicy_OnRequest_SingleHeader(t *testing.T) {
+func TestSetHeadersPolicy_OnRequestHeaders_SingleHeader(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -107,27 +115,31 @@ func TestSetHeadersPolicy_OnRequest_SingleHeader(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 1 {
-		t.Errorf("Expected 1 header to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 1 {
+		t.Errorf("Expected 1 header to be set, got %d headers", len(mods.HeadersToSet))
 	}
 
 	expectedHeaderName := "x-custom-header" // Should be normalized to lowercase
-	if mods.SetHeaders[expectedHeaderName] != "custom-value" {
+	if mods.HeadersToSet[expectedHeaderName] != "custom-value" {
 		t.Errorf("Expected header '%s' to have value 'custom-value', got '%s'",
-			expectedHeaderName, mods.SetHeaders[expectedHeaderName])
+			expectedHeaderName, mods.HeadersToSet[expectedHeaderName])
 	}
 }
 
-func TestSetHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnRequestHeaders_MultipleHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -150,15 +162,15 @@ func TestSetHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 3 {
-		t.Errorf("Expected 3 headers to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 3 {
+		t.Errorf("Expected 3 headers to be set, got %d headers", len(mods.HeadersToSet))
 	}
 
 	expectedHeaders := map[string]string{
@@ -168,16 +180,20 @@ func TestSetHeadersPolicy_OnRequest_MultipleHeaders(t *testing.T) {
 	}
 
 	for name, expectedValue := range expectedHeaders {
-		if actualValue := mods.SetHeaders[name]; actualValue != expectedValue {
+		if actualValue := mods.HeadersToSet[name]; actualValue != expectedValue {
 			t.Errorf("Expected header '%s' to have value '%s', got '%s'",
 				name, expectedValue, actualValue)
 		}
 	}
 }
 
-func TestSetHeadersPolicy_OnRequest_HeaderNameNormalization(t *testing.T) {
+func TestSetHeadersPolicy_OnRequestHeaders_HeaderNameNormalization(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -190,23 +206,27 @@ func TestSetHeadersPolicy_OnRequest_HeaderNameNormalization(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	expectedHeaderName := "x-upper-case" // Should be trimmed and lowercase
-	if mods.SetHeaders[expectedHeaderName] != "test-value" {
+	if mods.HeadersToSet[expectedHeaderName] != "test-value" {
 		t.Errorf("Expected header '%s' to be normalized and set, got headers: %v",
-			expectedHeaderName, mods.SetHeaders)
+			expectedHeaderName, mods.HeadersToSet)
 	}
 }
 
-func TestSetHeadersPolicy_OnResponse_NoHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnResponseHeaders_NoHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -214,22 +234,26 @@ func TestSetHeadersPolicy_OnResponse_NoHeaders(t *testing.T) {
 
 	// No responseHeaders parameter
 	params := map[string]interface{}{}
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
 	// Should return empty modifications
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 0 {
-		t.Errorf("Expected no headers to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers to be set, got %d headers", len(mods.HeadersToSet))
 	}
 }
 
-func TestSetHeadersPolicy_OnResponse_SingleHeader(t *testing.T) {
+func TestSetHeadersPolicy_OnResponseHeaders_SingleHeader(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -244,27 +268,31 @@ func TestSetHeadersPolicy_OnResponse_SingleHeader(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 1 {
-		t.Errorf("Expected 1 header to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 1 {
+		t.Errorf("Expected 1 header to be set, got %d headers", len(mods.HeadersToSet))
 	}
 
 	expectedHeaderName := "x-response-time" // Should be normalized to lowercase
-	if mods.SetHeaders[expectedHeaderName] != "123ms" {
+	if mods.HeadersToSet[expectedHeaderName] != "123ms" {
 		t.Errorf("Expected header '%s' to have value '123ms', got '%s'",
-			expectedHeaderName, mods.SetHeaders[expectedHeaderName])
+			expectedHeaderName, mods.HeadersToSet[expectedHeaderName])
 	}
 }
 
-func TestSetHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnResponseHeaders_MultipleHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{
 			"content-type": "application/json",
 		}),
@@ -287,15 +315,15 @@ func TestSetHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
+	result := p.OnResponseHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 3 {
-		t.Errorf("Expected 3 headers to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 3 {
+		t.Errorf("Expected 3 headers to be set, got %d headers", len(mods.HeadersToSet))
 	}
 
 	expectedHeaders := map[string]string{
@@ -305,7 +333,7 @@ func TestSetHeadersPolicy_OnResponse_MultipleHeaders(t *testing.T) {
 	}
 
 	for name, expectedValue := range expectedHeaders {
-		if actualValue := mods.SetHeaders[name]; actualValue != expectedValue {
+		if actualValue := mods.HeadersToSet[name]; actualValue != expectedValue {
 			t.Errorf("Expected header '%s' to have value '%s', got '%s'",
 				name, expectedValue, actualValue)
 		}
@@ -316,7 +344,11 @@ func TestSetHeadersPolicy_BothRequestAndResponse(t *testing.T) {
 	p := &SetHeadersPolicy{}
 
 	// Test request phase
-	reqCtx := &policy.RequestContext{
+	reqCtx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -335,35 +367,43 @@ func TestSetHeadersPolicy_BothRequestAndResponse(t *testing.T) {
 		},
 	}
 
-	reqResult := p.OnRequest(reqCtx, params)
-	reqMods, ok := reqResult.(policy.UpstreamRequestModifications)
+	reqResult := p.OnRequestHeaders(reqCtx, params)
+	reqMods, ok := reqResult.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", reqResult)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", reqResult)
 	}
 
-	if reqMods.SetHeaders["x-request-header"] != "request-value" {
+	if reqMods.HeadersToSet["x-request-header"] != "request-value" {
 		t.Errorf("Expected request header to be set")
 	}
 
 	// Test response phase
-	respCtx := &policy.ResponseContext{
+	respCtx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{}),
 	}
 
-	respResult := p.OnResponse(respCtx, params)
-	respMods, ok := respResult.(policy.UpstreamResponseModifications)
+	respResult := p.OnResponseHeaders(respCtx, params)
+	respMods, ok := respResult.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", respResult)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", respResult)
 	}
 
-	if respMods.SetHeaders["x-response-header"] != "response-value" {
+	if respMods.HeadersToSet["x-response-header"] != "response-value" {
 		t.Errorf("Expected response header to be set")
 	}
 }
 
 func TestSetHeadersPolicy_EmptyHeadersList(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -371,21 +411,25 @@ func TestSetHeadersPolicy_EmptyHeadersList(t *testing.T) {
 		"requestHeaders": []interface{}{}, // Empty array
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 0 {
-		t.Errorf("Expected no headers to be set for empty array, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers to be set for empty array, got %d headers", len(mods.HeadersToSet))
 	}
 }
 
 func TestSetHeadersPolicy_InvalidHeadersType(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -393,21 +437,25 @@ func TestSetHeadersPolicy_InvalidHeadersType(t *testing.T) {
 		"requestHeaders": "not-an-array", // Invalid type
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if len(mods.SetHeaders) != 0 {
-		t.Errorf("Expected no headers to be set for invalid type, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers to be set for invalid type, got %d headers", len(mods.HeadersToSet))
 	}
 }
 
 func TestSetHeadersPolicy_InvalidHeaderEntry(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -421,26 +469,30 @@ func TestSetHeadersPolicy_InvalidHeaderEntry(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	// Should only process valid entries
-	if len(mods.SetHeaders) != 1 {
-		t.Errorf("Expected 1 valid header to be set, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 1 {
+		t.Errorf("Expected 1 valid header to be set, got %d headers", len(mods.HeadersToSet))
 	}
 
-	if mods.SetHeaders["valid-header"] != "valid-value" {
+	if mods.HeadersToSet["valid-header"] != "valid-value" {
 		t.Errorf("Expected valid header to be processed correctly")
 	}
 }
 
 func TestSetHeadersPolicy_SpecialCharactersInValues(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -453,24 +505,28 @@ func TestSetHeadersPolicy_SpecialCharactersInValues(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	expectedValue := "value with spaces, symbols: !@#$%^&*()_+{}|:<>?[]\\;'\""
-	if mods.SetHeaders["x-special-chars"] != expectedValue {
+	if mods.HeadersToSet["x-special-chars"] != expectedValue {
 		t.Errorf("Expected special characters to be preserved in header value, got '%s'",
-			mods.SetHeaders["x-special-chars"])
+			mods.HeadersToSet["x-special-chars"])
 	}
 }
 
 // Test the key difference: overwrite behavior when same header name appears multiple times
 func TestSetHeadersPolicy_MultipleHeadersSameName_OverwriteBehavior(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -493,28 +549,28 @@ func TestSetHeadersPolicy_MultipleHeadersSameName_OverwriteBehavior(t *testing.T
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
+	result := p.OnRequestHeaders(ctx, params)
 
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
 	// Should have 2 unique header names (last value wins for duplicates)
-	if len(mods.SetHeaders) != 2 {
-		t.Errorf("Expected 2 unique headers in SetHeaders, got %d headers", len(mods.SetHeaders))
+	if len(mods.HeadersToSet) != 2 {
+		t.Errorf("Expected 2 unique headers in HeadersToSet, got %d headers", len(mods.HeadersToSet))
 	}
 
 	// Check that the last value for X-Custom-Header is used (overwrite behavior)
-	if mods.SetHeaders["x-custom-header"] != "second-value" {
+	if mods.HeadersToSet["x-custom-header"] != "second-value" {
 		t.Errorf("Expected 'x-custom-header' to have last value 'second-value' (overwrite), got '%s'",
-			mods.SetHeaders["x-custom-header"])
+			mods.HeadersToSet["x-custom-header"])
 	}
 
 	// Check that the other header is present with single value
-	if mods.SetHeaders["x-another-header"] != "another-value" {
+	if mods.HeadersToSet["x-another-header"] != "another-value" {
 		t.Errorf("Expected 'x-another-header' to have value 'another-value', got '%s'",
-			mods.SetHeaders["x-another-header"])
+			mods.HeadersToSet["x-another-header"])
 	}
 }
 
@@ -658,9 +714,13 @@ func TestSetHeadersPolicy_Validate_BothInvalid(t *testing.T) {
 	}
 }
 
-func TestSetHeadersPolicy_OnRequest_NestedHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnRequestHeaders_NestedHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.RequestContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		Headers: createTestHeaders(map[string]string{}),
 	}
 
@@ -675,20 +735,24 @@ func TestSetHeadersPolicy_OnRequest_NestedHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnRequest(ctx, params)
-	mods, ok := result.(policy.UpstreamRequestModifications)
+	result := p.OnRequestHeaders(ctx, params)
+	mods, ok := result.(policyv1alpha2.UpstreamRequestHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamRequestModifications, got %T", result)
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
 	}
 
-	if mods.SetHeaders["x-nested-request"] != "nested-request-value" {
-		t.Errorf("Expected nested request header to be set, got %v", mods.SetHeaders)
+	if mods.HeadersToSet["x-nested-request"] != "nested-request-value" {
+		t.Errorf("Expected nested request header to be set, got %v", mods.HeadersToSet)
 	}
 }
 
-func TestSetHeadersPolicy_OnResponse_NestedHeaders(t *testing.T) {
+func TestSetHeadersPolicy_OnResponseHeaders_NestedHeaders(t *testing.T) {
 	p := &SetHeadersPolicy{}
-	ctx := &policy.ResponseContext{
+	ctx := &policyv1alpha2.ResponseHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
 		ResponseHeaders: createTestHeaders(map[string]string{}),
 	}
 
@@ -703,14 +767,14 @@ func TestSetHeadersPolicy_OnResponse_NestedHeaders(t *testing.T) {
 		},
 	}
 
-	result := p.OnResponse(ctx, params)
-	mods, ok := result.(policy.UpstreamResponseModifications)
+	result := p.OnResponseHeaders(ctx, params)
+	mods, ok := result.(policyv1alpha2.DownstreamResponseHeaderModifications)
 	if !ok {
-		t.Errorf("Expected UpstreamResponseModifications, got %T", result)
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
 	}
 
-	if mods.SetHeaders["x-nested-response"] != "nested-response-value" {
-		t.Errorf("Expected nested response header to be set, got %v", mods.SetHeaders)
+	if mods.HeadersToSet["x-nested-response"] != "nested-response-value" {
+		t.Errorf("Expected nested response header to be set, got %v", mods.HeadersToSet)
 	}
 }
 

--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v0.3.0
+version: v0.9.0
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,

--- a/policies/subscription-validation/subscriptionvalidation_test.go
+++ b/policies/subscription-validation/subscriptionvalidation_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policyenginev1 "github.com/wso2/api-platform/sdk/gateway/policyengine/v1"
 )
 
@@ -20,7 +20,7 @@ func newStore(entries []policyenginev1.SubscriptionData) *policyenginev1.Subscri
 func newPolicy(cfg PolicyConfig, store *policyenginev1.SubscriptionStore) *SubscriptionValidationPolicy {
 	return &SubscriptionValidationPolicy{
 		cfg:         cfg,
-		store:      store,
+		store:       store,
 		rateLimitMu: sharedRateLimitMu,
 		rateLimits:  make(map[string]*rateLimitEntry),
 	}
@@ -33,43 +33,55 @@ func defaultCfg() PolicyConfig {
 	}
 }
 
-func ctxWithToken(apiID, token, headerName string) *policy.RequestContext {
+func headerCtxWithToken(apiID, token, headerName string) *policyv1alpha2.RequestHeaderContext {
 	if headerName == "" {
 		headerName = defaultSubscriptionKeyHeader
 	}
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId:    apiID,
 			Metadata: map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(map[string][]string{
+		Headers: policyv1alpha2.NewHeaders(map[string][]string{
 			headerName: {token},
 		}),
 	}
 }
 
-func ctxWithAppID(apiID, appID string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+func headerCtxWithAppID(apiID, appID string) *policyv1alpha2.RequestHeaderContext {
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId: apiID,
 			Metadata: map[string]interface{}{
 				applicationIDMetadataKey: appID,
 			},
 		},
-		Headers: policy.NewHeaders(nil),
+		Headers: policyv1alpha2.NewHeaders(nil),
 	}
 }
 
-func assertNil(t *testing.T, action policy.RequestAction) {
-	t.Helper()
-	if action != nil {
-		t.Fatalf("expected nil action, got %#v", action)
+func headerCtxWithCookie(apiID, token, cookieName string) *policyv1alpha2.RequestHeaderContext {
+	return &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
+			APIId:    apiID,
+			Metadata: map[string]interface{}{},
+		},
+		Headers: policyv1alpha2.NewHeaders(map[string][]string{
+			"Cookie": {cookieName + "=" + token},
+		}),
 	}
 }
 
-func assertImmediate(t *testing.T, action policy.RequestAction, wantStatus int, wantErrorKey string) {
+func assertSuccess(t *testing.T, action policyv1alpha2.RequestHeaderAction) {
 	t.Helper()
-	resp, ok := action.(policy.ImmediateResponse)
+	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications (allow), got %#v", action)
+	}
+}
+
+func assertImmediate(t *testing.T, action policyv1alpha2.RequestHeaderAction, wantStatus int, wantErrorKey string) {
+	t.Helper()
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -85,7 +97,7 @@ func assertImmediate(t *testing.T, action policy.RequestAction, wantStatus int, 
 	}
 }
 
-func assertRateLimitHeaders(t *testing.T, resp policy.ImmediateResponse, wantLimit, wantRemaining int) {
+func assertRateLimitHeaders(t *testing.T, resp policyv1alpha2.ImmediateResponse, wantLimit, wantRemaining int) {
 	t.Helper()
 	if resp.Headers == nil {
 		t.Fatalf("expected headers to be set")
@@ -172,34 +184,34 @@ func TestMergeConfig_Overrides(t *testing.T) {
 
 // --- token path (primary) ----------------------------------------------------
 
-func TestOnRequest_AllowsValidToken(t *testing.T) {
+func TestOnRequestHeaders_AllowsValidToken(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
-	ctx := ctxWithToken("api-1", "tok-1", "")
-	assertNil(t, p.OnRequest(ctx, nil))
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
-func TestOnRequest_DeniesInvalidToken(t *testing.T) {
+func TestOnRequestHeaders_DeniesInvalidToken(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
-	ctx := ctxWithToken("api-1", "wrong-token", "")
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	ctx := headerCtxWithToken("api-1", "wrong-token", "")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
-func TestOnRequest_DeniesInactiveToken(t *testing.T) {
+func TestOnRequestHeaders_DeniesInactiveToken(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "INACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
-	ctx := ctxWithToken("api-1", "tok-1", "")
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
-func TestOnRequest_CustomHeaderName(t *testing.T) {
+func TestOnRequestHeaders_CustomHeaderName(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
@@ -207,84 +219,72 @@ func TestOnRequest_CustomHeaderName(t *testing.T) {
 	cfg.SubscriptionKeyHeader = "X-Custom-Sub"
 	p := newPolicy(cfg, store)
 
-	ctx := ctxWithToken("api-1", "tok-1", "X-Custom-Sub")
-	assertNil(t, p.OnRequest(ctx, nil))
+	ctx := headerCtxWithToken("api-1", "tok-1", "X-Custom-Sub")
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
 // --- cookie path -------------------------------------------------------------
 
-func ctxWithCookie(apiID, token, cookieName string) *policy.RequestContext {
-	return &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
-			APIId:    apiID,
-			Metadata: map[string]interface{}{},
-		},
-		Headers: policy.NewHeaders(map[string][]string{
-			"Cookie": {cookieName + "=" + token},
-		}),
-	}
-}
-
-func TestOnRequest_AllowsValidTokenFromCookie(t *testing.T) {
+func TestOnRequestHeaders_AllowsValidTokenFromCookie(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	cfg := defaultCfg()
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
-	ctx := ctxWithCookie("api-1", "tok-1", "sub-key")
-	assertNil(t, p.OnRequest(ctx, nil))
+	ctx := headerCtxWithCookie("api-1", "tok-1", "sub-key")
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
-func TestOnRequest_CookieDeniesInvalidToken(t *testing.T) {
+func TestOnRequestHeaders_CookieDeniesInvalidToken(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	cfg := defaultCfg()
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
-	ctx := ctxWithCookie("api-1", "wrong-token", "sub-key")
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	ctx := headerCtxWithCookie("api-1", "wrong-token", "sub-key")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
-func TestOnRequest_HeaderTakesPrecedenceOverCookie(t *testing.T) {
+func TestOnRequestHeaders_HeaderTakesPrecedenceOverCookie(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	cfg := defaultCfg()
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId:    "api-1",
 			Metadata: map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(map[string][]string{
+		Headers: policyv1alpha2.NewHeaders(map[string][]string{
 			defaultSubscriptionKeyHeader: {"tok-1"},
 			"Cookie":                    {"sub-key=wrong-token"},
 		}),
 	}
 	// Header value should be used; tok-1 is valid
-	assertNil(t, p.OnRequest(ctx, nil))
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
-func TestOnRequest_CookieUsedWhenHeaderMissing(t *testing.T) {
+func TestOnRequestHeaders_CookieUsedWhenHeaderMissing(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	cfg := defaultCfg()
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
-	ctx := ctxWithCookie("api-1", "tok-1", "sub-key")
-	assertNil(t, p.OnRequest(ctx, nil))
+	ctx := headerCtxWithCookie("api-1", "tok-1", "sub-key")
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
-func TestGetCookieValue(t *testing.T) {
+func TestGetCookieValueV2(t *testing.T) {
 	tests := []struct {
-		name     string
-		headers  map[string][]string
-		cookie   string
-		want     string
+		name    string
+		headers map[string][]string
+		cookie  string
+		want    string
 	}{
 		{"single cookie", map[string][]string{"Cookie": {"sub-key=tok-1"}}, "sub-key", "tok-1"},
 		{"multiple cookies", map[string][]string{"Cookie": {"a=1; sub-key=tok-1; b=2"}}, "sub-key", "tok-1"},
@@ -294,10 +294,10 @@ func TestGetCookieValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := policy.NewHeaders(tt.headers)
-			got := getCookieValue(h, tt.cookie)
+			h := policyv1alpha2.NewHeaders(tt.headers)
+			got := getCookieValueV2(h, tt.cookie)
 			if got != tt.want {
-				t.Fatalf("getCookieValue(%q) = %q, want %q", tt.cookie, got, tt.want)
+				t.Fatalf("getCookieValueV2(%q) = %q, want %q", tt.cookie, got, tt.want)
 			}
 		})
 	}
@@ -305,57 +305,57 @@ func TestGetCookieValue(t *testing.T) {
 
 // --- appId fallback (legacy) -------------------------------------------------
 
-func TestOnRequest_FallbackAppIdAllows(t *testing.T) {
+func TestOnRequestHeaders_FallbackAppIdAllows(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", ApplicationId: "app-1", Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
-	ctx := ctxWithAppID("api-1", "app-1")
-	assertNil(t, p.OnRequest(ctx, nil))
+	ctx := headerCtxWithAppID("api-1", "app-1")
+	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 }
 
-func TestOnRequest_FallbackAppIdDenies(t *testing.T) {
+func TestOnRequestHeaders_FallbackAppIdDenies(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", ApplicationId: "app-1", Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
-	ctx := ctxWithAppID("api-1", "app-wrong")
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	ctx := headerCtxWithAppID("api-1", "app-wrong")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
 // --- no identity at all ------------------------------------------------------
 
-func TestOnRequest_DeniesWhenNoIdentity(t *testing.T) {
+func TestOnRequestHeaders_DeniesWhenNoIdentity(t *testing.T) {
 	store := newStore(nil)
 	p := newPolicy(defaultCfg(), store)
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId:    "api-1",
 			Metadata: map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(nil),
+		Headers: policyv1alpha2.NewHeaders(nil),
 	}
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
 // --- missing apiId fails closed ----------------------------------------------
 
-func TestOnRequest_FailsClosedWhenAPIIdMissing(t *testing.T) {
+func TestOnRequestHeaders_FailsClosedWhenAPIIdMissing(t *testing.T) {
 	store := newStore(nil)
 	p := newPolicy(defaultCfg(), store)
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId:    "",
 			Metadata: map[string]interface{}{},
 		},
-		Headers: policy.NewHeaders(nil),
+		Headers: policyv1alpha2.NewHeaders(nil),
 	}
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
 // --- rate limiting -----------------------------------------------------------
 
-func TestOnRequest_RateLimitEnforced(t *testing.T) {
+func TestOnRequestHeaders_RateLimitEnforced(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{
 			APIId:              "api-1",
@@ -369,16 +369,13 @@ func TestOnRequest_RateLimitEnforced(t *testing.T) {
 	p := newPolicy(defaultCfg(), store)
 
 	for i := 0; i < 3; i++ {
-		ctx := ctxWithToken("api-1", "tok-1", "")
-		action := p.OnRequest(ctx, nil)
-		if action != nil {
-			t.Fatalf("request %d should be allowed, got %#v", i+1, action)
-		}
+		ctx := headerCtxWithToken("api-1", "tok-1", "")
+		assertSuccess(t, p.OnRequestHeaders(ctx, nil))
 	}
 
-	ctx := ctxWithToken("api-1", "tok-1", "")
-	action := p.OnRequest(ctx, nil)
-	resp, ok := action.(policy.ImmediateResponse)
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	action := p.OnRequestHeaders(ctx, nil)
+	resp, ok := action.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse, got %T", action)
 	}
@@ -395,7 +392,7 @@ func TestOnRequest_RateLimitEnforced(t *testing.T) {
 	assertRateLimitHeaders(t, resp, 3, 0)
 }
 
-func TestOnRequest_RateLimitNotEnforcedWhenStopOnQuotaFalse(t *testing.T) {
+func TestOnRequestHeaders_RateLimitNotEnforcedWhenStopOnQuotaFalse(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{
 			APIId:              "api-1",
@@ -409,24 +406,24 @@ func TestOnRequest_RateLimitNotEnforcedWhenStopOnQuotaFalse(t *testing.T) {
 	p := newPolicy(defaultCfg(), store)
 
 	for i := 0; i < 5; i++ {
-		ctx := ctxWithToken("api-1", "tok-1", "")
-		action := p.OnRequest(ctx, nil)
-		if action != nil {
+		ctx := headerCtxWithToken("api-1", "tok-1", "")
+		action := p.OnRequestHeaders(ctx, nil)
+		if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
 			t.Fatalf("request %d should be allowed (stopOnQuotaReach=false), got %#v", i+1, action)
 		}
 	}
 }
 
-func TestOnRequest_NoRateLimitWithoutPlan(t *testing.T) {
+func TestOnRequestHeaders_NoRateLimitWithoutPlan(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
 
 	for i := 0; i < 100; i++ {
-		ctx := ctxWithToken("api-1", "tok-1", "")
-		action := p.OnRequest(ctx, nil)
-		if action != nil {
+		ctx := headerCtxWithToken("api-1", "tok-1", "")
+		action := p.OnRequestHeaders(ctx, nil)
+		if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
 			t.Fatalf("request %d should be allowed (no throttle plan), got %#v", i+1, action)
 		}
 	}
@@ -434,38 +431,38 @@ func TestOnRequest_NoRateLimitWithoutPlan(t *testing.T) {
 
 // --- token takes precedence over appId ---------------------------------------
 
-func TestOnRequest_TokenTakesPrecedenceOverAppId(t *testing.T) {
+func TestOnRequestHeaders_TokenTakesPrecedenceOverAppId(t *testing.T) {
 	store := newStore([]policyenginev1.SubscriptionData{
 		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
 		{APIId: "api-1", ApplicationId: "app-1", Status: "ACTIVE"},
 	})
 	p := newPolicy(defaultCfg(), store)
 
-	ctx := &policy.RequestContext{
-		SharedContext: &policy.SharedContext{
+	ctx := &policyv1alpha2.RequestHeaderContext{
+		SharedContext: &policyv1alpha2.SharedContext{
 			APIId: "api-1",
 			Metadata: map[string]interface{}{
 				applicationIDMetadataKey: "app-1",
 			},
 		},
-		Headers: policy.NewHeaders(map[string][]string{
+		Headers: policyv1alpha2.NewHeaders(map[string][]string{
 			defaultSubscriptionKeyHeader: {"wrong-token"},
 		}),
 	}
 	// Token path should be tried first and should fail (wrong token),
 	// even though appId path would succeed.
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }
 
 // --- nil context / nil store guards ------------------------------------------
 
-func TestOnRequest_NilContext(t *testing.T) {
+func TestOnRequestHeaders_NilContext(t *testing.T) {
 	p := newPolicy(defaultCfg(), policyenginev1.NewSubscriptionStore())
-	assertImmediate(t, p.OnRequest(nil, nil), 403, "forbidden")
+	assertImmediate(t, p.OnRequestHeaders(nil, nil), 403, "forbidden")
 }
 
-func TestOnRequest_NilStore(t *testing.T) {
+func TestOnRequestHeaders_NilStore(t *testing.T) {
 	p := newPolicy(defaultCfg(), nil)
-	ctx := ctxWithToken("api-1", "tok-1", "")
-	assertImmediate(t, p.OnRequest(ctx, nil), 403, "forbidden")
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	assertImmediate(t, p.OnRequestHeaders(ctx, nil), 403, "forbidden")
 }

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/wso2/api-platform/sdk v0.3.8
 	github.com/wso2/api-platform/sdk/core v0.1.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.3.2 //upgrade
 	golang.org/x/sync v0.19.0
 )
 

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v0.8.4
+version: v0.9.0
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: url-guardrail
-version: v0.2.1
+version: v0.9.0
 description: |
   Validate URLs in request or response content using JSONPath extraction with DNS-only or HTTP reachability checks.
 

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -622,6 +622,9 @@ func (p *URLGuardrailPolicy) OnResponseBodyChunk(ctx *policyv1alpha2.ResponseStr
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
+		if ctx.Metadata == nil {
+			ctx.Metadata = make(map[string]interface{})
+		}
 		prev, _ := ctx.Metadata[metaKeyAccJsonBody].(string)
 		full := prev + chunkStr
 		ctx.Metadata[metaKeyAccJsonBody] = full

--- a/policies/url-guardrail/urlguardrail_test.go
+++ b/policies/url-guardrail/urlguardrail_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
@@ -75,9 +75,10 @@ func TestParseParams(t *testing.T) {
 			name:  "valid defaults",
 			input: map[string]interface{}{},
 			expected: URLGuardrailPolicyParams{
-				Enabled:  RequestFlowEnabledByDefault,
-				JsonPath: DefaultRequestJSONPath,
-				Timeout:  DefaultTimeout,
+				Enabled:           RequestFlowEnabledByDefault,
+				JsonPath:          DefaultRequestJSONPath,
+				StreamingJsonPath: DefaultStreamingJsonPath,
+				Timeout:           DefaultTimeout,
 			},
 		},
 		{
@@ -89,11 +90,12 @@ func TestParseParams(t *testing.T) {
 				"showAssessment": true,
 			},
 			expected: URLGuardrailPolicyParams{
-				Enabled:        RequestFlowEnabledByDefault,
-				JsonPath:       "$.data.text",
-				OnlyDNS:        true,
-				Timeout:        2500,
-				ShowAssessment: true,
+				Enabled:           RequestFlowEnabledByDefault,
+				JsonPath:          "$.data.text",
+				StreamingJsonPath: DefaultStreamingJsonPath,
+				OnlyDNS:           true,
+				Timeout:           2500,
+				ShowAssessment:    true,
 			},
 		},
 		{
@@ -258,7 +260,7 @@ func TestGetPolicy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pRaw, err := GetPolicy(policy.PolicyMetadata{}, tc.params)
+			pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tc.params)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -288,17 +290,17 @@ func TestMode(t *testing.T) {
 	p := &URLGuardrailPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected RequestHeaderMode=Skip, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeBuffer {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected RequestBodyMode=Buffer, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode=Skip, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeBuffer {
-		t.Fatalf("expected ResponseBodyMode=Buffer, got %v", mode.ResponseBodyMode)
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeStream {
+		t.Fatalf("expected ResponseBodyMode=Stream, got %v", mode.ResponseBodyMode)
 	}
 }
 
@@ -343,13 +345,13 @@ func TestValidatePayload_RequestPaths(t *testing.T) {
 
 	p := &URLGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"text":"`+server.URL+`"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 1000}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"text":"`+server.URL+`"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 1000}, false)
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on valid URL payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"text":"http://127.0.0.1:1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 200, ShowAssessment: true}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	fail := p.validatePayloadV2([]byte(`{"text":"http://127.0.0.1:1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 200, ShowAssessment: true}, false)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on invalid URL payload, got %T", fail)
 	}
@@ -376,21 +378,21 @@ func TestValidatePayload_RequestPaths(t *testing.T) {
 func TestValidatePayload_ResponsePaths(t *testing.T) {
 	p := &URLGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"text":"no urls here"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 100}, true)
-	if _, ok := pass.(policy.UpstreamResponseModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"text":"no urls here"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 100}, true)
+	if _, ok := pass.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications on no-url payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"text":"http://127.0.0.1:1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 200, ShowAssessment: false}, true)
-	resp, ok := fail.(policy.UpstreamResponseModifications)
+	fail := p.validatePayloadV2([]byte(`{"text":"http://127.0.0.1:1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", Timeout: 200, ShowAssessment: false}, true)
+	resp, ok := fail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications on invalid response URL payload, got %T", fail)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected response status %d, got %#v", GuardrailErrorCode, resp.StatusCode)
 	}
-	if resp.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("expected response content-type header, got %#v", resp.SetHeaders)
+	if resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("expected response content-type header, got %#v", resp.DownstreamResponseHeaderModifications.HeadersToSet)
 	}
 	msg := mustMessageMap(t, resp.Body)
 	if msg["direction"] != "RESPONSE" {
@@ -404,16 +406,16 @@ func TestValidatePayload_ResponsePaths(t *testing.T) {
 func TestValidatePayload_OnlyDNSMode(t *testing.T) {
 	p := &URLGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"text":"http://127.0.0.1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", OnlyDNS: true, Timeout: 200}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"text":"http://127.0.0.1"}`), URLGuardrailPolicyParams{JsonPath: "$.text", OnlyDNS: true, Timeout: 200}, false)
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications for valid DNS-only check, got %T", pass)
 	}
 }
 
 func TestValidatePayload_JSONPathExtractionFailure(t *testing.T) {
 	p := &URLGuardrailPolicy{}
-	fail := p.validatePayload([]byte(`{"text":"hello"}`), URLGuardrailPolicyParams{JsonPath: "$.missing", Timeout: 100, ShowAssessment: true}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	fail := p.validatePayloadV2([]byte(`{"text":"hello"}`), URLGuardrailPolicyParams{JsonPath: "$.missing", Timeout: 100, ShowAssessment: true}, false)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on jsonPath extraction failure, got %T", fail)
 	}
@@ -452,31 +454,31 @@ func TestBuildAssessmentObject(t *testing.T) {
 	}
 }
 
-func TestOnRequestAndOnResponse(t *testing.T) {
+func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	// No params configured -> no-op.
 	p := &URLGuardrailPolicy{hasRequestParams: false, hasResponseParams: false}
-	reqNoOp := p.OnRequest(&policy.RequestContext{}, nil)
-	if _, ok := reqNoOp.(policy.UpstreamRequestModifications); !ok {
+	reqNoOp := p.OnRequestBody(&policyv1alpha2.RequestContext{}, nil)
+	if _, ok := reqNoOp.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op modifications, got %T", reqNoOp)
 	}
-	respNoOp := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := respNoOp.(policy.UpstreamResponseModifications); !ok {
+	respNoOp := p.OnResponseBody(&policyv1alpha2.ResponseContext{}, nil)
+	if _, ok := respNoOp.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op modifications, got %T", respNoOp)
 	}
 
 	// Request validation with nil body and explicit jsonPath should fail extraction.
 	p.hasRequestParams = true
 	p.requestParams = URLGuardrailPolicyParams{Enabled: true, JsonPath: "$.text", Timeout: 100}
-	reqFail := p.OnRequest(&policy.RequestContext{Body: nil}, nil)
-	if _, ok := reqFail.(policy.ImmediateResponse); !ok {
+	reqFail := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: nil}, nil)
+	if _, ok := reqFail.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse for request nil-body extraction failure, got %T", reqFail)
 	}
 
 	// Response validation with nil body and explicit jsonPath should fail extraction.
 	p.hasResponseParams = true
 	p.responseParams = URLGuardrailPolicyParams{Enabled: true, JsonPath: "$.text", Timeout: 100}
-	respFail := p.OnResponse(&policy.ResponseContext{ResponseBody: nil}, nil)
-	respMod, ok := respFail.(policy.UpstreamResponseModifications)
+	respFail := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
+	respMod, ok := respFail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications for response nil-body extraction failure, got %T", respFail)
 	}
@@ -485,14 +487,14 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 	}
 
 	p.requestParams.Enabled = false
-	reqDisabled := p.OnRequest(&policy.RequestContext{Body: &policy.Body{Content: []byte(`{"text":"https://example.com"}`)}}, nil)
-	if _, ok := reqDisabled.(policy.UpstreamRequestModifications); !ok {
+	reqDisabled := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: &policyv1alpha2.Body{Content: []byte(`{"text":"https://example.com"}`)}}, nil)
+	if _, ok := reqDisabled.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op when request.enabled=false, got %T", reqDisabled)
 	}
 
 	p.responseParams.Enabled = false
-	respDisabled := p.OnResponse(&policy.ResponseContext{ResponseBody: &policy.Body{Content: []byte(`{"text":"https://example.com"}`)}}, nil)
-	if _, ok := respDisabled.(policy.UpstreamResponseModifications); !ok {
+	respDisabled := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"text":"https://example.com"}`)}}, nil)
+	if _, ok := respDisabled.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: word-count-guardrail
-version: v0.2.3
+version: v0.9.0
 description: |
   Validate word counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/word-count-guardrail/wordcountguardrail_test.go
+++ b/policies/word-count-guardrail/wordcountguardrail_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	policy "github.com/wso2/api-platform/sdk/gateway/policy/v1alpha"
+	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
@@ -130,10 +130,11 @@ func TestParseParams(t *testing.T) {
 				"max": 10,
 			},
 			expected: WordCountGuardrailPolicyParams{
-				Enabled:  RequestFlowEnabledByDefault,
-				Min:      1,
-				Max:      10,
-				JsonPath: DefaultJSONPath,
+				Enabled:           RequestFlowEnabledByDefault,
+				Min:               1,
+				Max:               10,
+				JsonPath:          DefaultJSONPath,
+				StreamingJsonPath: DefaultStreamingJsonPath,
 			},
 		},
 		{
@@ -146,12 +147,13 @@ func TestParseParams(t *testing.T) {
 				"showAssessment": true,
 			},
 			expected: WordCountGuardrailPolicyParams{
-				Enabled:        RequestFlowEnabledByDefault,
-				Min:            2,
-				Max:            20,
-				JsonPath:       "",
-				Invert:         true,
-				ShowAssessment: true,
+				Enabled:           RequestFlowEnabledByDefault,
+				Min:               2,
+				Max:               20,
+				JsonPath:          "",
+				StreamingJsonPath: DefaultStreamingJsonPath,
+				Invert:            true,
+				ShowAssessment:    true,
 			},
 		},
 	}
@@ -219,7 +221,7 @@ func TestParseParams_DisabledFlow_DoesNotRequireMinMax(t *testing.T) {
 
 func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 	t.Run("request flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -233,16 +235,16 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected request params present and disabled, got hasRequest=%v enabled=%v", p.hasRequestParams, p.requestParams.Enabled)
 		}
 
-		action := p.OnRequest(&policy.RequestContext{
-			Body: &policy.Body{Content: []byte(`{"messages":[{"content":"hello world"}]}`)},
+		action := p.OnRequestBody(&policyv1alpha2.RequestContext{
+			Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"hello world"}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		if _, ok := action.(policyv1alpha2.UpstreamRequestModifications); !ok {
 			t.Fatalf("expected request no-op when request.enabled=false, got %T", action)
 		}
 	})
 
 	t.Run("response flow disabled", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"response": map[string]interface{}{"enabled": false},
 		})
 		if err != nil {
@@ -256,10 +258,10 @@ func TestDisabledFlow_GetPolicyAndHandlers_NoRequiredParams(t *testing.T) {
 			t.Fatalf("expected response params present and disabled, got hasResponse=%v enabled=%v", p.hasResponseParams, p.responseParams.Enabled)
 		}
 
-		action := p.OnResponse(&policy.ResponseContext{
-			ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"hello world"}}]}`)},
+		action := p.OnResponseBody(&policyv1alpha2.ResponseContext{
+			ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"hello world"}}]}`)},
 		}, nil)
-		if _, ok := action.(policy.UpstreamResponseModifications); !ok {
+		if _, ok := action.(policyv1alpha2.DownstreamResponseModifications); !ok {
 			t.Fatalf("expected response no-op when response.enabled=false, got %T", action)
 		}
 	})
@@ -284,7 +286,7 @@ func TestParseParams_DisabledFlow_IgnoresProvidedMinMax(t *testing.T) {
 }
 
 func TestGetPolicy_DisabledResponseWithZeroMinMax_IsAccepted(t *testing.T) {
-	pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"request": map[string]interface{}{
 			"enabled":        true,
 			"min":            2,
@@ -319,7 +321,7 @@ func TestGetPolicy_DisabledResponseWithZeroMinMax_IsAccepted(t *testing.T) {
 }
 
 func TestGetPolicy_DisabledRequestWithZeroMinMax_IsAccepted(t *testing.T) {
-	pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+	pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 		"request": map[string]interface{}{
 			"enabled":        false,
 			"min":            0,
@@ -355,7 +357,7 @@ func TestGetPolicy_DisabledRequestWithZeroMinMax_IsAccepted(t *testing.T) {
 
 func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	t.Run("request configured with empty response object", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{"min": 1, "max": 10},
 			"response": map[string]interface{}{},
 		})
@@ -376,7 +378,7 @@ func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	})
 
 	t.Run("response configured with empty request object", func(t *testing.T) {
-		pRaw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{},
 			"response": map[string]interface{}{"enabled": true, "min": 1, "max": 10},
 		})
@@ -397,7 +399,7 @@ func TestGetPolicy_EmptyFlowObject_IsIgnored(t *testing.T) {
 	})
 
 	t.Run("both empty objects still fail", func(t *testing.T) {
-		_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		_, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, map[string]interface{}{
 			"request":  map[string]interface{}{},
 			"response": map[string]interface{}{},
 		})
@@ -512,7 +514,7 @@ func TestGetPolicy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pRaw, err := GetPolicy(policy.PolicyMetadata{}, tc.params)
+			pRaw, err := GetPolicyV2(policyv1alpha2.PolicyMetadata{}, tc.params)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -542,30 +544,30 @@ func TestMode(t *testing.T) {
 	p := &WordCountGuardrailPolicy{}
 	mode := p.Mode()
 
-	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+	if mode.RequestHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected RequestHeaderMode=Skip, got %v", mode.RequestHeaderMode)
 	}
-	if mode.RequestBodyMode != policy.BodyModeBuffer {
+	if mode.RequestBodyMode != policyv1alpha2.BodyModeBuffer {
 		t.Fatalf("expected RequestBodyMode=Buffer, got %v", mode.RequestBodyMode)
 	}
-	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+	if mode.ResponseHeaderMode != policyv1alpha2.HeaderModeSkip {
 		t.Fatalf("expected ResponseHeaderMode=Skip, got %v", mode.ResponseHeaderMode)
 	}
-	if mode.ResponseBodyMode != policy.BodyModeBuffer {
-		t.Fatalf("expected ResponseBodyMode=Buffer, got %v", mode.ResponseBodyMode)
+	if mode.ResponseBodyMode != policyv1alpha2.BodyModeStream {
+		t.Fatalf("expected ResponseBodyMode=Stream, got %v", mode.ResponseBodyMode)
 	}
 }
 
 func TestValidatePayload_RequestPaths(t *testing.T) {
 	p := &WordCountGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"messages":"hello world"}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"messages":"hello world"}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, false)
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications on valid payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"messages":""}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: true}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	fail := p.validatePayloadV2([]byte(`{"messages":""}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: true}, false)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on invalid payload, got %T", fail)
 	}
@@ -587,21 +589,21 @@ func TestValidatePayload_RequestPaths(t *testing.T) {
 func TestValidatePayload_ResponsePaths(t *testing.T) {
 	p := &WordCountGuardrailPolicy{}
 
-	pass := p.validatePayload([]byte(`{"messages":"hello world"}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, true)
-	if _, ok := pass.(policy.UpstreamResponseModifications); !ok {
+	pass := p.validatePayloadV2([]byte(`{"messages":"hello world"}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, true)
+	if _, ok := pass.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected UpstreamResponseModifications on valid response payload, got %T", pass)
 	}
 
-	fail := p.validatePayload([]byte(`{"messages":""}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: false}, true)
-	resp, ok := fail.(policy.UpstreamResponseModifications)
+	fail := p.validatePayloadV2([]byte(`{"messages":""}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: false}, true)
+	resp, ok := fail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications on invalid response payload, got %T", fail)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected response status %d, got %#v", GuardrailErrorCode, resp.StatusCode)
 	}
-	if resp.SetHeaders["Content-Type"] != "application/json" {
-		t.Fatalf("expected response content-type header, got %#v", resp.SetHeaders)
+	if resp.DownstreamResponseHeaderModifications.HeadersToSet["Content-Type"] != "application/json" {
+		t.Fatalf("expected response content-type header, got %#v", resp.DownstreamResponseHeaderModifications.HeadersToSet)
 	}
 	msg := mustMessageMap(t, resp.Body)
 	if msg["direction"] != "RESPONSE" {
@@ -622,14 +624,14 @@ func TestValidatePayload_InvertMode(t *testing.T) {
 	}
 
 	// In invert mode, content within range should fail.
-	within := p.validatePayload([]byte(`{"messages":"one two"}`), params, false)
-	if _, ok := within.(policy.ImmediateResponse); !ok {
+	within := p.validatePayloadV2([]byte(`{"messages":"one two"}`), params, false)
+	if _, ok := within.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse when in-range payload is rejected in invert mode, got %T", within)
 	}
 
 	// In invert mode, content outside range should pass.
-	outside := p.validatePayload([]byte(`{"messages":"one two three four"}`), params, false)
-	if _, ok := outside.(policy.UpstreamRequestModifications); !ok {
+	outside := p.validatePayloadV2([]byte(`{"messages":"one two three four"}`), params, false)
+	if _, ok := outside.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected UpstreamRequestModifications when out-of-range payload passes in invert mode, got %T", outside)
 	}
 }
@@ -638,22 +640,22 @@ func TestValidatePayload_JSONPathExtraction(t *testing.T) {
 	p := &WordCountGuardrailPolicy{}
 	payload := []byte(`{"data":{"text":"one two"}}`)
 
-	pass := p.validatePayload(payload, WordCountGuardrailPolicyParams{
+	pass := p.validatePayloadV2(payload, WordCountGuardrailPolicyParams{
 		Min:      2,
 		Max:      2,
 		JsonPath: "$.data.text",
 	}, false)
-	if _, ok := pass.(policy.UpstreamRequestModifications); !ok {
+	if _, ok := pass.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected pass using jsonPath extraction, got %T", pass)
 	}
 
-	fail := p.validatePayload(payload, WordCountGuardrailPolicyParams{
+	fail := p.validatePayloadV2(payload, WordCountGuardrailPolicyParams{
 		Min:            1,
 		Max:            10,
 		JsonPath:       "$.missing",
 		ShowAssessment: true,
 	}, false)
-	imm, ok := fail.(policy.ImmediateResponse)
+	imm, ok := fail.(policyv1alpha2.ImmediateResponse)
 	if !ok {
 		t.Fatalf("expected ImmediateResponse on jsonPath extraction failure, got %T", fail)
 	}
@@ -692,31 +694,31 @@ func TestBuildAssessmentObject(t *testing.T) {
 	}
 }
 
-func TestOnRequestAndOnResponse(t *testing.T) {
+func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	// No request params configured -> no-op.
 	p := &WordCountGuardrailPolicy{hasRequestParams: false, hasResponseParams: false}
-	reqNoOp := p.OnRequest(&policy.RequestContext{}, nil)
-	if _, ok := reqNoOp.(policy.UpstreamRequestModifications); !ok {
+	reqNoOp := p.OnRequestBody(&policyv1alpha2.RequestContext{}, nil)
+	if _, ok := reqNoOp.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op modifications, got %T", reqNoOp)
 	}
-	respNoOp := p.OnResponse(&policy.ResponseContext{}, nil)
-	if _, ok := respNoOp.(policy.UpstreamResponseModifications); !ok {
+	respNoOp := p.OnResponseBody(&policyv1alpha2.ResponseContext{}, nil)
+	if _, ok := respNoOp.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op modifications, got %T", respNoOp)
 	}
 
 	// Request validation with nil body should fail when min > 0.
 	p.hasRequestParams = true
 	p.requestParams = WordCountGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10, JsonPath: ""}
-	reqFail := p.OnRequest(&policy.RequestContext{Body: nil}, nil)
-	if _, ok := reqFail.(policy.ImmediateResponse); !ok {
+	reqFail := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: nil}, nil)
+	if _, ok := reqFail.(policyv1alpha2.ImmediateResponse); !ok {
 		t.Fatalf("expected ImmediateResponse for request nil-body validation failure, got %T", reqFail)
 	}
 
 	// Response validation with nil body should fail when min > 0.
 	p.hasResponseParams = true
 	p.responseParams = WordCountGuardrailPolicyParams{Enabled: true, Min: 1, Max: 10, JsonPath: ""}
-	respFail := p.OnResponse(&policy.ResponseContext{ResponseBody: nil}, nil)
-	respMod, ok := respFail.(policy.UpstreamResponseModifications)
+	respFail := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
+	respMod, ok := respFail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
 		t.Fatalf("expected UpstreamResponseModifications for response nil-body validation failure, got %T", respFail)
 	}
@@ -725,14 +727,14 @@ func TestOnRequestAndOnResponse(t *testing.T) {
 	}
 
 	p.requestParams.Enabled = false
-	reqDisabled := p.OnRequest(&policy.RequestContext{Body: &policy.Body{Content: []byte(`{"messages":[{"content":"hello world"}]}`)}}, nil)
-	if _, ok := reqDisabled.(policy.UpstreamRequestModifications); !ok {
+	reqDisabled := p.OnRequestBody(&policyv1alpha2.RequestContext{Body: &policyv1alpha2.Body{Content: []byte(`{"messages":[{"content":"hello world"}]}`)}}, nil)
+	if _, ok := reqDisabled.(policyv1alpha2.UpstreamRequestModifications); !ok {
 		t.Fatalf("expected request no-op when request.enabled=false, got %T", reqDisabled)
 	}
 
 	p.responseParams.Enabled = false
-	respDisabled := p.OnResponse(&policy.ResponseContext{ResponseBody: &policy.Body{Content: []byte(`{"choices":[{"message":{"content":"hello world"}}]}`)}}, nil)
-	if _, ok := respDisabled.(policy.UpstreamResponseModifications); !ok {
+	respDisabled := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: &policyv1alpha2.Body{Content: []byte(`{"choices":[{"message":{"content":"hello world"}}]}`)}}, nil)
+	if _, ok := respDisabled.(policyv1alpha2.DownstreamResponseModifications); !ok {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }

--- a/policies/word-count-guardrail/wordcountguardrail_test.go
+++ b/policies/word-count-guardrail/wordcountguardrail_test.go
@@ -591,13 +591,13 @@ func TestValidatePayload_ResponsePaths(t *testing.T) {
 
 	pass := p.validatePayloadV2([]byte(`{"messages":"hello world"}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages"}, true)
 	if _, ok := pass.(policyv1alpha2.DownstreamResponseModifications); !ok {
-		t.Fatalf("expected UpstreamResponseModifications on valid response payload, got %T", pass)
+		t.Fatalf("expected DownstreamResponseModifications on valid response payload, got %T", pass)
 	}
 
 	fail := p.validatePayloadV2([]byte(`{"messages":""}`), WordCountGuardrailPolicyParams{Min: 1, Max: 10, JsonPath: "$.messages", ShowAssessment: false}, true)
 	resp, ok := fail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications on invalid response payload, got %T", fail)
+		t.Fatalf("expected DownstreamResponseModifications on invalid response payload, got %T", fail)
 	}
 	if resp.StatusCode == nil || *resp.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected response status %d, got %#v", GuardrailErrorCode, resp.StatusCode)
@@ -720,7 +720,7 @@ func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 	respFail := p.OnResponseBody(&policyv1alpha2.ResponseContext{ResponseBody: nil}, nil)
 	respMod, ok := respFail.(policyv1alpha2.DownstreamResponseModifications)
 	if !ok {
-		t.Fatalf("expected UpstreamResponseModifications for response nil-body validation failure, got %T", respFail)
+		t.Fatalf("expected DownstreamResponseModifications for response nil-body validation failure, got %T", respFail)
 	}
 	if respMod.StatusCode == nil || *respMod.StatusCode != GuardrailErrorCode {
 		t.Fatalf("expected status code %d, got %#v", GuardrailErrorCode, respMod.StatusCode)


### PR DESCRIPTION
## Purpose
$subject

Policies with dependent policies
- token based ratelimit
- basic rate limiter
- mcp

Relates to 
- https://github.com/wso2/gateway-controllers/pull/108
- https://github.com/wso2/api-platform/issues/1386
- https://github.com/wso2/api-platform/issues/1386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced response body processing for MCP policies (ACL list filtering and item rewriting)

* **Bug Fixes**
  * Added stability improvements with nil-guard checks to prevent potential panics during metadata operations

* **Chores**
  * Updated all policies to version 0.9.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->