### PR TITLE
Remove subscription token from passing through to backend

### DIFF
--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v0.9.0
+version: v0.9.1
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -183,13 +183,32 @@ func (p *SubscriptionValidationPolicy) OnRequest(ctx *policy.RequestContext, par
 		if len(headerValues) > 0 {
 			token := strings.TrimSpace(headerValues[0])
 			if token != "" {
-				return p.validateByToken(apiID, token)
+				if action := p.validateByToken(apiID, token); action != nil {
+					return action
+				}
+				return policy.UpstreamRequestModifications{
+					RemoveHeaders: []string{normalizeHeaderName(p.cfg.SubscriptionKeyHeader)},
+				}
 			}
 		}
 		// Path 1b: Check subscription key cookie if configured
 		if p.cfg.SubscriptionKeyCookie != "" {
 			if token := getCookieValue(ctx.Headers, p.cfg.SubscriptionKeyCookie); token != "" {
-				return p.validateByToken(apiID, token)
+				if action := p.validateByToken(apiID, token); action != nil {
+					return action
+				}
+
+				cookieValues := ctx.Headers.Get("Cookie")
+				updated, removed := stripCookie(cookieValues, p.cfg.SubscriptionKeyCookie)
+				if removed {
+					if updated == "" {
+						return policy.UpstreamRequestModifications{RemoveHeaders: []string{"cookie"}}
+					}
+					return policy.UpstreamRequestModifications{SetHeaders: map[string]string{"cookie": updated}}
+				}
+
+				// Token came from cookie lookup, but we couldn't safely strip it; fail open on stripping only.
+				return policy.UpstreamRequestModifications{}
 			}
 		}
 	}
@@ -398,6 +417,46 @@ func entryThrottleUnitString(window time.Duration) string {
 	}
 }
 
+func normalizeHeaderName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// stripCookie removes the cookie with the given name from Cookie header values.
+// It returns the updated Cookie header (single header value) and whether a removal occurred.
+func stripCookie(cookieHeaderValues []string, cookieName string) (string, bool) {
+	if cookieName == "" || len(cookieHeaderValues) == 0 {
+		return "", false
+	}
+
+	parts := make([]string, 0, 8)
+	removed := false
+
+	for _, raw := range cookieHeaderValues {
+		for _, part := range strings.Split(raw, ";") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			idx := strings.Index(part, "=")
+			if idx < 0 {
+				parts = append(parts, part)
+				continue
+			}
+			name := strings.TrimSpace(part[:idx])
+			if strings.EqualFold(name, cookieName) {
+				removed = true
+				continue
+			}
+			parts = append(parts, part)
+		}
+	}
+
+	if !removed {
+		return "", false
+	}
+	return strings.Join(parts, "; "), true
+}
+
 // OnRequestHeaders validates the subscription in the request header phase.
 func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx *policyv1alpha2.RequestHeaderContext, params map[string]interface{}) policyv1alpha2.RequestHeaderAction {
 	if ctx == nil || ctx.SharedContext == nil {
@@ -422,7 +481,9 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx *policyv1alpha2.Requ
 			if token != "" {
 				result := p.validateByTokenV2(apiID, token)
 				if result == nil {
-					return policyv1alpha2.UpstreamRequestHeaderModifications{}
+					return policyv1alpha2.UpstreamRequestHeaderModifications{
+						HeadersToRemove: []string{normalizeHeaderName(p.cfg.SubscriptionKeyHeader)},
+					}
 				}
 				return result.(policyv1alpha2.ImmediateResponse)
 			}
@@ -431,6 +492,18 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx *policyv1alpha2.Requ
 			if token := getCookieValueV2(ctx.Headers, p.cfg.SubscriptionKeyCookie); token != "" {
 				result := p.validateByTokenV2(apiID, token)
 				if result == nil {
+					cookieValues := ctx.Headers.Get("Cookie")
+					updated, removed := stripCookie(cookieValues, p.cfg.SubscriptionKeyCookie)
+					if removed {
+						if updated == "" {
+							return policyv1alpha2.UpstreamRequestHeaderModifications{
+								HeadersToRemove: []string{"cookie"},
+							}
+						}
+						return policyv1alpha2.UpstreamRequestHeaderModifications{
+							HeadersToSet: map[string]string{"cookie": updated},
+						}
+					}
 					return policyv1alpha2.UpstreamRequestHeaderModifications{}
 				}
 				return result.(policyv1alpha2.ImmediateResponse)

--- a/policies/subscription-validation/subscriptionvalidation_test.go
+++ b/policies/subscription-validation/subscriptionvalidation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"testing"
+	"strings"
 
 	policyv1alpha2 "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policyenginev1 "github.com/wso2/api-platform/sdk/gateway/policyengine/v1"
@@ -76,6 +77,46 @@ func assertSuccess(t *testing.T, action policyv1alpha2.RequestHeaderAction) {
 	t.Helper()
 	if _, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications); !ok {
 		t.Fatalf("expected UpstreamRequestHeaderModifications (allow), got %#v", action)
+	}
+}
+
+func assertHeaderRemoved(t *testing.T, action policyv1alpha2.RequestHeaderAction, header string) {
+	t.Helper()
+	mod, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %#v", action)
+	}
+	header = strings.ToLower(strings.TrimSpace(header))
+	for _, h := range mod.HeadersToRemove {
+		if strings.ToLower(strings.TrimSpace(h)) == header {
+			return
+		}
+	}
+	t.Fatalf("expected header %q to be removed; got HeadersToRemove=%v", header, mod.HeadersToRemove)
+}
+
+func assertCookieStripped(t *testing.T, action policyv1alpha2.RequestHeaderAction, cookieName string) {
+	t.Helper()
+	mod, ok := action.(policyv1alpha2.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %#v", action)
+	}
+	// Either Cookie is fully removed...
+	for _, h := range mod.HeadersToRemove {
+		if strings.EqualFold(strings.TrimSpace(h), "cookie") {
+			return
+		}
+	}
+	// ...or rewritten without the cookieName.
+	cookieHeader, ok := mod.HeadersToSet["cookie"]
+	if !ok {
+		cookieHeader, ok = mod.HeadersToSet["Cookie"]
+	}
+	if !ok {
+		t.Fatalf("expected cookie to be removed or rewritten; got HeadersToRemove=%v HeadersToSet=%v", mod.HeadersToRemove, mod.HeadersToSet)
+	}
+	if strings.Contains(strings.ToLower(cookieHeader), strings.ToLower(cookieName)+"=") {
+		t.Fatalf("expected cookie %q to be stripped; got Cookie header %q", cookieName, cookieHeader)
 	}
 }
 
@@ -190,7 +231,9 @@ func TestOnRequestHeaders_AllowsValidToken(t *testing.T) {
 	})
 	p := newPolicy(defaultCfg(), store)
 	ctx := headerCtxWithToken("api-1", "tok-1", "")
