### PR TITLE
Bump policy versions and add missing buildErrorResponseV2 analytics metadata

### DIFF
--- a/policies/api-key-auth/go.mod
+++ b/policies/api-key-auth/go.mod
@@ -1,10 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/api-key-auth
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/wso2/api-platform/common v0.0.0-20260323041357-1f55a5a9ac34
 	github.com/wso2/api-platform/sdk v0.4.6
 )
 
-require github.com/wso2/api-platform/sdk/core v0.1.2 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/api-key-auth/go.sum
+++ b/policies/api-key-auth/go.sum
@@ -6,9 +6,9 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/common v0.0.0-20260323041357-1f55a5a9ac34 h1:u5Os8Jc5XCG8VyUB25cLsWJ/D2bFf8E3+xXkz4DEItk=
 github.com/wso2/api-platform/common v0.0.0-20260323041357-1f55a5a9ac34/go.mod h1:Tv4pznkS1TK3tJvUmbgGD40Efdv063aaHG/J0TDkAzQ=
-github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
-github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk v0.4.6 h1:mH/VojkAuvcNd+QWKz13HBzqeHQklY1zQ7fRFXUK75w=
+github.com/wso2/api-platform/sdk v0.4.6/go.mod h1:Ib95qHuBaE02TkMGOYcLKVIaSyKi3WcapoHEXxQxySs=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v0.9.0
+version: v0.9.1
 description: |
   Secures APIs by validating API keys in incoming requests. API keys can be
   provided through a configured HTTP header or query parameter.

--- a/policies/aws-bedrock-guardrail/go.mod
+++ b/policies/aws-bedrock-guardrail/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.31.0

--- a/policies/aws-bedrock-guardrail/go.sum
+++ b/policies/aws-bedrock-guardrail/go.sum
@@ -30,5 +30,5 @@ github.com/aws/smithy-go v1.21.0 h1:H7L8dtDRk0P1Qm6y0ji7MCYMQObJ5R9CRpyPhRUkLYA=
 github.com/aws/smithy-go v1.21.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: aws-bedrock-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 

--- a/policies/azure-content-safety-content-moderation/go.mod
+++ b/policies/azure-content-safety-content-moderation/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 

--- a/policies/azure-content-safety-content-moderation/go.sum
+++ b/policies/azure-content-safety-content-moderation/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: azure-content-safety-content-moderation
-version: v0.9.0
+version: v0.9.1
 description: |
   Validates request and response content with Azure Content Safety moderation
   checks.

--- a/policies/content-length-guardrail/go.mod
+++ b/policies/content-length-guardrail/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/content-length-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.2 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/content-length-guardrail/go.sum
+++ b/policies/content-length-guardrail/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: content-length-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate content byte lengths in request or response payloads using min/max limits.
 

--- a/policies/json-schema-guardrail/go.mod
+++ b/policies/json-schema-guardrail/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/gateway-controllers/policies/json-schema-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk v0.4.5

--- a/policies/json-schema-guardrail/go.sum
+++ b/policies/json-schema-guardrail/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/policies/json-schema-guardrail/policy-definition.yaml
+++ b/policies/json-schema-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-schema-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate request or response content against a JSON Schema.
 

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: regex-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate request or response content against regex patterns using optional JSONPath extraction and optional inverted matching.
 

--- a/policies/semantic-prompt-guard/go.mod
+++ b/policies/semantic-prompt-guard/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/semantic-prompt-guard
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.0 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/semantic-prompt-guard/go.sum
+++ b/policies/semantic-prompt-guard/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/semantic-prompt-guard/policy-definition.yaml
+++ b/policies/semantic-prompt-guard/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-prompt-guard
-version: v0.9.0
+version: v0.9.1
 description: |
   Evaluates request prompts using embedding similarity against configured allow
   and deny phrases. Blocks prompts that match denied phrases or fail allow

