### PR TITLE
Update Go version to 1.26.1 and bump sdk/core dependency to v0.1.2

### DIFF
--- a/policies/regex-guardrail/go.mod
+++ b/policies/regex-guardrail/go.mod
@@ -1,7 +1,7 @@
 module github.com/wso2/gateway-controllers/policies/regex-guardrail
 
-go 1.25.7
+go 1.26.1
 
 require github.com/wso2/api-platform/sdk v0.4.5
 
-require github.com/wso2/api-platform/sdk/core v0.1.2 // indirect
+require github.com/wso2/api-platform/sdk/core v0.1.2

--- a/policies/regex-guardrail/go.sum
+++ b/policies/regex-guardrail/go.sum
@@ -1,4 +1,4 @@
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.0 h1:yxxlgmrZLztCqHzAW7GdRnUNBFOA2l8AX6fphMZaly0=
-github.com/wso2/api-platform/sdk/core v0.1.0/go.mod h1:R114dV8/EAl843+16zi97Cbd5+iPPYjHKdN7Nik3EUw=
+github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.26.1.
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->