### PR TITLE
Update policies to use api-platform/sdk/core v0.1.4 and refactor

### DIFF
--- a/policies/advanced-ratelimit/go.mod
+++ b/policies/advanced-ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/google/cel-go v0.26.1
 	github.com/redis/go-redis/v9 v9.17.3
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )
 
 require (

--- a/policies/advanced-ratelimit/go.sum
+++ b/policies/advanced-ratelimit/go.sum
@@ -30,8 +30,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -99,7 +99,7 @@ type RateLimitPolicy struct {
 	apiId          string         // From metadata, API identifier
 	apiName        string         // From metadata, API name for scope-based caching
 	apiVersion     string         // From metadata, API version
-	attachedTo     policy.Level // From metadata, whether policy is attached at API or route level
+	attachedTo     policy.Level   // From metadata, whether policy is attached at API or route level
 	baseCacheKey   string         // Base cache key for tracking limiters in memory backend
 	statusCode     int
 	responseBody   string
@@ -215,8 +215,8 @@ func GetPolicy(
 
 		// Create Redis client
 		redisClient = redis.NewClient(&redis.Options{
-			Addr:         fmt.Sprintf("%s:%d", 
-			redisHost, redisPort),
+			Addr: fmt.Sprintf("%s:%d",
+				redisHost, redisPort),
 			Username:     redisUsername,
 			Password:     redisPassword,
 			DB:           redisDB,
@@ -444,7 +444,6 @@ const (
 	rateLimitHeaderHandledKey = "ratelimit:header_handled" // Quota names fully handled in header phase
 )
 
-
 // quotaResult stores the result of checking a single quota
 type quotaResult struct {
 	QuotaName string
@@ -452,10 +451,6 @@ type quotaResult struct {
 	Key       string
 	Duration  time.Duration // Window duration for IETF RateLimit-Policy header
 }
-
-
-
-
 
 // buildMultiQuotaHeaders creates rate limit headers for all quotas.
 // For IETF headers, uses Structured Fields format to report all quotas.
@@ -1576,7 +1571,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx *policy.ResponseHeaderContext, p
 		return nil
 	}
 
-	return policyv1alpha2.DownstreamResponseHeaderModifications{
+	return policy.DownstreamResponseHeaderModifications{
 		HeadersToSet: headers,
 	}
 }
@@ -1736,9 +1731,7 @@ func (p *RateLimitPolicy) OnResponseBody(
 		}
 
 		return policy.DownstreamResponseModifications{
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: headers,
-			},
+			HeadersToSet: headers,
 		}
 	}
 	return policy.DownstreamResponseModifications{}

--- a/policies/analytics-header-filter/go.mod
+++ b/policies/analytics-header-filter/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/analytics-header-filter
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/analytics-header-filter/go.sum
+++ b/policies/analytics-header-filter/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/api-key-auth/go.mod
+++ b/policies/api-key-auth/go.mod
@@ -4,5 +4,5 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )

--- a/policies/api-key-auth/go.sum
+++ b/policies/api-key-auth/go.sum
@@ -6,7 +6,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71 h1:vnK2p6QV2kqOhs2iFpuYKVV6jpu8/Q1QuVz14UlQsn0=
 github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71/go.mod h1:Tv4pznkS1TK3tJvUmbgGD40Efdv063aaHG/J0TDkAzQ=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -1014,9 +1014,7 @@ func (p *AWSBedrockGuardrailPolicy) buildErrorResponse(reason string, validation
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/aws-bedrock-guardrail/go.mod
+++ b/policies/aws-bedrock-guardrail/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.16
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.10
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )
 
 require (

--- a/policies/aws-bedrock-guardrail/go.sum
+++ b/policies/aws-bedrock-guardrail/go.sum
@@ -28,5 +28,5 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.10 h1:69tpbPED7jKPyzMcrwSvhWcJ9bP
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.10/go.mod h1:0Aqn1MnEuitqfsCNyKsdKLhDUOr4txD/g19EfiUqgws=
 github.com/aws/smithy-go v1.21.0 h1:H7L8dtDRk0P1Qm6y0ji7MCYMQObJ5R9CRpyPhRUkLYA=
 github.com/aws/smithy-go v1.21.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
@@ -394,10 +394,8 @@ func (p *AzureContentSafetyContentModerationPolicy) buildErrorResponse(reason st
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{
-					"Content-Type": "application/json",
-				},
+			HeadersToSet: map[string]string{
+				"Content-Type": "application/json",
 			},
 		}
 	}

--- a/policies/azure-content-safety-content-moderation/go.mod
+++ b/policies/azure-content-safety-content-moderation/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/azure-content-safety-content
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/azure-content-safety-content-moderation/go.sum
+++ b/policies/azure-content-safety-content-moderation/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/basic-auth/go.mod
+++ b/policies/basic-auth/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/basic-auth
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/basic-auth/go.sum
+++ b/policies/basic-auth/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -3,7 +3,7 @@ module github.com/wso2/gateway-controllers/policies/basic-ratelimit
 go 1.26.1
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3
 )
 

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3 h1:JV1130GfL5We+29GvMFqvJcedjrdk0v0fNJvGnloL3A=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3/go.mod h1:pIlUs5OHcYPHGyf3UNT7ZGnuK6jHRS+ad4w/Tz0ICK4=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/content-length-guardrail/contentlengthguardrail.go
+++ b/policies/content-length-guardrail/contentlengthguardrail.go
@@ -646,9 +646,7 @@ func (p *ContentLengthGuardrailPolicy) buildErrorResponse(reason string, validat
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/content-length-guardrail/go.mod
+++ b/policies/content-length-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/content-length-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/content-length-guardrail/go.sum
+++ b/policies/content-length-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/cors/go.mod
+++ b/policies/cors/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/cors
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/cors/go.sum
+++ b/policies/cors/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/dynamic-endpoint/go.mod
+++ b/policies/dynamic-endpoint/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/dynamic-endpoint
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/dynamic-endpoint/go.sum
+++ b/policies/dynamic-endpoint/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/json-schema-guardrail/go.mod
+++ b/policies/json-schema-guardrail/go.mod
@@ -3,7 +3,7 @@ module github.com/wso2/gateway-controllers/policies/json-schema-guardrail
 go 1.26.1
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 	github.com/xeipuuv/gojsonschema v1.2.0
 )
 

--- a/policies/json-schema-guardrail/go.sum
+++ b/policies/json-schema-guardrail/go.sum
@@ -5,8 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/policies/json-schema-guardrail/jsonschemaguardrail.go
+++ b/policies/json-schema-guardrail/jsonschemaguardrail.go
@@ -339,9 +339,7 @@ func (p *JSONSchemaGuardrailPolicy) buildErrorResponse(reason string, validation
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/json-xml-mediator/go.mod
+++ b/policies/json-xml-mediator/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/json-xml-mediator
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/json-xml-mediator/go.sum
+++ b/policies/json-xml-mediator/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/json-xml-mediator/jsonxmlmediation.go
+++ b/policies/json-xml-mediator/jsonxmlmediation.go
@@ -418,11 +418,9 @@ func (p *JSONXMLMediationPolicy) OnRequestBody(ctx *policy.RequestContext, _ map
 
 	return policy.UpstreamRequestModifications{
 		Body: convertedBody,
-		UpstreamRequestHeaderModifications: policy.UpstreamRequestHeaderModifications{
-			HeadersToSet: map[string]string{
-				"content-type":   convertedContentType,
-				"content-length": fmt.Sprintf("%d", len(convertedBody)),
-			},
+		HeadersToSet: map[string]string{
+			"content-type":   convertedContentType,
+			"content-length": fmt.Sprintf("%d", len(convertedBody)),
 		},
 	}
 }
@@ -464,11 +462,9 @@ func (p *JSONXMLMediationPolicy) OnResponseBody(ctx *policy.ResponseContext, _ m
 
 	return policy.DownstreamResponseModifications{
 		Body: convertedBody,
-		DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-			HeadersToSet: map[string]string{
-				"content-type":   convertedContentType,
-				"content-length": fmt.Sprintf("%d", len(convertedBody)),
-			},
+		HeadersToSet: map[string]string{
+			"content-type":   convertedContentType,
+			"content-length": fmt.Sprintf("%d", len(convertedBody)),
 		},
 	}
 }
@@ -525,11 +521,9 @@ func (p *JSONXMLMediationPolicy) handleInternalServerErrorResponse(message strin
 	return policy.DownstreamResponseModifications{
 		StatusCode: &statusCode,
 		Body:       bodyBytes,
-		DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-			HeadersToSet: map[string]string{
-				"content-type":   "application/json",
-				"content-length": fmt.Sprintf("%d", len(bodyBytes)),
-			},
+		HeadersToSet: map[string]string{
+			"content-type":   "application/json",
+			"content-length": fmt.Sprintf("%d", len(bodyBytes)),
 		},
 	}
 }

--- a/policies/jwt-auth/go.mod
+++ b/policies/jwt-auth/go.mod
@@ -4,5 +4,5 @@ go 1.26.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )

--- a/policies/jwt-auth/go.sum
+++ b/policies/jwt-auth/go.sum
@@ -1,4 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -3,7 +3,7 @@ module github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit
 go 1.26.1
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3
 )
 

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3 h1:JV1130GfL5We+29GvMFqvJcedjrdk0v0fNJvGnloL3A=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3/go.mod h1:pIlUs5OHcYPHGyf3UNT7ZGnuK6jHRS+ad4w/Tz0ICK4=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/llm-cost/go.mod
+++ b/policies/llm-cost/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/llm-cost
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/llm-cost/go.sum
+++ b/policies/llm-cost/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/log-message/go.mod
+++ b/policies/log-message/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/log-message
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/log-message/go.sum
+++ b/policies/log-message/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/mcp-acl-list/go.mod
+++ b/policies/mcp-acl-list/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-acl-list
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/mcp-acl-list/go.sum
+++ b/policies/mcp-acl-list/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -2,7 +2,7 @@ module github.com/wso2/gateway-controllers/policies/mcp-auth
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4
 
 require github.com/wso2/gateway-controllers/policies/jwt-auth v0.9.0
 

--- a/policies/mcp-auth/go.sum
+++ b/policies/mcp-auth/go.sum
@@ -2,7 +2,7 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/wso2/gateway-controllers/policies/jwt-auth v0.9.0 h1:UwjkkbNG5sSJl9+RY+CaADo9w/q6Tz5f8ckZBC4kbBU=
 github.com/wso2/gateway-controllers/policies/jwt-auth v0.9.0/go.mod h1:wVd0UTGsCKKK8helu5MWnCFmeiQCoyxLG/06mPcANSI=

--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -112,7 +112,6 @@ func GetPolicyV2(
 	return GetPolicy(metadata, params)
 }
 
-
 // parseAuthority extracts host and port from an authority string (e.g., "example.com:8080")
 func parseAuthority(authority string) (host string, port int) {
 	if authority == "" {
@@ -552,7 +551,16 @@ func (p *McpAuthPolicy) handleAuth(ctx *policy.RequestContext, params map[string
 	}
 	if a, ok := headerAction.(policy.UpstreamRequestHeaderModifications); ok {
 		return policy.UpstreamRequestModifications{
-			UpstreamRequestHeaderModifications: a,
+			HeadersToSet:            a.HeadersToSet,
+			HeadersToRemove:         a.HeadersToRemove,
+			UpstreamName:            a.UpstreamName,
+			Path:                    a.Path,
+			Method:                  a.Method,
+			QueryParametersToAdd:    a.QueryParametersToAdd,
+			QueryParametersToRemove: a.QueryParametersToRemove,
+			AnalyticsMetadata:       a.AnalyticsMetadata,
+			DynamicMetadata:         a.DynamicMetadata,
+			AnalyticsHeaderFilter:   a.AnalyticsHeaderFilter,
 		}
 	}
 	return nil

--- a/policies/mcp-authz/go.mod
+++ b/policies/mcp-authz/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-authz
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/mcp-authz/go.sum
+++ b/policies/mcp-authz/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/mcp-rewrite/go.mod
+++ b/policies/mcp-rewrite/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-rewrite
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/mcp-rewrite/go.sum
+++ b/policies/mcp-rewrite/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/model-round-robin/go.mod
+++ b/policies/model-round-robin/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/model-round-robin
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/model-round-robin/go.sum
+++ b/policies/model-round-robin/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/model-weighted-round-robin/go.mod
+++ b/policies/model-weighted-round-robin/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/model-weighted-round-robin
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/model-weighted-round-robin/go.sum
+++ b/policies/model-weighted-round-robin/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/pii-masking-regex/go.mod
+++ b/policies/pii-masking-regex/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/pii-masking-regex
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/pii-masking-regex/go.sum
+++ b/policies/pii-masking-regex/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/prompt-decorator/go.mod
+++ b/policies/prompt-decorator/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/prompt-decorator
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/prompt-decorator/go.sum
+++ b/policies/prompt-decorator/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/prompt-template/go.mod
+++ b/policies/prompt-template/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/prompt-template
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/prompt-template/go.sum
+++ b/policies/prompt-template/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/regex-guardrail/go.mod
+++ b/policies/regex-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/regex-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/regex-guardrail/go.sum
+++ b/policies/regex-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/regex-guardrail/regexguardrail.go
+++ b/policies/regex-guardrail/regexguardrail.go
@@ -498,9 +498,7 @@ func (p *RegexGuardrailPolicy) buildErrorResponse(reason string, validationError
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/remove-headers/go.mod
+++ b/policies/remove-headers/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/remove-headers
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/remove-headers/go.sum
+++ b/policies/remove-headers/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/request-rewrite/go.mod
+++ b/policies/request-rewrite/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/request-rewrite
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/request-rewrite/go.sum
+++ b/policies/request-rewrite/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/respond/go.mod
+++ b/policies/respond/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/respond
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/respond/go.sum
+++ b/policies/respond/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/semantic-cache/go.mod
+++ b/policies/semantic-cache/go.mod
@@ -4,8 +4,8 @@ go 1.26.1
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/wso2/api-platform/sdk/ai v0.1.1
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/ai v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )
 
 require (

--- a/policies/semantic-cache/go.sum
+++ b/policies/semantic-cache/go.sum
@@ -385,10 +385,10 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/wso2/api-platform/sdk/ai v0.1.1 h1:+HjL/mYP7m9jZdkmjTyR2gwUxbbwzUs4w1a1eVA1ORc=
-github.com/wso2/api-platform/sdk/ai v0.1.1/go.mod h1:EFQ6w1Orv6uyjNhCDxAr9Sanh33NmgoBCQyA9qHMudk=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/ai v0.1.2 h1:z1OUFVT4IDxmH40or5ZSPL8rVp2dc4QDnFKPpFjt9oo=
+github.com/wso2/api-platform/sdk/ai v0.1.2/go.mod h1:EFQ6w1Orv6uyjNhCDxAr9Sanh33NmgoBCQyA9qHMudk=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:zcSZoa7JLBPhRyqIGxD24h8RG9otBKRnL59GYlBE01s=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/policies/semantic-prompt-guard/go.mod
+++ b/policies/semantic-prompt-guard/go.mod
@@ -3,6 +3,6 @@ module github.com/wso2/gateway-controllers/policies/semantic-prompt-guard
 go 1.26.1
 
 require (
-	github.com/wso2/api-platform/sdk/ai v0.1.0
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/ai v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )

--- a/policies/semantic-prompt-guard/go.sum
+++ b/policies/semantic-prompt-guard/go.sum
@@ -1,4 +1,4 @@
-github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
-github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/ai v0.1.2 h1:z1OUFVT4IDxmH40or5ZSPL8rVp2dc4QDnFKPpFjt9oo=
+github.com/wso2/api-platform/sdk/ai v0.1.2/go.mod h1:EFQ6w1Orv6uyjNhCDxAr9Sanh33NmgoBCQyA9qHMudk=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:zcSZoa7JLBPhRyqIGxD24h8RG9otBKRnL59GYlBE01s=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/semantic-prompt-guard/semanticpromptguard.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard.go
@@ -25,9 +25,9 @@ import (
 	"strconv"
 	"strings"
 
+	embeddingproviders "github.com/wso2/api-platform/sdk/ai/embeddings"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	utils "github.com/wso2/api-platform/sdk/core/utils"
-	embeddingproviders "github.com/wso2/api-platform/sdk/ai/utils/embeddingproviders"
 )
 
 const (

--- a/policies/semantic-prompt-guard/semanticpromptguard_test.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	embeddingproviders "github.com/wso2/api-platform/sdk/ai/embeddings"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
-	embeddingproviders "github.com/wso2/api-platform/sdk/ai/utils/embeddingproviders"
 )
 
 type mockEmbeddingProvider struct {

--- a/policies/semantic-tool-filtering/go.mod
+++ b/policies/semantic-tool-filtering/go.mod
@@ -4,5 +4,5 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/ai v0.1.0
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 )

--- a/policies/semantic-tool-filtering/semantictoolfiltering.go
+++ b/policies/semantic-tool-filtering/semantictoolfiltering.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 	"strings"
 
+	embeddingproviders "github.com/wso2/api-platform/sdk/ai/embeddings"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
-	embeddingproviders "github.com/wso2/api-platform/sdk/ai/utils/embeddingproviders"
 )
 
 const (

--- a/policies/sentence-count-guardrail/go.mod
+++ b/policies/sentence-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/sentence-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/sentence-count-guardrail/go.sum
+++ b/policies/sentence-count-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -511,9 +511,7 @@ func (p *SentenceCountGuardrailPolicy) buildErrorResponse(reason string, validat
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/set-headers/go.mod
+++ b/policies/set-headers/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/set-headers
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/set-headers/go.sum
+++ b/policies/set-headers/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/subscription-validation/go.mod
+++ b/policies/subscription-validation/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/subscription-validation
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
-	policyenginev1 "github.com/wso2/api-platform/sdk/core/gateway/policyengine/v1"
+	policyenginev1 "github.com/wso2/api-platform/sdk/core/policyengine"
 )
 
 const (

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -3,7 +3,7 @@ module github.com/wso2/gateway-controllers/policies/token-based-ratelimit
 go 1.26.1
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.1.4
 	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3 //upgrade
 	golang.org/x/sync v0.20.0
 )

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk v0.4.5 h1:1T5bY4W0No8SKZiydg8dt/x0iFKWiRTgquzoQd7EXU4=
 github.com/wso2/api-platform/sdk v0.4.5/go.mod h1:Zoaj0dOuHmI96K9rY9w2qunjjT4Lcvlq9AYezL4a3/0=
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3 h1:JV1130GfL5We+29GvMFqvJcedjrdk0v0fNJvGnloL3A=
 github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.9.3/go.mod h1:pIlUs5OHcYPHGyf3UNT7ZGnuK6jHRS+ad4w/Tz0ICK4=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/url-guardrail/go.mod
+++ b/policies/url-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/url-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/url-guardrail/go.sum
+++ b/policies/url-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -697,9 +697,7 @@ func (p *URLGuardrailPolicy) buildErrorResponse(reason string, validationError e
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{"Content-Type": "application/json"},
-			},
+			HeadersToSet:      map[string]string{"Content-Type": "application/json"},
 		}
 	}
 

--- a/policies/word-count-guardrail/go.mod
+++ b/policies/word-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/word-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.1.2
+require github.com/wso2/api-platform/sdk/core v0.1.4

--- a/policies/word-count-guardrail/go.sum
+++ b/policies/word-count-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.1.2 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
-github.com/wso2/api-platform/sdk/core v0.1.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.1.4 h1:p/J9pxlxLF+VKkW+BY3x1sh6F7VbiRPKjOOhnUs4Hs0=
+github.com/wso2/api-platform/sdk/core v0.1.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -299,9 +299,9 @@ func extractStringFromJSONPath(payload []byte, jsonPath string) (string, error) 
 
 func normalizeExtractedValue(value interface{}) (string, error) {
 	// 1. Handle nil immediately to avoid pointer panics
-    if value == nil {
-        return "", nil 
-    }
+	if value == nil {
+		return "", nil
+	}
 	switch v := value.(type) {
 	case string:
 		return v, nil
@@ -506,10 +506,8 @@ func (p *WordCountGuardrailPolicy) buildErrorResponse(reason string, validationE
 			StatusCode:        &statusCode,
 			Body:              bodyBytes,
 			AnalyticsMetadata: analyticsMetadata,
-			DownstreamResponseHeaderModifications: policy.DownstreamResponseHeaderModifications{
-				HeadersToSet: map[string]string{
-					"Content-Type": "application/json",
-				},
+			HeadersToSet: map[string]string{
+				"Content-Type": "application/json",
 			},
 		}
 	}


### PR DESCRIPTION
## Purpose
- Updated go.mod and go.sum files across multiple policies to require github.com/wso2/api-platform/sdk/core v0.1.4.
- Refactored header modifications in McpAuthPolicy and other policies to streamline response handling.
- Adjusted imports in semantic-prompt-guard and semantic-tool-filtering to use the new embedding providers path.
- Cleaned up error response building in regex-guardrail, sentence-count-guardrail, URL-guardrail, and word-count-guardrail policies to directly set headers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core platform SDK dependency across all policy modules from v0.1.2 to v0.1.4
  * Updated AI SDK dependencies in semantic caching and semantic prompt guard policies
  * Reorganized internal package structure for embedding providers in semantic policies

* **Bug Fixes**
  * Fixed response header modification formatting across multiple policies to improve consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->