-	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+	action := p.OnRequestHeaders(ctx, nil)
+	assertSuccess(t, action)
+	assertHeaderRemoved(t, action, defaultSubscriptionKeyHeader)
 }
 
 func TestOnRequestHeaders_DeniesInvalidToken(t *testing.T) {
@@ -220,7 +263,9 @@ func TestOnRequestHeaders_CustomHeaderName(t *testing.T) {
 	p := newPolicy(cfg, store)
 
 	ctx := headerCtxWithToken("api-1", "tok-1", "X-Custom-Sub")
-	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+	action := p.OnRequestHeaders(ctx, nil)
+	assertSuccess(t, action)
+	assertHeaderRemoved(t, action, "X-Custom-Sub")
 }
 
 // --- cookie path -------------------------------------------------------------
@@ -233,7 +278,9 @@ func TestOnRequestHeaders_AllowsValidTokenFromCookie(t *testing.T) {
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
 	ctx := headerCtxWithCookie("api-1", "tok-1", "sub-key")
-	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+	action := p.OnRequestHeaders(ctx, nil)
+	assertSuccess(t, action)
+	assertCookieStripped(t, action, "sub-key")
 }
 
 func TestOnRequestHeaders_CookieDeniesInvalidToken(t *testing.T) {
@@ -265,7 +312,9 @@ func TestOnRequestHeaders_HeaderTakesPrecedenceOverCookie(t *testing.T) {
 		}),
 	}
 	// Header value should be used; tok-1 is valid
-	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+	action := p.OnRequestHeaders(ctx, nil)
+	assertSuccess(t, action)
+	assertHeaderRemoved(t, action, defaultSubscriptionKeyHeader)
 }
 
 func TestOnRequestHeaders_CookieUsedWhenHeaderMissing(t *testing.T) {
@@ -276,7 +325,9 @@ func TestOnRequestHeaders_CookieUsedWhenHeaderMissing(t *testing.T) {
 	cfg.SubscriptionKeyCookie = "sub-key"
 	p := newPolicy(cfg, store)
 	ctx := headerCtxWithCookie("api-1", "tok-1", "sub-key")
-	assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+	action := p.OnRequestHeaders(ctx, nil)
+	assertSuccess(t, action)
+	assertCookieStripped(t, action, "sub-key")
 }
 
 func TestGetCookieValueV2(t *testing.T) {
@@ -370,7 +421,9 @@ func TestOnRequestHeaders_RateLimitEnforced(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		ctx := headerCtxWithToken("api-1", "tok-1", "")
-		assertSuccess(t, p.OnRequestHeaders(ctx, nil))
+		action := p.OnRequestHeaders(ctx, nil)
+		assertSuccess(t, action)
+		assertHeaderRemoved(t, action, defaultSubscriptionKeyHeader)
 	}
 
 	ctx := headerCtxWithToken("api-1", "tok-1", "")


### PR DESCRIPTION
## Purpose
Remove subscription token from passing through to backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription validation policy now removes authentication headers and cookies after successful token validation, preventing credentials from being forwarded to upstream services.

* **Chores**
  * Subscription validation policy version updated to v0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->