--- a/policies/semantic-prompt-guard/semanticpromptguard.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard.go
@@ -616,6 +616,10 @@ func (p *SemanticPromptGuardPolicy) validatePayloadV2(payload []byte, params Sem
 // buildErrorResponseV2 builds a policyv1alpha2 error response for request phase.
 func (p *SemanticPromptGuardPolicy) buildErrorResponseV2(reason string, validationError error, showAssessment bool) policyv1alpha2.RequestAction {
 	assessment := p.buildAssessmentObject(reason, validationError, showAssessment)
+	analyticsMetadata := map[string]interface{}{
+		"isGuardrailHit": true,
+		"guardrailName":  "SemanticPromptGuard",
+	}
 
 	responseBody := map[string]interface{}{
 		"type":    "SEMANTIC_PROMPT_GUARD",
@@ -628,7 +632,8 @@ func (p *SemanticPromptGuardPolicy) buildErrorResponseV2(reason string, validati
 	}
 
 	return policyv1alpha2.ImmediateResponse{
-		StatusCode: GuardrailErrorCode,
+		StatusCode:        GuardrailErrorCode,
+		AnalyticsMetadata: analyticsMetadata,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},

--- a/policies/sentence-count-guardrail/go.mod
+++ b/policies/sentence-count-guardrail/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/sentence-count-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.0 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/sentence-count-guardrail/go.sum
+++ b/policies/sentence-count-guardrail/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: sentence-count-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate sentence counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -612,6 +612,10 @@ func (p *SentenceCountGuardrailPolicy) validatePayloadV2(payload []byte, params 
 // buildErrorResponseV2 builds a policyv1alpha2 error response for both request and response phases.
 func (p *SentenceCountGuardrailPolicy) buildErrorResponseV2(reason string, validationError error, isResponse bool, showAssessment bool, min, max int) interface{} {
 	assessment := p.buildAssessmentObject(reason, validationError, isResponse, showAssessment, min, max)
+	analyticsMetadata := map[string]interface{}{
+		"isGuardrailHit": true,
+		"guardrailName":  "sentence-count-guardrail",
+	}
 
 	responseBody := map[string]interface{}{
 		"type":    "SENTENCE_COUNT_GUARDRAIL",
@@ -626,8 +630,9 @@ func (p *SentenceCountGuardrailPolicy) buildErrorResponseV2(reason string, valid
 	if isResponse {
 		statusCode := GuardrailErrorCode
 		return policyv1alpha2.DownstreamResponseModifications{
-			StatusCode: &statusCode,
-			Body:       bodyBytes,
+			StatusCode:        &statusCode,
+			Body:              bodyBytes,
+			AnalyticsMetadata: analyticsMetadata,
 			DownstreamResponseHeaderModifications: policyv1alpha2.DownstreamResponseHeaderModifications{
 				HeadersToSet: map[string]string{"Content-Type": "application/json"},
 			},
@@ -635,7 +640,8 @@ func (p *SentenceCountGuardrailPolicy) buildErrorResponseV2(reason string, valid
 	}
 
 	return policyv1alpha2.ImmediateResponse{
-		StatusCode: GuardrailErrorCode,
+		StatusCode:        GuardrailErrorCode,
+		AnalyticsMetadata: analyticsMetadata,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},

--- a/policies/url-guardrail/go.mod
+++ b/policies/url-guardrail/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/url-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.0 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/url-guardrail/go.sum
+++ b/policies/url-guardrail/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: url-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate URLs in request or response content using JSONPath extraction with DNS-only or HTTP reachability checks.
 

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -806,6 +806,10 @@ func (p *URLGuardrailPolicy) validateURLsInTextV2(text string, params URLGuardra
 // buildErrorResponseV2 builds a policyv1alpha2 error response for both request and response phases.
 func (p *URLGuardrailPolicy) buildErrorResponseV2(reason string, validationError error, isResponse bool, showAssessment bool, invalidURLs []string) interface{} {
 	assessment := p.buildAssessmentObject(reason, validationError, isResponse, showAssessment, invalidURLs)
+	analyticsMetadata := map[string]interface{}{
+		"isGuardrailHit": true,
+		"guardrailName":  "url-guardrail",
+	}
 
 	responseBody := map[string]interface{}{
 		"type":    "URL_GUARDRAIL",
@@ -820,8 +824,9 @@ func (p *URLGuardrailPolicy) buildErrorResponseV2(reason string, validationError
 	if isResponse {
 		statusCode := GuardrailErrorCode
 		return policyv1alpha2.DownstreamResponseModifications{
-			StatusCode: &statusCode,
-			Body:       bodyBytes,
+			StatusCode:        &statusCode,
+			Body:              bodyBytes,
+			AnalyticsMetadata: analyticsMetadata,
 			DownstreamResponseHeaderModifications: policyv1alpha2.DownstreamResponseHeaderModifications{
 				HeadersToSet: map[string]string{"Content-Type": "application/json"},
 			},
@@ -829,7 +834,8 @@ func (p *URLGuardrailPolicy) buildErrorResponseV2(reason string, validationError
 	}
 
 	return policyv1alpha2.ImmediateResponse{
-		StatusCode: GuardrailErrorCode,
+		StatusCode:        GuardrailErrorCode,
+		AnalyticsMetadata: analyticsMetadata,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},

--- a/policies/word-count-guardrail/go.mod
+++ b/policies/word-count-guardrail/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/word-count-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.0 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/word-count-guardrail/go.sum
+++ b/policies/word-count-guardrail/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: word-count-guardrail
-version: v0.9.0
+version: v0.9.1
 description: |
   Validate word counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -588,6 +588,10 @@ func joinSSEFragments(value interface{}) string {
 // buildErrorResponseV2 builds a v1alpha2 error response for both request and response phases.
 func (p *WordCountGuardrailPolicy) buildErrorResponseV2(reason string, validationError error, isResponse bool, showAssessment bool, min, max int) interface{} {
 	assessment := p.buildAssessmentObject(reason, validationError, isResponse, showAssessment, min, max)
+	analyticsMetadata := map[string]interface{}{
+		"isGuardrailHit": true,
+		"guardrailName":  "word-count-guardrail",
+	}
 
 	responseBody := map[string]interface{}{
 		"type":    "WORD_COUNT_GUARDRAIL",
@@ -602,8 +606,9 @@ func (p *WordCountGuardrailPolicy) buildErrorResponseV2(reason string, validatio
 	if isResponse {
 		statusCode := GuardrailErrorCode
 		return policyv1alpha2.DownstreamResponseModifications{
-			StatusCode: &statusCode,
-			Body:       bodyBytes,
+			StatusCode:        &statusCode,
+			Body:              bodyBytes,
+			AnalyticsMetadata: analyticsMetadata,
 			DownstreamResponseHeaderModifications: policyv1alpha2.DownstreamResponseHeaderModifications{
 				HeadersToSet: map[string]string{
 					"Content-Type": "application/json",
@@ -613,7 +618,8 @@ func (p *WordCountGuardrailPolicy) buildErrorResponseV2(reason string, validatio
 	}
 
 	return policyv1alpha2.ImmediateResponse{
-		StatusCode: GuardrailErrorCode,
+		StatusCode:        GuardrailErrorCode,
+		AnalyticsMetadata: analyticsMetadata,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics metadata tracking for guardrail policy violations, now reporting guardrail names and trigger status when policies are enforced.

* **Chores**
  * Updated all guardrail policies to version v0.9.1.
  * Upgraded Go toolchain version to support latest language features and security updates.
  * Updated internal dependencies across policy modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->