### PR TITLE
Refactor Rate Limiting Related Policies

### DIFF
--- a/docs/advanced-ratelimit/v1.0/docs/advanced-ratelimit.md
+++ b/docs/advanced-ratelimit/v1.0/docs/advanced-ratelimit.md
@@ -1,0 +1,639 @@
+---
+title: "Overview"
+---
+# Rate Limiting (Advanced)
+
+## Overview
+
+The Rate Limiting policy controls the rate of requests to your APIs by enforcing configurable limits based on various criteria. This policy is essential for protecting backend services from overload, ensuring fair usage, and maintaining service availability.
+
+## Features
+
+- Multiple rate limiting algorithms (GCRA, Fixed Window)
+- Weighted rate limiting via cost parameter
+- Post-response cost extraction for dynamic rate limiting (e.g., LLM token usage)
+- Multiple concurrent limits (e.g., 10/second AND 1000/hour)
+- Flexible key extraction (headers, metadata, IP, API name, route name)
+- Dual backends: in-memory (single instance) or Redis (distributed)
+- Graceful degradation with fail-open/fail-closed modes for Redis failures
+- Comprehensive rate limit headers (X-RateLimit-*, IETF RateLimit, Retry-After)
+- Customizable error responses
+
+## Configuration
+
+The Rate Limiting policy uses a two-level configuration
+
+### System Parameters (From config.toml)
+
+These parameters are set by the administrator and apply globally to all rate limiting policies:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `algorithm` | string | No | `"fixed-window"` | Rate limiting algorithm: `"gcra"` (smooth rate limiting with burst support) or `"fixed-window"` (simple counter per time window). |
+| `backend` | string | No | `"memory"` | Storage backend: `"memory"` for single-instance or `"redis"` for distributed rate limiting. |
+| `redis` | ```Redis``` object | No | - | Redis configuration (only used when `backend=redis`). |
+| `memory` | ```Memory``` object | No | - | In-memory storage configuration (only used when `backend=memory`). |
+| `headers` | ```Headers``` object | No | - | Control which rate limit headers are included in responses. |
+
+#### Redis Configuration
+
+When using Redis backend, the following parameters can be configured under `redis`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `host` | string | No | `"localhost"` | Redis server hostname or IP address. |
+| `port` | integer | No | `6379` | Redis server port. |
+| `password` | string | No | `""` | Redis authentication password (optional). |
+| `username` | string | No | `""` | Redis ACL username (optional, Redis 6+). |
+| `db` | integer | No | `0` | Redis database number (0-15). |
+| `keyPrefix` | string | No | `"ratelimit:v1:"` | Prefix for all Redis keys to avoid conflicts. |
+| `failureMode` | string | No | `"open"` | Behavior when Redis is unavailable: `"open"` allows requests through, `"closed"` denies requests. |
+| `connectionTimeout` | string | No | `"5s"` | Redis connection timeout (Go duration string). |
+| `readTimeout` | string | No | `"3s"` | Redis read timeout (Go duration string). |
+| `writeTimeout` | string | No | `"3s"` | Redis write timeout (Go duration string). |
+
+#### Memory Configuration
+
+When using in-memory backend, the following parameters can be configured under `memory`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `maxEntries` | integer | No | `10000` | Maximum number of rate limit entries to store. Oldest entries are evicted when limit is reached. |
+| `cleanupInterval` | string | No | `"5m"` | Interval for cleaning up expired entries. Use `"0"` to disable periodic cleanup. |
+
+#### Headers Configuration
+
+Control which rate limit headers are included in responses under `headers`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `includeXRateLimit` | boolean | No | `true` | Include X-RateLimit-* headers (X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset). |
+| `includeIETF` | boolean | No | `true` | Include IETF RateLimit headers (RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, RateLimit-Policy). |
+| `includeRetryAfter` | boolean | No | `true` | Include Retry-After header when rate limited (RFC 7231). Only set on 429 responses. |
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `quotas` | `Quota` array | Yes | - | Defines quota entries (1-10). Each quota applies independent limits with its own `keyExtraction` and `costExtraction` settings. |
+| `keyExtraction` | `KeyExtraction` array | No | `[{type: "routename"}]` | Global key extraction applied to quotas that do not define their own `keyExtraction`. Defaults to `routename` if omitted. |
+| `onRateLimitExceeded` | `onRateLimitExceeded` object | No | - | Customizes the response returned when a request exceeds rate limits. |
+
+#### Quota Configuration
+
+Each entry in the `quotas` array defines an independent rate limit bucket:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | No | - | Quota name used in logs and `X-RateLimit-Quota` response headers (1-128 chars). |
+| `limits` | `Limit` array | Yes | - | One or more limit windows for the quota (1-10). The strictest limit is enforced. |
+| `keyExtraction` | `KeyExtraction` array | No | - | Per-quota key extraction. Overrides the global `keyExtraction` when set. |
+| `costExtraction` | `CostExtraction` object | No | - | Per-quota dynamic cost extraction from request or response data. |
+
+#### Limit Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `limit` | integer | Yes | - | Maximum number of requests or tokens allowed in the duration (1-1,000,000,000). |
+| `duration` | string | Yes | - | Time window for the limit (Go duration format: `"1s"`, `"1m"`, `"1h"`, `"24h"`). |
+| `burst` | integer | No | Same as `limit` | Maximum burst capacity (GCRA only). Number of requests that can accumulate (1-1,000,000,000). |
+
+#### KeyExtraction Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `type` | string | Yes | Type of component: `"header"`, `"metadata"`, `"ip"`, `"apiname"`, `"apiversion"`, `"routename"`, `"cel"`, `"constant"`. |
+| `key` | string | Conditional | Header name or metadata key. Required for `header` and `metadata` types (1-256 chars). |
+| `expression` | string | Conditional | CEL expression returning a string. Required for `cel` type (1-1024 chars). |
+
+**Key extraction types:**
+- `header`: Extract from HTTP header (requires `key` field)
+- `metadata`: Extract from SharedContext.Metadata (requires `key` field)
+- `ip`: Extract client IP from X-Forwarded-For/X-Real-IP headers
+- `apiname`: Use API name from context
+- `apiversion`: Use API version from context
+- `routename`: Use route name from metadata (default)
+- `cel`: Evaluate a CEL expression returning a string (requires `expression` field)
+- `constant`: Use a fixed constant string value (requires `key` field)
+
+> **Important: Component Order Matters**
+>
+> The order of components in the `keyExtraction` array affects the generated rate limit key. Components are joined with `:` separator in the exact order specified:
+>
+> ```yaml
+> # Example 1: User ID then IP
+> keyExtraction:
+>   - type: header
+>     key: X-User-ID
+>   - type: ip
+> # Generates key: "user123:192.168.1.1"
+> ```
+>
+> ```yaml
+> # Example 2: IP then User ID (different from Example 1!)
+> keyExtraction:
+>   - type: ip
+>   - type: header
+>     key: X-User-ID
+> # Generates key: "192.168.1.1:user123"
+> ```
+>
+> These are treated as **different rate limit buckets** with separate counters. If you change the component order in your configuration, it will effectively reset all rate limit counters for that policy.
+>
+> **Best Practice:** Maintain consistent component ordering across all environments and configuration updates to avoid unexpected rate limit resets.
+
+#### CostExtraction Configuration
+
+Configures per-quota dynamic cost extraction from request or response data. Values from all successful sources are summed (after applying multipliers). If all sources fail, the `default` cost is used.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables dynamic cost extraction for the quota. |
+| `sources` | `Source` array | Yes (if enabled) | - | Cost extraction sources (1-10). Successful values are summed with multipliers applied. |
+| `default` | number | No | `1` | Fallback cost when all source extractions fail (0 to 1,000,000,000). |
+
+**Source Configuration:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `type` | string | Yes | Source type. See **Source Types** below. |
+| `key` | string | Conditional | Header name or metadata key. Required for `request_header`, `request_metadata`, `response_header`, `response_metadata` types (1-256 chars). |
+| `jsonPath` | string | Conditional | JSONPath expression. Required for `request_body` and `response_body` types (1-512 chars). |
+| `expression` | string | Conditional | CEL expression returning a numeric result. Required for `request_cel` and `response_cel` types (1-1024 chars). |
+| `multiplier` | number | No | `1.0` | Multiplier applied to the extracted value (minimum 0). |
+
+**Source Types:**
+
+- `request_header`: Extract cost from a request header
+- `request_metadata`: Extract cost from request shared metadata
+- `request_body`: Extract cost from request JSON body using JSONPath
+- `response_header`: Extract cost from a response header
+- `response_metadata`: Extract cost from response shared metadata
+- `response_body`: Extract cost from response JSON body using JSONPath
+- `request_cel`: Evaluate a CEL expression on request data (numeric result)
+- `response_cel`: Evaluate a CEL expression on response data (numeric result)
+
+> **Important: Post-Response Rate Limiting Behavior**
+>
+> When `costExtraction.enabled: true`:
+> - A **pre-flight quota check** is performed: if the key's remaining quota is already exhausted (≤ 0), the request is blocked with a 429 response
+> - If quota is available, the request proceeds to upstream without consuming tokens
+> - Cost is extracted from the response and consumed **after** the response is received
+> - If the rate limit is exceeded post-response, the **current request has already succeeded**, but headers indicate quota exhaustion
+> - **Subsequent requests** using the same key will be impacted by the consumed quota
+>
+> This model is appropriate for:
+> - Use cases where cost is only known after the operation completes (e.g., LLM token usage)
+> - Usage tracking with pre-flight protection against fully exhausted quotas
+
+#### RateLimitExceeded Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `statusCode` | integer | No | `429` | HTTP status code for rate limit response (400-599). |
+| `body` | string | No | `{"error": "Too Many Requests", "message": "Rate limit exceeded. Please try again later."}` | Custom error message body. |
+| `bodyFormat` | string | No | `"json"` | Response body content type: `"json"` or `"plain"`. |
+
+#### Sample System Configuration
+
+##### Memory Backend Configuration
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "fixed-window"
+backend = "memory"
+
+[policy_configurations.ratelimit_v0.memory]
+max_entries = 10000
+cleanup_interval = "5m"
+
+[policy_configurations.ratelimit_v0.headers]
+include_x_rate_limit = true
+include_ietf = true
+include_retry_after = true
+```
+
+##### Redis Backend Configuration
+
+For distributed rate limiting across multiple gateway instances:
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "fixed-window"
+backend = "redis"
+
+[policy_configurations.ratelimit_v0.redis]
+host = "redis.example.com"
+port = 6379
+password = "your-redis-password"
+db = 0
+key_prefix = "ratelimit:v1:"
+failure_mode = "open"
+connection_timeout = "5s"
+read_timeout = "3s"
+write_timeout = "3s"
+
+[policy_configurations.ratelimit_v0.headers]
+include_x_rate_limit = true
+include_ietf = true
+include_retry_after = true
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: advanced-ratelimit
+  gomodule: github.com/wso2/gateway-controllers/policies/advanced-ratelimit@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Rate Limiting
+
+Apply a simple rate limit to an API:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: advanced-ratelimit
+          version: v0
+          params:
+            quotas:
+              - limits:
+                  - limit: 10
+                    duration: "1m"
+    - method: GET
+      path: /alerts/active
+```
+
+### Example 2: Multiple Time Windows
+
+Enforce multiple rate limits simultaneously (e.g., per-second and per-hour):
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: advanced-ratelimit
+          version: v0
+          params:
+            quotas:
+              - limits:
+                  - limit: 10
+                    duration: "1m"
+                  - limit: 20
+                    duration: "1h"
+    - method: GET
+      path: /alerts/active
+```
+
+### Example 3: Per-User Rate Limiting
+
+Rate limit based on user identity from a header:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: advanced-ratelimit
+          version: v0
+          params:
+            quotas:
+              - limits:
+                  - limit: 10
+                    duration: "1m"
+                keyExtraction:
+                  - type: header
+                    key: X-User-ID
+    - method: GET
+      path: /alerts/active
+```
+
+### Example 4: Per-IP Rate Limiting
+
+Rate limit based on client IP address:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: public-api
+  version: v1.0
+  context: /public
+  upstream:
+    main:
+      url: https://public-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 60
+                duration: "1m"
+            keyExtraction:
+              - type: ip
+  operations:
+    - method: GET
+      path: /data
+    - method: POST
+      path: /submit
+```
+
+### Example 5: Composite Key Rate Limiting
+
+Rate limit based on multiple factors (API name + user ID):
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: multi-tenant-api
+  version: v1.0
+  context: /tenant
+  upstream:
+    main:
+      url: https://tenant-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 500
+                duration: "1h"
+            keyExtraction:
+              - type: apiname
+              - type: header
+                key: X-Tenant-ID
+  operations:
+    - method: GET
+      path: /resources
+    - method: POST
+      path: /resources
+```
+
+### Example 6: Multi-Quota Rate Limiting
+
+Apply multiple independent quotas with separate limits and key extraction:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: analytics-api
+  version: v1.0
+  context: /analytics
+  upstream:
+    main:
+      url: https://analytics-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - name: per-user
+            limits:
+              - limit: 1000
+                duration: "1h"
+            keyExtraction:
+              - type: header
+                key: X-User-ID
+          - name: global
+            limits:
+              - limit: 10000
+                duration: "1h"
+            keyExtraction:
+              - type: routename
+  operations:
+    - method: GET
+      path: /query
+    - method: POST
+      path: /report
+```
+
+### Example 7: Burst Rate Limiting with GCRA
+
+Allow burst traffic with GCRA algorithm:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: burst-api
+  version: v1.0
+  context: /burst
+  upstream:
+    main:
+      url: https://burst-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 10
+                duration: "1s"
+                burst: 20
+  operations:
+    - method: GET
+      path: /data
+    - method: POST
+      path: /data
+```
+
+### Example 8: Custom Error Response
+
+Customize the rate limit exceeded response:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: custom-error-api
+  version: v1.0
+  context: /custom
+  upstream:
+    main:
+      url: https://backend-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 100
+                duration: "1m"
+        onRateLimitExceeded:
+          statusCode: 429
+          body: '{"code": "RATE_LIMIT_EXCEEDED", "message": "You have exceeded the rate limit. Please wait before making more requests.", "retryAfter": "60s"}'
+          bodyFormat: json
+  operations:
+    - method: GET
+      path: /resource
+```
+
+### Example 9: LLM Token-Based Rate Limiting (Post-Response Cost Extraction)
+
+Rate limit based on actual token usage from an LLM API response:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: llm-api
+  version: v1.0
+  context: /llm
+  upstream:
+    main:
+      url: https://llm-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 100000
+                duration: "24h"
+            keyExtraction:
+              - type: header
+                key: X-User-ID
+            costExtraction:
+              enabled: true
+              sources:
+                - type: response_header
+                  key: X-Token-Usage
+                - type: response_body
+                  jsonPath: "$.usage.total_tokens"
+              default: 100
+  operations:
+    - method: POST
+      path: /chat/completions
+    - method: POST
+      path: /completions
+```
+
+### Example 10: Compute Unit Rate Limiting with Fallback Sources
+
+Rate limit based on compute units with multiple extraction sources:
+
+```yaml
+version: api-platform.wso2.com/v1
+kind: http/rest
+spec:
+  name: compute-api
+  version: v1.0
+  context: /compute
+  upstream:
+    main:
+      url: https://compute-service:8080
+  policies:
+    - name: advanced-ratelimit
+      version: v0
+      params:
+        quotas:
+          - limits:
+              - limit: 1000
+                duration: "1h"
+            costExtraction:
+              enabled: true
+              sources:
+                - type: response_header
+                  key: X-Compute-Units
+                - type: response_metadata
+                  key: compute_units
+                - type: response_body
+                  jsonPath: "$.metrics.compute_units"
+              default: 1
+  operations:
+    - method: POST
+      path: /process
+    - method: POST
+      path: /analyze
+```
+
+## How it Works
+
+#### GCRA (Generic Cell Rate Algorithm)
+
+- Token bucket semantics with smooth rate limiting
+- **Best for**: Smooth traffic shaping, burst handling, consistent rate enforcement
+- **Advantages**: Prevents traffic bursts at window boundaries, supports burst capacity
+- **Use when**: You need consistent rate enforcement and burst tolerance
+
+#### Fixed Window
+
+- Divides time into fixed intervals and counts requests per window
+- **Best for**: Simple counting, lower computational overhead
+- **Advantages**: Simple to understand, lower memory overhead
+- **Limitation**: Can allow up to 2x burst at window boundaries
+- **Use when**: Simplicity is preferred and boundary bursts are acceptable
+
+
+## Notes:
+
+When rate limiting is applied, the following headers may be included in responses:
+
+##### X-RateLimit Headers (Industry Standard)
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current window |
+| `X-RateLimit-Remaining` | Remaining requests in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the rate limit resets |
+
+##### IETF RateLimit Headers (Draft Standard)
+
+| Header | Description |
+|--------|-------------|
+| `RateLimit-Limit` | Maximum requests allowed in the current window |
+| `RateLimit-Remaining` | Remaining requests in the current window |
+| `RateLimit-Reset` | Seconds until the rate limit resets |
+| `RateLimit-Policy` | Rate limit policy description |
+
+##### Retry-After Header (RFC 7231)
+
+| Header | Description |
+|--------|-------------|
+| `Retry-After` | Seconds to wait before retrying (only on 429 responses) |

--- a/docs/advanced-ratelimit/v1.0/metadata.json
+++ b/docs/advanced-ratelimit/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "advanced-ratelimit",
+  "displayName": "Rate Limit - Advanced",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas,\nweighted rate limiting, flexible key extraction, and both in-memory and Redis backends. Supports\nfail-open behavior for Redis failures and provides comprehensive rate limit headers (X-RateLimit-*,\nIETF RateLimit, and Retry-After).\n\nKey features:\n- Multi-dimensional quotas: Each quota can have its own key extraction and cost extraction\n- Multiple algorithms: GCRA (smooth rate limiting) or Fixed Window (simple counter)\n- Dynamic cost extraction: Extract costs from request/response headers, metadata, or JSON body\n- Weighted multipliers: Apply multipliers to extracted costs (e.g., prompt tokens @ 0.1, completion tokens @ 0.3)\n- Multiple concurrent limits (e.g., 10/second AND 1000/hour)\n- Array-based key extraction with sensible defaults (route name)\n- Dual backends: in-memory (single instance) or Redis (distributed)\n- Graceful degradation: missing key components log warnings but don't fail requests\n- Atomic operations via Lua scripts (GCRA+Redis) or native Redis commands (Fixed Window)"
+}

--- a/docs/analytics-header-filter/v1.0/docs/analytics-header-filter.md
+++ b/docs/analytics-header-filter/v1.0/docs/analytics-header-filter.md
@@ -1,0 +1,133 @@
+---
+title: "Overview"
+---
+# Analytics Header Filter
+
+## Overview
+
+The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. This policy is intended to prevent sensitive, noisy, or irrelevant headers from being sent to analytics backends while preserving the rest of the request and response context.
+
+The policy is only effective when analytics is enabled at the system level and must be explicitly added to the API's policy chain.
+
+**Operation modes:**
+- **"allow"**: Only the specified headers will be included in analytics (whitelist mode)
+- **"deny"**: All headers except the specified ones will be included in analytics (blacklist mode)
+
+Request and response headers can have different operation modes, allowing for flexible filtering strategies.
+
+
+## Features
+
+* Filters request and response headers from analytics data collection using allow or deny modes
+* Case-insensitive header matching
+* Supports independent configuration with flexible filtering strategies with whitelist (allow) and blacklist (deny) modes
+* Operates transparently without affecting request or response processing
+* Helps protect sensitive information from being exposed in analytics systems
+
+
+## Configuration
+
+Analytics Header Filter requires two levels of configuration.
+
+### System Parameters (From config.toml)
+
+| Parameter                                  | Type     | Default | Description                                                                      |
+| -------------------- | -------- | ------- | -------------------------------------------------------------------------------- |
+| `analytics.enabled`                          | boolean  | false   | Enables or disables analytics processing.                                        |
+| `analytics.allow_payloads`                  | boolean  | false   | Determines whether request and response payloads are included in analytics data. |
+| `analytics.enabled_publishers`               | string[] | []      | List of analytics publishers to enable.                                          |
+| `analytics.publishers.moesif.application_id` | string   | —       | Application ID used to authenticate with the Moesif analytics service.           |
+
+
+#### Sample System Configuration
+
+```toml
+
+[analytics]
+enabled = true
+allow_payloads = false
+enabled_publishers = ["moesif"]
+
+[analytics.publishers.moesif]
+application_id = "<MOESIF_APPLICATION_ID>"
+
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+| --------- | ---- | -------- | ------- | ----------- |
+| `request` | object | No | - | Configuration for filtering request headers in analytics. At least one of `request` or `response` must be provided. |
+| `response` | object | No | - | Configuration for filtering response headers in analytics. At least one of `request` or `response` must be provided. |
+
+### Request / Response Configuration
+
+| Property | Type | Required | Default | Description |
+| -------- | ---- | -------- | ------- | ----------- |
+| `mode` | string | Yes | `"deny"` | Operation mode: `"allow"` (whitelist) or `"deny"` (blacklist). Header names are matched case-insensitively. |
+| `headers` | array | No | `[]` | List of header names to allow or deny. Each header name must be 1-256 characters. Unique items only. |
+
+**Note**:
+This policy only affects analytics data collection. It does not remove or modify headers sent to upstream services or returned to clients.
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: analytics-header-filter
+  gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Analytics Header Filter policy to a LlmProvider:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  template: openai
+  upstream:
+    url: https://api.openai.com/v1
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+        policies:
+          - name: analytics-header-filter
+            version: v0
+            params:
+              request:
+                mode: deny
+                headers:
+                  - "authorization"
+                  - "x-api-key"
+              response:
+                mode: allow
+                headers:
+                  - "content-type"
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+
+```
+
+
+## Notes
+
+* Header name matching is case-insensitive.
+* The `mode` field is required and must be either `"allow"` or `"deny"`.
+* The `headers` array is optional and defaults to `[]`. When the array is empty, all original headers are included (if allowed explicitly) in analytics for both `"allow"` and `"deny"` modes (safe fallback behavior).
+* Request and response headers can use different operation modes independently.
+* This policy does not block requests or responses.
+* Filtering applies only to analytics collection, not to runtime request handling.
+* The policy must be applied per API and does not operate implicitly.

--- a/docs/analytics-header-filter/v1.0/metadata.json
+++ b/docs/analytics-header-filter/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "analytics-header-filter",
+  "displayName": "Analytics Header Filter",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Logging",
+    "Analytics & Monitoring"
+  ],
+  "description": "The Analytics Header Filter policy allows you to control which request and response headers \nare included in analytics data using allow or deny modes. This policy is intended to prevent sensitive, \nnoisy, or irrelevant headers from being sent to analytics backends while preserving the rest of the request \nand response context.\n\nThe policy only affects analytics data collection. It does not remove or modify headers sent to upstream \nservices or returned to clients."
+}

--- a/docs/api-key-auth/v1.0/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.0/docs/apikey-authentication.md
@@ -1,0 +1,251 @@
+---
+title: "Overview"
+---
+# API Key Authentication
+
+## Overview
+
+The API Key Authentication policy validates API keys to secure APIs by verifying pre-generated keys before allowing access to protected resources. This policy is essential for API security, supporting both header-based and query parameter-based key validation.
+
+## Features
+
+- Validates API keys from request headers or query parameters
+- Configurable key extraction from headers (case-insensitive) or query parameters (exact match)
+- Pre-generated key validation against gateway-managed key lists
+- Request context enrichment with authentication metadata
+- Issuer-based key validation via system configuration
+- Streaming-compatible request processing (header-phase only)
+
+## Configuration
+
+The API Key Authentication policy uses a two-level configuration model. User parameters are configured per-API/route in the API definition YAML, and system parameters are resolved from gateway configuration.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | string | Yes | `API-Key` | The name of the header or query parameter that contains the API key. For headers: case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). For query parameters: exact name matching is used (e.g., "api_key", "token"). Length: 1-128 characters. |
+| `in` | string | Yes | `header` | Specifies where to look for the API key. Must be either "header" or "query". |
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `issuer` | string | No | `""` | Identifier of the portal associated with this gateway. Resolved from `config.toml` `[api_key] issuer` at startup. When set to a non-empty string, the policy rejects any API key whose issuer field is non-null and does not match this value. When empty or absent, the issuer check is skipped entirely. |
+
+#### Sample System Configuration
+
+```toml
+[api_key]
+issuer = "https://portal.example.com"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: api-key-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic API Key Authentication (Header)
+
+Apply API key authentication using a custom header
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v0
+      params:
+        key: X-API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 2: Default Header Name
+
+Use the default API-Key header name
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v0
+      params:
+        key: API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 3: Query Parameter Authentication
+
+Extract API key from query parameter
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v0
+      params:
+        key: api_key
+        in: query
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 4: Custom Header Name
+
+Use a custom header for API key authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v0
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 5: Route-Specific Authentication
+
+Apply different API key configurations to different routes
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v0
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: api-key-auth
+          version: v0
+          params:
+            key: X-API-Key
+            in: header
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: api-key-auth
+          version: v0
+          params:
+            key: Authorization
+            in: header
+    - method: POST
+      path: /alerts/active
+```
+
+## How it Works
+
+- On each request, the gateway policy reads `key` and `in` from the policy configuration and validates that required parameters are present.
+
+- Based on `in`, it extracts the API key either from a request header (case-insensitive header lookup) or from a query parameter in the request URL.
+
+- If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
+
+- For valid inputs, the policy calls the API key store validator using API and operation context (`apiId`, operation path, HTTP method) to determine whether the key is allowed for the target operation.
+
+- If an `issuer` is configured at the system level, the policy additionally verifies that the API key's issuer field matches the configured value. Keys with a non-null issuer that does not match are rejected.
+
+- On successful validation, the request continues upstream and authentication metadata is added to the shared context (`auth.success=true`, `auth.method=api-key`). The policy does not modify response traffic.
+
+- Key lifecycle and control-plane capabilities still apply, but are handled outside this gateway runtime policy: quota enforcement (including `remaining_api_key_quota` in key management APIs), key generation/regeneration, key format, secure hashing/storage, masking, access control, and audit logging.
+
+
+## Notes:
+
+- API keys offer a lightweight, secure authentication mechanism for internal services, partner and third-party integrations, legacy systems, development and testing environments, and service-to-service communication, providing a practical alternative to complex OAuth flows while ensuring controlled access through HTTPS-only transmission, secure hashing, masking, and constant-time validation.
+
+- Store API keys securely, never exposing them in client-side code, logs, or version control systems.
+
+- The platform enforces access control, audit logging, and quota limits to prevent abuse and support traceability. To maintain security over time, keys should be regenerated regularly, handled carefully in logs and query parameters, and revoked immediately if compromised.
+
+- Use clear, descriptive naming and maintain separate keys per environment (development, staging, production) to simplify management.
+
+- Always transmit API keys over HTTPS only and ensure logging practices do not inadvertently expose sensitive key material.
+

--- a/docs/api-key-auth/v1.0/metadata.json
+++ b/docs/api-key-auth/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "api-key-auth",
+  "displayName": "API Key Auth",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
+}

--- a/docs/aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md
@@ -1,0 +1,287 @@
+---
+title: "Overview"
+---
+# AWS Bedrock Guardrail
+
+## Overview
+
+The AWS Bedrock Guardrail policy validates request or response body content against AWS Bedrock Guardrails, which provide enterprise-grade content filtering, topic detection, word filtering, and PII (Personally Identifiable Information) detection and masking. This guardrail enables you to enforce content safety policies consistently across your LLM applications using AWS Bedrock's managed guardrail service.
+
+The policy supports multiple authentication modes including AWS IAM role assumption, static credentials, and default credential chain, making it flexible for various AWS deployment scenarios. It can mask or redact PII entities in requests and restore them in responses, ensuring data privacy while maintaining functionality.
+
+## Features
+
+- **Content filtering**: Detects and blocks prohibited content based on guardrail policies
+- **Topic detection**: Validates content against configured topic restrictions
+- **Word filtering**: Blocks content containing prohibited words or phrases
+- **PII detection and masking**: Identifies and masks PII entities (emails, phone numbers, SSNs, etc.)
+- **PII restoration**: Restores masked PII in responses when configured (masking mode)
+- **PII redaction**: Permanently removes PII by replacing with "*****" (redaction mode)
+- **Multiple authentication modes**: Supports role assumption, static credentials, or default AWS credential chain
+- **JSONPath support**: Extract and validate specific fields within JSON payloads
+- **Separate request/response configuration**: Independent configuration for request and response phases
+- **Detailed assessment information**: Optional detailed violation information in error responses
+
+## Configuration
+
+The AWS Bedrock Guardrail policy uses a two-level configuration
+
+### System Parameters (From config.toml)
+
+These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all AWS Bedrock Guardrail policy instances, they can be customized for individual policies within the API configuration when necessary.
+
+##### AWS Bedrock Guardrail Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `region` | string | Yes | AWS region where the Bedrock Guardrail is located (e.g., `us-east-1`, `us-west-2`). |
+| `guardrailID` | string | Yes | AWS Bedrock Guardrail identifier (the unique ID of your guardrail). |
+| `guardrailVersion` | string | Yes | AWS Bedrock Guardrail version (e.g., `DRAFT`, `1`, `2`). Use `DRAFT` for testing, numbered versions for production. |
+| `awsAccessKeyID` | string | No | AWS access key ID (for static credentials or role assumption). If omitted, runtime uses default AWS credential chain (environment variables, IAM roles, etc.). |
+| `awsSecretAccessKey` | string | No | AWS secret access key (for static credentials or role assumption). If omitted, runtime uses default AWS credential chain. |
+| `awsSessionToken` | string | No | AWS session token (optional, for temporary credentials). |
+| `awsRoleARN` | string | No | AWS IAM role ARN to assume (for role-based authentication). If specified, runtime assumes this role instead of using static credentials. |
+| `awsRoleRegion` | string | No | AWS region for role assumption (required if `awsRoleARN` is specified). |
+| `awsRoleExternalID` | string | No | External ID for role assumption (optional, for cross-account access security). |
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+awsbedrock_guardrail_region = "us-east-1"
+awsbedrock_guardrail_id = "your-guardrail-id"
+awsbedrock_guardrail_version = "DRAFT"
+awsbedrock_access_key_id = ""
+awsbedrock_secret_access_key = ""
+awsbedrock_session_token = ""
+awsbedrock_role_arn = ""
+awsbedrock_role_region = ""
+awsbedrock_role_external_id = ""
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No | - | Configuration for request-phase validation. |
+| `response` | object | No | - | Configuration for response-phase validation. |
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the request JSON payload. If empty, validates the entire payload as a string. |
+| `redactPII` | boolean | No | `false` | If `true`, redacts PII by replacing with `*****` (permanent). If `false`, masks PII with placeholders that can be restored in responses. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows the request to proceed when the AWS Bedrock Guardrail API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information from AWS Bedrock Guardrail in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the response JSON payload. If empty, validates the entire payload as a string. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows the response to proceed when the AWS Bedrock Guardrail API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information from AWS Bedrock Guardrail in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+- `$.messages[0].content` - Extracts content from the first message in a messages array
+- `$.messages[-1].content` - Extracts content from the last message in a messages array
+
+If `jsonPath` is empty or not specified, the entire payload is treated as a string and validated.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: aws-bedrock-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Guardrail with Static Credentials
+
+Deploy an LLM provider with AWS Bedrock Guardrail validation:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: bedrock-guardrail-provider
+spec:
+  displayName: AWS Bedrock Guardrail Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: aws-bedrock-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              jsonPath: "$.messages[0].content"
+              redactPII: false
+              showAssessment: true
+            response:
+              jsonPath: "$.choices[0].message.content"
+              showAssessment: true
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# Request with prohibited content (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "This is prohibited content"
+      }
+    ]
+  }'
+
+# Request with PII (should mask PII and proceed)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Contact me at user@example.com or call 555-123-4567"
+      }
+    ]
+  }'
+```
+
+### Example 2: PII Redaction Mode
+
+Configure to redact PII:
+
+```yaml
+policies:
+  - name: aws-bedrock-guardrail
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[0].content"
+            redactPII: true  # Redact mode
+            showAssessment: false
+          response:
+            jsonPath: "$.choices[0].message.content"
+```
+
+### Example 3: Error Response
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "AWS_BEDROCK_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "AWS Bedrock Guardrail",
+    "actionReason": "Violation of AWS Bedrock Guardrail detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "AWS_BEDROCK_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "AWS Bedrock Guardrail",
+    "actionReason": "Violation of AWS Bedrock Guardrail detected.",
+    "direction": "REQUEST",
+    "assessments": {
+      "topicPolicy": {
+        "topics": ["Topic1", "Topic2"]
+      },
+      "contentPolicy": {
+        "filters": ["Filter1"]
+      },
+      "sensitiveInformationPolicy": {
+        "piiEntities": [...],
+        "regexes": [...]
+      }
+    }
+  }
+}
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Guardrail Evaluation**: Sends the extracted content to AWS Bedrock Guardrail using configured region, guardrail ID, and version.
+3. **PII Processing**: If `redactPII` is `false`, masks PII entities with placeholders for potential restoration. If `redactPII` is `true`, replaces PII with `*****` permanently.
+4. **Violation Handling**: Blocks and returns HTTP `422` when Bedrock reports a violation.
+5. **Error Strategy**: Applies `passthroughOnError` behavior to decide whether to fail closed or allow traffic on Bedrock API failures.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload.
+2. **Guardrail Evaluation**: Validates response content through AWS Bedrock Guardrail.
+3. **PII Restoration**: In masking mode (`redactPII: false`), restores masked PII values in response content when mappings are available from request metadata.
+4. **Violation Handling**: Blocks and returns HTTP `422` when Bedrock reports a violation.
+5. **Error Strategy**: Applies `passthroughOnError` behavior for Bedrock API failures.
+
+#### PII Handling Modes
+
+- **Masking Mode (`redactPII: false`)**: PII entities are replaced with placeholders such as `EMAIL_0001`, `PHONE_0002`, and can be restored in the response phase.
+- **Redaction Mode (`redactPII: true`)**: PII entities are permanently replaced with `*****`, and original values cannot be restored.
+
+#### Authentication Modes
+
+- **Default Credential Chain**: Uses runtime AWS credentials from environment variables, IAM roles, or other default provider sources.
+- **Static Credentials**: Uses `awsAccessKeyID`, `awsSecretAccessKey`, and optional `awsSessionToken`.
+- **Role Assumption**: Uses `awsRoleARN` (and related role fields) to assume a target IAM role before calling Bedrock.
+
+## Notes
+
+- The guardrail must be created in AWS Bedrock before use. Use AWS Console, CLI, or SDK to create guardrails with your policies.
+- Guardrail version "DRAFT" is useful for testing. Use numbered versions (e.g., "1", "2") for production.
+- PII masking with restoration (`redactPII: false`) stores mapping between original and masked values in request metadata, which is used during response processing.
+- When using role assumption, ensure the IAM role has `bedrock:ApplyGuardrail` permission.
+- The policy uses AWS SDK v2 for authentication and API calls.
+- Content modifications (PII masking) are applied to the payload and forwarded to upstream if no blocking violation occurs.
+- The policy validates both request and response phases independently when both are configured.
+- Ensure your guardrail is in the specified AWS region; cross-region calls are not supported.

--- a/docs/aws-bedrock-guardrail/v1.0/metadata.json
+++ b/docs/aws-bedrock-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-bedrock-guardrail",
+  "displayName": "AWS Bedrock Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request or response body content against AWS Bedrock Guardrails.\nSupports content filtering, topic detection, word filtering, and PII detection/masking.\nSupports three authentication modes: role-based (AssumeRole), static credentials, or default credential chain.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nSupports separate configuration for request and response phases."
+}

--- a/docs/azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md
+++ b/docs/azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md
@@ -1,0 +1,351 @@
+---
+title: "Overview"
+---
+# Azure Content Safety
+
+## Overview
+
+The Azure Content Safety guardrail validates request or response body content against Microsoft Azure Content Safety API for content moderation. It detects and blocks harmful content across four categories: hate speech, sexual content, self-harm, and violence. Each category can be configured with a severity threshold (0-7) or disabled entirely, providing flexible content moderation policies tailored to your application's requirements.
+
+The policy uses Azure Content Safety's text analysis API to evaluate content and blocks requests or responses that exceed configured severity thresholds. This enables enterprise-grade content filtering for LLM applications integrated with Azure services.
+
+## Features
+
+- **Multi-category detection**: Detects hate speech, sexual content, self-harm, and violence
+- **Configurable severity thresholds**: Set per-category thresholds (0-7) or disable categories
+- **Eight severity levels**: Uses Azure's 8-level severity scale (0=Safe, 7=Most severe)
+- **JSONPath support**: Extract and validate specific fields within JSON payloads
+- **Separate request/response configuration**: Independent configuration for request and response phases
+- **Detailed assessment information**: Optional detailed violation information in error responses
+- **Error handling**: Configurable passthrough behavior on API errors
+- **Retry logic**: Automatic retry with exponential backoff for transient API failures
+
+## Configuration
+
+The Azure Content Safety policy uses a two-level configuration
+
+### System Parameters (From config.toml)
+
+These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all Azure Content Safety policy instances, they can be customized for individual policies within the API configuration when necessary.
+
+##### Azure Content Safety Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `azureContentSafetyEndpoint` | string | Yes | Azure Content Safety API endpoint URL (without trailing slash). Example: `https://your-resource.cognitiveservices.azure.com` |
+| `azureContentSafetyKey` | string | Yes | Azure Content Safety API subscription key for authentication. Found in Azure Portal under your Content Safety resource's "Keys and Endpoint" section. |
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+azurecontentsafety_endpoint = "https://your-resource.cognitiveservices.azure.com"
+azurecontentsafety_key = "<your-azure-content-safety-key>"
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | `AzureContentSafetyConfig` object | No | - | Configuration for request-phase moderation. Supports `jsonPath`, `passthroughOnError`, `showAssessment`, and per-category severity thresholds. |
+| `response` | `AzureContentSafetyConfig` object | No | - | Configuration for response-phase moderation. Supports `jsonPath`, `passthroughOnError`, `showAssessment`, and per-category severity thresholds. |
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the request JSON payload. If empty, validates the entire payload as a string. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows traffic to proceed if Azure Content Safety API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+| `hateSeverityThreshold` | integer | No | `4` | Severity threshold for hate content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `sexualSeverityThreshold` | integer | No | `5` | Severity threshold for sexual content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `selfHarmSeverityThreshold` | integer | No | `3` | Severity threshold for self-harm content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `violenceSeverityThreshold` | integer | No | `4` | Severity threshold for violence content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the response JSON payload. If empty, validates the entire payload as a string. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows traffic to proceed if Azure Content Safety API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+| `hateSeverityThreshold` | integer | No | `4` | Severity threshold for hate content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `sexualSeverityThreshold` | integer | No | `5` | Severity threshold for sexual content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `selfHarmSeverityThreshold` | integer | No | `3` | Severity threshold for self-harm content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+| `violenceSeverityThreshold` | integer | No | `4` | Severity threshold for violence content (-1 to 7). `-1` disables this category. Content with severity >= threshold will be blocked. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+- `$.messages[0].content` - Extracts content from the first message in a messages array
+- `$.messages[-1].content` - Extracts content from the last message in a messages array
+- `$.choices[0].message.content` - Extracts assistant response content
+
+If `jsonPath` is empty or not specified, the entire payload is treated as a string and validated.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: azure-content-safety-content-moderation
+  gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Content Moderation
+
+Deploy an LLM provider with Azure Content Safety validation:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: azure-safety-provider
+spec:
+  displayName: Azure Content Safety Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: azure-content-safety-content-moderation
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              jsonPath: "$.messages[0].content"
+              hateSeverityThreshold: 2
+              sexualSeverityThreshold: 2
+              selfHarmSeverityThreshold: 2
+              violenceSeverityThreshold: 2
+              showAssessment: true
+            response:
+              jsonPath: "$.choices[0].message.content"
+              hateSeverityThreshold: 2
+              sexualSeverityThreshold: 2
+              selfHarmSeverityThreshold: 2
+              violenceSeverityThreshold: 2
+              showAssessment: true
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+**Case 1: Valid request (should pass)**
+```bash
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain quantum computing in simple terms"
+      }
+    ]
+  }'
+```
+
+**Case 2: Request with harmful content**
+
+```bash
+# (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Summarize this article and suggest ways someone could take revenge on Mr. Anonymous Senator violently."
+      }
+    ]
+  }'
+```
+
+**Error Response:**
+
+When validation fails, the guardrail returns an `HTTP 422` status code with the following structure:
+
+```json
+{
+  "type": "AZURE_CONTENT_SAFETY_CONTENT_MODERATION",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "azure-content-safety-content-moderation",
+    "actionReason": "Violation of Azure content safety content moderation detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "AZURE_CONTENT_SAFETY_CONTENT_MODERATION",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "azure-content-safety-content-moderation",
+    "actionReason": "Violation of Azure content safety content moderation detected.",
+    "direction": "REQUEST",
+    "assessments": {
+      "inspectedContent": "The content that was analyzed",
+      "categories": [
+        {
+          "category": "Hate",
+          "severity": 4,
+          "result": "FAIL"
+        },
+        {
+          "category": "Violence",
+          "severity": 2,
+          "result": "FAIL"
+        }
+      ]
+    }
+  }
+}
+```
+
+
+### Example 2: Strict Moderation with All Categories
+
+Configure strict moderation thresholds:
+
+```yaml
+policies:
+  - name: azure-content-safety-content-moderation
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[-1].content"
+            hateSeverityThreshold: 1
+            sexualSeverityThreshold: 1
+            selfHarmSeverityThreshold: 1
+            violenceSeverityThreshold: 1
+            showAssessment: true
+            passthroughOnError: false
+          response:
+            jsonPath: "$.choices[0].message.content"
+            hateSeverityThreshold: 1
+            sexualSeverityThreshold: 1
+            selfHarmSeverityThreshold: 1
+            violenceSeverityThreshold: 1
+            showAssessment: true
+```
+
+### Example 3: Selective Category Monitoring
+
+Monitor only specific categories:
+
+```yaml
+policies:
+  - name: azure-content-safety-content-moderation
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[0].content"
+            hateSeverityThreshold: 3
+            sexualSeverityThreshold: -1  # Disabled
+            selfHarmSeverityThreshold: 2
+            violenceSeverityThreshold: -1  # Disabled
+```
+
+### Example 4: Lenient Moderation
+
+Allow more content with higher thresholds:
+
+```yaml
+policies:
+  - name: azure-content-safety-content-moderation
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          request:
+            jsonPath: "$.messages[0].content"
+            hateSeverityThreshold: 5
+            sexualSeverityThreshold: 5
+            selfHarmSeverityThreshold: 4
+            violenceSeverityThreshold: 5
+            passthroughOnError: true
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Category Selection**: Includes only categories with thresholds >= `0` for moderation checks.
+3. **Moderation Analysis**: Sends content to Azure Content Safety text analysis API and receives per-category severity scores.
+4. **Threshold Evaluation**: Compares each configured category score against its threshold and blocks when severity >= threshold.
+5. **Error Strategy**: Applies `passthroughOnError` behavior to determine fail-open or fail-closed behavior on API failures.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload.
+2. **Category Selection**: Includes only categories with thresholds >= `0` for moderation checks.
+3. **Moderation Analysis**: Sends response content to Azure Content Safety and receives per-category severities.
+4. **Threshold Evaluation**: Blocks and returns HTTP `422` if any configured threshold is violated.
+5. **Error Strategy**: Applies `passthroughOnError` behavior for API errors.
+
+#### Severity Levels
+
+Azure Content Safety uses an 8-level severity scale (`0-7`):
+
+- **0**: Safe - No harmful content detected
+- **1-2**: Low severity - Mildly concerning content
+- **3-4**: Medium severity - Moderately concerning content
+- **5-6**: High severity - Highly concerning content
+- **7**: Maximum severity - Most severe harmful content
+
+#### Severity Threshold Guidelines
+
+- **Threshold behavior**: Set a threshold value (`0-7`) to block content at or above that severity; set `-1` to disable a category.
+- **Strict** (family-friendly applications): `1-2` across all categories.
+- **Moderate** (general business applications): `3-4` across all categories.
+- **Lenient** (technical/professional contexts): `5-6` for most categories, disable non-applicable ones.
+- **Category tuning**: Hate (`2-3`), Sexual (`1-4` depending on context), Self-harm (`1-2`), Violence (`1-2` general use, higher for educational/historical content).
+
+## Notes
+
+- Azure Content Safety API requires an active Azure subscription and Content Safety resource.
+- The API endpoint URL must not include a trailing slash (e.g., `https://resource.cognitiveservices.azure.com`).
+- API keys are found in Azure Portal under your Content Safety resource's "Keys and Endpoint" section.
+- Category thresholds are independent - you can disable any category by setting it to `-1`.
+- Only categories with thresholds >= 0 are sent to the Azure API for analysis (performance optimization).
+- The policy validates both request and response phases independently when both are configured.
+- Content is sent to Azure Content Safety API for analysis, so ensure compliance with data residency requirements.
+- Rate limits may apply based on your Azure Content Safety subscription tier.
+- The API uses Azure's 8-severity-level analysis, providing fine-grained control over content moderation.
+- For production deployments, monitor API response times and adjust retry/timeout settings if needed.

--- a/docs/azure-content-safety-content-moderation/v1.0/metadata.json
+++ b/docs/azure-content-safety-content-moderation/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "azure-content-safety-content-moderation",
+  "displayName": "Azure Content Safety Content Moderation",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request or response body content against Azure Content Safety API for content moderation.\nSupports detection of hate speech, sexual content, self-harm, and violence with configurable severity thresholds.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nSupports separate configuration for request and response phases."
+}

--- a/docs/basic-auth/v1.0/docs/basic-auth.md
+++ b/docs/basic-auth/v1.0/docs/basic-auth.md
@@ -1,0 +1,173 @@
+---
+title: "Overview"
+---
+# Basic Auth
+
+## Overview
+
+The Basic Auth policy implements HTTP Basic Authentication to protect APIs with username and password credentials. It validates incoming requests against configured credentials, enforces authentication before allowing access to downstream services, and sets authentication metadata for downstream policies and logging. The policy provides flexible authentication modes, including an optional unauthenticated pass-through option for conditional authentication scenarios.
+
+## Features
+
+- **HTTP Basic Authentication**: Validates `Authorization` header with Base64-encoded username:password credentials
+- **Secure Credential Comparison**: Uses constant-time comparison to prevent timing attacks
+- **Flexible Authentication Modes**: Optional `allowUnauthenticated` flag to permit unauthenticated requests with metadata tracking
+- **RFC 7235 Compliance**: Proper WWW-Authenticate header formatting with custom realm support
+- **Metadata Tracking**: Sets authentication metadata (`auth.success`, `auth.username`, `auth.method`) for downstream policies
+- **401 Unauthorized Responses**: Standard HTTP status with proper error messaging for failed authentication
+- **Input Validation**: Validates Base64 encoding and credential format at request time
+- **Configurable Realm**: Custom authentication realm for browser-based auth prompts
+
+## Configuration
+
+The Basic Auth policy uses a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `username` | string | Yes | - | Expected username for authentication. Compared against the username extracted from the Basic auth header using constant-time comparison. Length: 1-256 characters. |
+| `password` | string | Yes | - | Expected password for authentication. Compared against the password extracted from the Basic auth header using constant-time comparison. Length: 1-256 characters. |
+| `allowUnauthenticated` | boolean | No | `false` | If `true`, allows unauthenticated requests to proceed to upstream services. Authentication status is still recorded in metadata (`auth.success = false`). If `false` (default), returns 401 Unauthorized response for authentication failures. |
+| `realm` | string | No | `"Restricted"` | Authentication realm displayed in the WWW-Authenticate header. Used in browser authentication prompts to identify the protected resource. Must be non-empty if specified. Length: 1-256 characters. Defaults to "Restricted". |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: basic-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/basic-auth@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Authentication with Default Settings
+
+Enforce Basic Auth with default realm and deny unauthenticated access:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: protected-api-v1.0
+spec:
+  displayName: Protected API
+  version: v1.0
+  context: /protected/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: basic-auth
+      version: v0
+      params:
+        username: "admin"
+        password: "secure-password-123"
+  operations:
+    - method: GET
+      path: /data
+    - method: POST
+      path: /submit
+    - method: PUT
+      path: /update
+```
+
+### Example 2: Custom Realm Configuration
+
+Specify a custom authentication realm for improved user experience:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: customer-api-v1.0
+spec:
+  displayName: Customer Portal API
+  version: v1.0
+  context: /customer/$version
+  upstream:
+    main:
+      url: http://customer-service:8080
+  policies:
+    - name: basic-auth
+      version: v0
+      params:
+        username: "customer_user"
+        password: "customer_password"
+        realm: "Customer Portal"
+  operations:
+    - method: GET
+      path: /profile
+    - method: POST
+      path: /orders
+    - method: GET
+      path: /invoices
+```
+
+### Example 3: Optional Authentication with Metadata Tracking
+
+Allow unauthenticated access while recording authentication status for downstream processing:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: optional-auth-api-v1.0
+spec:
+  displayName: Optional Auth API
+  version: v1.0
+  context: /optional/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: basic-auth
+      version: v0
+      params:
+        username: "service_user"
+        password: "service_password"
+        allowUnauthenticated: true
+        realm: "API Service"
+  operations:
+    - method: GET
+      path: /public
+    - method: GET
+      path: /restricted
+    - method: POST
+      path: /submit
+```
+
+
+## How it Works
+
+* **Request Validation Flow**: The policy extracts the `Authorization` header from the request, validates that it uses the "Basic" scheme, Base64-decodes the credentials, parses the "username:password" format, and compares both values using constant-time comparison to prevent timing attacks.
+
+* **Credential Format**: Clients send credentials as `Authorization: Basic <base64(username:password)>`. For example, username "admin" and password "secret" would be encoded as "Basic YWRtaW46c2VjcmV0".
+
+* **Constant-Time Comparison**: The policy compares both username and password using Go's `subtle.ConstantTimeCompare()` function to prevent timing-based attacks where attackers could infer correct characters by measuring response times.
+
+* **Authentication Success**: When credentials match, the policy sets metadata (`auth.success=true`, `auth.username=<username>`, `auth.method=basic`) and allows the request to proceed to upstream services without modification.
+
+* **Authentication Failure Handling**: On failed authentication, the policy either returns an immediate 401 Unauthorized response (default) or allows the request to proceed with `auth.success=false` metadata if `allowUnauthenticated=true`. The 401 response includes the `WWW-Authenticate` header following RFC 7235 for browser-based auth prompts.
+
+* **Metadata for Downstream Policies**: Downstream policies can inspect the `auth.*` metadata to make decisions based on authentication status, enabling conditional processing and logging of authentication events.
+
+
+## Notes
+
+* **Security and credential management**: Store credentials securely, transmit them only over HTTPS, rotate them regularly, avoid hardcoding, exclude `Authorization` headers from logs, and rely on strong, randomly generated credentials with constant-time comparison to prevent attacks.
+* **Authentication flow and metadata usage**: Use authentication metadata for conditional logic, auditing, and access control, apply `allowUnauthenticated` selectively, and combine with rate limiting and conditional policies to mitigate brute-force attempts and trigger alerts on failures.
+* **Operational best practices**: Configure clear realm values, monitor authentication metrics and logs, ensure consistent credentials across gateway instances, apply authentication selectively to sensitive routes, and maintain secure documentation and credential inventories.
+
+
+## Related Policies
+
+- **JWT Auth**: Use as an alternative to Basic Auth for token-based authentication with better performance and stateless design
+- **API Key Auth**: Use for machine-to-machine communication when Basic Auth is insufficient
+- **Log Message**: Combine to audit authentication attempts while carefully excluding the Authorization header from logs
+- **Rate Limiting**: Protect against brute force attacks on authenticated endpoints by limiting request rates
+- **Add Headers**: Add authentication headers to upstream requests or responses based on authentication status
+- **Request Rewrite**: Conditionally rewrite requests based on authentication metadata for downstream service compatibility

--- a/docs/basic-auth/v1.0/metadata.json
+++ b/docs/basic-auth/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "basic-auth",
+  "displayName": "Basic Auth",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
+}

--- a/docs/basic-ratelimit/v1.0/docs/basic-ratelimit.md
+++ b/docs/basic-ratelimit/v1.0/docs/basic-ratelimit.md
@@ -1,0 +1,146 @@
+---
+title: "Overview"
+---
+# Basic Rate Limiting
+
+## Overview
+
+The Basic Rate Limiting policy provides a simplified way to control request volume and protect APIs from excessive traffic. It enforces one or more request quotas using a fixed key strategy, making it suitable for common per-route throttling scenarios without advanced key configuration.
+
+For advanced use cases (for example, custom key extraction, weighted costs, and post-response cost extraction), use the **Advanced Rate Limiting** policy.
+
+## Features
+
+- **Simple Configuration**: Define only `limits` in API definitions to enable rate limiting.
+- **Multiple Concurrent Limits**: Enforce multiple windows simultaneously (for example, per-second and per-hour).
+- **Deterministic Keying**: Uses route-level identity by default for predictable quota behavior. When attached at the API level, uses the API name as the rate limit key.
+- **Shared Engine**: Uses the same backend and algorithm capabilities as the advanced policy (`memory`/`redis`, `gcra`/`fixed-window`).
+- **Distributed or Local Operation**: Supports in-memory single-instance mode and Redis-based distributed mode.
+- **Operational Compatibility**: Reuses the global rate-limit system configuration in `config.toml`.
+
+## Configuration
+
+This policy requires two-level configuration which includes both system parameters (configured by administrators) and user parameters (configured in API definitions).
+
+### System Parameters (From config.toml)
+
+These parameters are configured globally and shared with the advanced rate limiting policy.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `algorithm` | string | No | `"fixed-window"` | Rate limiting algorithm: `"gcra"` for smooth token-bucket-style throttling, or `"fixed-window"` for window-based counters. |
+| `backend` | string | No | `"memory"` | Storage backend: `"memory"` for single-instance operation, or `"redis"` for distributed quotas across gateway instances. |
+| `redis` | `Redis` object | No | - | Redis configuration. Used when `backend=redis`. |
+| `memory` | `Memory` object | No | - | In-memory storage configuration. Used when `backend=memory`. |
+
+#### Redis Configuration
+
+When using Redis as the backend, configure the following under `redis`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `host` | string | No | `"localhost"` | Redis server hostname or IP address. |
+| `port` | integer | No | `6379` | Redis server port. |
+| `password` | string | No | `""` | Redis authentication password (optional). |
+| `username` | string | No | `""` | Redis ACL username (optional, Redis 6+). |
+| `db` | integer | No | `0` | Redis database index (0-15). |
+| `keyPrefix` | string | No | `"ratelimit:v1:"` | Prefix for Redis keys to avoid collisions with other applications. |
+| `failureMode` | string | No | `"open"` | Behavior when Redis is unavailable: `"open"` allows traffic, `"closed"` blocks traffic. |
+| `connectionTimeout` | string | No | `"5s"` | Redis connection timeout (Go duration format). |
+| `readTimeout` | string | No | `"3s"` | Redis read timeout (Go duration format). |
+| `writeTimeout` | string | No | `"3s"` | Redis write timeout (Go duration format). |
+
+#### Memory Configuration
+
+When using in-memory backend, configure the following under `memory`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `maxEntries` | integer | No | `10000` | Maximum number of rate limit entries stored in memory. Old entries are evicted when this limit is reached. |
+| `cleanupInterval` | string | No | `"5m"` | Interval for cleaning up expired entries (Go duration format). Use `"0"` to disable periodic cleanup. |
+
+### User Parameters (API Definition)
+
+This policy requires only the list of limits in the API definition.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limits` | `Limit` array | Yes | Array of limits to enforce (1 to 10 entries). Multiple limits can be defined and all are evaluated. |
+
+#### Limit Object
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `requests` | integer | Yes | Maximum requests allowed in the specified duration (1 to 1,000,000,000). |
+| `duration` | string | Yes | Time window in Go duration format (for example, `"1s"`, `"1m"`, `"1h"`, `"24h"`). |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: basic-ratelimit
+  gomodule: github.com/wso2/gateway-controllers/policies/basic-ratelimit@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Simple Per-Route Request Limit
+
+Allow 1000 requests per minute for a route:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: basic-ratelimit
+          version: v0
+          params:
+            limits:
+              - requests: 1000
+                duration: "1m"
+```
+
+### Example 2: Multiple Time Windows
+
+Enforce a short-term burst limit and a long-term quota.
+- 10 requests per second
+- 500 requests per hour
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: alerts-api-v1.0
+spec:
+  displayName: Alerts API
+  version: v1.0
+  context: /alerts/$version
+  upstream:
+    main:
+      url: http://alerts-service:8080
+  operations:
+    - method: GET
+      path: /active
+      policies:
+        - name: basic-ratelimit
+          version: v0
+          params:
+            limits:
+              - requests: 10
+                duration: "1s"
+              - requests: 500
+                duration: "1h"
+```

--- a/docs/basic-ratelimit/v1.0/metadata.json
+++ b/docs/basic-ratelimit/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "basic-ratelimit",
+  "displayName": "Rate Limit - Basic",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Simple request rate limiting policy that limits the number of requests per time window.\nUses route name as the rate limit key. For advanced rate limiting with multi-dimensional\nquotas, weighted costs, and custom key extraction, use the full 'ratelimit' policy."
+}

--- a/docs/content-length-guardrail/v1.0/docs/content-length.md
+++ b/docs/content-length-guardrail/v1.0/docs/content-length.md
@@ -1,0 +1,271 @@
+---
+title: "Overview"
+---
+# Content Length Guardrail
+
+## Overview
+
+The Content Length Guardrail validates the byte length of request or response body content against configurable minimum and maximum thresholds. This guardrail is essential for controlling payload sizes, preventing resource exhaustion, and ensuring efficient data transfer.
+
+This policy supports SSE streaming responses. When the upstream returns a streaming response (`stream: true`), the guardrail accumulates SSE delta content and validates the byte length across the full streamed output, using a configurable `streamingJsonPath` to extract content from each SSE event.
+
+## Features
+
+- Validates byte length against minimum and maximum thresholds
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable inverted logic to pass when content length is outside the range
+- Supports independent request and response phase configuration
+- Optional detailed assessment information in error responses
+- **SSE Streaming Support**: Processes streaming responses in real time using a gate-then-stream pattern, buffering until minimum thresholds are met before releasing to the client
+- Configurable `streamingJsonPath` for extracting content from SSE delta chunks
+
+## Configuration
+
+This policy uses a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request-phase content length validation. |
+| `response` | object | No* | - | Configuration for response-phase content length validation. |
+
+*At least one of `request` or `response` must be provided.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `min` | integer | Conditional | - | Minimum allowed byte length (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed byte length (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when content length is NOT within the min-max range. If `false`, validation passes when content length is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `min` | integer | Conditional | - | Minimum allowed byte length (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed byte length (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload. |
+| `streamingJsonPath` | string | No | `"$.choices[0].delta.content"` | JSONPath expression to extract content from SSE streaming delta chunks. Used when the upstream returns a streaming (`stream: true`) response. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when content length is NOT within the min-max range. If `false`, validation passes when content length is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages[-1].content` - Extracts content from the last message in a messages array (default for request)
+- `$.choices[0].message.content` - Extracts content from the first choice message (default for response)
+- `$.choices[0].delta.content` - Extracts content from SSE delta chunks (default for streaming)
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+
+Set `jsonPath` to `""` to validate the entire payload as a string.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: content-length-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/content-length-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Content Length Validation
+
+Deploy an LLM provider that limits request payloads to between 100 bytes and 1MB:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: content-length-provider
+spec:
+  displayName: Content Length Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: content-length-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              min: 100
+              max: 1048576
+              jsonPath: "$.messages[-1].content"
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Please explain artificial intelligence in simple terms for beginners"
+      }
+    ]
+  }'
+
+# Invalid request - too small (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hi"
+      }
+    ]
+  }'
+```
+
+**In Case of Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "CONTENT_LENGTH_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "content-length-guardrail",
+    "actionReason": "Violation of applied content length constraints detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "CONTENT_LENGTH_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "content-length-guardrail",
+    "actionReason": "Violation of applied content length constraints detected.",
+    "assessments": "Violation of content length detected. Expected between 10 and 100 bytes.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Response Streaming Validation
+
+Validate content length on streaming LLM responses using a custom streaming JSONPath:
+
+```yaml
+  policies:
+    - name: content-length-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            response:
+              enabled: true
+              min: 100
+              max: 1048576
+              jsonPath: "$.choices[0].message.content"
+              streamingJsonPath: "$.choices[0].delta.content"
+```
+
+When the upstream returns an SSE streaming response, the guardrail accumulates delta content from each SSE event and validates the total byte length. For non-streaming responses, the standard `jsonPath` is used instead. If the byte length exceeds the maximum during streaming, an SSE error event is injected into the stream. If the byte length is below the minimum when the stream completes, an SSE error event is appended.
+
+## How it Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Byte Length Calculation**: Calculates the byte length of the extracted content using UTF-8 encoding.
+3. **Range Evaluation**: Validates whether the content length is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` and blocks further processing.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload. For SSE streaming responses, delta content is extracted using `streamingJsonPath` instead.
+2. **Byte Length Calculation**: Calculates the byte length of the extracted content using UTF-8 encoding.
+3. **Range Evaluation**: Validates whether the content length is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` to the client. For streaming responses, an SSE error event is injected into the stream.
+
+#### Streaming (SSE) Processing
+
+This guardrail supports **Server-Sent Events (SSE) streaming responses** commonly used by LLM providers (e.g., OpenAI with `stream: true`).
+
+**How SSE content extraction works:**
+
+- The `streamingJsonPath` parameter (default: `$.choices[0].delta.content`) specifies a JSONPath expression used to extract text content from each SSE `data:` event in the response stream.
+- Each SSE event is a JSON object like `data: {"choices":[{"delta":{"content":"token"}}]}`. The policy uses the JSONPath to extract the incremental token text.
+- The extracted text is accumulated across all SSE events to build the full response content for byte length validation.
+
+**Gate-then-stream buffering (`NeedsMoreResponseData`):**
+
+- Before any response data reaches the client, the policy evaluates `NeedsMoreResponseData` on the accumulated content.
+- When `NeedsMoreResponseData` returns `true`, the gateway kernel **buffers SSE chunks silently** -- the client does not receive anything yet.
+- Once `NeedsMoreResponseData` returns `false` (e.g., the minimum byte length threshold is met), the gateway **releases all buffered chunks** and begins streaming subsequent chunks to the client immediately.
+- This ensures the response meets the minimum byte length threshold before any data is sent to the client.
+
+**Mode-specific gating behavior:**
+
+- **Normal mode (`invert: false`)**: The guardrail buffers SSE events silently until the accumulated byte length reaches the configured `min`. Once the minimum is met, buffered chunks are flushed to the client. If the byte length exceeds `max` at any point during streaming, an SSE error event replaces the offending chunk. If the stream completes (the `[DONE]` sentinel arrives) with the length below `min`, an SSE error event is appended.
+- **Inverted mode (`invert: true`)**: The guardrail buffers until the byte length exceeds `max` (guaranteed outside the excluded range). At stream completion, if the length falls within the excluded `[min, max]` range, an SSE error event is appended.
+
+**Error handling in streaming:**
+
+- Since HTTP headers are already committed once streaming begins, the policy cannot return a traditional HTTP error response.
+- Instead, it injects an **SSE error event** into the stream (e.g., `data: {"type":"CONTENT_LENGTH_GUARDRAIL","message":{...}}`) to notify the client of a violation.
+- Max violations are caught in real-time as chunks arrive. Min violations are caught when the `[DONE]` sentinel arrives (end of stream).
+
+#### Validation Behavior
+
+- **Length Measurement Rules**: Byte length is calculated on the UTF-8 encoded representation of the content.
+- **Normal Mode (`invert: false`)**: Validation passes only when the content length is within the configured `[min, max]` range.
+- **Inverted Mode (`invert: true`)**: Validation passes only when the content length is outside the configured `[min, max]` range.
+
+## Notes
+
+- Byte length is calculated on the UTF-8 encoded representation of the content.
+- Use `request` and `response` independently to validate one or both directions.
+- When using JSONPath, if the path does not exist or the extracted value is not a string, validation will fail.
+- Inverted logic is useful for blocking content that falls outside acceptable size ranges.
+- Consider network and storage constraints when setting maximum values.
+- Minimum values help ensure content quality and completeness.
+- The `streamingJsonPath` parameter is only used during SSE streaming responses. For non-streaming responses, the standard `jsonPath` is used.

--- a/docs/content-length-guardrail/v1.0/metadata.json
+++ b/docs/content-length-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "content-length-guardrail",
+  "displayName": "Content Length Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates the byte length of request or response body content.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan be configured with min/max byte length constraints and inverted logic.\nSupports separate configuration for request and response phases."
+}

--- a/docs/cors/v1.0/docs/cors.md
+++ b/docs/cors/v1.0/docs/cors.md
@@ -1,0 +1,327 @@
+---
+title: "Overview"
+---
+# CORS Policy
+
+## Overview
+
+The CORS (Cross-Origin Resource Sharing) policy handles cross-origin requests by validating preflight requests and adding appropriate CORS headers to responses. This policy enables controlled access to resources from different origins by configuring allowed origins, methods, headers, and credentials.
+
+## Features
+
+- Handles CORS preflight (OPTIONS) requests with automatic validation
+- Configurable allowed origins with wildcard and regex pattern support
+- Control over allowed HTTP methods for cross-origin requests
+- Request header validation and filtering
+- Configurable exposed response headers for client-side access
+- Support for credentials in cross-origin requests
+- Preflight response caching with configurable max age
+- Option to forward non-compliant preflight requests to upstream service
+- Validates CORS constraints (e.g., credentials with wildcard origins)
+
+## Configuration
+
+The CORS policy uses a single-level configuration model where all parameters are configured per-API in the API definition YAML. This policy does not require system-level configuration.
+
+> **Important**: The CORS policy MUST be applied at the API level only, not at individual resource/operation level. Additionally, you MUST explicitly define OPTIONS operations for all resources where you expect to handle CORS preflight requests. This is not needed for MCP Proxies as the gateway internally handles the operations for them. The gateway will automatically handle preflight requests (OPTIONS method) when they match the allowed origins and methods.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `allowedOrigins` | array | Yes | `["*"]` | List of origins allowed to access the resource. Use `"*"` to allow all origins, or specify exact origins (e.g., `"https://example.com"`) or regex patterns. At least one origin must be specified. When using credentials, specific origins must be listed (no wildcards). |
+| `allowedMethods` | array | No | `["GET", "POST", "PUT", "DELETE", "OPTIONS"]` | HTTP methods allowed for cross-origin requests. Valid values: GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD. |
+| `allowedHeaders` | array | No | `[]` | Request headers that can be used in the actual request. Specify exact header names (e.g., `"Content-Type"`, `"Authorization"`). When using credentials, specific headers must be listed (no wildcards). |
+| `exposedHeaders` | array | No | `[]` | Response headers that browsers are allowed to access. Only these headers will be exposed to the client-side JavaScript code. |
+| `allowCredentials` | boolean | No | `false` | Indicates whether the response can be shared when credentials (cookies, authorization headers, TLS certificates) are included. When true, `allowedOrigins` cannot contain `"*"` and `allowedHeaders` cannot contain `"*"`. |
+| `maxAge` | integer | No | `3600` | Maximum time in seconds that a preflight response can be cached by the browser. Valid range: 0 to 86400. Helps reduce the number of preflight requests. |
+| `forwardPreflight` | boolean | No | `false` | If true, forwards preflight requests that do not match the CORS policy to the upstream service instead of responding with CORS headers. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: cors
+  gomodule: github.com/wso2/gateway-controllers/policies/cors@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic CORS Configuration (Allow All Origins)
+
+Enable CORS for a public API that allows requests from any origin:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: cors
+      version: v0
+      params:
+        allowedOrigins:
+          - "*"
+        allowedMethods:
+          - GET
+          - POST
+          - OPTIONS
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: POST
+      path: /alerts/active
+    - method: OPTIONS
+      path: /{country_code}/{city}
+    - method: OPTIONS
+      path: /alerts/active
+```
+
+### Example 2: Specific Origins with Credentials
+
+Allow requests from specific origins with credential support:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: user-api-v1.0
+spec:
+  displayName: User-API
+  version: v1.0
+  context: /users/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api
+  policies:
+    - name: cors
+      version: v0
+      params:
+        allowedOrigins:
+          - "https://app.example.com"
+          - "https://admin.example.com"
+        allowedMethods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - OPTIONS
+        allowedHeaders:
+          - "Content-Type"
+          - "Authorization"
+          - "X-Requested-With"
+        exposedHeaders:
+          - "X-Total-Count"
+          - "X-Page-Number"
+        allowCredentials: true
+        maxAge: 7200
+  operations:
+    - method: GET
+      path: /profile
+    - method: POST
+      path: /profile
+    - method: PUT
+      path: /profile/{id}
+    - method: OPTIONS
+      path: /profile
+    - method: OPTIONS
+      path: /profile/{id}
+```
+
+### Example 3: Regex Pattern Origins
+
+Allow origins matching a regex pattern:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: api-v1.0
+spec:
+  displayName: API
+  version: v1.0
+  context: /api/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: cors
+      version: v0
+      params:
+        allowedOrigins:
+          - "https://.*\.example\.com"  # Matches any subdomain of example.com
+          - "http://localhost:3000"
+          - "http://localhost:8080"
+        allowedMethods:
+          - GET
+          - POST
+          - PUT
+          - OPTIONS
+        allowedHeaders:
+          - "Content-Type"
+          - "Authorization"
+        maxAge: 3600
+  operations:
+    - method: GET
+      path: /data
+    - method: POST
+      path: /data
+    - method: OPTIONS
+      path: /data
+```
+
+### Example 4: Limited Headers with Exposed Headers
+
+Control which headers can be sent and which can be accessed:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: public-api-v1.0
+spec:
+  displayName: Public-API
+  version: v1.0
+  context: /public/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: cors
+      version: v0
+      params:
+        allowedOrigins:
+          - "https://example.com"
+        allowedMethods:
+          - GET
+          - POST
+          - OPTIONS
+        allowedHeaders:
+          - "Content-Type"
+          - "Accept"
+        exposedHeaders:
+          - "Content-Type"
+          - "X-RateLimit-Limit"
+          - "X-RateLimit-Remaining"
+          - "X-RateLimit-Reset"
+        maxAge: 1800
+  operations:
+    - method: GET
+      path: /products
+    - method: POST
+      path: /products/search
+    - method: OPTIONS
+      path: /products
+    - method: OPTIONS
+      path: /products/search
+```
+
+### Example 5: Forward Non-Compliant Preflight Requests
+
+Forward preflight requests that don't match the policy to upstream:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: dynamic-api-v1.0
+spec:
+  displayName: Dynamic-API
+  version: v1.0
+  context: /dynamic/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: cors
+      version: v0
+      params:
+        allowedOrigins:
+          - "https://app.example.com"
+        allowedMethods:
+          - GET
+          - POST
+          - PUT
+          - OPTIONS
+        allowedHeaders:
+          - "Content-Type"
+          - "Authorization"
+        forwardPreflight: true
+        maxAge: 3600
+  operations:
+    - method: GET
+      path: /resource/{id}
+    - method: POST
+      path: /resource
+    - method: PUT
+      path: /resource/{id}
+    - method: OPTIONS
+      path: /resource
+    - method: OPTIONS
+      path: /resource/{id}
+```
+
+## Notes:
+
+**API-Level Configuration Requirement**
+
+The CORS policy MUST be applied at the API level in the `policies` section of the API definition, not at individual operation/resource level. Even though the policy framework technically supports operation-level configuration, CORS handling requires API-level application to work correctly with preflight requests.
+
+Additionally, you MUST explicitly define OPTIONS operations for each resource path where you expect to handle CORS preflight requests. For example:
+
+```yaml
+operations:
+  - method: GET
+    path: /users
+  - method: POST
+    path: /users
+  - method: OPTIONS      # Required for CORS preflight
+    path: /users
+  - method: GET
+    path: /users/{id}
+  - method: PUT
+    path: /users/{id}
+  - method: DELETE
+    path: /users/{id}
+  - method: OPTIONS      # Required for CORS preflight
+    path: /users/{id}
+```
+
+**CORS Constraints**
+
+When `allowCredentials` is set to `true`, the following constraints apply:
+
+- `allowedOrigins` cannot contain `"*"` (wildcard). You must specify explicit origins.
+- `allowedHeaders` cannot contain `"*"` (wildcard). You must specify explicit header names.
+- `allowedMethods` cannot contain `"*"` (wildcard). You must specify explicit methods.
+- `exposedHeaders` cannot contain `"*"` (wildcard). You must specify explicit header names.
+
+These constraints are enforced by the CORS specification to prevent security issues when credentials are involved.
+
+**Regex Pattern Origins**
+
+You can use regex patterns for `allowedOrigins` to match multiple origins dynamically. For example:
+
+- `"https://.*\.example\.com"` matches `https://app.example.com`, `https://api.example.com`, etc.
+- `"http://localhost:(3000|8080)"` matches `http://localhost:3000` and `http://localhost:8080`
+
+**Preflight Caching**
+
+The `maxAge` parameter controls how long browsers cache the preflight response. A higher value reduces preflight requests but means changes to CORS configuration take longer to take effect. Recommended values:
+
+- Development: 300-600 seconds (5-10 minutes)
+- Production: 3600-86400 seconds (1-24 hours)
+
+**Forward Preflight**
+
+When `forwardPreflight` is enabled, preflight requests that don't match the CORS policy are forwarded to the upstream service. This is useful when the upstream service handles CORS validation directly. By default, non-compliant requests receive an empty response.

--- a/docs/cors/v1.0/metadata.json
+++ b/docs/cors/v1.0/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "cors",
+  "displayName": "CORS",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI",
+    "MCP"
+  ],
+  "description": "Cross-Origin Resource Sharing (CORS) policy that handles preflight requests and adds\nappropriate CORS headers to responses. Enables controlled access to resources from different\norigins by configuring allowed origins, methods, headers, and credentials."
+}

--- a/docs/dynamic-endpoint/v1.0/docs/dynamic-endpoint.md
+++ b/docs/dynamic-endpoint/v1.0/docs/dynamic-endpoint.md
@@ -1,0 +1,125 @@
+---
+title: "Overview"
+---
+# Dynamic Endpoint
+
+## Overview
+
+The Dynamic Endpoint policy routes requests to a named upstream definition at request time. It is useful when an API or operation needs to target a specific upstream definition without changing the primary API structure.
+
+The policy sets the SDK `UpstreamName` field during the request phase. The configured `targetUpstream` value must match the `name` of an entry in the API's `upstreamDefinitions` section.
+
+## Features
+
+- Routes requests to a named upstream definition
+- Uses request-phase upstream selection
+- Simple per-route configuration with a single required parameter
+- Useful for APIs that need explicit routing to alternate upstream definitions
+
+## Configuration
+
+The Dynamic Endpoint policy uses a single-level configuration model where parameters are configured per API or route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `targetUpstream` | string | Yes | - | Name of the upstream definition to route requests to. This must match the `name` of an entry in `upstreamDefinitions`. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: dynamic-endpoint
+  gomodule: github.com/wso2/gateway-controllers/policies/dynamic-endpoint@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Route an Operation to a Named Upstream Definition
+
+Apply the policy to route requests for a specific operation to the `orders-v2` upstream definition:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: orders-api-v1.0
+spec:
+  displayName: Orders API
+  version: v1.0
+  context: /orders/$version
+  upstreamDefinitions:
+    - name: orders-v1
+      basePath: /api/v1
+      upstreams:
+        - url: http://orders-v1.internal:8080
+    - name: orders-v2
+      basePath: /api/v2
+      upstreams:
+        - url: http://orders-v2.internal:8080
+  operations:
+    - method: GET
+      path: /orders/*
+      policies:
+        - name: dynamic-endpoint
+          version: v0
+          params:
+            targetUpstream: orders-v2
+```
+
+### Example 2: Use Different Upstream Definitions on Different Operations
+
+Different operations can point to different named upstream definitions by using separate policy instances:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: customer-api-v1.0
+spec:
+  displayName: Customer API
+  version: v1.0
+  context: /customer/$version
+  upstreamDefinitions:
+    - name: customer-read
+      basePath: /api/read
+      upstreams:
+        - url: http://customer-read.internal:8080
+          weight: 100
+    - name: customer-write
+      basePath: /api/write
+      upstreams:
+        - url: http://customer-write.internal:8080
+          weight: 100
+  operations:
+    - method: GET
+      path: /profiles/*
+      policies:
+        - name: dynamic-endpoint
+          version: v0
+          params:
+            targetUpstream: customer-read
+    - method: POST
+      path: /profiles
+      policies:
+        - name: dynamic-endpoint
+          version: v0
+          params:
+            targetUpstream: customer-write
+```
+
+## How It Works
+
+1. The policy reads the configured `targetUpstream` value during initialization.
+2. During the request phase, it sets `UpstreamName` to that configured value.
+3. The gateway uses the named upstream definition for routing.
+4. If `targetUpstream` is empty, the policy leaves upstream routing unchanged.
+
+## Notes
+
+- `targetUpstream` is required by the policy definition and should always be configured.
+- The configured value must exactly match an upstream definition name.
+- The selected upstream definition can include its own `basePath` and one or more weighted `upstreams`.
+- This policy only changes request routing. It does not modify headers, body content, or responses.

--- a/docs/dynamic-endpoint/v1.0/metadata.json
+++ b/docs/dynamic-endpoint/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "dynamic-endpoint",
+  "displayName": "Dynamic Endpoint",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation"
+  ],
+  "description": "Routes requests to a named upstream definition at request time.\nUses a single required targetUpstream parameter to select the upstream definition.\nUseful for directing specific API routes or operations to alternate backends."
+}

--- a/docs/json-schema-guardrail/v1.0/docs/json-schema.md
+++ b/docs/json-schema-guardrail/v1.0/docs/json-schema.md
@@ -1,0 +1,240 @@
+---
+title: "Overview"
+---
+# JSON Schema Guardrail
+
+## Overview
+
+The JSON Schema Guardrail validates request or response body content against a JSON Schema definition. This guardrail enables structured data validation, ensuring that JSON payloads conform to expected formats, data types, and constraints.
+
+## Features
+
+- Validates content against JSON Schema Draft 7
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable inverted logic to pass when schema validation fails
+- Supports independent request and response phase configuration
+- Detailed validation error information in error responses
+
+## Configuration
+
+This policy uses a single-level configuration model where all parameters are configured per-API in the API definition YAML. This policy does not require system-level configuration.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request-phase schema validation. |
+| `response` | object | No* | - | Configuration for response-phase schema validation. |
+
+*At least one of `request` or `response` must be provided.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the request flow. |
+| `schema` | string | Conditional | - | JSON Schema as a valid JSON string for validating the extracted or full payload. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when schema validation fails. If `false`, validation passes when schema validation succeeds. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed validation error information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the response flow. |
+| `schema` | string | Conditional | - | JSON Schema as a valid JSON string for validating the extracted or full payload. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when schema validation fails. If `false`, validation passes when schema validation succeeds. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed validation error information in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages[-1].content` - Extracts content from the last message in a messages array (default for request)
+- `$.choices[0].message.content` - Extracts content from the first choice message (default for response)
+- `$.data` - Extracts the `data` object for validation
+- `$.userInfo` - Extracts user information object
+- `$.items[0]` - Extracts the first item in an array
+
+Set `jsonPath` to `""` to validate the entire payload against the schema.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: json-schema-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/json-schema-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Object Validation
+
+Deploy an LLM provider that validates that request contains a user object with required fields:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: json-schema-provider
+spec:
+  displayName: JSON Schema Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: json-schema-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              enabled: true
+              jsonPath: ""
+              schema: |
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "email": {"type": "string", "format": "email"},
+                    "age": {"type": "integer", "minimum": 18}
+                  },
+                  "required": ["name", "email"]
+                }
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ],
+    "name": "John Doe",
+    "email": "john@example.com",
+    "age": 25
+  }'
+
+# Invalid request - missing required fields (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+```
+
+**Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "JSON_SCHEMA_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "json-schema-guardrail",
+    "actionReason": "Violation of JSON schema detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, detailed validation errors are included:
+
+```json
+{
+  "type": "JSON_SCHEMA_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "json-schema-guardrail",
+    "actionReason": "Violation of JSON schema detected.",
+    "assessments": [
+      {
+        "description": "String length must be greater than or equal to 5",
+        "field": "messages.0.content",
+        "value": "Hi"
+      }
+    ],
+    "direction": "REQUEST"
+  }
+}
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Schema Validation**: Validates the extracted JSON content against the configured `schema`.
+3. **Invert Handling**: Uses `invert` to decide whether valid or invalid schema results should pass.
+4. **Decision Enforcement**: Blocks with HTTP `422` when validation fails per configured mode; otherwise, request proceeds upstream.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload.
+2. **Schema Validation**: Validates the extracted JSON content against the configured `schema`.
+3. **Invert Handling**: Uses `invert` to decide whether valid or invalid schema results should pass.
+4. **Decision Enforcement**: Blocks with HTTP `422` when validation fails per configured mode; otherwise, response is returned to the client.
+
+#### Validation Behavior
+
+- **Normal Mode (`invert: false`)**: Validation passes when schema validation succeeds.
+- **Inverted Mode (`invert: true`)**: Validation passes when schema validation fails.
+- **Assessment Details**: When `showAssessment` is enabled, failure responses include detailed schema validation errors.
+
+#### JSON Schema Features
+
+The guardrail supports JSON Schema Draft 7, including:
+
+- **Types**: `string`, `number`, `integer`, `boolean`, `object`, `array`, `null`
+- **Properties**: Define object properties and their schemas
+- **Required Fields**: Specify which properties are mandatory
+- **Constraints**: `minLength`, `maxLength`, `minimum`, `maximum`, `pattern`, `enum`
+- **Nested Structures**: Complex nested objects and arrays
+- **Conditional Logic**: `if`, `then`, `else`, `allOf`, `anyOf`, `oneOf`, `not`
+
+## Notes
+
+- The schema must be valid JSON. Use proper escaping when embedding in YAML.
+- JSON Schema Draft 7 is supported with all standard features.
+- Use `request` and `response` independently to validate one or both directions.
+- When using JSONPath, if the path does not exist or the extracted value is not valid JSON, validation will fail.
+- Inverted logic is useful for blocking content that matches specific schema patterns.
+- Complex schemas may impact performance; test thoroughly with expected content volumes.
+- The guardrail validates the structure and types but does not validate business logic or semantic meaning.

--- a/docs/json-schema-guardrail/v1.0/metadata.json
+++ b/docs/json-schema-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "json-schema-guardrail",
+  "displayName": "JSON Schema Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request or response body content against a JSON Schema.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan be configured with inverted logic to pass when schema validation fails.\nSupports separate configuration for request and response phases."
+}

--- a/docs/json-xml-mediator/v1.0/docs/json-xml-mediator.md
+++ b/docs/json-xml-mediator/v1.0/docs/json-xml-mediator.md
@@ -1,0 +1,281 @@
+---
+title: "Overview"
+---
+# JSON/XML Mediator
+
+## Overview
+
+The JSON/XML Mediator policy provides bidirectional payload transformation between JSON and XML formats. It operates on both request and response flows, converting requests from the downstream client format to the upstream service format, and converting responses from the upstream format back to the downstream format.
+
+This policy is designed for integration scenarios where downstream clients and upstream services use different payload formats.
+
+## Features
+
+- **Bidirectional Transformation**: Converts payloads in both request and response flows
+- **Format Configuration**: Specify expected formats for downstream clients and upstream services
+- **Automatic Content-Type Management**: Updates Content-Type headers appropriately after transformation
+- **Intelligent Element Naming**: Handles JSON arrays with singularized XML element names
+- **Proper XML Formatting**: Generates well-formed XML with declaration and proper escaping
+- **Robust JSON Parsing**: Handles all JSON data types (objects, arrays, strings, numbers, booleans, null)
+- **Content-Length Updates**: Automatically adjusts Content-Length headers for transformed payloads
+
+## Configuration
+
+The JSON/XML Mediator policy uses a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `downsteamPayloadFormat` | string | Yes | Defines the payload format expected by downstream clients. Requests are converted from this format before reaching upstream, and responses are converted back to this format before returning to the client. Valid values: `"xml"`, `"json"`. This value must differ from `upstreamPayloadFormat`. |
+| `upstreamPayloadFormat` | string | Yes | Defines the payload format expected by the upstream service. Requests are converted to this format before reaching upstream, and responses are interpreted as arriving in this format before any downstream conversion is applied. Valid values: `"xml"`, `"json"`. |
+
+**Note:**
+
+- The `downsteamPayloadFormat` and `upstreamPayloadFormat` must be different. Configuring both as `"xml"` or both as `"json"` is not allowed.
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: json-xml-mediator
+  gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v0
+```
+
+## Reference Scenarios
+
+### Example 1: JSON Client to XML Backend
+
+Transform JSON requests from clients to XML for a legacy backend, and XML responses back to JSON for clients:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: legacy-integration-api-v1.0
+spec:
+  displayName: Legacy Integration API
+  version: v1.0
+  context: /legacy/$version
+  upstream:
+    main:
+      url: http://xml-backend:8080
+  policies:
+    - name: json-xml-mediator
+      version: v0
+      params:
+        downsteamPayloadFormat: json
+        upstreamPayloadFormat: xml
+  operations:
+    - method: POST
+      path: /orders
+    - method: PUT
+      path: /orders/{id}
+    - method: GET
+      path: /orders/{id}
+```
+
+**Request transformation:**
+
+Original client request (JSON):
+```http
+POST /legacy/v1.0/orders HTTP/1.1
+Host: api-gateway.example.com
+Content-Type: application/json
+
+{
+  "orderId": "12345",
+  "customer": "John Doe",
+  "items": [
+    {"name": "Widget", "quantity": 2},
+    {"name": "Gadget", "quantity": 1}
+  ]
+}
+```
+
+Transformed upstream request (XML):
+```http
+POST /orders HTTP/1.1
+Host: xml-backend:8080
+Content-Type: application/xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <orderId>12345</orderId>
+  <customer>John Doe</customer>
+  <items>
+    <item>
+      <name>Widget</name>
+      <quantity>2</quantity>
+    </item>
+    <item>
+      <name>Gadget</name>
+      <quantity>1</quantity>
+    </item>
+  </items>
+</root>
+```
+
+**Response transformation:**
+
+Original upstream response (XML):
+```http
+HTTP/1.1 200 OK
+Content-Type: application/xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<orderResponse>
+  <status>created</status>
+  <orderId>12345</orderId>
+</orderResponse>
+```
+
+Transformed client response (JSON):
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "orderResponse": {
+    "status": "created",
+    "orderId": "12345"
+  }
+}
+```
+
+### Example 2: XML Client to JSON Backend
+
+Transform XML requests from clients to JSON for a modern REST backend, and JSON responses back to XML for clients:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: soap-to-rest-api-v1.0
+spec:
+  displayName: SOAP to REST API
+  version: v1.0
+  context: /soap-bridge/$version
+  upstream:
+    main:
+      url: http://rest-service:8080
+  policies:
+    - name: json-xml-mediator
+      version: v0
+      params:
+        downsteamPayloadFormat: xml
+        upstreamPayloadFormat: json
+  operations:
+    - method: POST
+      path: /users
+    - method: GET
+      path: /users/{id}
+```
+
+**Request transformation:**
+
+Original client request (XML):
+```http
+POST /soap-bridge/v1.0/users HTTP/1.1
+Host: api-gateway.example.com
+Content-Type: application/xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<user>
+  <name>Jane Smith</name>
+  <email>jane@example.com</email>
+  <role>admin</role>
+</user>
+```
+
+Transformed upstream request (JSON):
+```http
+POST /users HTTP/1.1
+Host: rest-service:8080
+Content-Type: application/json
+
+{
+  "user": {
+    "name": "Jane Smith",
+    "email": "jane@example.com",
+    "role": "admin"
+  }
+}
+```
+
+### Example 3: Operation-Level Configuration
+
+Apply different mediation settings to specific operations:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: hybrid-api-v1.0
+spec:
+  displayName: Hybrid API
+  version: v1.0
+  context: /hybrid/$version
+  upstream:
+    main:
+      url: http://backend:8080
+  operations:
+    - method: POST
+      path: /xml-endpoint
+      policies:
+        - name: json-xml-mediator
+          version: v0
+          params:
+            downsteamPayloadFormat: json
+            upstreamPayloadFormat: xml
+    - method: POST
+      path: /json-endpoint
+      policies:
+        - name: json-xml-mediator
+          version: v0
+          params:
+            downsteamPayloadFormat: xml
+            upstreamPayloadFormat: json
+    - method: GET
+      path: /passthrough
+      # No mediator - payload passed through unchanged
+```
+
+
+## How it Works
+
+* **Request Flow**: When a request arrives, the policy checks the `downsteamPayloadFormat`. If transformation is needed (downstream format differs from upstream format), the request body is converted to the `upstreamPayloadFormat` before forwarding to the upstream service.
+
+* **Response Flow**: When a response returns from upstream, the policy converts the body from the `upstreamPayloadFormat` back to the `downsteamPayloadFormat` before returning to the client.
+
+* **JSON to XML**: Converts JSON objects to XML elements, JSON arrays to repeated XML elements with singularized names, and handles all JSON primitive types appropriately.
+
+* **XML to JSON**: Parses XML elements into JSON objects, handles attributes and text content, and converts repeated elements to JSON arrays.
+
+* **Content-Type Headers**: The policy automatically updates the `Content-Type` header to match the transformed payload format (`application/json` or `application/xml`).
+
+
+## Limitations
+
+1. **Binary Content**: Does not support transformation of binary payloads
+2. **Streaming**: Large payloads are buffered in memory for transformation
+3. **XML Namespaces**: Complex XML namespace handling may require additional configuration
+4. **Schema Validation**: Does not validate transformed payloads against schemas
+
+
+## Notes
+
+* **Format Validation**: The policy validates that `downsteamPayloadFormat` and `upstreamPayloadFormat` are different. Configuring both as the same format will result in a validation error.
+
+* **Empty Payloads**: Requests or responses with empty bodies are passed through without transformation.
+
+* **Error Handling**: If transformation fails (for example, malformed JSON or XML), the policy returns an appropriate error response to the client.
+
+
+## Related Policies
+
+- **JSON to XML**: Use for one-way JSON to XML transformation when bidirectional mediation is not needed
+- **XML to JSON**: Use for one-way XML to JSON transformation when bidirectional mediation is not needed
+- **Request Rewrite**: Combine with payload transformation for complete request modification
+- **Log Message**: Log payloads before and after transformation for debugging

--- a/docs/json-xml-mediator/v1.0/metadata.json
+++ b/docs/json-xml-mediator/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "json-xml-mediator",
+  "displayName": "JSON/XML Mediator",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation"
+  ],
+  "description": "Mediates request and response payloads between downstream and upstream JSON/XML formats.\nAutomatically converts requests from the downstream format to the upstream format, and responses\nfrom the upstream format back to the downstream format."
+}

--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -1,0 +1,257 @@
+---
+title: "Overview"
+---
+# JWT Authentication
+
+## Overview
+
+The JWT Authentication policy validates JWT access tokens using one or more JWKS (JSON Web Key Set) providers. It is typically applied to operations that require bearer token authentication before requests are forwarded upstream.
+
+## Features
+
+- Validates JWTs using multiple key managers (JWKS providers)
+- Supports remote JWKS endpoints and local certificates
+- Configurable issuer, audience, scope, and claim validation
+- Claim-to-header mappings for downstream services
+- Configurable JWKS cache and retry settings
+- Allowed signing algorithm allowlist
+- Authorization header scheme enforcement and clock skew tolerance
+- Customizable error responses
+- Optional `userIdClaim` mapping for analytics
+
+## Configuration
+
+JWT Authentication requires two levels of configuration.
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `keymanagers` | ```KeyManager``` array | Yes | - | List of key manager definitions with JWKS configuration. |
+| `jwkscachettl` | string | No | `"5m"` | JWKS cache TTL. |
+| `jwksfetchtimeout` | string | No | `"5s"` | JWKS fetch timeout. |
+| `jwksfetchretrycount` | integer | No | `3` | JWKS fetch retry count. |
+| `jwksfetchretryinterval` | string | No | `"2s"` | JWKS fetch retry interval. |
+| `allowedalgorithms` | array | No | `["RS256", "ES256"]` | Allowed JWT signing algorithms. |
+| `leeway` | string | No | `"30s"` | Clock skew allowance for exp/nbf. |
+| `authheaderscheme` | string | No | `"Bearer"` | Expected authorization scheme prefix. |
+| `headername` | string | No | `"Authorization"` | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | HTTP status code on authentication failure. |
+| `errormessageformat` | string | No | `"json"` | Error format: `"json"`, `"plain"`, or `"minimal"`. |
+| `errormessage` | string | No | `"Authentication failed"` | Error message body for failures. |
+| `validateissuer` | boolean | No | `true` | Validate the token `iss` claim against key managers. |
+
+#### KeyManager Configuration
+
+Each entry in `keymanagers` must include a unique `name` and either `jwks.remote` or `jwks.local`.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Unique key manager name. |
+| `issuer` | string | No | Optional issuer (`iss`) value for this key manager. |
+| `jwks.remote.uri` | string | Conditional | JWKS endpoint URL. Required if using remote JWKS. |
+| `jwks.remote.certificatePath` | string | No | CA cert path for self-signed JWKS endpoints. |
+| `jwks.remote.skipTlsVerify` | boolean | No | Skip TLS verification (use with caution). |
+| `jwks.local.inline` | string | Conditional | Inline PEM certificate or public key. |
+| `jwks.local.certificatePath` | string | Conditional | Path to certificate or public key file. |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.jwtauth_v0]
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
+allowedalgorithms = ["RS256", "ES256"]
+leeway = "30s"
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed"
+validateissuer = true
+
+[[policy_configurations.jwtauth_v0.keymanagers]]
+name = "PrimaryIDP"
+issuer = "https://idp.example.com/oauth2/token"
+
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+uri = "https://idp.example.com/oauth2/jwks"
+skipTlsVerify = false
+
+[[policy_configurations.jwtauth_v0.keymanagers]]
+name = "SecondaryIDP"
+issuer = "https://auth.example.org/oauth2/token"
+
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
+uri = "https://auth.example.org/oauth2/jwks"
+skipTlsVerify = false
+```
+
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `issuers` | array | No | List of key manager names (or issuer values) to use. If omitted, runtime matches token `iss` or tries all key managers. |
+| `audiences` | array | No | Acceptable audience values. Token must contain at least one. |
+| `requiredScopes` | array | No | Required scopes. Uses space-delimited `scope` claim or array `scp` claim. |
+| `requiredClaims` | object | No | Map of claim name to expected value. |
+| `claimMappings` | object | No | Map of claim name to downstream header name. |
+| `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
+| `headerName` | string | No | Header name to extract the token from (e.g., `"Authorization"`). Overrides `system.headerName`. Must be a valid HTTP header field name (non-empty, no spaces or control characters). |
+| `userIdClaim` | string | No | Claim name to extract user ID for analytics. Defaults to `sub`. |
+
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: jwt-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic JWT Authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-basic-api
+spec:
+  displayName: JWT Auth Basic API
+  version: v1.0
+  context: /jwt-auth-basic/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /health
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v0
+          params:
+            issuers:
+              - PrimaryIDP
+```
+
+### Example 2: Audience and Scope Validation
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-audience-api
+spec:
+  displayName: JWT Auth Audience API
+  version: v1.0
+  context: /jwt-auth-audience/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v0
+          params:
+            issuers:
+              - PrimaryIDP
+            audiences:
+              - "test-audience"
+            requiredScopes:
+              - read:data
+```
+
+### Example 3: Claim Mapping to Downstream Headers
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-claims-api
+spec:
+  displayName: JWT Auth Claims API
+  version: v1.0
+  context: /jwt-auth-claims/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /profile
+      policies:
+        - name: jwt-auth
+          version: v0
+          params:
+            issuers:
+              - PrimaryIDP
+            claimMappings:
+              sub: X-User-ID
+              email: X-User-Email
+              role: X-User-Role
+```
+
+### Example 4: Custom Token Header
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-custom-header-api
+spec:
+  displayName: JWT Auth Custom Header API
+  version: v1.0
+  context: /jwt-auth-custom/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v0
+          params:
+            issuers:
+              - PrimaryIDP
+            headerName: X-API-Token
+```
+
+### Example 5: Custom User ID Claim for Analytics
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-claims-api
+spec:
+  displayName: JWT Auth Claims API
+  version: v1.0
+  context: /jwt-auth-claims/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /profile
+      policies:
+        - name: jwt-auth
+          version: v0
+          params:
+            issuers:
+              - PrimaryIDP
+            claimMappings:
+              sub: X-User-ID
+              email: X-User-Email
+              role: X-User-Role
+            userIdClaim: username
+```

--- a/docs/jwt-auth/v1.0/metadata.json
+++ b/docs/jwt-auth/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "jwt-auth",
+  "displayName": "JWT Auth",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
+}

--- a/docs/llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md
+++ b/docs/llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md
@@ -1,0 +1,310 @@
+---
+title: "Overview"
+---
+# LLM Cost Based Ratelimit
+
+## Overview
+
+The LLM Cost Based Ratelimit policy enforces monetary spending budgets on LLM API usage. Rather than limiting by request count or token count, it limits by the actual dollar cost of each call, allowing you to cap spending within configurable time windows (for example, $10 per hour or $100 per day).
+
+This policy reads the pre-calculated cost from `SharedContext.Metadata`, which is set by the [LLM Cost](../../llm-cost/v0.1/docs/llm-cost.md) policy. The `llm-cost` policy must be applied on the same path for this policy to function correctly.
+
+Use this policy when you need to:
+
+- Enforce monetary spending budgets on LLM API routes.
+- Protect against runaway LLM costs caused by unexpectedly expensive models or high request volumes.
+- Apply different budget limits for different time horizons (for example, per hour, per day, and per month simultaneously).
+
+## Features
+
+- **Monetary Budget Enforcement**: Define spending limits in dollars with per-window granularity.
+- **Multiple Time Windows**: Configure multiple concurrent budget limits per route (for example, $5 per hour AND $50 per day).
+- **Dollar-Denominated Headers**: Responses include `x-ratelimit-cost-limit-dollars` and `x-ratelimit-cost-remaining-dollars` headers for client-side visibility.
+- **Multiple Algorithms**: Supports GCRA (smooth rate limiting with burst support) and Fixed Window (simple counter per time window).
+- **Dual Backends**: Choose between in-memory storage (single instance) or Redis (distributed rate limiting across multiple gateway instances).
+- **Pre-Flight Quota Check**: Requests are blocked upfront when the budget is already exhausted, preventing unnecessary upstream calls.
+- **Precision Scaling**: Dollar amounts are scaled to nano-dollars internally (configurable) to preserve precision in integer counters.
+
+## Configuration
+
+This policy uses a two-level configuration: user parameters that define the spending budgets and system parameters configured by administrators.
+
+### User Parameters (LLM Provider Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `budgetLimits` | `BudgetLimit` array | Yes | - | One or more spending limits, each defining a maximum dollar amount within a time window. Minimum 1 entry, maximum 10. |
+
+#### BudgetLimit Configuration
+
+Each entry in `budgetLimits` defines a spending cap for a specific time window:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `amount` | number | Yes | - | Maximum dollar amount allowed in the time window. Minimum: `0.000001`, Maximum: `1000000`. |
+| `duration` | string | Yes | - | Time window for the limit in Go duration format (for example, `"1h"`, `"24h"`, `"168h"` for 1 week, `"720h"` for 30 days). |
+
+### System Parameters (From config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `costScaleFactor` | integer | No | `1000000000` | Scale factor for converting dollar amounts to internal integer units. Higher values preserve more decimal precision. See [Precision Scaling](#precision-scaling) for details. |
+| `algorithm` | string | No | `"gcra"` | Rate limiting algorithm: `"gcra"` (smooth rate limiting with burst support) or `"fixed-window"` (simple counter per time window). |
+| `backend` | string | No | `"memory"` | Storage backend: `"memory"` for single-instance or `"redis"` for distributed rate limiting. |
+| `redis` | `Redis` object | No | - | Redis configuration. Used when `backend=redis`. |
+| `memory` | `Memory` object | No | - | In-memory storage configuration. Used when `backend=memory`. |
+
+#### Redis Configuration
+
+When using Redis as the backend, configure the following under `redis`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `host` | string | No | `"localhost"` | Redis server hostname or IP address. |
+| `port` | integer | No | `6379` | Redis server port. |
+| `password` | string | No | `""` | Redis authentication password (optional). |
+| `username` | string | No | `""` | Redis ACL username (optional, Redis 6+). |
+| `db` | integer | No | `0` | Redis database index (0-15). |
+| `keyPrefix` | string | No | `"ratelimit:v1:"` | Prefix for Redis keys to avoid collisions with other applications. |
+| `failureMode` | string | No | `"open"` | Behavior when Redis is unavailable: `"open"` allows traffic, `"closed"` blocks traffic. |
+| `connectionTimeout` | string | No | `"5s"` | Redis connection timeout (Go duration format). |
+| `readTimeout` | string | No | `"3s"` | Redis read timeout (Go duration format). |
+| `writeTimeout` | string | No | `"3s"` | Redis write timeout (Go duration format). |
+
+#### Memory Configuration
+
+When using in-memory backend, configure the following under `memory`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `maxEntries` | integer | No | `10000` | Maximum number of rate limit entries stored in memory. Old entries are evicted when this limit is reached. |
+| `cleanupInterval` | string | No | `"5m"` | Interval for cleaning up expired entries (Go duration format). Use `"0"` to disable periodic cleanup. |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.llm_cost_ratelimit_v0]
+cost_scale_factor = 1000000000
+
+[policy_configurations.ratelimit_v0]
+algorithm = "gcra"
+backend = "memory"
+
+[policy_configurations.ratelimit_v0.memory]
+max_entries = 10000
+cleanup_interval = "5m"
+```
+
+For distributed rate limiting across multiple gateway instances:
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "gcra"
+backend = "redis"
+
+[policy_configurations.ratelimit_v0.redis]
+host = "redis.example.com"
+port = 6379
+password = "your-redis-password"
+db = 0
+key_prefix = "ratelimit:v1:"
+failure_mode = "open"
+connection_timeout = "5s"
+read_timeout = "3s"
+write_timeout = "3s"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure both policy modules are added under `policies:`:
+
+```yaml
+- name: llm-cost
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v0
+- name: llm-cost-based-ratelimit
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit@v0
+```
+
+## Reference Scenarios
+
+This policy requires the `llm-cost` policy to run on the same path. Because response-phase policies execute in reverse order of the policy list, place `llm-cost-based-ratelimit` before `llm-cost` in the list -- this ensures `llm-cost` runs first in the response phase to calculate the cost, and then `llm-cost-based-ratelimit` deducts it.
+
+### Example 1: Simple Daily Spending Budget
+
+Limit the total spend on a route to $50 per day:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 50
+                duration: "24h"
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+Once the $50 daily budget is exhausted, subsequent requests receive a `429` response until the 24-hour window resets.
+
+### Example 2: Hourly and Daily Budget Limits
+
+Apply both a short-term burst limit and a long-term daily budget:
+
+```yaml
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 5
+                duration: "1h"
+              - amount: 50
+                duration: "24h"
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+This enforces a $5 per hour burst limit alongside a $50 daily cap. Both limits are evaluated independently -- a request is rejected if either limit is exceeded.
+
+### Example 3: Weekly and Monthly Budget Limits
+
+Apply long-horizon budget controls suitable for subscription-style APIs:
+
+```yaml
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 25
+                duration: "168h"
+              - amount: 100
+                duration: "720h"
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+This sets a $25 weekly budget and a $100 monthly budget. Both limits are tracked concurrently.
+
+### Example 4: Different Budgets on Multiple Paths
+
+Apply different spending limits to different endpoints within the same provider:
+
+```yaml
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 10
+                duration: "24h"
+        - path: /completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 5
+                duration: "24h"
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+        - path: /completions
+          methods: [POST]
+```
+
+Each path tracks its own independent budget. The `/chat/completions` path is limited to $10 per day, while `/completions` is limited to $5 per day.
+
+## Notes
+
+### Response Headers
+
+When rate limiting is applied, the following headers are included in responses:
+
+##### Dollar-Denominated Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Cost-Limit-Dollars` | Maximum dollar budget allowed in the current window |
+| `X-RateLimit-Cost-Remaining-Dollars` | Remaining dollar budget in the current window |
+
+##### X-RateLimit Headers (Industry Standard)
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum budget in scaled internal units |
+| `X-RateLimit-Remaining` | Remaining budget in scaled internal units |
+| `X-RateLimit-Reset` | Unix timestamp when the rate limit resets |
+
+##### IETF RateLimit Headers (Draft Standard)
+
+| Header | Description |
+|--------|-------------|
+| `RateLimit-Limit` | Maximum budget in scaled internal units |
+| `RateLimit-Remaining` | Remaining budget in scaled internal units |
+| `RateLimit-Reset` | Seconds until the rate limit resets |
+| `RateLimit-Policy` | Rate limit policy description |
+
+##### Retry-After Header (RFC 7231)
+
+| Header | Description |
+|--------|-------------|
+| `Retry-After` | Seconds to wait before retrying (only on 429 responses) |
+
+### Precision Scaling
+
+The underlying rate limiter uses `int64` counters internally. Since LLM call costs are small decimal values (for example, `$0.000042`), they must be scaled to integers to avoid truncation. The `costScaleFactor` controls this scaling:
+
+| Scale Factor | Unit | Precision | Example: $1.00 |
+|---|---|---|---|
+| `1000000000` (default) | Nano-dollars | 9 decimal places | 1,000,000,000 |
+| `1000000` | Micro-dollars | 6 decimal places | 1,000,000 |
+| `1000` | Milli-dollars | 3 decimal places | 1,000 |
+| `100` | Cents | 2 decimal places | 100 |
+
+The default of `1000000000` (nano-dollars) is recommended for production use with LLM APIs where per-token costs can be very small. The dollar-denominated headers (`x-ratelimit-cost-limit-dollars`, `x-ratelimit-cost-remaining-dollars`) are always formatted in human-readable dollars regardless of the scale factor.
+
+### Dependency on llm-cost
+
+This policy reads `x-llm-cost` from `SharedContext.Metadata`. If the `llm-cost` policy is not attached to the same path, or if the model is not found in the pricing database (causing `x-llm-cost-status` to be `not_calculated`), the deducted cost defaults to `0`. In this case, budget limits are not consumed and requests pass through without restriction.

--- a/docs/llm-cost-based-ratelimit/v1.0/metadata.json
+++ b/docs/llm-cost-based-ratelimit/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "llm-cost-based-ratelimit",
+  "displayName": "LLM Cost Based Ratelimit",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "A specialized rate limiting policy that enforces monetary budget limits on LLM API usage. Reads pre-calculated costs from the llm-cost policy and blocks requests when configured spending budgets are exceeded within the defined time windows."
+}

--- a/docs/llm-cost/v1.0/docs/llm-cost.md
+++ b/docs/llm-cost/v1.0/docs/llm-cost.md
@@ -1,0 +1,147 @@
+---
+title: "Overview"
+---
+# LLM Cost
+
+## Overview
+
+The LLM Cost policy calculates the monetary cost of an LLM API call at response time and stores the result in `SharedContext.Metadata`. The cost is not exposed as a response header -- it is only available to other policies in the same request pipeline, such as the [LLM Cost Based Ratelimit](../../llm-cost-based-ratelimit/v0.1/docs/llm-cost-based-ratelimit.md) policy.
+
+The policy reads the model name from the response body, looks it up in a pricing database, and computes the cost using provider-specific calculators that normalise token usage fields across different response formats.
+
+Use this policy when you need to:
+
+- Track the monetary cost of each LLM API call for billing or observability.
+- Feed downstream policies (such as budget-based rate limiting) with accurate per-call cost data.
+- Support cost attribution across multiple LLM providers from a single gateway.
+
+## Features
+
+- **Automatic Cost Calculation**: Computes cost from token usage fields in the LLM response -- no manual configuration per model.
+- **Multi-Provider Support**: Built-in calculators for OpenAI, Anthropic, Gemini (Google AI Studio and Vertex AI), and Mistral.
+- **Pricing Database**: Model pricing is loaded once at startup from a JSON file shipped with the gateway image.
+- **SharedContext Integration**: Stores the calculated cost in `SharedContext.Metadata` under `x-llm-cost` for use by downstream policies.
+- **Non-Blocking on Failure**: If the model is not found in the pricing database or usage cannot be parsed, the cost is set to `0.0000000000` and the request is not blocked.
+- **Status Metadata**: Sets `x-llm-cost-status` to `calculated` or `not_calculated` to disambiguate a zero cost from a failed calculation.
+
+## Configuration
+
+This policy has no user parameters. All configuration is handled by the gateway administrator via system parameters.
+
+### System Parameters (From config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pricing_file` | string | Yes | - | Path to the model pricing JSON file shipped with the gateway image. Can be overridden by the gateway administrator via `config.toml`. |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.llm_cost_v0]
+pricing_file = "/etc/gateway/pricing.json"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: llm-cost
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v0
+```
+
+## Reference Scenarios
+
+This policy runs in the response phase and is designed to be placed before cost-consuming policies in the policy chain (such as `llm-cost-based-ratelimit`).
+
+### Example 1: Attach LLM Cost Policy to an OpenAI Provider
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+After each successful response, the policy stores the calculated cost in `SharedContext.Metadata`:
+
+- `x-llm-cost`: USD dollar amount formatted to 10 decimal places (for example, `"0.0000423100"`).
+- `x-llm-cost-status`: `"calculated"` if the cost was computed successfully, or `"not_calculated"` if the model was not found in the pricing database or parsing failed.
+
+### Example 2: Use with LLM Cost Based Ratelimit
+
+The primary use case is pairing this policy with `llm-cost-based-ratelimit` to enforce monetary budget limits. Place `llm-cost-based-ratelimit` before `llm-cost` in the policy list -- because response-phase policies execute in reverse order, `llm-cost` runs first in the response to calculate the cost, and then `llm-cost-based-ratelimit` deducts it:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 10
+                duration: "24h"
+    - name: llm-cost
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+## How It Works
+
+1. **Response phase**: The response body is buffered and parsed.
+2. The model name is extracted from `$.model` in the response body. For Gemini native format, `$.modelVersion` is used as a fallback.
+3. The model name is looked up in the pricing database loaded at startup.
+4. A provider-specific calculator normalises the usage fields (prompt tokens, completion tokens, and any provider-specific fields such as cache read tokens or reasoning tokens) into a common `Usage` struct.
+5. The cost is calculated using the normalised usage and the pricing entry, then adjusted for any provider-specific multipliers (such as geographic pricing tiers or speed multipliers for Anthropic).
+6. The final cost and status are written to `SharedContext.Metadata` and the response continues unmodified.
+
+## Notes
+
+- The pricing file is loaded once at process startup using a singleton pattern. All APIs and routes that attach this policy share the same pricing data.
+- If the model name is not found in the pricing database, `x-llm-cost` is set to `0.0000000000`, `x-llm-cost-status` is set to `not_calculated`, and a warning is logged. The request is **not** blocked.
+- The cost is stored internally only and is never sent to the client as a response header.
+- Supported providers: **OpenAI**, **Anthropic**, **Gemini** (Google AI Studio and Vertex AI), **Mistral**.

--- a/docs/llm-cost/v1.0/metadata.json
+++ b/docs/llm-cost/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "llm-cost",
+  "displayName": "LLM Cost",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. Supports OpenAI, Anthropic, Gemini, and Mistral providers with automatic model pricing lookup."
+}

--- a/docs/log-message/v1.0/docs/log-message.md
+++ b/docs/log-message/v1.0/docs/log-message.md
@@ -1,0 +1,399 @@
+---
+title: "Overview"
+---
+# Log Message
+
+## Overview
+
+The Log Message policy provides the capability to log the payload and headers of request/response messages.
+This policy operates on both the request flow (logging client requests) and the response flow (logging responses from upstream services before returning to clients).
+It is designed for observability and debugging purposes without modifying the actual request/response data.
+
+The policy also supports streaming (SSE) payloads, logging each chunk independently as it arrives for real-time observability into streaming LLM responses.
+
+## Features
+
+- **Configurable Logging**: Control logging of payloads and headers independently
+- **Header Filtering**: Exclude sensitive headers from logging using a comma-separated list
+- **Security**: Authorization headers are automatically masked with "***"
+- **Request ID Tracking**: Tracks request IDs for correlation across request/response flows
+- **Structured Logging**: JSON-formatted log output using Go's `slog` package at INFO level for easy parsing and analysis
+- **Flow Identification**: Logs are tagged with mediation flow (REQUEST/RESPONSE)
+- **Non-intrusive**: Does not modify request/response data, only logs for observability
+- **Case-insensitive Header Handling**: Header exclusion works regardless of header name casing
+- **Streaming Support**: Logs streaming (SSE) request and response chunks independently as they arrive, providing real-time visibility without buffering or latency overhead
+
+## Configuration
+
+Log Message policy uses a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request logging. |
+| `request.payload` | boolean | No | `false` | Enables logging of request payloads. When set to `true`, the request bodies will be logged. |
+| `request.headers` | boolean | No | `false` | Enables logging of request headers. When set to `true`, the request headers will be logged. |
+| `request.excludeHeaders` | array | No | `[]` | An array of header names to exclude from request logging when `request.headers` is enabled. Example: `["Authorization", "X-API-Key"]` will exclude these headers from being logged. Header names are case-insensitive. |
+| `response` | object | No* | - | Configuration for response logging. |
+| `response.payload` | boolean | No | `false` | Enables logging of response payloads. When set to `true`, the response bodies will be logged. |
+| `response.headers` | boolean | No | `false` | Enables logging of response headers. When set to `true`, the response headers will be logged. |
+| `response.excludeHeaders` | array | No | `[]` | An array of header names to exclude from response logging when `response.headers` is enabled. Example: `["Set-Cookie", "X-Internal-Token"]` will exclude these headers from being logged. Header names are case-insensitive. |
+
+*At least one of `request` or `response` must be provided.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: log-message
+  gomodule: github.com/wso2/gateway-controllers/policies/log-message@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Default Behavior (No Logging)
+
+When no parameters are specified, no logging is performed (all parameters default to false):
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: no-logging-api-v1.0
+spec:
+  displayName: No Logging API
+  version: v1.0
+  context: /no-logging/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      # No params specified - defaults to all false (no logging)
+  operations:
+    - method: GET
+      path: /data
+    - method: POST
+      path: /submit
+```
+
+### Example 2: Basic Log Message Configuration
+
+Log both payloads and headers for all requests and responses:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: user-api-v1.0
+spec:
+  displayName: User API with Logging
+  version: v1.0
+  context: /users/$version
+  upstream:
+    main:
+      url: http://user-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      params:
+        request:
+          payload: true
+          headers: true
+        response:
+          payload: true
+          headers: true
+  operations:
+    - method: GET
+      path: /profile
+    - method: POST
+      path: /profile
+    - method: PUT
+      path: /settings
+```
+
+### Example 3: Request-Only Logging
+
+Log only request payloads and headers, skip response logging:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: request-only-api-v1.0
+spec:
+  displayName: Request Only API
+  version: v1.0
+  context: /request-only/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      params:
+        request:
+          payload: true
+          headers: true
+  operations:
+    - method: POST
+      path: /sensitive-data
+```
+
+### Example 4: Response-Only Logging
+
+Log only response payloads and headers, skip request logging:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: response-only-api-v1.0
+spec:
+  displayName: Response Only API
+  version: v1.0
+  context: /response-only/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      params:
+        response:
+          payload: true
+          headers: true
+  operations:
+    - method: GET
+      path: /public-data
+```
+
+### Example 5: Headers with Different Exclusions
+
+Log headers but exclude different sensitive headers for requests vs responses:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: payment-api-v1.0
+spec:
+  displayName: Payment API
+  version: v1.0
+  context: /payments/$version
+  upstream:
+    main:
+      url: http://payment-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      params:
+        request:
+          payload: true
+          headers: true
+          excludeHeaders:
+            - Authorization
+            - X-API-Key
+            - X-Payment-Token
+        response:
+          payload: true
+          headers: true
+          excludeHeaders:
+            - Set-Cookie
+            - X-Internal-Token
+  operations:
+    - method: GET
+      path: /transactions
+    - method: POST
+      path: /charge
+```
+
+### Example 6: Selective Logging
+
+Log only request payloads and response headers:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: selective-api-v1.0
+spec:
+  displayName: Selective API
+  version: v1.0
+  context: /selective/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  policies:
+    - name: log-message
+      version: v0
+      params:
+        request:
+          payload: true
+        response:
+          headers: true
+  operations:
+    - method: POST
+      path: /analyze
+```
+
+### Example 7: Operation-Specific Logging
+
+Apply different logging configurations to different operations:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: mixed-api-v1.0
+spec:
+  displayName: Mixed API
+  version: v1.0
+  context: /mixed/$version
+  upstream:
+    main:
+      url: http://backend-service:8080
+  operations:
+    - method: GET
+      path: /public-data
+      policies:
+        - name: log-message
+          version: v0
+          params:
+            request:
+              headers: true
+              excludeHeaders:
+                - Authorization
+            response:
+              payload: true
+    - method: POST
+      path: /sensitive-operation
+      policies:
+        - name: log-message
+          version: v0
+          params:
+            request:
+              payload: true
+    - method: PUT
+      path: /debug-endpoint
+      policies:
+        - name: log-message
+          version: v0
+          params:
+            request:
+              payload: true
+              headers: true
+              excludeHeaders:
+                - Authorization
+                - X-Debug-Token
+            response:
+              payload: true
+              headers: true
+              excludeHeaders:
+                - X-Internal-Key
+                - Set-Cookie
+```
+
+### Example 8: Streaming LLM Response Logging
+
+Log streaming SSE response payloads from an LLM provider for real-time observability:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: streaming-log-provider
+spec:
+  displayName: Streaming Log Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: log-message
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              payload: true
+            response:
+              payload: true
+```
+
+When the upstream returns a streaming response (`stream: true`), each SSE chunk is logged independently as it arrives. No buffering or accumulation is performed, providing real-time visibility into the token stream without added latency.
+
+## How it Works
+
+* The log-message policy automatically masks only the `Authorization` header with `"***"` by default (case-insensitive), preventing accidental exposure of bearer tokens and basic auth credentials carried in that header.
+* Administrators can configure **header exclusions** separately for requests and responses using `request.excludeHeaders` and `response.excludeHeaders` arrays; excluded headers are completely omitted from log output.
+* Sensitive headers other than `Authorization` (for example `X-API-Key`, `Cookie`, or `Set-Cookie`) are not masked automatically and should be explicitly excluded when header logging is enabled.
+* The policy supports **request ID correlation** by extracting the `x-request-id` header, using the same ID in both request and response logs, or `<request-id-unavailable>` if absent, enabling end-to-end tracing.
+* **Content processing** is non-intrusive: request and response bodies are buffered in memory, headers are filtered for security, and flows are automatically identified and tagged as REQUEST or RESPONSE.
+* When content is missing or empty, the policy still creates log entries with placeholders -- omitting payloads or headers fields as needed, and providing fallback values for missing request IDs.
+
+### Streaming (SSE) Processing
+
+When the upstream returns an SSE streaming response, each SSE event arrives as a `data:` line containing a JSON payload, for example:
+
+```
+data: {"choices":[{"delta":{"content":"token"}}]}
+```
+
+The log-message policy uses a **no-buffering pattern** for streaming:
+
+1. **Immediate Processing**: `NeedsMoreResponseData` always returns `false`. Each chunk is logged independently as soon as it arrives, with no accumulation or delay.
+2. **Per-Chunk Logging**: Every streaming chunk (both request and response) is logged as a separate structured JSON log record, including the chunk payload, request ID, HTTP method, and resource path.
+3. **No Modification**: The policy never modifies or blocks streaming data. Chunks pass through untouched after being logged.
+4. **Bidirectional Streaming**: Both request and response streaming chunks are supported. `NeedsMoreRequestData` and `NeedsMoreResponseData` both return `false`.
+5. **Error Handling**: Since this policy is read-only and never intervenes, there are no SSE error events to inject. Logging failures are reported via `slog.Error` without affecting the stream.
+
+This no-buffering approach provides real-time observability into streaming LLM responses without adding latency or memory overhead.
+
+## Limitations
+
+1. **Memory Buffering**: Large payloads require significant memory for buffering during logging
+2. **No Partial Logging**: Cannot log only specific parts of payloads (logs entire content)
+3. **Binary Content**: Binary payloads may not log readably (will be logged as raw bytes)
+4. **Real-time Constraints**: Logging overhead may not be suitable for ultra-low-latency requirements
+5. **Log Format**: Output format is fixed JSON structure and cannot be customized
+
+
+## Notes
+
+**Sensitive Data Protection and Security**
+
+Protect sensitive data by excluding authentication and confidential headers, relying on default masking only for the `Authorization` header, and carefully evaluating the sensitivity of logged payload content. Regularly review the excluded headers list to ensure headers with credentials or personal data are not logged, and apply selective logging per operation. Beyond technical controls, control log access and handling by restricting log visibility to authorized personnel and ensuring secure transmission and storage of logs. Maintain compliance with data privacy regulations such as GDPR and CCPA by aligning your logging practices accordingly.
+
+**Performance and Resource Management**
+
+Payload buffering, JSON marshaling, and logging introduce additional memory and CPU usage per request. In high-traffic environments, high log volume and large payloads can significantly increase storage and I/O pressure. To mitigate performance impact, avoid large payload logging in high-traffic scenarios, manage log storage proactively, and enforce appropriate log retention policies. Enable detailed logging selectively to minimize performance degradation rather than logging everything by default.
+
+**Operational Best Practices**
+
+Improve traceability by including `x-request-id` headers in client requests to correlate logs across systems and monitor log volume and disk usage continuously. Be aware that logging is disabled by default; ensure the relevant request/response logging parameters are explicitly set to `true`. Verify that sensitive headers are excluded and disable payload logging for large uploads and downloads to avoid both security exposure and performance slowdown. All logging parameters are optional, must be boolean, and default to `false`. Ensure excluded header names are correctly spelled, case-insensitive, and properly comma-separated in your configuration.
+
+
+
+## Related Policies
+
+- **Request/Response Transformation**: Use alongside transformation policies for complete request/response visibility
+- **Authentication Policies**: Combine with authentication policies while excluding auth headers from logging
+- **Rate Limiting**: Log rate-limited requests for analysis and monitoring
+- **Error Handling**: Capture request details when custom error responses are generated

--- a/docs/log-message/v1.0/metadata.json
+++ b/docs/log-message/v1.0/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "log-message",
+  "displayName": "Log Message",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Logging",
+    "Analytics & Monitoring",
+    "MCP"
+  ],
+  "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows.\nSupports streaming (SSE) payloads by logging each chunk independently as it arrives."
+}

--- a/docs/mcp-acl-list/v1.0/docs/mcp-acl-list.md
+++ b/docs/mcp-acl-list/v1.0/docs/mcp-acl-list.md
@@ -1,0 +1,199 @@
+---
+title: "Overview"
+---
+# MCP ACL List
+
+## Overview
+
+The MCP Access Control Logic(***ACL***) List policy provides access control for Model Context Protocol (***MCP***) tools, resources, and prompts using an allow/deny mode with exceptions. This policy filters list responses and enforces access rules on request paths based on configured mode and exceptions. Unlike the [MCP Rewrite policy](./mcp-rewrite.md), this policy does not rewrite capability names or modify list entry contents -- it purely controls visibility and access.
+
+The policy operates on three types of MCP capabilities: tools, resources, and prompts. For each type, you can specify a mode (allow or deny) and a list of exceptions. Requests for capabilities not matching the access control rules are rejected with an appropriate error.
+
+## Features
+
+- **Tool-Level Access Control**: Allow or deny access to specific tools using allow/deny mode with exceptions.
+- **Resource-Level Access Control**: Control access to specific resources (identified by URI) using flexible ACL rules.
+- **Prompt-Level Access Control**: Manage access to specific prompts using configurable access modes.
+- **Flexible ACL Modes**: Support both allow-with-exceptions and deny-with-exceptions patterns.
+- **List Filtering**: Filter list responses to only include capabilities that match the access control rules.
+- **Request Path Enforcement**: Enforce the same allow/deny rules on request paths, rejecting access to denied capabilities.
+
+## Configuration
+
+The MCP ACL List policy uses a single-level configuration model where all parameters are configured per-MCP-API/route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per MCP Proxy by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `tools` | `ToolACLConfig` object | Conditional | - | ACL configuration for tools. |
+| `resources` | `ResourceACLConfig` object | Conditional | - | ACL configuration for resources. |
+| `prompts` | `PromptACLConfig` object | Conditional | - | ACL configuration for prompts. |
+
+> **Note**: At least one of `tools`, `resources`, or `prompts` must be specified.
+
+### ToolACLConfig Configuration
+
+Each `ToolACLConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | string | No | `"deny"` | ACL mode for tools: `allow` (allow all except listed exceptions) or `deny` (deny all except listed exceptions). |
+| `exceptions` | string array | No | - | List of tool names that are exceptions to the selected mode. Tool names must be 1-256 characters. |
+
+### ResourceACLConfig Configuration
+
+Each `ResourceACLConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | string | No | `"deny"` | ACL mode for resources: `allow` (allow all except listed exceptions) or `deny` (deny all except listed exceptions). |
+| `exceptions` | string array | No | - | List of resource URIs that are exceptions to the selected mode. Resource URIs must be 1-2048 characters. |
+
+### PromptACLConfig Configuration
+
+Each `PromptACLConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | string | No | `"deny"` | ACL mode for prompts: `allow` (allow all except listed exceptions) or `deny` (deny all except listed exceptions). |
+| `exceptions` | string array | No | - | List of prompt names that are exceptions to the selected mode. Prompt names must be 1-256 characters. |
+
+
+
+For each capability type (tools, resources, prompts):
+
+- **Missing capability config**: All capabilities of that type are allowed (no restrictions).
+- **mode: allow, exceptions: [...]**: Allow all capabilities except those listed in exceptions.
+- **mode: deny, exceptions: [...]**: Deny all capabilities except those listed in exceptions.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: mcp-acl-list
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Deny Specific Tools
+
+Deny access to certain tools while allowing all others:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-acl-list
+      version: v0
+      params:
+        tools:
+          mode: allow
+          exceptions:
+            - delete-all
+            - drop-database
+  tools:
+    ...
+```
+
+### Example 2: Allow Only Specific Resources
+
+Allow access to only whitelisted resources:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-acl-list
+      version: v0
+      params:
+        resources:
+          mode: deny
+          exceptions:
+            - file:///public/documents
+            - file:///public/images
+  resources:
+    ...
+```
+
+### Example 3: Mixed Access Control
+
+Apply different access control rules to different capability types:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-acl-list
+      version: v0
+      params:
+        tools:
+          mode: allow
+          exceptions:
+            - admin-only-tool
+            - deprecated-tool
+        resources:
+          mode: allow
+          exceptions:
+            - file:///internal-resources
+        prompts:
+          mode: deny
+          exceptions:
+            - standard-prompt
+            - approved-prompt
+  tools:
+    ...
+```
+
+
+## Notes
+
+**Comparison with MCP Rewrite Policy**
+
+| Aspect | MCP ACL List | MCP Rewrite |
+|--------|--------------|-------------|
+| **Primary Purpose** | Access control via allow/deny | Capability name mapping |
+| **Rewrites Names** | No | Yes |
+| **Filters Lists** | Yes | Yes |
+| **Enforces Request Paths** | Yes | Yes |
+| **Configuration Complexity** | Simple (mode + exceptions) | Detailed (names, descriptions, targets) |
+| **Metadata Modification** | No | Yes |
+
+Both policies can be used together: use MCP ACL List for access control and MCP Rewrite for name mapping.
+
+**Access control and security enforcement**
+Deny access to sensitive operations, internal resources, or non-approved tools to meet security and compliance requirements.
+
+**Policy-driven authorization**
+Combine with authentication and authorization policies to implement role-based access and tenant- or environment-specific restrictions.
+
+**Operational governance**
+Control costs and risk by restricting access to expensive, experimental, or beta features during rollout phases.

--- a/docs/mcp-acl-list/v1.0/metadata.json
+++ b/docs/mcp-acl-list/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcp-acl-list",
+  "displayName": "MCP Access Control",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "MCP",
+    "AI"
+  ],
+  "description": "MCP ACL List policy controls access to tools, resources, and prompts using\nmode and exceptions. It filters list responses based on the configured mode\nand enforces the same allow/deny rules on request paths. This policy does not\nrewrite capability fields (tools, resources, or prompts) or modify list entry contents.\n\n- Missing capability config: Allow all capabilities of that type\n- mode: allow, exceptions: [..] => allow all except listed exceptions\n- mode: deny, exceptions: [..] => deny all except listed exceptions"
+}

--- a/docs/mcp-auth/v1.0/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v1.0/docs/mcp-authentication.md
@@ -1,0 +1,288 @@
+---
+title: "Overview"
+---
+# MCP Authentication
+
+## Overview
+
+The MCP Authentication policy is designed to secure traffic to Model Context Protocol (MCP) servers. The Gateway acts as a resource server, protecting MCP resources by validating access tokens presented in requests. This policy leverages the underlying JWT Authentication mechanism for token validation and additionally handles MCP-specific requirements such as serving protected resource metadata. This policy supports the auth requirements mentioned in the [MCP Specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#introduction).
+
+## Features
+
+- **Access Token Validation**: Validates JWT access tokens using configured key managers. Please refer to the [JWT Authentication Policy](../../../gateway/policies/jwt-authentication.md) for more information on how the key validation works.
+- **Resource-Specific Security**: Configure authentication independently for tools, resources, prompts, and JSON-RPC methods.
+- **Exception Lists**: Exclude specific resources from authentication using exception lists.
+- **Protected Resource Metadata**: Intercepts `GET /.well-known/oauth-protected-resource` requests to return resource metadata, including authorization servers and supported scopes.
+- **Standardized Error Handling**: Returns `WWW-Authenticate` headers with `resource_metadata` on authentication failures.
+- **Claim Mapping**: Maps token claims to downstream headers for use by backend services.
+- **Configurable Issuers**: Specify which key managers to use for token validation and metadata publication.
+
+## Configuration
+
+The MCP Authentication policy uses a two-level configuration model:
+
+### System Parameters (config.toml)
+
+Configured by the administrator in `config.toml` under `policy_configurations.mcpauth_v0` or `policy_configurations.jwtauth_v0` depending on the parameter.
+
+| Parameter | Type | Required | Default | Path | Description |
+|-----------|------|----------|---------|------|-------------|
+| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwksCacheTtl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksFetchTimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksFetchRetryCount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
+| `jwksFetchRetryInterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `allowedAlgorithms` | string array | No | - | jwtauth_v0 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
+| `leeway` | string | No | - | jwtauth_v0 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
+| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
+| `headerName` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
+| `onFailureStatusCode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errorMessageFormat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errorMessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
+| `validateIssuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayHost` | string | No | `"localhost"` | mcpauth_v0 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
+
+#### KeyManager Configuration
+
+Each key manager in the `keyManagers` array supports the following structure:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Unique name for this key manager (used in user-level `issuers` configuration). |
+| `issuer` | string | Yes | Issuer (`iss`) value associated with keys from this provider. |
+| `jwks.remote.uri` | string | Conditional | JWKS endpoint URL. Required if using remote JWKS. |
+| `jwks.remote.certificatePath` | string | No | Path to CA certificate file for validating self-signed JWKS endpoints. |
+| `jwks.remote.skipTlsVerify` | boolean | No | If true, skip TLS certificate verification. Use with caution. |
+| `jwks.local.inline` | string | Conditional | Inline PEM-encoded certificate or public key. |
+| `jwks.local.certificatePath` | string | Conditional | Path to certificate or public key file. |
+
+> **Note**: Either `jwks.remote` or `jwks.local` must be specified, but not both.
+
+#### System Configuration Example
+
+```toml
+[policy_configurations.mcpauth_v0]
+gatewayHost = "gw.example.com"
+
+[policy_configurations.jwtauth_v0]
+jwksCacheTtl = "5m"
+jwksFetchTimeout = "5s"
+jwksFetchRetryCount = 3
+jwksFetchRetryInterval = "2s"
+allowedAlgorithms = ["RS256", "ES256"]
+leeway = "30s"
+authHeaderScheme = "Bearer"
+headerName = "Authorization"
+onFailureStatusCode = 401
+errorMessageFormat = "json"
+errorMessage = "Authentication failed."
+validateIssuer = true
+
+[[policy_configurations.jwtauth_v0.keyManagers]]
+name = "PrimaryIDP"
+issuer = "https://idp.example.com/oauth2/token"
+
+[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+uri = "https://idp.example.com/oauth2/jwks"
+skipTlsVerify = false
+
+[[policy_configurations.jwtauth_v0.keyManagers]]
+name = "SecondaryIDP"
+issuer = "https://auth.example.org/oauth2/token"
+
+[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+uri = "https://auth.example.org/oauth2/jwks"
+skipTlsVerify = false
+```
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+#### Resource Type Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `tools` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP tools. |
+| `resources` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP resources. |
+| `prompts` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP prompts. |
+| `methods` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP (JSON-RPC) methods. |
+| `issuers` | string array | No | `[]` | List of issuer names from `system.keyManagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
+| `requiredScopes` | string array | No | `[]` | List of scopes that should be included in the token generated through MCP auth flow. These are advertised in the protected resource metadata but **not enforced** by this policy. Use the MCP Authorization policy to enforce scopes. |
+| `claimMappings` | object | No | `{}` | Map of claimName → downstream header or context key to expose claims for downstream services. |
+
+#### SecurityConfig Object
+
+Each resource type configuration supports the following structure:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Whether security is enabled for this resource type. |
+| `exceptions` | string array | No | `[]` | List of resource names to exclude from security checks. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: mcp-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic MCP Authentication
+
+Apply MCP authentication to an API using a specific key manager:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+    name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+  tools:
+    ...
+```
+
+### Example 2: Disable Security for Specific Tools
+
+Disable authentication for specific tools while keeping it enabled for others:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+    name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+        tools:
+          enabled: true
+          exceptions:
+            - health_check
+            - list_public_resources
+        resources:
+          enabled: true
+        prompts:
+          enabled: true
+        methods:
+          enabled: true
+  tools:
+    ...
+```
+
+### Example 3: Scope Advertisement in Protected Resource Metadata
+
+Advertise required scopes in the protected resource metadata (scopes are not enforced by this policy):
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+    name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+        requiredScopes:
+          - mcp:read
+          - mcp:write
+  tools:
+    ...
+```
+
+### Example 4: Claim Mapping for Downstream Services
+
+Map JWT claims to downstream headers for use by backend services:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+    name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+        claimMappings:
+          sub: x-user-id
+          email: x-user-email
+          department: x-user-department
+  tools:
+    ...
+```
+
+### Example 5: Disable Authentication for Resources
+
+Completely disable authentication for MCP resources while keeping it for tools:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+    name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+        tools:
+          enabled: true
+        resources:
+          enabled: false
+        prompts:
+          enabled: true
+        methods:
+          enabled: true
+  tools:
+    ...
+```

--- a/docs/mcp-auth/v1.0/metadata.json
+++ b/docs/mcp-auth/v1.0/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "mcp-auth",
+  "displayName": "MCP Authentication",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "MCP",
+    "AI",
+    "Security"
+  ],
+  "description": "This policy is used to secure traffic to Model Context Protocol server as defined in the specification \n(https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). The Gateway acts as the \nresource server and protects the MCP resources by validating the access tokens presented in the requests.\nThis uses the JwtAuthentication policy underneath to validate the access tokens."
+}

--- a/docs/mcp-authz/v1.0/docs/mcp-authorization.md
+++ b/docs/mcp-authz/v1.0/docs/mcp-authorization.md
@@ -1,0 +1,336 @@
+---
+title: "Overview"
+---
+# MCP Authorization
+
+## Overview
+
+The MCP Authorization policy provides fine-grained access control for Model Context Protocol (MCP) server resources. It enables API administrators to define authorization rules based on user claims and scopes extracted from validated JWT tokens, controlling access to specific MCP tools, resources, prompts, and JSON-RPC methods.
+
+> **Prerequisite**: The MCP Authorization policy requires the [MCP Authentication policy](./mcp-authentication.md) to be applied first. The MCP Authentication policy validates and extracts JWT claims that are used by the authorization policy for access control decisions.
+
+## Features
+
+- **Tool-Level Access Control**: Restrict access to specific MCP tools based on user claims and scopes
+- **Resource-Level Access Control**: Control access to specific MCP resources based on authorization rules
+- **Prompt-Level Access Control**: Manage access to specific MCP prompts
+- **JSON-RPC Method-Level Access Control**: Apply authorization rules at the JSON-RPC method level (e.g., `tools/call`, `resources/read`, `prompts/get`) for fine-grained control
+- **Flexible Rule-Based Authorization**: Define multiple authorization rules with name matching (exact or wildcard `*`)
+- **Claim-Based Validation**: Validate custom claims (e.g., department, role, team) in user tokens
+- **Scope-Based Validation**: Require specific OAuth scopes for accessing protected resources
+- **Wildcard Matching**: Use wildcard patterns (`*`) to create default rules for all resources of a type
+- **Rule Specificity**: Exact-name rules are evaluated before wildcards, and all matching rules must pass
+
+## Configuration
+
+The MCP Authorization policy uses a single-level configuration model where all parameters are configured per-MCP-API/route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per MCP Proxy by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `tools` | `AuthzRule` array | No | `[]` | Authorization rules for MCP tools. |
+| `resources` | `AuthzRule` array | No | `[]` | Authorization rules for MCP resources. |
+| `prompts` | `AuthzRule` array | No | `[]` | Authorization rules for MCP prompts. |
+| `methods` | `AuthzRule` array | No | `[]` | Authorization rules for MCP (JSON-RPC) methods. |
+
+### AuthzRule Configuration
+
+Each authorization rule object supports the following fields:
+
+> Each rule must specify at least one of `requiredScopes` (with at least one scope) or `requiredClaims` (with at least one claim). Rules with both are also valid — in that case, both conditions must pass.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | `"*"` | Name of the resource to authorize, or `*` to match all resources of this type (1–256 characters). |
+| `requiredScopes` | string array | Conditional | `[]` | List of OAuth scopes required to access this resource. The token must contain all specified scopes. |
+| `requiredClaims` | object | Conditional | `{}` | Map of claim names to expected values. All specified claims must be present in the token with matching values. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: mcp-authz
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-authz@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Tool Access Control
+
+Restrict access to specific tools based on scopes:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+    - name: mcp-authz
+      version: v0
+      params:
+        tools:
+          - name: list_files
+            requiredScopes:
+              - mcp:tool:read
+          - name: create_file
+            requiredScopes:
+              - mcp:tool:write
+          - name: "*"
+            requiredScopes:
+              - mcp:tool:execute
+  tools:
+    ...
+```
+
+**Authorization decision examples:**
+
+**Scenario 1**: User with scope `mcp:tool:read` attempts to call `list_files` tool
+- Rule: `name="list_files", requiredScopes=["mcp:tool:read"]`
+- Result: ✅ Access Granted
+
+**Scenario 2**: User with scope `mcp:tool:execute` (no write scope) attempts to call `create_file` tool
+- Rule: `name="create_file", requiredScopes=["mcp:tool:write"]`
+- Result: ❌ Access Denied (insufficient scopes)
+
+**Scenario 3**: User with scopes `mcp:tool:write` and `mcp:tool:execute` attempts to call `create_file` tool
+- Matching rules:
+  - `name="create_file", requiredScopes=["mcp:tool:write"]`
+  - `name="*", requiredScopes=["mcp:tool:execute"]`
+- Result: ✅ Access Granted (both matching rules pass)
+
+### Example 2: Claim-Based Resource Access
+
+Control resource access based on user claims:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+    - name: mcp-authz
+      version: v0
+      params:
+        resources:
+          - name: "file:///private/main"
+            requiredClaims:
+              department: "engineering"
+            requiredScopes:
+              - mcp:resource:read
+          - name: "file:///public/main"
+            requiredScopes:
+              - mcp:resource:read
+  tools:
+    ...
+```
+
+**Authorization decision examples:**
+
+**Scenario 4**: User with claim `department="engineering"` and scope `mcp:resource:read` attempts to read resource `file:///private/main`
+- Rule: `name="file:///private/main", requiredClaims={department="engineering"}, requiredScopes=["mcp:resource:read"]`
+- Result: ✅ Access Granted
+
+**Scenario 5**: User with claim `department="finance"` (no engineering) and scope `mcp:resource:read` attempts to read resource `file:///private/main`
+- Rule: `name="file:///private/main", requiredClaims={department="engineering"}, requiredScopes=["mcp:resource:read"]`
+- Result: ❌ Access Denied (claim mismatch)
+
+**Scenario 6**: User with claim `department="engineering"` but no `mcp:resource:read` scope attempts to read resource `file:///private/main`
+- Rule: `name="file:///private/main", requiredClaims={department="engineering"}, requiredScopes=["mcp:resource:read"]`
+- Result: ❌ Access Denied (scope mismatch)
+
+### Example 3: Role-Based Prompt Access
+
+Restrict prompt access based on user roles:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+    - name: mcp-authz
+      version: v0
+      params:
+        prompts:
+          - name: "admin_summary"
+            requiredClaims:
+              role: "admin"
+            requiredScopes:
+              - mcp:prompt:admin
+          - name: "*"
+            requiredScopes:
+              - mcp:prompt:read
+  tools:
+    ...
+```
+
+### Example 4: Method-Level Authorization
+
+Apply authorization at the JSON-RPC method level:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+    - name: mcp-authz
+      version: v0
+      params:
+        methods:
+          - name: "tools/call"
+            requiredScopes:
+              - mcp:method:tools:call
+          - name: "resources/write"
+            requiredClaims:
+              role: "admin"
+            requiredScopes:
+              - mcp:method:resources:write
+          - name: "*"
+            requiredScopes:
+              - mcp:method:general
+  tools:
+    ...
+```
+
+### Example 5: Multi-Level Authorization
+
+Combine different resource types with varying access requirements:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  vhost: mcp1.gw.example.com
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-auth
+      version: v0
+      params:
+        issuers:
+          - PrimaryIDP
+        requiredScopes:
+          - mcp:access
+    - name: mcp-authz
+      version: v0
+      params:
+        # Restrictive tool access
+        tools:
+          - name: "execute_command"
+            requiredClaims:
+              department: "platform"
+              role: "admin"
+            requiredScopes:
+              - mcp:tool:execute:admin
+          - name: "*"
+            requiredScopes:
+              - mcp:tool:execute
+        # Resource access for finance department
+        resources:
+          - name: "file:///finance/*"
+            requiredClaims:
+              department: "finance"
+            requiredScopes:
+              - mcp:resource:read:finance
+          - name: "*"
+            requiredScopes:
+              - mcp:resource:read
+        # Prompt access
+        prompts:
+          - name: "admin_dashboard"
+            requiredClaims:
+              role: "admin"
+            requiredScopes:
+              - mcp:prompt:admin
+  tools:
+    ...
+```
+
+## Authorization Logic
+
+The MCP Authorization policy evaluates rules using the following logic:
+
+1. **Specificity Ordering**: Exact-name rules are evaluated before wildcard (`*`) rules
+2. **Match All**: All rules that match the resource name are evaluated
+3. **All Must Pass**: For access to be granted, all matching rules must pass (both claims and scopes)
+4. **Default Allow**: If no rules match the resource, access is allowed (default permit)
+
+### Examples
+
+| Resource | Rules Defined | User Token | Result |
+|----------|--------------|------------|--------|
+| `list_files` | `[{name:"list_files", scopes:["read"]}, {name:"*", scopes:["execute"]}]` | Scopes: `["read", "execute"]` | ✅ Allowed |
+| `list_files` | `[{name:"list_files", scopes:["read"]}, {name:"*", scopes:["execute"]}]` | Scopes: `["execute"]` | ❌ Denied (exact rule fails) |
+| `delete_file` | `[{name:"list_files", scopes:["read"]}, {name:"*", scopes:["execute"]}]` | Scopes: `["execute"]` | ✅ Allowed (only wildcard matches) |
+| `admin_tool` | `[{name:"admin_tool", claims:{role:"admin"}, scopes:["write"]}]` | Claims: `{role:"admin"}`, Scopes: `["write"]` | ✅ Allowed |
+| `admin_tool` | `[{name:"admin_tool", claims:{role:"admin"}, scopes:["write"]}]` | Claims: `{role:"user"}`, Scopes: `["write"]` | ❌ Denied (claim mismatch) |
+
+## Notes
+
+When authorization fails, the policy returns:
+- **HTTP Status**: `403 Forbidden`
+- **Response Body**: JSON error response with a reason message
+- **WWW-Authenticate Header**: Contains information about required scopes for the denied resource
+
+## Related Policies
+
+- [MCP Authentication Policy](./mcp-authentication.md) - Validates JWT tokens and is a prerequisite for MCP Authorization
+- [JWT Authentication Policy](../../../gateway/policies/jwt-authentication.md) - Base JWT token validation mechanism

--- a/docs/mcp-authz/v1.0/metadata.json
+++ b/docs/mcp-authz/v1.0/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "mcp-authz",
+  "displayName": "MCP Authorization",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "MCP",
+    "AI",
+    "Security"
+  ],
+  "description": "MCP Authorization policy validates access to MCP resources (tools, resources, prompts) \nand methods based on JWT claims or OAuth scopes provided by the mcp-auth policy.\n\nThis policy enforces fine-grained authorization by checking that incoming JWT claims \nor scopes satisfy the access requirements for specific MCP attributes. The mcp-auth \npolicy must be applied before this policy to validate and extract claims from the token."
+}

--- a/docs/mcp-rewrite/v1.0/docs/mcp-rewrite.md
+++ b/docs/mcp-rewrite/v1.0/docs/mcp-rewrite.md
@@ -1,0 +1,177 @@
+---
+title: "Overview"
+---
+# MCP Rewrite
+
+## Overview
+
+The MCP Rewrite policy enables API administrators to expose user-facing names for Model Context Protocol (MCP) tools, resources, and prompts while mapping them to different backend capability names. This policy supports three types of MCP capabilities: tools, resources, and prompts. For each capability type, you can define a list of user-facing capabilities with optional mappings to backend names, and optionally specify additional metadata fields to be returned in list responses.
+
+When a list is provided for a capability type, only the configured capabilities are included in list responses. Requests for unlisted capabilities are rejected with an appropriate error. The policy rewrites request payloads to use backend capability names when configured, and rewrites list responses to return user-facing values.
+
+## Features
+
+- **Tool Rewriting**: Define user-facing tool names and map them to backend tool names with custom schemas and descriptions.
+- **Resource Rewriting**: Define user-facing resource identifiers and map them to backend resource identifiers with custom descriptions.
+- **Prompt Rewriting**: Define user-facing prompt names and map them to backend prompt names with custom metadata.
+- **Flexible Metadata**: Include additional fields (beyond `name`, `description`, `target`, etc.) in capability definitions for custom metadata in list responses.
+- **Optional Mapping**: Omit the `target` field to expose capabilities as-is without mapping to a different backend name.
+
+## Configuration
+
+The MCP Rewrite policy uses a single-level configuration model where all parameters are configured per-MCP-API/route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per MCP Proxy by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `tools` | `ToolRewriteConfig` array | Conditional | - | List of tools to expose and optionally rewrite. Omit to allow all tools. Set `[]` to deny all tools. When provided with entries, only these tools are included in `tools/list` responses and unlisted `tools/call` requests are rejected. |
+| `resources` | `ResourceRewriteConfig` array | Conditional | - | List of resources to expose and optionally rewrite. Omit to allow all resources. Set `[]` to deny all resources. When provided with entries, only these resources are included in `resources/list` responses and unlisted `resources/read` requests are rejected. |
+| `prompts` | `PromptRewriteConfig` array | Conditional | - | List of prompts to expose and optionally rewrite. Omit to allow all prompts. Set `[]` to deny all prompts. When provided with entries, only these prompts are included in `prompts/list` responses and unlisted `prompts/get` requests are rejected. |
+
+> **Note**: At least one of `tools`, `resources`, or `prompts` must be specified.
+
+### ToolRewriteConfig Configuration
+
+Each `ToolRewriteConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | - | User-facing tool name exposed to clients (1-256 characters). |
+| `description` | string | Yes | - | User-facing tool description returned in `tools/list`. |
+| `inputSchema` | string | Yes | - | Tool input schema returned in `tools/list`. |
+| `outputSchema` | string | No | - | Tool output schema returned in `tools/list`. |
+| `target` | string | No | - | Backend tool name to use when forwarding requests. If omitted, `name` is used. |
+
+### ResourceRewriteConfig Configuration
+
+Each `ResourceRewriteConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | - | User-facing resource identifier exposed to clients (1-1024 characters). |
+| `uri` | string | Yes | - | User-facing resource URI returned in `resources/list` (1-2048 characters). |
+| `description` | string | No | - | User-facing resource description returned in `resources/list`. |
+| `target` | string | No | - | Backend resource identifier (URI) to use when forwarding requests. If omitted, `uri` is used. |
+
+### PromptRewriteConfig Configuration
+
+Each `PromptRewriteConfig` object supports the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | - | User-facing prompt name exposed to clients (1-256 characters). |
+| `description` | string | No | - | User-facing prompt description returned in `prompts/list`. |
+| `target` | string | No | - | Backend prompt name to use when forwarding requests. If omitted, `name` is used. |
+
+> **Note**: Additional custom fields can be included in `tools`, `resources`, and `prompts` definitions and will be returned in the corresponding list responses.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: mcp-rewrite
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-rewrite@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Tool Rewriting
+
+Expose tools with different names than the backend:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-rewrite
+      version: v0
+      params:
+        tools:
+          - name: list-files
+            description: List files in a directory
+            inputSchema: '{"type": "object", "properties": {"path": {"type": "string"}}}'
+            target: backend_list_files
+          - name: read-file
+            description: Read file contents
+            inputSchema: '{"type": "object", "properties": {"path": {"type": "string"}}}'
+            target: backend_read_file
+  tools:
+    ...
+```
+
+### Example 2: Resource Rewriting with URI Mapping
+
+Expose resources with user-friendly URIs mapped to backend resources:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-rewrite
+      version: v0
+      params:
+        resources:
+          - name: user-docs
+            uri: file:///user-documentation
+            description: User documentation files
+            target: file:///internal/docs/users
+          - name: api-specs
+            uri: file:///api-specifications
+            description: API specification files
+            target: file:///internal/specs/api
+  resources:
+    ...
+```
+
+### Example 3: Prompt and Tool Rewriting Combined
+
+Rewrite prompts and tools with metadata:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: Mcp
+metadata:
+  name: mcp-server-api-v1.0
+spec:
+  displayName: mcp-server-api
+  version: v1.0
+  context: /mcpserver
+  upstream:
+    url: https://mcp-backend:8080
+  policies:
+    - name: mcp-rewrite
+      version: v0
+      params:
+        tools:
+          - name: create-document
+            description: Create a new document
+            inputSchema: '{"type": "object", "properties": {"title": {"type": "string"}}}'
+            target: create_doc
+        prompts:
+          - name: summarize
+            description: Summarize content
+            target: summarize_content
+            category: text-processing
+  tools:
+    ...
+```

--- a/docs/mcp-rewrite/v1.0/metadata.json
+++ b/docs/mcp-rewrite/v1.0/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "mcp-rewrite",
+  "displayName": "MCP Rewrite",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": ["MCP", "AI"],
+  "description": "MCP Rewrite policy defines user-facing tools, resources, and prompts and maps\nthem to backend capability names using optional \"target\" fields. Request payloads\nare rewritten to the backend capability name when configured, and list responses\nrewrite capability names in-place to return user-facing values. When a list is\nprovided, only the configured capabilities are included in list responses.\n\n- Null or omitted: Allow all capabilities of that type without rewriting"
+}

--- a/docs/model-round-robin/v1.0/docs/model-round-robin.md
+++ b/docs/model-round-robin/v1.0/docs/model-round-robin.md
@@ -1,0 +1,202 @@
+---
+title: "Overview"
+---
+# Model Round Robin
+
+## Overview
+
+The Model Round Robin policy implements round-robin load balancing for AI models. It distributes requests evenly across multiple configured AI models in a cyclic manner, ensuring equal request allocation over time and preventing overloading of any single model. This policy is useful for distributing load across multiple models, improving availability, and managing resource utilization.
+
+## Features
+
+- Even distribution of requests across multiple models in a cyclic pattern
+- Automatic model suspension on failures (5xx or 429 responses)
+- Configurable suspension duration for failed models
+- Support for extracting model identifier from payload, headers, query parameters, or path parameters
+- Dynamic model selection based on availability
+
+## Configuration
+
+This policy requires configuration in both the API definition YAML and the LLM provider template.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `models` | `Model` array | Yes | - | List of models for round-robin distribution. Each model must have a `model` name. |
+| `suspendDuration` | integer | No | `30` | Suspension time in seconds for failed models. Set to `0` to disable failed-model suspension tracking. Must be >= 0. |
+
+### Model Configuration
+
+Each model in the `models` array is an object with the following properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `model` | string | Yes | The AI model name to use for load balancing. |
+
+
+#### LLM provider template
+
+This policy depends on the `requestModel` configuration defined in the LLM provider template to identify and extract the model from incoming requests.
+
+> **Required:** The `requestModel` configuration must be provided; the policy will not function without it.
+
+### `requestModel` Parameters
+
+| Parameter                 | Type   | Required | Description                                                                                                                                                                                              |
+| ------------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requestModel.location`   | string | Yes      | Specifies where the model identifier is located in the request. Supported values: `payload`, `header`, `queryParam`, `pathParam`.                                                                        |
+| `requestModel.identifier` | string | Yes      | Extraction key used to identify the model. This can be a JSONPath expression (for `payload`), header name (for `header`), query parameter name (for `queryParam`), or a regex pattern (for `pathParam`). |
+
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: model-round-robin
+  gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Round Robin with Payload-based Model
+
+Deploy an LLM provider with round-robin load balancing across multiple models:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: round-robin-provider
+spec:
+  displayName: Round Robin Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: model-round-robin
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4
+              - model: gpt-3.5-turbo
+              - model: gpt-4-turbo
+            suspendDuration: 60
+```
+
+**Test the round-robin distribution:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# First request - will use gpt-4
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+
+# Second request - will use gpt-3.5-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+
+# Third request - will use gpt-4-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+```
+
+## How It Works
+
+#### Model Selection
+On each request, the policy selects the next available model in the configured list using a round-robin algorithm.
+- **Model Extraction**: The policy extracts the original model from the request (if configured) and stores it for reference.
+- **Model Modification**: The policy modifies the request to use the selected model based on the `requestModel` configuration.
+
+#### Request Model Locations
+
+The policy supports extracting the model identifier from different locations in the request:
+
+**Payload (JSONPath)**: Extract model from JSON payload using JSONPath:
+
+- **Location**: `payload`
+- **Identifier**: JSONPath expression (e.g., `$.model`, `$.messages[0].model`)
+
+**Header**: Extract model from HTTP header:
+- **Location**: `header`
+- **Identifier**: Header name (e.g., `X-Model-Name`, `X-LLM-Model`)
+
+**Query Parameter**: Extract model from URL query parameter:
+
+- **Location**: `queryParam`
+- **Identifier**: Query parameter name (e.g., `model`, `llm_model`)
+
+**Path Parameter**: Extract model from URL path using regex:
+
+- **Location**: `pathParam`
+- **Identifier**: Regex pattern to match model in path (e.g., `models/([a-zA-Z0-9.\-]+)`)
+
+#### Model Suspension
+
+When a model returns a 5xx or 429 response, the policy can automatically suspend that model for a configurable duration:
+
+- **Suspension Duration**: Configured via the `suspendDuration` parameter (in seconds)
+- **Automatic Recovery**: Suspended models are automatically re-enabled after the suspension period expires
+- **Availability Check**: Suspended models are skipped during round-robin selection until they recover
+
+#### Suspension Behavior
+
+- Suspension is tracked per model across all requests
+- If all models are suspended, the policy returns HTTP 503 with error: "All models are currently unavailable"
+- Suspension period starts from the time of failure
+
+
+## Notes
+- For path parameters, the regex pattern should include a capturing group to extract the model name. The policy uses the first capturing group as the model identifier.
+- This capability evenly distributes requests across multiple models to improve availability, balance load and cost, support A/B testing, and enable seamless traffic sharing across models from different providers.
+- The round-robin index is maintained per policy instance and increments for each request.
+- Model selection is deterministic and follows a strict cyclic pattern.
+- The original model from the request is stored in metadata but is replaced with the selected model for routing.
+- If `suspendDuration` is 0, failed models are not suspended and will continue to be selected in the round-robin cycle.
+- The `requestModel` configuration is required and must be provided by the LLM provider template.

--- a/docs/model-round-robin/v1.0/metadata.json
+++ b/docs/model-round-robin/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "model-round-robin",
+  "displayName": "Model Round Robin",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements round-robin load balancing for AI models. Distributes requests evenly\nacross multiple configured AI models in a cyclic manner, ensuring equal request\nallocation over time and preventing overloading of any single model."
+}

--- a/docs/model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md
+++ b/docs/model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md
@@ -1,0 +1,192 @@
+---
+title: "Overview"
+---
+# Model Weighted Round Robin
+
+## Overview
+
+The Model Weighted Round Robin policy implements weighted round-robin load balancing for AI models. It distributes requests based on predefined weight values assigned to each model, enabling probabilistic control over request distribution and giving higher priority to models with greater processing power or availability. This policy is useful for distributing load proportionally across models based on their capacity, cost, or performance characteristics.
+
+## Features
+
+- Weighted distribution of requests across multiple models based on assigned weights
+- Proportional request allocation (models with higher weights receive more requests)
+- Automatic model suspension on failures (5xx or 429 responses)
+- Configurable suspension duration for failed models
+- Support for extracting model identifier from payload, headers, query parameters, or path parameters
+- Dynamic model selection based on availability and weights
+
+## Configuration
+
+This policy requires configuration in both the API definition YAML and the LLM provider template.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `models` | `WeightedModel` array | Yes | - | List of models with weights for weighted round-robin distribution. Each model must have a `model` name and `weight`. |
+| `suspendDuration` | integer | No | `30` | Suspension time in seconds for failed models. Set to `0` to disable failed-model suspension tracking. Must be >= 0. |
+
+### WeightedModel Configuration
+
+Each model in the `models` array is an object with the following properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `model` | string | Yes | The AI model name to use for load balancing. |
+| `weight` | integer | Yes | The weight assigned to this model for distribution. Higher weights mean more requests will be routed to this model. Weight is relative to total weight of all models. Must be at least 1. |
+
+#### LLM provider template
+
+This policy depends on the `requestModel` configuration defined in the LLM provider template to identify and extract the model from incoming requests.
+
+> **Required:** The `requestModel` configuration must be provided; the policy will not function without it.
+
+### `requestModel` Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `requestModel.location` | string | Yes | Location of the model identifier: `payload`, `header`, `queryParam`, or `pathParam` |
+| `requestModel.identifier` | string | Yes | JSONPath (for payload), header name (for header), query param name (for queryParam), or regex pattern (for pathParam) to extract model |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: model-weighted-round-robin
+  gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Weighted Round Robin with Payload-based Model
+
+Deploy an LLM provider with weighted round-robin load balancing:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: weighted-round-robin-provider
+spec:
+  displayName: Weighted Round Robin Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: model-weighted-round-robin
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4
+                weight: 3
+              - model: gpt-3.5-turbo
+                weight: 2
+              - model: gpt-4-turbo
+                weight: 1
+            suspendDuration: 60
+```
+
+**Test the weighted round-robin distribution:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# Requests will be distributed: 50% gpt-4, 33.3% gpt-3.5-turbo, 16.7% gpt-4-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+```
+
+## How It Works
+
+#### Model Selection
+
+On each request, the policy selects the next available model in a weighted cyclic sequence.
+- **Weight Calculation**: During initialization, the policy computes total weight and builds a weighted sequence where each model appears proportional to its configured weight.
+- **Model Extraction**: The policy extracts the original model from the request (if configured) and stores it for reference.
+- **Model Modification**: The policy modifies the request to use the selected model based on the `requestModel` configuration.
+
+#### Request Model Locations
+
+The policy supports extracting the model identifier from different locations in the request:
+
+**Payload (JSONPath)**: Extract model from JSON payload using JSONPath:
+- **Location**: `payload`
+- **Identifier**: JSONPath expression (e.g., `$.model`, `$.messages[0].model`)
+
+**Header**: Extract model from HTTP header:
+- **Location**: `header`
+- **Identifier**: Header name (e.g., `X-Model-Name`, `X-LLM-Model`)
+
+**Query Parameter**: Extract model from URL query parameter:
+- **Location**: `queryParam`
+- **Identifier**: Query parameter name (e.g., `model`, `llm_model`)
+
+**Path Parameter**: Extract model from URL path using regex:
+- **Location**: `pathParam`
+- **Identifier**: Regex pattern to match model in path (e.g., `models/([a-zA-Z0-9.\-]+)`)
+
+#### Model Suspension
+
+When a model returns a 5xx or 429 response, the policy can automatically suspend that model for a configurable duration:
+
+- **Suspension Duration**: Configured via the `suspendDuration` parameter (in seconds)
+- **Automatic Recovery**: Suspended models are automatically re-enabled after the suspension period expires
+- **Availability Check**: Suspended models are skipped during weighted round-robin selection until they recover
+- **Weight Preservation**: When a model is suspended, the remaining models continue to be selected based on their relative weights
+
+#### Suspension Behavior
+
+- Suspension is tracked per model across all requests
+- If all models are suspended, the policy returns HTTP 503 with error: "All models are currently unavailable"
+- Suspension period starts from the time of failure
+- When a model is suspended, the weighted sequence is dynamically adjusted to exclude that model
+
+#### Weight Calculation
+
+The policy builds a weighted sequence by repeating each model a number of times equal to its weight:
+
+- **Total Weight**: Sum of all model weights
+- **Sequence Length**: Equal to the total weight
+- **Distribution**: Each model appears in the sequence `weight` times
+- **Proportional Selection**: Over time, each model receives requests proportional to `model_weight / total_weight`
+
+
+
+## Notes
+
+- For path parameters, the regex pattern should include a capturing group to extract the model name. The policy uses the first capturing group as the model identifier.
+- This capability distributes requests proportionally across multiple models to balance capacity, cost, performance tiers, and migration rollout needs.
+- The weighted sequence is pre-computed once during policy initialization and reused for all requests. It is not rebuilt on each request.
+- The round-robin index is maintained per policy instance and increments for each request.
+- Model selection follows the weighted sequence in a deterministic cyclic pattern.
+- The original model from the request is stored in metadata but is replaced with the selected model for routing.
+- If `suspendDuration` is 0, failed models are not suspended and will continue to be selected in the weighted round-robin cycle.
+- Higher weights result in more frequent selection but do not guarantee exact proportional distribution in small request volumes.
+- The weighted sequence ensures long-term proportional distribution, but short-term distribution may vary due to suspension and availability.
+- The `requestModel` configuration is required and must be provided by the LLM provider template. There is no default behavior.

--- a/docs/model-weighted-round-robin/v1.0/metadata.json
+++ b/docs/model-weighted-round-robin/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "model-weighted-round-robin",
+  "displayName": "Model Weighted Round Robin",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements weighted round-robin load balancing for AI models. Distributes requests\nbased on predefined weight values assigned to each model, enabling probabilistic\ncontrol over request distribution and giving higher priority to models with greater\nprocessing power or availability."
+}

--- a/docs/pii-masking-regex/v1.0/docs/pii-masking-regex.md
+++ b/docs/pii-masking-regex/v1.0/docs/pii-masking-regex.md
@@ -1,0 +1,220 @@
+---
+title: "Overview"
+---
+# PII Masking Regex Guardrail
+
+## Overview
+
+The PII Masking Regex Guardrail masks or redacts Personally Identifiable Information (PII) from request and response bodies using configurable regular expression patterns. This guardrail helps protect sensitive user data by replacing PII with placeholders or redaction markers before content is processed or returned.
+
+This policy supports SSE streaming responses. When the upstream returns a streaming response (`stream: true`), the guardrail detects PII placeholders in SSE delta content and restores masked values across chunk boundaries. Delta content is extracted from `choices[*].delta.content` in each SSE event.
+
+## Features
+
+- Configurable PII entity detection using regular expressions
+- Two modes: masking (reversible) and redaction (permanent)
+- Automatic PII restoration in responses when using masking mode
+- Supports JSONPath extraction to process specific fields within JSON payloads
+- SSE streaming response support with smart placeholder boundary detection -- buffers only when a PII placeholder (e.g., `[EMAIL_0000]`) may be split across SSE chunk boundaries
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `email` | boolean | No | `false` | Enables built-in EMAIL detection. At least one of `email`, `phone`, `ssn`, or `customPIIEntities` must be enabled. |
+| `phone` | boolean | No | `false` | Enables built-in PHONE detection. At least one of `email`, `phone`, `ssn`, or `customPIIEntities` must be enabled. |
+| `ssn` | boolean | No | `false` | Enables built-in SSN detection. At least one of `email`, `phone`, `ssn`, or `customPIIEntities` must be enabled. |
+| `customPIIEntities` | `CustomPIIEntity` array | No | - | Custom PII entity definitions for detection. Each item defines a `piiEntity` name and `piiRegex` pattern. At least one item required if provided. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from JSON payload. If empty, processes the entire payload as a string. |
+| `redactPII` | boolean | No | `false` | If `true`, redacts PII by replacing with "*****" (permanent, cannot be restored). If `false`, masks PII with placeholders that can be restored in responses. |
+
+### CustomPIIEntity Configuration
+
+Each item in the `customPIIEntities` array must contain:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `piiEntity` | string | Yes | Name/type of the PII entity (e.g., "CREDIT_CARD", "PASSPORT"). Must contain only uppercase letters and underscores. |
+| `piiRegex` | string | Yes | Regular expression pattern to match the PII entity. Must be a valid Go regexp pattern. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and process specific fields within JSON payloads. Common examples:
+
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+- `$.messages[0].content` - Extracts content from the first message in a messages array
+
+If `jsonPath` is empty or not specified, the entire payload is processed as a string.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: pii-masking-regex
+  gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic PII Masking
+
+Deploy an LLM provider that masks email addresses and phone numbers in requests and restores them in responses:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: pii-masking-provider
+spec:
+  displayName: PII Masking Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: pii-masking-regex
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            email: true
+            phone: true
+            jsonPath: "$.messages[-1].content"
+            redactPII: true
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Request with PII (should be masked)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Contact me at john.doe@example.com or call +1234567890"
+      }
+    ]
+  }'
+```
+
+ **Sample Payload after intervention from Regex PII Masking with redactPII=true**
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Prepare an email with my contact information, email: *****, and website: https://example.com."
+    }
+  ]
+}
+```
+
+### Example 2: Streaming Response PII Restoration
+
+When using masking mode with a streaming LLM endpoint, PII placeholders sent to the upstream are automatically restored in the SSE response stream:
+
+```yaml
+  policies:
+    - name: pii-masking-regex
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            email: true
+            phone: true
+            jsonPath: "$.messages[-1].content"
+            redactPII: false
+```
+
+When the upstream returns an SSE streaming response, the policy detects placeholders such as `[EMAIL_0000]` in the delta content across chunk boundaries and restores them to the original PII values. The smart boundary detection ensures placeholders split across multiple SSE events (e.g., `[`, `EMAIL`, `_`, `0000`, `]` arriving in separate tokens) are correctly reassembled before restoration.
+
+## How It Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content using `jsonPath` (if configured) or uses the entire payload as a string.
+2. **PII Detection**: Applies each configured `piiRegex` pattern to detect matching PII entities.
+3. **Intervention**: Replaces matches with placeholders (`[ENTITY_TYPE_XXXX]`) in masking mode or with `*****` in redaction mode.
+4. **Metadata Storage**: Stores placeholder-to-original mappings in request metadata when masking mode is used.
+5. **Forwarding**: Sends the transformed payload to the upstream service.
+
+#### Response Phase
+
+1. **Mapping Check**: Checks whether masking metadata is available from request processing.
+2. **Restoration**: If `redactPII: false`, replaces placeholders with original values in the response.
+3. **Redaction Preservation**: If `redactPII: true`, no restoration is performed.
+4. **Response Return**: Returns restored or redacted content to the client.
+
+#### PII Modes
+
+- **Masking Mode (`redactPII: false`)**: Uses placeholders such as `[EMAIL_0000]` and original PII values are stored temporarily in request metadata for restoration. Recommended when you need to preserve data for downstream processing or response generation
+- **Redaction Mode (`redactPII: true`)**: Permanently replaces detected PII with `*****` and does not restore original values. Recommended for maximum privacy protection when original values are not needed
+
+### Streaming (SSE) Processing
+
+When the upstream returns an SSE streaming response, each SSE event arrives as a `data:` line containing a JSON payload, for example:
+
+```
+data: {"choices":[{"delta":{"content":"token"}}]}
+```
+
+The PII masking policy restores masked placeholders in streaming responses using smart placeholder boundary detection:
+
+1. **Delta Content Extraction**: Content is extracted from `choices[*].delta.content` in each SSE `data:` line.
+2. **Placeholder Boundary Detection**: `NeedsMoreResponseData` checks whether the accumulated delta content contains an unclosed `[` character that may be the start of a PII placeholder (e.g., `[EMAIL_0000]`). If an unclosed bracket is detected, the policy continues buffering for up to 5 additional SSE data lines to allow the full placeholder to arrive.
+3. **Placeholder Restoration**: Once the placeholder boundary is resolved (the closing `]` arrives or the buffering limit is reached), the accumulated chunk is processed. All `delta.content` values are concatenated, placeholders are restored to their original PII values, and the restored text is placed into the first content-bearing SSE event while subsequent merged events are dropped.
+4. **Redaction Mode**: When `redactPII: true`, no restoration is performed in the response phase, so streaming chunks pass through without buffering.
+5. **Error Handling**: Since HTTP response headers are already committed when streaming begins, errors cannot be reported via HTTP status codes. If an error occurs during restoration, the chunk passes through unmodified.
+
+**Non-SSE chunked responses**: For plain JSON responses delivered via chunked transfer encoding (e.g., `stream: false` with `Transfer-Encoding: chunked`), chunks are accumulated until the full JSON body is parseable, then restored as a complete body.
+
+#### Processing Behavior
+
+- Supports multiple entity patterns in one policy and processes each detected match by entity type.
+- Placeholder format is `[ENTITY_TYPE_XXXX]`, where `XXXX` is a 4-digit hexadecimal sequence.
+- Full payload processing is used when `jsonPath` is not configured.
+
+## Notes
+
+- Common use cases include privacy protection, compliance (GDPR/CCPA/HIPAA), data minimization, secure AI processing, and audit-friendly masking workflows.
+- Regular expressions use Go's regexp package (RE2 syntax).
+- PII detection is case-sensitive by default. Use `(?i)` flag for case-insensitive matching.
+- The `piiEntity` name must contain only uppercase letters and underscores (e.g., "EMAIL", "PHONE_NUMBER", "SSN").
+- When using masking mode, the placeholder-to-original mapping is stored in request metadata and automatically used for response restoration.
+- Multiple PII entities can match the same content; each match is processed according to its entity type.
+- Placeholder format is `[ENTITY_TYPE_XXXX]` where XXXX is a 4-digit hexadecimal number (e.g., `[EMAIL_0000]`, `[EMAIL_0001]`, `[PHONE_000a]`).
+- When using JSONPath, if the path does not exist or the extracted value is not a string, an error response (HTTP 500) is returned.
+- Redaction mode is irreversible; use masking mode if you need to restore PII in responses.
+- In streaming mode, `redactPII: true` disables response-phase processing entirely since there is nothing to restore. Chunks pass through without buffering overhead.
+- In streaming mode, placeholder boundary detection buffers up to 5 additional SSE data lines when an unclosed `[` is found. This prevents false negatives from placeholders split across SSE event boundaries.
+- Complex regex patterns may impact performance; test thoroughly with expected content volumes.

--- a/docs/pii-masking-regex/v1.0/metadata.json
+++ b/docs/pii-masking-regex/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "pii-masking-regex",
+  "displayName": "PII Masking Regex",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns.\nSupports two modes: masking (replaces with placeholders that can be restored in responses) and redaction (replaces with *****).\nWhen masking mode is used, PII is masked in requests and automatically restored in responses.\nSupports separate configuration for request and response phases."
+}

--- a/docs/prompt-decorator/v1.0/docs/prompt-decorator.md
+++ b/docs/prompt-decorator/v1.0/docs/prompt-decorator.md
@@ -1,0 +1,291 @@
+---
+title: "Overview"
+---
+# Prompt Decorator
+
+## Overview
+
+The Prompt Decorator policy dynamically modifies prompts by prepending or appending custom content to specific fields in JSON payloads. This policy supports two decoration modes: **text prompt decoration** (for string content fields) and **chat prompt decoration** (for message arrays). It's useful for adding consistent instructions, system messages, or standardized prefixes/suffixes to prompts before they're sent to AI services.
+
+## Features
+
+- Two decoration modes: text decoration (string fields) and chat decoration (message arrays)
+- Configurable prepend or append behavior
+- JSONPath support for targeting specific fields in JSON payloads
+- Flexible decoration format: simple strings or structured message objects
+- Processes request body only (response phase not supported)
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `promptDecoratorConfig` | object | Yes | - | Specifies prompt decoration configuration. Provide exactly one of `text` or `messages`. |
+| `promptDecoratorConfig.text` | string | Conditional | - | Specifies text decoration applied when targeting a string prompt. Required if `messages` is not provided. |
+| `promptDecoratorConfig.messages` | array | Conditional | - | Specifies chat message decorations applied when targeting a messages array. Required if `text` is not provided. |
+| `jsonPath` | string | No | `""` | JSONPath expression used to locate the prompt segment to decorate. If omitted, defaults to `"$.messages[-1].content"` for `text` decorations and `"$.messages"` for `messages` decorations. |
+| `append` | boolean | No | `false` | If `true`, decoration is appended to the content. If `false`, decoration is prepended (default). |
+
+### PromptDecoratorConfig.messages Array Item
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `role` | string | Yes | Role for the chat message. Valid values: `system`, `user`, `assistant`, `tool`. |
+| `content` | string | Yes | Message content to prepend or append in chat decoration mode. |
+
+#### JSONPath Support
+
+The decorator supports JSONPath expressions to target specific fields. Common examples:
+
+- `$.messages[0].content` - First message's content field (text decoration)
+- `$.messages[-1].content` - Last message's content field (text decoration)
+- `$.messages` - Entire messages array (chat decoration)
+- `$.data.text` - Nested text field (text decoration)
+
+**Array Index Syntax:**
+- Use `[0]` for first element, `[1]` for second, etc.
+- Use `[-1]` for last element, `[-2]` for second-to-last, etc.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: prompt-decorator
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Text Prompt Decoration - Summarization Directive
+
+Add a summarization instruction to user prompts:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: summarization-provider
+spec:
+  displayName: Summarization Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-decorator
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            promptDecoratorConfig:
+              text: "Summarize the following content in a concise, neutral, and professional tone. Structure the summary using bullet points if appropriate.\n\n"
+            jsonPath: "$.messages[0].content"
+            append: false
+```
+
+**Test the decorator:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# Original request
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Large text block to summarize here..."
+      }
+    ]
+  }'
+
+# After decoration, the request sent to OpenAI will be:
+# {
+#   "model": "gpt-4",
+#   "messages": [
+#     {
+#       "role": "user",
+#       "content": "Summarize the following content in a concise, neutral, and professional tone. Structure the summary using bullet points if appropriate.
+
+ Large text block to summarize here..."
+#     }
+#   ]
+# }
+```
+
+**Error Response:**
+
+When the policy encounters an error (e.g., invalid JSONPath, invalid decoration config, or missing required fields), it returns an HTTP 500 status code with the following structure:
+
+```json
+{
+  "type": "PROMPT_DECORATOR_ERROR",
+  "message": "Error description here"
+}
+```
+
+### Example 2: Chat Prompt Decoration - System Persona
+
+Add a system message to define AI behavior:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: hotel-booking-provider
+spec:
+  displayName: Hotel Booking Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-decorator
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            promptDecoratorConfig:
+              messages:
+                - role: system
+                  content: "You are a helpful hotel booking receptionist for Azure Horizon Resort. Collect booking details: name, NIC, check-in time, staying duration (nights), and room type (single, double, suite). Ask one detail at a time in a friendly tone."
+            jsonPath: "$.messages"
+            append: false
+```
+
+**Test the decorator:**
+
+```bash
+# Original request
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hi, I would like to book a room."
+      }
+    ]
+  }'
+
+# After decoration, the request sent to OpenAI will be:
+# {
+#   "model": "gpt-4",
+#   "messages": [
+#     {
+#       "role": "system",
+#       "content": "You are a helpful hotel booking receptionist for Azure Horizon Resort. Collect booking details: name, NIC, check-in time, staying duration (nights), and room type (single, double, suite). Ask one detail at a time in a friendly tone."
+#     },
+#     {
+#       "role": "user",
+#       "content": "Hi, I would like to book a room."
+#     }
+#   ]
+# }
+```
+
+### Example 3: Append Mode - Adding Suffix Instructions
+
+Append instructions to the end of user messages:
+
+```yaml
+policies:
+  - name: prompt-decorator
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          promptDecoratorConfig:
+            text: "\n\nPlease respond in JSON format."
+          jsonPath: "$.messages[-1].content"
+          append: true
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Target Extraction**: Resolves the target field using `jsonPath` from the request payload.
+2. **Mode Detection**: Determines decoration mode based on target type and `promptDecoratorConfig.decoration` shape (string vs message array).
+3. **Decoration Application**: Prepends or appends decoration based on `append` configuration.
+4. **Payload Update**: Writes the decorated value back to the request payload and forwards it upstream.
+
+#### Decoration Modes
+
+
+**Mode 1: Text Prompt Decoration**
+
+Text decoration is used when the JSONPath targets a string field (e.g., `$.messages[0].content`). Use the `text` field in `promptDecoratorConfig`:
+
+*Configuration Example:*
+```yaml
+promptDecoratorConfig:
+  text: "Summarize the following content in a concise, neutral, and professional tone.\n\n"
+```
+
+*Behavior:*
+- Decoration string is prepended or appended to the target content field
+- A space is automatically added between the decoration and original content
+
+
+**Mode 2: Chat Prompt Decoration**
+
+Chat decoration is used when the JSONPath targets an array field (e.g., `$.messages`). Use the `messages` field in `promptDecoratorConfig`:
+
+*Configuration Example:*
+```yaml
+promptDecoratorConfig:
+  messages:
+    - role: system
+      content: "You are a helpful hotel booking receptionist for the imaginary hotel 'Azure Horizon Resort'. Your job is to collect all the necessary booking details from guests."
+```
+
+*Behavior:*
+- Decoration messages are prepended or appended to the messages array
+- Each decoration object must have `role` and `content` fields
+- Multiple decoration messages can be added
+
+## Notes
+
+- Common use cases include prompt standardization, persona injection, output-format enforcement, and contextual prompt enrichment.
+- The policy only processes request bodies.
+- For text decoration, a space is automatically added between the decoration and original content.
+- JSONPath expressions must correctly identify the target field. Invalid paths will result in errors.
+- When decorating message arrays, ensure the target field is actually an array of message objects.
+- The `append: false` (default) means decoration is prepended. Set `append: true` to append decoration.
+- Messages in chat mode must have both `role` and `content` fields; both are required.
+- Valid role values are: `system`, `user`, `assistant`, `tool`.
+- Negative array indices (e.g., `[-1]` for last element) are supported in JSONPath expressions.
+- If `jsonPath` is omitted, it defaults to `"$.messages[-1].content"` for `text` decorations and `"$.messages"` for `messages` decorations.

--- a/docs/prompt-decorator/v1.0/metadata.json
+++ b/docs/prompt-decorator/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "prompt-decorator",
+  "displayName": "Prompt Decorator",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Dynamically modifies the prompt by applying custom decorations using a configured strategy.\nOnly processes request body."
+}

--- a/docs/prompt-template/v1.0/docs/prompt-template.md
+++ b/docs/prompt-template/v1.0/docs/prompt-template.md
@@ -1,0 +1,274 @@
+---
+title: "Overview"
+---
+# Prompt Template
+
+## Overview
+
+The Prompt Template policy enables dynamic prompt transformation by replacing `template://` URI patterns in JSON payloads with predefined templates. Template placeholders are resolved using parameters passed in the URI query string, allowing you to standardize and reuse prompts across different API calls. This is particularly useful for AI/LLM APIs where consistent prompt formatting improves response quality and maintainability.
+
+## Features
+
+- Pattern-based template matching using `template://` URI format
+- Parameter substitution with `[[parameter-name]]` placeholder syntax
+- Multiple templates per policy configuration
+- JSON-safe string replacement and escaping
+- Processes entire JSON payload as string to find and replace patterns
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `templates` | array | Yes | - | Specifies one or more reusable prompt templates. Each template must include a unique name and template content. |
+| `jsonPath` | string | No | `""` | Specifies the JSONPath to limit template resolution to a specific string field. If empty, template references are resolved across the entire request payload string. |
+| `onMissingTemplate` | string | No | `"error"` | Specifies behavior when a referenced template name is not found. `error` returns an immediate error response, `passthrough` leaves the original template reference unchanged. |
+| `onUnresolvedPlaceholder` | string | No | `"keep"` | Specifies behavior when placeholders remain unresolved after query substitution. `keep` keeps placeholders as-is, `empty` replaces them with an empty string, and `error` returns an immediate error response. |
+
+#### Template Object
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Unique identifier for the template (used in `template://` URIs). Must match pattern `^[a-zA-Z0-9_-]+$`. |
+| `template` | string | Yes | Template text with `[[parameter]]` placeholder syntax. Query parameters are substituted using these placeholders. |
+
+### Template Configuration Format
+
+The `templates` value is an array of template objects:
+
+```yaml
+templates:
+  - name: template-name
+    template: "Template text with [[placeholder]] syntax"
+```
+
+Each template object contains:
+- **name**: Unique identifier for the template (used in `template://` URIs)
+- **template**: The template string with `[[parameter-name]]` placeholders that will be replaced
+
+#### Template Syntax
+
+##### Template URI Format
+
+Templates are referenced in JSON payloads using the following URI format:
+
+```
+template://<template-name>?<param1>=<value1>&<param2>=<value2>
+```
+
+Example:
+```
+template://translate?from=english&to=spanish&text=Hello world
+```
+
+##### Placeholder Syntax
+
+Within template prompts, use double square brackets to define placeholders:
+
+```
+[[parameter-name]]
+```
+
+During resolution, placeholders are replaced with values from the URI query parameters. Parameter names are case-sensitive and must match exactly between the placeholder and the URI parameter.
+
+Example template:
+```
+Translate the following text from [[from]] to [[to]]: [[text]]
+```
+
+When called with `template://translate?from=english&to=spanish&text=Hello`, the resolved prompt would be:
+```
+Translate the following text from english to spanish: Hello
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: prompt-template
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-template@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Translation Template
+
+Deploy an LLM provider with a translation prompt template:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: translation-provider
+spec:
+  displayName: Translation Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-template
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            templates:
+              - name: translate
+                template: "Translate the following text from [[from]] to [[to]]: [[text]]"
+```
+
+**Test the template:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "template://translate?from=english&to=spanish&text=Hello world"
+      }
+    ]
+  }'
+```
+
+The policy will transform the request to:
+
+```json
+{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Translate the following text from english to spanish: Hello world"
+    }
+  ]
+}
+```
+
+### Example 2: Summarization Template
+
+Create a template for summarizing content with configurable length:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: summarization-provider
+spec:
+  displayName: Summarization Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-template
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            templates:
+              - name: summarize
+                template: "Summarize the following content in [[length]] words: [[content]]"
+```
+
+**Test with template:**
+
+```bash
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "template://summarize?length=50&content=Artificial intelligence is a branch of computer science that aims to create intelligent machines capable of performing tasks that typically require human intelligence."
+      }
+    ]
+  }'
+```
+
+### Example 3: Multiple Templates
+
+Configure multiple templates in a single policy:
+
+```yaml
+policies:
+  - name: prompt-template
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          templates:
+            - name: translate
+              template: "Translate from [[from]] to [[to]]: [[text]]"
+            - name: summarize
+              template: "Summarize in [[length]] words: [[content]]"
+            - name: explain
+              template: "Explain [[topic]] to a [[audience]] audience: [[question]]"
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Pattern Detection**: Scans the incoming JSON payload (or targeted field if `jsonPath` is specified) for `template://` URI patterns.
+2. **Template Resolution**: Extracts template name and query parameters, then finds the matching template in `templates`.
+3. **Placeholder Substitution**: Replaces `[[parameter-name]]` placeholders in the template using URL-decoded query parameter values.
+4. **Missing Template Handling**: If a referenced template is not found, behavior is controlled by `onMissingTemplate` (`error` or `passthrough`).
+5. **Unresolved Placeholder Handling**: If placeholders remain after substitution, behavior is controlled by `onUnresolvedPlaceholder` (`keep`, `empty`, or `error`).
+6. **Safe Replacement**: JSON-escapes the resolved template and replaces the matched `template://` pattern in the payload.
+7. **Forwarding**: Sends the transformed payload to the upstream API.
+
+#### Template Pattern Matching
+
+- **Pattern**: `template://[a-zA-Z0-9_-]+\?[^\s"']*`
+- **Location**: Searches the entire JSON payload as a string.
+- **Replacement**: Each matched pattern is replaced with the resolved template string (JSON-escaped).
+- **Multi-match support**: Multiple `template://` patterns can exist in a single payload and are resolved independently.
+
+
+
+## Notes
+
+- Common use cases include standardized prompts, reusable prompt libraries, parameterized prompts, multi-language prompt generation, and centralized prompt versioning.
+- Template names must match pattern `^[a-zA-Z0-9_-]+$` and are case-sensitive.
+- Parameter names in placeholders `[[param]]` are case-sensitive and must match query parameter names exactly.
+- Query parameter values are URL-decoded before being inserted into templates.
+- The resolved template string is JSON-escaped (special characters like quotes, newlines are escaped) before replacement.
+- Use `jsonPath` to limit template resolution to a specific field instead of the entire payload.
+- Use `onMissingTemplate: passthrough` to leave unresolved template references unchanged instead of returning an error.
+- Use `onUnresolvedPlaceholder: empty` to replace missing placeholders with empty strings, or `error` to fail on missing placeholders.
+- Multiple `template://` patterns can appear in a single payload and will all be processed.

--- a/docs/prompt-template/v1.0/metadata.json
+++ b/docs/prompt-template/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "prompt-template",
+  "displayName": "Prompt Template",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Dynamically modifies the prompt by applying custom templates using a configured strategy.\nOnly processes request body."
+}

--- a/docs/regex-guardrail/v1.0/docs/regex.md
+++ b/docs/regex-guardrail/v1.0/docs/regex.md
@@ -1,0 +1,288 @@
+---
+title: "Overview"
+---
+# Regex Guardrail
+
+## Overview
+
+The Regex Guardrail validates request or response body content against regular expression patterns. This guardrail enables pattern-based content validation, allowing you to enforce specific formats, detect prohibited patterns, or ensure content matches expected structures. It supports both buffered and SSE streaming responses, with cross-chunk pattern matching for streaming scenarios.
+
+## Features
+
+- Pattern matching using regular expressions
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable inverted logic to pass when pattern does not match
+- Supports independent request and response phase configuration
+- Optional detailed assessment information in error responses
+- SSE streaming response validation with cross-chunk content accumulation
+- Configurable streaming JSONPath for extracting delta content from SSE events
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No | - | Configuration for request-phase regex validation. At least one of `request` or `response` must be provided. |
+| `response` | object | No | - | Configuration for response-phase regex validation. At least one of `request` or `response` must be provided. |
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `regex` | string | Conditional | - | Regular expression pattern to match against the content. Required when `enabled: true`. Must be at least 1 character. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the request JSON payload. If empty, validates the entire payload as a string. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when regex does NOT match. If `false`, validation passes when regex matches. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `regex` | string | Conditional | - | Regular expression pattern to match against the content. Required when `enabled: true`. Must be at least 1 character. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the response JSON payload. If empty, validates the entire payload as a string. |
+| `streamingJsonPath` | string | No | `"$.choices[0].delta.content"` | JSONPath expression to extract content from SSE streaming delta chunks. Used when the upstream returns a streaming (`stream: true`) response. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when regex does NOT match. If `false`, validation passes when regex matches. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+- `$.messages[0].content` - Extracts content from the first message in a messages array
+
+If `jsonPath` is empty or not specified, the entire payload is treated as a string and validated.
+
+#### Regular Expression Syntax
+
+The guardrail uses Go's standard regexp package, which supports RE2 syntax. Key features:
+
+- Case-sensitive matching by default
+- Use `(?i)` flag for case-insensitive matching
+- Anchors: `^` (start), `$` (end)
+- Character classes: `[a-z]`, `[0-9]`, `\d`, `\w`, `\s`
+- Quantifiers: `*`, `+`, `?`, `{n}`, `{n,m}`
+- Groups and alternation: `(abc|def)`, `(?:non-capturing)`
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: regex-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/regex-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Email Validation
+
+Deploy an LLM provider that protects against sensitive data leaks by blocking any payloads that mention the word "password" (case-insensitive) in either the user's message or the LLM's response. This is achieved by using the regex policy to validate both request and response payloads:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: regex-provider
+spec:
+  displayName: Regex Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: regex-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              regex: "(?i).*password.*"
+              invert: true
+              jsonPath: "$.messages[0].content"
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "This is a safe message without sensitive data"
+      }
+    ]
+  }'
+
+# Invalid request - no email (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "My password is 1234567"
+      }
+    ]
+  }'
+```
+
+**Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "REGEX_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "regex-guardrail",
+    "actionReason": "Violation of regular expression detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "REGEX_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "regex-guardrail",
+    "actionReason": "Violation of regular expression detected.",
+    "assessments": "Violation of regular expression detected. (?i)ignore\s+all\s+previous\s+instructions",
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Streaming Response Validation
+
+Validate streaming SSE responses with a custom delta content path:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: regex-streaming-provider
+spec:
+  displayName: Regex Streaming Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: regex-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            response:
+              enabled: true
+              regex: "(?i).*confidential.*"
+              invert: true
+              streamingJsonPath: "$.choices[0].delta.content"
+```
+
+When a streaming response violation is detected, the offending chunk is replaced with an SSE error event:
+
+```
+data: {"type":"REGEX_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"regex-guardrail","actionReason":"Violation of regular expression detected.","direction":"RESPONSE"}}
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Pattern Evaluation**: Applies the configured `regex` pattern to the extracted content.
+3. **Invert Handling**: Uses `invert` to decide whether matching or non-matching content should pass.
+4. **Decision Enforcement**: Blocks with HTTP `422` when validation fails; otherwise, request proceeds upstream.
+
+#### Response Phase (Buffered)
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload.
+2. **Pattern Evaluation**: Applies the configured `regex` pattern to the extracted content.
+3. **Invert Handling**: Uses `invert` to decide whether matching or non-matching content should pass.
+4. **Decision Enforcement**: Blocks with HTTP `422` when validation fails; otherwise, response is returned to the client.
+
+#### Response Phase (Streaming SSE)
+
+When the upstream returns an SSE streaming response, each SSE event arrives as a `data:` line containing a JSON payload, for example:
+
+```
+data: {"choices":[{"delta":{"content":"token"}}]}
+```
+
+The regex guardrail uses a **no-buffering pattern** for streaming. `NeedsMoreResponseData` always returns `false` -- each chunk is processed immediately as it arrives. Cross-chunk pattern matching is achieved through state accumulation via `ctx.Metadata` (a persistent key-value store shared across all chunks in a stream) rather than kernel-level buffering.
+
+1. **Chunk Detection**: Each response chunk is inspected to determine whether it is an SSE event (contains `data: ` lines) or a plain JSON chunk.
+2. **Content Accumulation**: Delta content is extracted from each SSE event using `streamingJsonPath` (default: `$.choices[0].delta.content`) and accumulated in `ctx.Metadata` across chunks. This enables cross-boundary pattern matching where a prohibited phrase may be split across multiple SSE events.
+3. **Pattern Evaluation**: The full accumulated content is evaluated against the `regex` pattern after each chunk arrives.
+4. **Invert Semantics**:
+   - `invert: true` (blocklist): Violation is detected as soon as the pattern appears in the accumulated content. The offending chunk is replaced with an SSE error event injected into the stream.
+   - `invert: false` (allowlist): The full response must match the pattern. Validation can only be confirmed at stream end (`[DONE]`), so an SSE error event is injected at the terminal chunk if no match was found. Content already forwarded to the client cannot be retracted.
+5. **Error Handling**: Since HTTP response headers are already committed when streaming begins, violations cannot be reported via HTTP status codes. Instead, the offending chunk is replaced with an SSE error event in the stream.
+6. **Plain JSON Chunks**: For non-SSE chunked responses (e.g., `Transfer-Encoding: chunked` without SSE), chunks are accumulated and validated as a complete body at end of stream.
+
+#### Validation Behavior
+
+- **Normal Mode (`invert: false`)**: Validation passes when regex matches.
+- **Inverted Mode (`invert: true`)**: Validation passes when regex does not match.
+- **Assessment Details**: When `showAssessment` is enabled, failure responses include regex-related assessment information.
+
+
+## Notes
+
+- Regular expressions are evaluated using Go's regexp package (RE2 syntax).
+- Pattern matching is case-sensitive by default. Use `(?i)` flag for case-insensitive matching.
+- Use `request` and `response` independently to validate one or both directions.
+- When using JSONPath, if the path does not exist or the extracted value is not a string, validation will fail.
+- Inverted logic is useful for blocking content that matches prohibited patterns.
+- Complex regex patterns may impact performance; test thoroughly with expected content volumes.
+- In streaming mode, content already forwarded to the client cannot be retracted when using `invert: false` (allowlist). This is an inherent limitation of response streaming.
+- The `streamingJsonPath` parameter is only used for SSE streaming responses. For buffered responses, the `jsonPath` parameter is used instead.

--- a/docs/regex-guardrail/v1.0/metadata.json
+++ b/docs/regex-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "regex-guardrail",
+  "displayName": "Regex Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request or response body content against a regular expression pattern.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan be configured to match or invert the regex pattern.\nSupports separate configuration for request and response phases.\nSupports SSE streaming response validation with cross-chunk pattern matching."
+}

--- a/docs/remove-headers/v1.0/docs/remove-headers.md
+++ b/docs/remove-headers/v1.0/docs/remove-headers.md
@@ -1,0 +1,381 @@
+---
+title: "Overview"
+---
+# Remove Headers
+
+## Overview
+
+The Remove Headers policy dynamically removes HTTP headers from incoming requests before they are forwarded to upstream services, and/or removes headers from outgoing responses before they are returned to clients. This policy provides comprehensive header removal functionality for both request and response flows.
+
+## Features
+
+- Removes specified headers from requests before forwarding to upstream services
+- Removes specified headers from responses before returning to clients
+- Supports both request and response phases independently or simultaneously
+- Case-insensitive header name matching for reliable removal
+- Header name normalization (lowercase conversion for consistency)
+- Works with any HTTP method and request type
+- Graceful handling of non-existent headers (no error if header doesn't exist)
+- Comprehensive validation of header configurations
+
+## Configuration
+
+The Remove Headers policy can be configured for removal in request phase, response phase, or both.
+This policy does not require system-level configuration and operates entirely based on the configured header name arrays.
+At least one of `request` or `response` must be specified in the policy configuration. The policy will fail validation if both are omitted.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No | - | Specifies request-phase header removal settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+| `response` | object | No | - | Specifies response-phase header removal settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+
+### Request / Response Header Configuration
+
+Each header entry in the `request.headers` or `response.headers` array must contain:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | The name of the HTTP header to remove. Header names are matched case-insensitively. Must match pattern `^[a-zA-Z0-9-_]+$` and be between 1 and 256 characters. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: remove-headers
+  gomodule: github.com/wso2/gateway-controllers/policies/remove-headers@v0
+```
+
+## Reference Scenarios:
+
+### Example 1: Removing Sensitive Request Headers
+
+Remove authentication headers before forwarding to upstream:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: remove-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: Authorization
+            - name: X-API-Key
+            - name: Cookie
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Request transformation:**
+
+Original client request:
+```
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+Authorization: Bearer secret-token
+X-API-Key: client-secret-key
+User-Agent: WeatherApp/1.0
+```
+
+Resulting upstream request:
+```
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+User-Agent: WeatherApp/1.0
+```
+
+### Example 2: Removing Server Information from Responses
+
+Remove server identification headers from responses:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: remove-headers
+      version: v0
+      params:
+        response:
+          headers:
+            - name: Server
+            - name: X-Powered-By
+            - name: X-AspNet-Version
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Response transformation:**
+
+Original upstream response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Server: Apache/2.4.41
+X-Powered-By: PHP/7.4.0
+X-AspNet-Version: 4.0.30319
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+### Example 3: Removing Headers from Both Request and Response
+
+Remove sensitive headers from both directions:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: remove-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: X-Internal-Token
+            - name: X-Debug-Mode
+        response:
+          headers:
+            - name: X-Internal-Server-ID
+            - name: X-Debug-Info
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Request and response transformation:**
+
+Original client request:
+```
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+X-Internal-Token: internal-secret
+X-Debug-Mode: enabled
+```
+
+Resulting upstream request:
+```
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+```
+
+Original upstream response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Internal-Server-ID: server-123
+X-Debug-Info: processed-in-45ms
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+### Example 4: Route-Specific Header Removal
+
+Apply different header removal rules to different routes:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: remove-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: X-Cache-Control  # Remove caching hints for weather data
+            response:
+              headers:
+                - name: Last-Modified    # Remove caching headers
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: remove-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: If-Modified-Since  # Remove conditional headers for alerts
+            response:
+              headers:
+                - name: ETag               # Remove caching headers for real-time alerts
+    - method: POST
+      path: /alerts/active
+      policies:
+        - name: remove-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: X-Requested-With  # Remove AJAX headers
+            response:
+              headers:
+                - name: Location          # Remove redirect headers for API responses
+```
+
+### Example 5: Multiple Remove Headers Policies
+
+Use multiple remove-headers policies for different purposes:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    # Remove authentication headers
+    - name: remove-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: Authorization
+            - name: X-API-Key
+            - name: Cookie
+    # Remove server identification
+    - name: remove-headers
+      version: v0
+      params:
+        response:
+          headers:
+            - name: Server
+            - name: X-Powered-By
+    # Remove debugging headers
+    - name: remove-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: X-Debug-Mode
+        response:
+          headers:
+            - name: X-Debug-Info
+            - name: X-Trace-ID
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+## How it Works
+
+* The policy reads `request.headers` and `response.headers` independently and removes matching headers in request and response flows.
+* Header name matching is case-insensitive, and configured names are normalized for consistent processing.
+* Removing a header that is not present is a no-op and does not produce runtime errors.
+* For multi-value headers, removal deletes all values for the matched header name.
+* Request flow removes headers before forwarding to upstream; response flow removes headers before returning to clients.
+* If a flow has no configured header list, that flow passes through unchanged.
+
+
+## Limitations
+
+1. **Remove-Only Behavior**: This policy removes headers only and does not set or append new values.
+2. **No Conditional Logic**: Header removal is static per policy configuration and cannot be conditional on payload or context.
+3. **Configuration Dependency**: At least one of `request` or `response` must be configured.
+4. **Ordering Sensitivity**: Policy order can affect final header output when used with other header manipulation policies.
+5. **Header Constraints Apply**: Header names must comply with configured schema constraints (pattern `^[a-zA-Z0-9-_]+$`, max length 256).
+
+
+## Notes
+
+**Security and Data Handling**
+
+Use header removal to strip sensitive or internal headers before requests leave trust boundaries and before responses reach clients. Prioritize removal of server-identification, debug, and internal tracing headers where they are not required. Ensure removed headers are not needed by downstream security controls or application behavior.
+
+**Performance and Operational Impact**
+
+Header removal is lightweight and local, with minimal processing overhead. Even so, validate changes in environments with strict intermediary rules to ensure removed headers do not affect caching, routing, or observability unexpectedly. Monitor for client or backend dependency on headers that are being removed.
+
+**Operational Best Practices**
+
+Apply route-specific rules when only selected operations require header removal, rather than enforcing broad removal globally. Document removed headers for client and backend teams to keep integration contracts clear. Test policy interactions with `add-headers`, `set-headers`, and `modify-headers` to confirm final header outcomes.

--- a/docs/remove-headers/v1.0/metadata.json
+++ b/docs/remove-headers/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "remove-headers",
+  "displayName": "Remove Headers",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation",
+    "MCP"
+  ],
+  "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
+}

--- a/docs/request-rewrite/v1.0/docs/request-rewrite.md
+++ b/docs/request-rewrite/v1.0/docs/request-rewrite.md
@@ -1,0 +1,270 @@
+---
+title: "Overview"
+---
+# Request Rewrite
+
+## Overview
+
+The Request Rewrite policy updates incoming requests before they are sent to the upstream service. It can rewrite the request path, query parameters, and HTTP method. Rewrites can also be gated with optional header and query-parameter match conditions.
+
+At least one of `pathRewrite`, `queryRewrite`, or `methodRewrite` must be configured.
+
+## Features
+
+- Rewrites paths using prefix replacement, full path replacement, or regex substitution
+- Rewrites query parameters using ordered rules
+- Rewrites HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`)
+- Supports conditional execution based on request headers and query parameters
+- Supports regex matching and substitution with capture groups (RE2 syntax)
+
+## Configuration
+
+The Request Rewrite policy uses a single-level configuration model where all parameters are configured per-API/route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per API/route by the API developer:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `match` | `MatchConfig` object | No | Optional match conditions that gate whether rewrite actions are applied. |
+| `pathRewrite` | `PathRewriteConfig` object | No | Path rewrite configuration. |
+| `queryRewrite` | `QueryRewriteConfig` object | No | Query parameter rewrite configuration. |
+| `methodRewrite` | string | No | HTTP method to rewrite to. Allowed values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`. |
+
+> **Note**: At least one of `pathRewrite`, `queryRewrite`, or `methodRewrite` is required.
+
+
+### MatchConfig Configuration
+
+The `MatchConfig` object supports the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `headers` | `MatchCondition` array | No | Header matchers. All entries must match for rewrite execution. |
+| `queryParams` | `MatchCondition` array | No | Query parameter matchers. All entries must match for rewrite execution. |
+
+### MatchCondition Configuration
+
+Both header and query parameter matchers use the same structure:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Header/query-parameter name. Header matching is case-insensitive. |
+| `type` | string | Yes | Match type: `Exact`, `Regex`, or `Present`. |
+| `value` | string | Conditional | Required for `Exact` and `Regex`; not used for `Present`. |
+
+### PathRewriteConfig Configuration
+
+The `PathRewriteConfig` object supports the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Path rewrite type: `ReplacePrefixMatch`, `ReplaceFullPath`, or `ReplaceRegexMatch`. |
+| `replacePrefixMatch` | string | Conditional | Required when `type` is `ReplacePrefixMatch`. Replaces the matched operation path prefix. |
+| `replaceFullPath` | string | Conditional | Required when `type` is `ReplaceFullPath`. Replaces the full relative path. |
+| `replaceRegexMatch` | `ReplaceRegexMatchConfig` object | Conditional | Required when `type` is `ReplaceRegexMatch`. Applies regex substitution on the relative path. |
+
+`pathRewrite.type` controls how the path is transformed:
+
+| Type | Required Fields | Description |
+|------|------------------|-------------|
+| `ReplacePrefixMatch` | `replacePrefixMatch` | Replaces the matched operation path prefix with `replacePrefixMatch`. |
+| `ReplaceFullPath` | `replaceFullPath` | Replaces the full relative path with `replaceFullPath`. |
+| `ReplaceRegexMatch` | `replaceRegexMatch.pattern`, `replaceRegexMatch.substitution` | Applies regex substitution on the relative path. |
+
+### ReplaceRegexMatchConfig Configuration
+
+The `ReplaceRegexMatchConfig` object supports:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pattern` | string | Yes | Regex pattern (RE2 syntax). |
+| `substitution` | string | Yes | Replacement string. Capture groups can be referenced using `\1`, `\2`, etc. |
+
+### QueryRewriteConfig Configuration
+
+The `QueryRewriteConfig` object supports:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rules` | `QueryRewriteRule` array | Yes | Ordered list of query rewrite rules. Rules are applied sequentially. |
+
+`queryRewrite.rules` are applied in order.
+
+### QueryRewriteRule Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | string | Yes | `Replace`, `Remove`, `Add`, `Append`, or `ReplaceRegexMatch`. |
+| `name` | string | Yes | Target query parameter name. |
+| `value` | string | Conditional | Used by `Replace`, `Add`, and `Append`. |
+| `separator` | string | No | Used by `Append`; defaults to empty string when omitted. |
+| `pattern` | string | Conditional | Used by `ReplaceRegexMatch`. |
+| `substitution` | string | Conditional | Used by `ReplaceRegexMatch`. Supports capture groups (`\1`, `\2`, etc.). |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: request-rewrite
+  gomodule: github.com/wso2/gateway-controllers/policies/request-rewrite@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Prefix Path Rewrite
+
+Replace an operation path prefix while preserving the remaining path:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: catalog-api-v1.0
+spec:
+  displayName: Catalog API
+  version: v1.0
+  context: /catalog/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  operations:
+    - method: GET
+      path: /products/*
+      policies:
+        - name: request-rewrite
+          version: v0
+          params:
+            pathRewrite:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /items
+```
+
+### Example 2: Query Rewrite with Ordered Rules
+
+Normalize and enrich query parameters before forwarding:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: search-api-v1.0
+spec:
+  displayName: Search API
+  version: v1.0
+  context: /search/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: request-rewrite
+      version: v0
+      params:
+        queryRewrite:
+          rules:
+            - action: Replace
+              name: q
+              value: "latest news"
+            - action: Append
+              name: tags
+              separator: ","
+              value: "gateway"
+            - action: Remove
+              name: debug
+  operations:
+    - method: GET
+      path: /documents
+```
+
+### Example 3: Conditional Rewrite + Method Rewrite
+
+Apply rewrites only when match conditions are satisfied:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: orders-api-v1.0
+spec:
+  displayName: Orders API
+  version: v1.0
+  context: /orders/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  operations:
+    - method: POST
+      path: /submit
+      policies:
+        - name: request-rewrite
+          version: v0
+          params:
+            match:
+              headers:
+                - name: X-Client-Type
+                  type: Exact
+                  value: mobile
+              queryParams:
+                - name: preview
+                  type: Present
+            pathRewrite:
+              type: ReplaceFullPath
+              replaceFullPath: /v2/orders/preview
+            methodRewrite: GET
+```
+
+## How it Works
+
+**Configuration Object Flow**
+
+```mermaid
+flowchart TD
+  A[RequestRewritePolicyParams]
+
+  A --> B[match MatchConfig]
+  A --> C[pathRewrite PathRewriteConfig]
+  A --> D[queryRewrite QueryRewriteConfig]
+  A --> E[methodRewrite string]
+
+  B --> B1[headers MatchConditionArray]
+  B --> B2[queryParams MatchConditionArray]
+
+  B1 --> M1[matchName]
+  B1 --> M2[matchType]
+  B1 --> M3[matchValue]
+
+  B2 --> M1
+  B2 --> M2
+  B2 --> M3
+
+  C --> C1[pathRewriteType]
+  C --> C2[replacePrefixMatch]
+  C --> C3[replaceFullPath]
+  C --> C4[replaceRegexMatch ReplaceRegexMatchConfig]
+
+  C4 --> C41[regexPattern]
+  C4 --> C42[regexSubstitution]
+
+  D --> D1[rules QueryRewriteRuleArray]
+  D1 --> D2[ruleAction]
+  D1 --> D3[ruleName]
+  D1 --> D4[ruleValue]
+  D1 --> D5[ruleSeparator]
+  D1 --> D6[rulePattern]
+  D1 --> D7[ruleSubstitution]
+```
+
+- The policy evaluates optional `match` conditions first; rewrites are applied only when all configured header and query matchers succeed.
+- Path rewrite, query rewrite, and method rewrite are then applied in request phase using the configured objects; at least one rewrite object must be present.
+- Path rewriting operates on the path relative to API context, and query rewrite rules are executed sequentially in the order provided.
+- Regex-based path and query substitutions use RE2 syntax and support capture-group substitutions in replacement strings.
+- Invalid rewrite configuration at runtime results in an immediate `500` configuration error response.
+
+
+## Notes
+
+- Path rewrites are applied to the path relative to API context, then API context is preserved in the final forwarded path.
+- For `ReplacePrefixMatch`, the matched prefix is derived from the operation path where the policy is attached.
+- Query rewrite rules run sequentially; later rules see the results of earlier rules.

--- a/docs/request-rewrite/v1.0/metadata.json
+++ b/docs/request-rewrite/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "request-rewrite",
+  "displayName": "Request Rewrite",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation"
+  ],
+  "description": "Rewrites incoming requests by updating path, query parameters, and/or HTTP method before forwarding to upstream services.\nSupports prefix replacement, full path replacement, and regex-based path substitution.\nSupports query parameter actions including replace, remove, add, append, and regex-based substitution.\nOptional header and query match conditions control when rewrites are applied."
+}

--- a/docs/respond/v1.0/docs/respond.md
+++ b/docs/respond/v1.0/docs/respond.md
@@ -1,0 +1,317 @@
+---
+title: "Overview"
+---
+# Respond
+
+## Overview
+
+The Respond policy returns an immediate HTTP response to the client without forwarding the request to the upstream backend. This policy short-circuits the request processing pipeline in the request phase and is useful for API mocking, maintenance-mode responses, feature gating, and controlled error handling.
+
+Because the response is generated at the gateway, no upstream call is made and response-phase policies are not involved for that request path.
+
+## Features
+
+- Returns immediate responses from the gateway request phase
+- Skips upstream backend invocation entirely
+- Configurable HTTP status code (`100`-`599`, default `200`)
+- Configurable response body for JSON, text, XML, or other content
+- Configurable custom response headers
+- Useful for mocks, fallback responses, and temporary endpoint stubs
+- Fail-fast validation for malformed `headers` parameter entries
+- Deterministic response behavior independent of upstream availability
+
+## Configuration
+
+The Respond policy uses single-level API definition parameters and does not require any system-level configuration.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `statusCode` | integer | No | `200` | HTTP status code for the immediate response. Valid range: 100-599. |
+| `body` | string | No | `""` | Response body content returned to the client. Maximum length: 1048576 characters. |
+| `headers` | array | No | `[]` | Array of response headers to include in the immediate response. |
+
+### Headers Array Item
+
+Each item in `headers` supports:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Header name. Must match pattern `^[a-zA-Z0-9-_]+$`. Length: 1-256 characters. |
+| `value` | string | Yes | Header value. Maximum length: 8192 characters. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: respond
+  gomodule: github.com/wso2/gateway-controllers/policies/respond@v0
+```
+
+## Reference Scenarios:
+
+### Example 1: Simple Static Success Response
+
+Return a static success message directly from the gateway:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: health-api-v1.0
+spec:
+  displayName: Health-API
+  version: v1.0
+  context: /health/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: respond
+      version: v0
+      params:
+        statusCode: 200
+        body: '{"status":"ok","source":"gateway"}'
+        headers:
+          - name: content-type
+            value: application/json
+  operations:
+    - method: GET
+      path: /status
+```
+
+**Response behavior:**
+
+Incoming client request
+```http
+GET /health/v1.0/status HTTP/1.1
+Host: api-gateway.company.com
+```
+
+Immediate gateway response
+```http
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"status":"ok","source":"gateway"}
+```
+
+### Example 2: Maintenance Mode Response
+
+Return `503 Service Unavailable` during planned downtime:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: maintenance-api-v1.0
+spec:
+  displayName: Maintenance-API
+  version: v1.0
+  context: /service/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: respond
+      version: v0
+      params:
+        statusCode: 503
+        body: '{"error":"Service Unavailable","message":"Scheduled maintenance in progress"}'
+        headers:
+          - name: content-type
+            value: application/json
+          - name: retry-after
+            value: "300"
+  operations:
+    - method: GET
+      path: /orders
+    - method: POST
+      path: /orders
+```
+
+**Response behavior:**
+
+Incoming client request
+```http
+GET /service/v1.0/orders HTTP/1.1
+Host: api-gateway.company.com
+```
+
+Immediate gateway response
+```http
+HTTP/1.1 503 Service Unavailable
+content-type: application/json
+retry-after: 300
+
+{"error":"Service Unavailable","message":"Scheduled maintenance in progress"}
+```
+
+### Example 3: Route-Specific Mock Responses
+
+Use route-level policy attachment for endpoint-specific mocks:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: mock-api-v1.0
+spec:
+  displayName: Mock-API
+  version: v1.0
+  context: /mock/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  operations:
+    - method: GET
+      path: /users
+      policies:
+        - name: respond
+          version: v0
+          params:
+            statusCode: 200
+            body: '[{"id":1,"name":"Alex"},{"id":2,"name":"Sam"}]'
+            headers:
+              - name: content-type
+                value: application/json
+    - method: GET
+      path: /users/{id}
+      policies:
+        - name: respond
+          version: v0
+          params:
+            statusCode: 404
+            body: '{"error":"Not Found","message":"User not found"}'
+            headers:
+              - name: content-type
+                value: application/json
+```
+
+**Response behavior:**
+
+For `GET /users`
+```http
+HTTP/1.1 200 OK
+content-type: application/json
+
+[{"id":1,"name":"Alex"},{"id":2,"name":"Sam"}]
+```
+
+For `GET /users/{id}`
+```http
+HTTP/1.1 404 Not Found
+content-type: application/json
+
+{"error":"Not Found","message":"User not found"}
+```
+
+### Example 4: Plain Text and Custom Headers
+
+Return plain text with custom diagnostic headers:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: text-response-api-v1.0
+spec:
+  displayName: Text-Response-API
+  version: v1.0
+  context: /text/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: respond
+      version: v0
+      params:
+        statusCode: 202
+        body: Accepted by gateway
+        headers:
+          - name: content-type
+            value: text/plain
+          - name: x-response-source
+            value: gateway-respond-policy
+  operations:
+    - method: POST
+      path: /submit
+```
+
+**Response behavior:**
+
+Immediate gateway response
+```http
+HTTP/1.1 202 Accepted
+content-type: text/plain
+x-response-source: gateway-respond-policy
+
+Accepted by gateway
+```
+
+### Example 5: Default Behavior (Minimal Configuration)
+
+When parameters are omitted, status defaults to `200`, body is empty, and no headers are set:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: minimal-respond-api-v1.0
+spec:
+  displayName: Minimal-Respond-API
+  version: v1.0
+  context: /minimal/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000
+  policies:
+    - name: respond
+      version: v0
+  operations:
+    - method: GET
+      path: /ping
+```
+
+**Response behavior:**
+
+Immediate gateway response
+```http
+HTTP/1.1 200 OK
+
+```
+
+## How it Works
+
+* The policy executes in request phase and immediately returns a `policy.ImmediateResponse` to the client.
+* If `statusCode` is omitted, the response status defaults to `200`.
+* If `body` is omitted, the response body is empty.
+* If `headers` are configured, they are added to the immediate response as provided.
+* Header entries are validated at runtime; malformed `headers` entries return a `500 Configuration Error` response.
+* Because response is produced in request phase, the upstream backend is not called.
+
+## Limitations
+
+1. **Short-Circuit Behavior**: Upstream services are never invoked when this policy executes.
+2. **Request-Phase Only**: Response-phase policy logic is not applicable for requests terminated by this policy.
+3. **Static Response Content**: Response body and headers are configuration-driven and not derived from upstream runtime data.
+4. **Header Validation Strictness**: Invalid `headers` structure or field types result in `500 Configuration Error` responses.
+5. **No Built-in Templating**: Body generation does not include dynamic templating logic by default.
+
+## Notes
+
+**Operational Usage**
+
+Use this policy for controlled stubbing, maintenance windows, and temporary feature shutdowns without changing backend deployments. It is especially useful when you need deterministic responses even if upstream systems are unstable or unavailable. Apply route-level attachment when only specific operations should be short-circuited.
+
+**Security and Governance**
+
+Do not expose sensitive internal details in static response bodies or headers. Ensure custom error payloads are consistent with your API error contract and avoid leaking stack traces or internal identifiers. Restrict who can change policy parameters, since this policy can fully bypass backend enforcement paths.
+
+**Performance and Reliability**
+
+This policy reduces backend load and latency by terminating requests at the gateway. It can improve resilience during incidents by isolating failing upstreams while still returning predictable client responses. Monitor policy usage carefully to ensure temporary mock/maintenance rules are removed when no longer needed.

--- a/docs/respond/v1.0/metadata.json
+++ b/docs/respond/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "respond",
+  "displayName": "Respond",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Returns an immediate response to the client without forwarding the request to the upstream backend.\nThis policy terminates the request processing chain and is useful for mocking APIs, returning\nerror responses, or implementing custom short-circuit logic."
+}

--- a/docs/semantic-cache/v1.0/docs/semantic-caching.md
+++ b/docs/semantic-cache/v1.0/docs/semantic-caching.md
@@ -1,0 +1,256 @@
+---
+title: "Overview"
+---
+# Semantic Caching
+
+## Overview
+
+The Semantic Cache policy enables intelligent response caching for LLM (Large Language Model) APIs using vector similarity search. Unlike traditional key-based caching, semantic caching understands the meaning of requests and can serve cached responses for semantically similar queries, even when the exact wording differs. This dramatically improves performance and reduces costs by avoiding redundant API calls to upstream LLM services.
+
+The policy uses embedding models to convert request text into high-dimensional vectors, then performs similarity searches in a vector database to find previously cached responses. If a similar request is found within the configured similarity threshold, the cached response is returned immediately without calling the upstream service.
+
+## Features
+
+- **Vector-based similarity matching**: Uses embeddings to find semantically similar requests, not just exact matches
+- **Multiple embedding provider support**: Works with OpenAI, Mistral, and Azure OpenAI embedding services
+- **Multiple vector database support**: Supports Redis and Milvus as vector storage backends
+- **Configurable similarity threshold**: Control cache hit sensitivity (0.0 to 1.0)
+- **JSONPath extraction**: Extract specific fields from request body for embedding generation
+- **Automatic cache management**: Stores successful responses (200) automatically after upstream calls
+- **Immediate response on cache hit**: Returns cached response with `X-Cache-Status: HIT` header without upstream call
+- **TTL support**: Configurable time-to-live for cache entries
+
+
+## Configuration
+
+The Semantic Cache policy uses a two-level configuration
+
+### System Parameters (From config.toml)
+
+These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all Semantic Cache policy instances, they can be customized for individual policies within the API configuration when necessary.
+
+##### Embedding Provider Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `embeddingProvider` | string | Yes | Embedding provider type. Must be one of: `OPENAI`, `MISTRAL`, `AZURE_OPENAI` |
+| `embeddingEndpoint` | string | Yes | Endpoint URL for the embedding service. Examples: OpenAI: `https://api.openai.com/v1/embeddings`, Mistral: `https://api.mistral.ai/v1/embeddings`, Azure OpenAI: Your Azure OpenAI endpoint URL |
+| `embeddingModel` | string | Conditional | - | Embedding model name. **Required for OPENAI and MISTRAL**, not required for AZURE_OPENAI (deployment name is in endpoint URL). Examples: OpenAI: `text-embedding-ada-002` or `text-embedding-3-small`, Mistral: `mistral-embed` |
+| `embeddingDimension` | integer | Yes | Dimension of embedding vectors. Common values: 1536 (OpenAI ada-002), 1024 (Mistral). Must match the model's output dimension. |
+| `apiKey` | string | Yes | API key for the embedding service authentication. The authentication header is automatically set to `api-key` for Azure OpenAI and `Authorization` for other providers. |
+
+##### Vector Database Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `vectorStoreProvider` | string | Yes | Vector database provider. Must be one of: `REDIS`, `MILVUS` |
+| `dbHost` | string | Yes | Vector database host address |
+| `dbPort` | integer | Yes | Vector database port number |
+| `username` | string | No | Database username for authentication (if required) |
+| `password` | string | No | Database password for authentication (if required) |
+| `database` | string | No | Database name or index number (for Redis) |
+| `ttl` | integer | No | Time-to-live for cache entries in seconds. Default is 3600 (1 hour). Set to 0 for no expiration. |
+
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+embedding_provider = "MISTRAL" # Supported: MISTRAL, OPENAI, AZURE_OPENAI
+embedding_provider_endpoint = "https://api.mistral.ai/v1/embeddings"
+embedding_provider_model = "mistral-embed"
+embedding_provider_dimension = 1024
+embedding_provider_api_key = ""
+
+vector_db_provider = "REDIS" # Supported: REDIS, MILVUS
+vector_db_provider_host = "redis"
+vector_db_provider_port = 6379
+vector_db_provider_database = "0"
+vector_db_provider_username = "default"
+vector_db_provider_password = "default"
+vector_db_provider_ttl = 3600
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `similarityThreshold` | number | Yes | `0.5` | Similarity threshold for cache hits (0.0 to 1.0). Higher values require more similarity. For example, 0.9 means 90% similarity required. Recommended: 0.85-0.95 for strict matching, 0.70-0.85 for more flexible matching. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract text from request body for embedding generation. If empty, uses the entire request body. Example: `"$.messages[-1].content"` to extract the last message's content. |
+
+#### JSONPath Support
+
+The policy supports JSONPath expressions to extract specific text from request bodies before generating embeddings. This is useful for:
+- Extracting message content from chat completion requests
+- Focusing on specific prompt fields while ignoring metadata
+- Handling structured JSON payloads
+
+**Common JSONPath Examples**
+
+- `$.messages[0].content` - First message's content in chat completions
+- `$.messages[-1].content` - Last message's content
+- `$.prompt` - Extract prompt field from completions API
+- `$.input` - Extract input field from embeddings API
+- `$` - Entire request body (default if jsonPath is not specified)
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: semantic-cache
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v0
+```
+
+## Reference Scenarios
+
+### Example 1: OpenAI Embeddings with Redis
+
+Deploy an LLM provider with semantic caching using OpenAI embeddings and Redis vector store:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: cached-chat-provider
+spec:
+  displayName: OpenAI Cached Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: semantic-cache
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            similarityThreshold: 0.85
+            jsonPath: "$.messages[0].content"
+
+```
+
+**Test the semantic cache:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# First request - cache miss, will call upstream
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain quantum computing in simple terms"
+      }
+    ]
+  }'
+
+# Second request with similar but different wording - cache hit!
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Can you describe quantum computing using simple language?"
+      }
+    ]
+  }'
+# Response will include: X-Cache-Status: HIT
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Text Extraction**: Extracts text from the request body using JSONPath (if configured) or uses the entire request body
+2. **Embedding Generation**: Generates a vector embedding from the extracted text using the configured embedding provider
+3. **Cache Lookup**: Searches the vector database for semantically similar cached responses using cosine similarity
+4. **Threshold Check**: If a similar embedding is found with similarity >= similarityThreshold, returns the cached response immediately
+5. **Cache Miss**: If no similar response is found, the request proceeds to the upstream service
+
+#### Response Phase
+
+1. **Success Check**: Only processes responses with 200 status codes
+2. **Embedding Retrieval**: Retrieves the embedding generated during the request phase from metadata
+3. **Response Storage**: Stores the response payload along with its embedding in the vector database
+4. **TTL Application**: Applies the configured TTL to the cache entry
+
+
+#### Similarity Thresholds
+
+The `similarityThreshold` parameter controls how similar requests must be to trigger a cache hit:
+
+- **0.95-1.0**: Very strict matching. Only near-identical requests will hit cache. Use for exact-match scenarios.
+- **0.85-0.94**: Recommended for most use cases. Catches semantically equivalent requests with some wording variation.
+- **0.75-0.84**: More flexible matching. Useful for broader conceptual similarity.
+- **0.60-0.74**: Very flexible. May return cached responses for loosely related queries.
+- **Below 0.60**: Not recommended. Risk of returning irrelevant cached responses.
+
+**Recommendation**: Start with 0.85 and adjust based on your use case. Monitor cache hit rates and response relevance to fine-tune.
+
+#### Cache Behavior
+
+- **Cache Hit**: When a similar request is found, the policy immediately returns the cached response with a `200` status, adds the `X-Cache-Status: HIT` header, and avoids any upstream call, typically responding in under 50 ms.
+
+- **Cache Miss**: When no similar request exists, the request is forwarded to the upstream service, and upon a successful `200` response, the result is stored so that subsequent similar requests can be served from the cache.
+
+- **Cache Storage**: Only successful responses are cached along with their embeddings in the vector database, with a TTL applied to each entry and isolated cache namespaces maintained per route or API to prevent cross-contamination.
+
+
+#### Operational Resilience
+- **Graceful degradation**: If embedding generation, vector database access, cache storage, or JSONPath extraction fails, the request proceeds directly to the upstream service without blocking the client response.
+
+- **Non-blocking resilience**: Caching operations are best-effort and never interfere with normal request handling, ensuring uninterrupted service even when caching components are unavailable.
+
+
+- **Latency and efficiency trade-offs**: Embedding generation adds processing overhead, and vector database performance, embedding dimensions, and index creation time directly affect latency, storage, and search efficiency.
+
+- **Cache effectiveness**: Overall performance gains depend on achieving a healthy cache hit rate, with moderate hit ratios delivering meaningful cost and latency benefits that justify the added processing overhead.
+
+
+
+
+## Notes
+
+- This capability reduces cost and latency by serving cached responses, helps manage rate limits and high traffic, ensures consistent results, improves resilience during upstream outages, and supports faster development, testing, and experimentation such as A/B testing.
+
+- The policy requires both request and response phases to function properly (generates embeddings in request phase, stores responses in response phase).
+
+- Embedding generation adds latency to each request (~100-500ms). This overhead is typically offset by the performance gains from cache hits.
+
+- Cache entries are scoped per route/API to prevent cross-contamination between different APIs or routes.
+
+- Only responses with 200 status code are cached. Errors and non-200 responses are never cached.
+
+- The similarity search uses cosine similarity to compare embeddings. This is optimal for semantic similarity matching.
+
+- Vector database indexes are created automatically when the policy is first used. Ensure your vector database has sufficient resources.
+
+- The policy maintains provider instances per route for efficiency. Configuration changes require policy reinitialization.
+
+- TTL of 0 means no expiration. Use with caution as it may lead to unbounded cache growth.
+
+- JSONPath extraction is optional. If not specified, the entire request body (as string) is used for embedding generation.
+
+- The policy stores embeddings in metadata between request and response phases. Ensure metadata persistence is enabled in your gateway configuration.
+
+- For production deployments, monitor cache hit rates, embedding generation latency, and vector database performance metrics to optimize configuration.

--- a/docs/semantic-cache/v1.0/metadata.json
+++ b/docs/semantic-cache/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "semantic-cache",
+  "displayName": "Semantic Cache",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements semantic caching for LLM responses using vector similarity search.\nGenerates embeddings from request bodies and checks for semantically similar cached responses.\nIf a cache hit is found, returns the cached response immediately without calling the upstream.\nStores successful responses in the cache for future lookups.\n\nNote: This policy requires embedding providers (OpenAI, Mistral, Azure OpenAI) and vector database providers (Redis, Milvus) to be configured."
+}

--- a/docs/semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md
+++ b/docs/semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md
@@ -1,0 +1,363 @@
+---
+title: "Overview"
+---
+# Semantic Prompt Guardrail
+
+## Overview
+
+The Semantic Prompt Guardrail validates prompts using semantic similarity matching against configured allow and deny phrase lists. Unlike keyword-based filtering, this guardrail understands the meaning of prompts by converting them to vector embeddings and comparing them using cosine similarity. This enables more intelligent content filtering that can catch semantically similar content even when exact keywords differ.
+
+The policy uses embedding models (OpenAI, Mistral, or Azure OpenAI) to convert prompts and configured phrases into high-dimensional vectors, then performs similarity comparisons. Prompts are blocked if they are too similar to denied phrases or not similar enough to allowed phrases, based on configurable similarity thresholds.
+
+## Features
+
+- **Semantic similarity matching**: Uses embeddings to understand meaning, not just keywords
+- **Allow/Deny phrase lists**: Configure lists of allowed and denied phrases for flexible filtering
+- **Configurable similarity thresholds**: Control matching sensitivity separately for allow and deny lists (0.0 to 1.0)
+- **Multiple embedding provider support**: Works with OpenAI, Mistral, and Azure OpenAI embedding services
+- **JSONPath extraction**: Extract specific fields from request body for validation
+- **Detailed assessment information**: Optional detailed violation information in error responses
+
+## Configuration
+
+The Semantic Prompt Guardrail policy uses a two-level configuration.
+
+### System Parameters (From config.toml)
+
+These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all Semantic Prompt Guardrail policy instances, they can be customized for individual policies within the API configuration when necessary.
+
+##### Embedding Provider Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `embeddingProvider` | string | Yes | Embedding provider type. Must be one of: `OPENAI`, `MISTRAL`, `AZURE_OPENAI` |
+| `embeddingEndpoint` | string | Yes | Endpoint URL for the embedding service. Examples: OpenAI: `https://api.openai.com/v1/embeddings`, Mistral: `https://api.mistral.ai/v1/embeddings`, Azure OpenAI: Your Azure OpenAI endpoint URL |
+| `embeddingModel` | string | Conditional | - | Embedding model name. **Required for OPENAI and MISTRAL**, not required for AZURE_OPENAI (deployment name is in endpoint URL). Examples: OpenAI: `text-embedding-ada-002` or `text-embedding-3-small`, Mistral: `mistral-embed` |
+| `apiKey` | string | Yes | API key for the embedding service authentication |
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+embedding_provider = "MISTRAL" # Supported: MISTRAL, OPENAI, AZURE_OPENAI
+embedding_provider_endpoint = "https://api.mistral.ai/v1/embeddings"
+embedding_provider_model = "mistral-embed"
+embedding_provider_dimension = 1024
+embedding_provider_api_key = ""
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract the prompt from JSON payload. If empty, validates the entire payload as a string. Examples: `"$.messages[-1].content"`, `"$.prompt"` |
+| `allowSimilarityThreshold` | number | No | `0.65` | Minimum similarity threshold (0.0 to 1.0) for a prompt to be considered similar to an allowed phrase. Higher values mean stricter matching. |
+| `denySimilarityThreshold` | number | No | `0.65` | Similarity threshold (0.0 to 1.0) for blocking against denied phrases. If any denied phrase has similarity >= this threshold, the request is blocked. |
+| `allowedPhrases` | array | No* | `[]` | List of phrases that are considered safe. The prompt must match one of these within `allowSimilarityThreshold` when allow-list validation is configured. |
+| `deniedPhrases` | array | No* | `[]` | List of phrases that should block the prompt when similar within `denySimilarityThreshold`. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. If `false`, returns minimal error information. |
+
+\* At least one of `allowedPhrases` or `deniedPhrases` must be provided.
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract specific text from request bodies before validation. This is useful for:
+- Extracting message content from chat completion requests
+- Focusing on specific prompt fields while ignoring metadata
+- Handling structured JSON payloads
+
+**Common JSONPath Examples**
+
+- `$.messages[0].content` - First message's content in chat completions
+- `$.messages[-1].content` - Last message's content
+- `$.prompt` - Extract prompt field from completions API
+- `$.input` - Extract input field from embeddings API
+- `$` - Entire request body (default if jsonPath is not specified)
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: semantic-prompt-guard
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-prompt-guard@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Deny List Only - Blocking Prohibited Content
+
+Deploy an LLM provider that blocks prompts similar to prohibited phrases:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: semantic-guard-provider
+spec:
+  displayName: Semantic Guard Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: semantic-prompt-guard
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            jsonPath: "$.messages[0].content"
+            denySimilarityThreshold: 0.80
+            deniedPhrases:
+              - "How to hack into a system"
+              - "Create malicious code"
+              - "Bypass security measures"
+            showAssessment: true
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain how computer security works"
+      }
+    ]
+  }'
+
+# Invalid request - similar to denied phrase (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "How can I break into a computer system?"
+      }
+    ]
+  }'
+```
+
+**Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "SEMANTIC_PROMPT_GUARD",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "semantic-prompt-guard",
+    "actionReason": "Violation of applied semantic prompt guard constraints detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included in the `assessments` field:
+
+```json
+{
+  "type": "SEMANTIC_PROMPT_GUARD",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "semantic-prompt-guard",
+    "actionReason": "Violation of applied semantic prompt guard constraints detected.",
+    "direction": "REQUEST",
+    "assessments": "prompt is too similar to denied phrase 'How to hack into a system' (similarity=0.8500)"
+  }
+}
+```
+
+**In case of an error during processing** (e.g., JSONPath extraction failures, embedding generation errors), the `actionReason` contains the specific error message:
+
+```json
+{
+  "type": "SEMANTIC_PROMPT_GUARD",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "semantic-prompt-guard",
+    "actionReason": "Error extracting value from JSONPath",
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Allow List Only - Whitelist Approach
+
+Deploy an LLM provider that only allows prompts similar to approved phrases:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: whitelist-provider
+spec:
+  displayName: Whitelist Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: semantic-prompt-guard
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            jsonPath: "$.messages[0].content"
+            allowSimilarityThreshold: 0.75
+            allowedPhrases:
+              - "How can I help you with customer service?"
+              - "What product information do you need?"
+              - "Tell me about your order status"
+              - "I need help with my account"
+```
+
+**Allow list Violations:**
+For an allow list violations, the assessment message format is:
+
+```json
+{
+  "type": "SEMANTIC_PROMPT_GUARD",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "semantic-prompt-guard",
+    "actionReason": "Violation of applied semantic prompt guard constraints detected.",
+    "direction": "REQUEST",
+    "assessments": "prompt is not similar enough to allowed phrases (similarity=0.6000 < threshold=0.6500)"
+  }
+}
+```
+
+### Example 3: Combined Allow and Deny Lists
+
+Use both allow and deny lists for comprehensive filtering:
+
+```yaml
+policies:
+  - name: semantic-prompt-guard
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          jsonPath: "$.messages[0].content"
+          allowSimilarityThreshold: 0.70
+          denySimilarityThreshold: 0.75
+          allowedPhrases:
+            - "Customer service inquiry"
+            - "Product information request"
+            - "Technical support question"
+          deniedPhrases:
+            - "How to hack"
+            - "Create malware"
+            - "Bypass authentication"
+          showAssessment: true
+```
+
+### Example 4: Azure OpenAI with Custom Timeout
+
+Configure semantic prompt guardrail with Azure OpenAI and extended timeout:
+
+```yaml
+policies:
+  - name: semantic-prompt-guard
+    version: v0
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          jsonPath: "$.messages[-1].content"
+          denySimilarityThreshold: 0.80
+          deniedPhrases:
+            - "Prohibited content example"
+            - "Another prohibited phrase"
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Text Extraction**: Extracts prompt text from the request body using JSONPath (if configured) or uses the entire request body.
+2. **Embedding Generation**: Generates a vector embedding from the extracted prompt using the configured embedding provider.
+3. **Validation Strategy**: Applies deny-list checks, allow-list checks, or both, depending on configured phrase lists and thresholds.
+4. **Decision Enforcement**: Blocks with HTTP `422` when validation fails; otherwise, request proceeds upstream.
+
+#### Validation Strategy
+
+- **Deny list only**: Compares prompt embedding against all denied phrases. If any denied phrase has similarity >= `denySimilarityThreshold`, the request is blocked.
+- **Allow list only**: Compares prompt embedding against all allowed phrases. If no allowed phrase has similarity >= `allowSimilarityThreshold`, the request is blocked.
+- **Both lists**: Checks deny list first (blocks on deny match), then checks allow list (blocks on allow miss). Request proceeds only if both checks pass.
+
+#### Similarity Thresholds
+
+- **Allow threshold (`allowSimilarityThreshold`)**: Controls minimum similarity required for allow-list matching.
+- **Deny threshold (`denySimilarityThreshold`)**: Controls similarity level that triggers deny-list blocking.
+- **Strict matching (`0.85-1.0`)**: Captures near-identical semantics with fewer broad matches.
+- **Balanced matching (`0.70-0.84`)**: Recommended for most production use cases.
+- **Flexible matching (`0.60-0.69`)**: Broad matching with higher false positive/negative risk depending on list quality.
+
+#### Performance
+
+- **Embedding Generation Latency**: Embedding generation adds approximately `100-500ms` per request.
+- **Batch Initialization**: Allow/deny phrase embeddings are generated in batch during policy initialization.
+- **Similarity Computation**: Cosine similarity calculations are typically fast (< `10ms`) even with moderate phrase lists.
+- **Provider Trade-offs**: OpenAI, Mistral, and Azure OpenAI each have different latency and deployment characteristics.
+
+## Notes
+
+- The policy validates prompts in the request phase only (before sending to LLM). Response validation is not supported.
+
+- Embeddings for allow/deny phrases are generated automatically during policy initialization. Ensure the embedding provider is accessible at initialization time.
+
+- The policy uses cosine similarity to compare embeddings. This is optimal for semantic similarity matching.
+
+- At least one of `allowedPhrases` or `deniedPhrases` must be provided. An empty list for both will cause policy initialization to fail.
+
+- Similarity thresholds are independent for allow and deny lists. You can use different thresholds for each list based on your requirements.
+
+- JSONPath extraction is optional. If not specified, the entire request body (as string) is used for embedding generation.
+
+- The `embeddingModel` parameter is required for `OPENAI` and `MISTRAL` providers, but not for `AZURE_OPENAI` (the deployment name is included in the endpoint URL).
+
+- For Azure OpenAI, the authentication header is automatically set to `api-key`. For other providers, it's set to `Authorization`.
+
+- The policy processes all phrases in batch during initialization for efficiency. Large phrase lists (100+ phrases) may take a few seconds to initialize.
+
+- Similarity scores range from 0.0 (no similarity) to 1.0 (identical meaning). Higher thresholds mean stricter matching.
+
+- For production deployments, monitor false positive/negative rates and adjust similarity thresholds accordingly.

--- a/docs/semantic-prompt-guard/v1.0/metadata.json
+++ b/docs/semantic-prompt-guard/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "semantic-prompt-guard",
+  "displayName": "Semantic Prompt Guard",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Blocks or allows prompts based on semantic similarity to configured allow/deny\nphrase embeddings. The incoming prompt is embedded via the configured embedding provider\nand compared using cosine similarity against pre-computed vectors.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nValidates prompts in the request phase before they are sent to the LLM."
+}

--- a/docs/sentence-count-guardrail/v1.0/docs/sentence-count.md
+++ b/docs/sentence-count-guardrail/v1.0/docs/sentence-count.md
@@ -1,0 +1,271 @@
+---
+title: "Overview"
+---
+# Sentence Count Guardrail
+
+## Overview
+
+The Sentence Count Guardrail validates the sentence count of request or response body content against configurable minimum and maximum thresholds. This guardrail is useful for ensuring content completeness, controlling response verbosity, and maintaining consistent communication standards.
+
+This policy supports SSE streaming responses. When the upstream returns a streaming response (`stream: true`), the guardrail accumulates SSE delta content and validates the sentence count across the full streamed output, using a configurable `streamingJsonPath` to extract content from each SSE event.
+
+## Features
+
+- Validates sentence count against minimum and maximum thresholds
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable inverted logic to pass when sentence count is outside the range
+- Supports independent request and response phase configuration
+- Optional detailed assessment information in error responses
+- **SSE Streaming Support**: Processes streaming responses in real time using a gate-then-stream pattern, buffering until minimum thresholds are met before releasing to the client
+- Configurable `streamingJsonPath` for extracting content from SSE delta chunks
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request-phase sentence count validation. |
+| `response` | object | No* | - | Configuration for response-phase sentence count validation. |
+
+*At least one of `request` or `response` must be provided.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `min` | integer | Conditional | - | Minimum allowed sentence count (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed sentence count (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload as a string. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when sentence count is NOT within the min-max range. If `false`, validation passes when sentence count is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `min` | integer | Conditional | - | Minimum allowed sentence count (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed sentence count (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the JSON payload. Set to `""` to validate the entire payload as a string. |
+| `streamingJsonPath` | string | No | `"$.choices[0].delta.content"` | JSONPath expression to extract content from SSE streaming delta chunks. Used when the upstream returns a streaming (`stream: true`) response. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when sentence count is NOT within the min-max range. If `false`, validation passes when sentence count is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages[-1].content` - Extracts content from the last message in a messages array (default for request)
+- `$.choices[0].message.content` - Extracts content from the first choice message (default for response)
+- `$.choices[0].delta.content` - Extracts content from SSE delta chunks (default for streaming)
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+
+Set `jsonPath` to `""` to validate the entire payload as a string.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: sentence-count-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/sentence-count-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Sentence Count Validation
+
+Deploy an LLM provider that ensures requests contain between 1 and 10 sentences:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: sentence-count-provider
+spec:
+  displayName: Sentence Count Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: sentence-count-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              min: 2
+              max: 10
+              jsonPath: "$.messages[-1].content"
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is machine learning?. How does it work?. Can you explain it simply?"
+      }
+    ]
+  }'
+
+# Invalid request - too few sentences (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hi"
+      }
+    ]
+  }'
+```
+
+**In Case of Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "SENTENCE_COUNT_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "sentence-count-guardrail",
+    "actionReason": "Violation of applied sentence count constraints detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "SENTENCE_COUNT_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "sentence-count-guardrail",
+    "actionReason": "Violation of applied sentence count constraints detected.",
+    "assessments": "Violation of sentence count detected. Expected between 1 and 3 sentences.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Response Streaming Validation
+
+Validate sentence count on streaming LLM responses using a custom streaming JSONPath:
+
+```yaml
+  policies:
+    - name: sentence-count-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            response:
+              enabled: true
+              min: 2
+              max: 20
+              jsonPath: "$.choices[0].message.content"
+              streamingJsonPath: "$.choices[0].delta.content"
+```
+
+When the upstream returns an SSE streaming response, the guardrail accumulates delta content from each SSE event and validates the total sentence count. For non-streaming responses, the standard `jsonPath` is used instead. If the sentence count exceeds the maximum during streaming, an SSE error event is injected into the stream. If the sentence count is below the minimum when the stream completes, an SSE error event is appended.
+
+## How it Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Sentence Counting**: Counts detected sentences in the extracted content after trimming whitespace.
+3. **Range Evaluation**: Validates whether the sentence count is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` and blocks further processing.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload. For SSE streaming responses, delta content is extracted using `streamingJsonPath` instead.
+2. **Sentence Counting**: Counts detected sentences in the extracted content after trimming whitespace.
+3. **Range Evaluation**: Validates whether the sentence count is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` to the client. For streaming responses, an SSE error event is injected into the stream.
+
+#### Streaming (SSE) Processing
+
+This guardrail supports **Server-Sent Events (SSE) streaming responses** commonly used by LLM providers (e.g., OpenAI with `stream: true`).
+
+**How SSE content extraction works:**
+
+- The `streamingJsonPath` parameter (default: `$.choices[0].delta.content`) specifies a JSONPath expression used to extract text content from each SSE `data:` event in the response stream.
+- Each SSE event is a JSON object like `data: {"choices":[{"delta":{"content":"token"}}]}`. The policy uses the JSONPath to extract the incremental token text.
+- The extracted text is accumulated across all SSE events to build the full response content for sentence count validation.
+
+**Gate-then-stream buffering (`NeedsMoreResponseData`):**
+
+- Before any response data reaches the client, the policy evaluates `NeedsMoreResponseData` on the accumulated content.
+- When `NeedsMoreResponseData` returns `true`, the gateway kernel **buffers SSE chunks silently** -- the client does not receive anything yet.
+- Once `NeedsMoreResponseData` returns `false` (e.g., the minimum sentence count threshold is met), the gateway **releases all buffered chunks** and begins streaming subsequent chunks to the client immediately.
+- This ensures the response meets the minimum sentence count threshold before any data is sent to the client.
+
+**Mode-specific gating behavior:**
+
+- **Normal mode (`invert: false`)**: The guardrail buffers SSE events silently until the accumulated sentence count reaches the configured `min`. Once the minimum is met, buffered chunks are flushed to the client. If the sentence count exceeds `max` at any point during streaming, an SSE error event replaces the offending chunk. If the stream completes (the `[DONE]` sentinel arrives) with the count below `min`, an SSE error event is appended.
+- **Inverted mode (`invert: true`)**: The guardrail buffers until the sentence count exceeds `max` (guaranteed outside the excluded range). At stream completion, if the count falls within the excluded `[min, max]` range, an SSE error event is appended.
+
+**Error handling in streaming:**
+
+- Since HTTP headers are already committed once streaming begins, the policy cannot return a traditional HTTP error response.
+- Instead, it injects an **SSE error event** into the stream (e.g., `data: {"type":"SENTENCE_COUNT_GUARDRAIL","message":{...}}`) to notify the client of a violation.
+- Max violations are caught in real-time as chunks arrive. Min violations are caught when the `[DONE]` sentinel arrives (end of stream).
+
+#### Validation Behavior
+
+- **Sentence Detection Rules**: Sentences are detected using standard sentence-ending punctuation marks (`.`, `!`, `?`).
+- **Normal Mode (`invert: false`)**: Validation passes only when the sentence count is within the configured `[min, max]` range.
+- **Inverted Mode (`invert: true`)**: Validation passes only when the sentence count is outside the configured `[min, max]` range.
+
+## Notes
+
+- Sentence counting is performed on the extracted or full content after trimming whitespace.
+- Sentences are identified by standard punctuation marks (., !, ?).
+- Use `request` and `response` independently to validate one or both directions.
+- When using JSONPath, if the path does not exist or the extracted value is not a string, validation will fail.
+- Inverted logic is useful for blocking content that falls outside acceptable sentence count ranges.
+- Consider the nature of your content when setting thresholds, as some content types may naturally have different sentence counts.
+- The `streamingJsonPath` parameter is only used during SSE streaming responses. For non-streaming responses, the standard `jsonPath` is used.

--- a/docs/sentence-count-guardrail/v1.0/metadata.json
+++ b/docs/sentence-count-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "sentence-count-guardrail",
+  "displayName": "Sentence Count Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates the sentence count of request or response body content.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan be configured with min/max sentence count constraints and inverted logic.\nSupports separate configuration for request and response phases.\nSupports SSE streaming responses with configurable streaming JSONPath extraction."
+}

--- a/docs/set-headers/v1.0/docs/set-headers.md
+++ b/docs/set-headers/v1.0/docs/set-headers.md
@@ -1,0 +1,420 @@
+---
+title: "Overview"
+---
+# Set Headers
+
+## Overview
+
+The Set Headers policy dynamically sets HTTP headers on incoming requests before they are forwarded to upstream services, and/or sets headers on outgoing responses before they are returned to clients. **Headers are set/replaced instead of appended**, which means existing headers with the same name will be overwritten with the new value.
+
+## Features
+
+- Sets custom headers on requests before forwarding to upstream services
+- Sets custom headers on responses before returning to clients
+- Supports both request and response phases independently or simultaneously
+- **Overwrites headers instead of appending**: Existing headers with the same name are replaced
+- Proper header name normalization (lowercase conversion for HTTP/2 compatibility)
+- Static value assignment with support for special characters and complex values
+- Works with any HTTP method and request type
+- Last-value-wins behavior for duplicate header names in configuration
+- Comprehensive validation of header configurations
+
+## Configuration
+
+The Set Headers policy can be configured for request phase, response phase, or both.
+This policy does not require system-level configuration and operates entirely based on the configured header arrays.
+
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No | - | Specifies request-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+| `response` | object | No | - | Specifies response-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+
+### Request / Response Header Configuration
+
+Each header entry in the `request.headers` or `response.headers` array must contain:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | The name of the HTTP header to set. Header names are automatically normalized to lowercase for consistency. Must match pattern `^[a-zA-Z0-9-_]+$` and be between 1 and 256 characters. |
+| `value` | string | Yes | The value of the HTTP header to set. Can be static text, empty string, or contain special characters and complex values. Maximum length is 8192 characters. |
+
+**Note:**
+At least one of `request` or `response` must be specified in the policy configuration. The policy will fail validation if both are omitted.
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: set-headers
+  gomodule: github.com/wso2/gateway-controllers/policies/set-headers@v0
+```
+
+## Reference Scenarios:
+
+### Example 1: Setting Request Headers for Authentication
+
+Set authentication headers on all requests sent to upstream:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: X-API-Key
+              value: "12345-abcde-67890-fghij"
+            - name: X-Client-Version
+              value: "1.2.3"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Request transformation (header set):**
+
+Original client request
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+User-Agent: WeatherApp/1.0
+```
+
+Resulting upstream request
+```http
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+User-Agent: WeatherApp/1.0
+x-api-key: 12345-abcde-67890-fghij
+x-client-version: 1.2.3
+```
+
+### Example 2: Setting Response Headers for Security
+
+Set security headers on all responses returned to clients:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v0
+      params:
+        response:
+          headers:
+            - name: X-Content-Type-Options
+              value: "nosniff"
+            - name: X-Frame-Options
+              value: "DENY"
+            - name: X-XSS-Protection
+              value: "1; mode=block"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Response transformation (header set):**
+
+Original upstream response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+x-content-type-options: nosniff
+x-frame-options: DENY
+x-xss-protection: 1; mode=block
+
+{"temperature": 22, "humidity": 65}
+```
+
+### Example 3: Setting Headers on Both Request and Response
+
+Set headers on both requests (for upstream) and responses (for clients):
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v0
+      params:
+        request:
+          headers:
+            - name: X-Source
+              value: "api-gateway"
+            - name: X-Request-ID
+              value: "req-12345"
+        response:
+          headers:
+            - name: X-Cache-Status
+              value: "HIT"
+            - name: X-Server-Version
+              value: "2.1.0"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Bidirectional transformation sample:**
+
+Incoming client request headers
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+```
+
+Forwarded upstream request headers
+```http
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+x-source: api-gateway
+x-request-id: req-12345
+```
+
+Returned upstream response headers
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+Final client response headers
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+x-cache-status: HIT
+x-server-version: 2.1.0
+```
+
+### Example 4: Route-Specific Headers
+
+Apply different headers to different routes:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: set-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "weather-query"
+            response:
+              headers:
+                - name: X-Data-Source
+                  value: "weather-service"
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: set-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "alert-query"
+            response:
+              headers:
+                - name: X-Real-Time
+                  value: "true"
+    - method: POST
+      path: /alerts/active
+      policies:
+        - name: set-headers
+          version: v0
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "alert-create"
+            response:
+              headers:
+                - name: X-Processing-Mode
+                  value: "sync"
+```
+
+**Route-level transformation sample:**
+
+For `GET /{country_code}/{city}`
+```http
+Request to upstream includes: x-operation-type: weather-query
+Response to client includes: x-data-source: weather-service
+```
+
+For `GET /alerts/active`
+```http
+Request to upstream includes: x-operation-type: alert-query
+Response to client includes: x-real-time: true
+```
+
+For `POST /alerts/active`
+```http
+Request to upstream includes: x-operation-type: alert-create
+Response to client includes: x-processing-mode: sync
+```
+
+### Example 5: Overwriting Existing Headers (Set Behavior)
+
+Demonstrate header overwriting behavior where existing headers with same name are replaced:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v0
+      params:
+        response:
+          headers:
+            - name: Cache-Control
+              value: "public, max-age=3600"
+            - name: Server
+              value: "API-Gateway/2.1.0"
+            - name: Content-Type
+              value: "application/json; charset=utf-8"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Response transformation (header overwrite):**
+
+Original upstream response
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Server: Apache/2.4.41
+Cache-Control: no-cache
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response (headers overwritten)
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Server: API-Gateway/2.1.0
+Cache-Control: public, max-age=3600
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+
+## How it Works
+
+* The policy reads `request.headers` and `response.headers` arrays and applies them independently on request and response flows.
+* Header names are normalized (trimmed and lowercased) before application to ensure consistent behavior across HTTP versions.
+* Headers are applied using set semantics: if a header already exists, its value is replaced rather than appended.
+* If the same header is configured multiple times in the same array, the last configured value wins.
+* Request flow modifies outbound headers to upstream; response flow modifies outbound headers to clients.
+* If no headers are configured for a flow, that flow passes through without header modification.
+
+
+## Limitations
+
+1. **Set-Only Behavior**: This policy replaces existing header values and does not append additional values.
+2. **No Conditional Logic**: Header setting is static per policy configuration and cannot be conditional on runtime content.
+3. **Configuration Dependency**: At least one of `request` or `response` must be configured; omitting both fails validation.
+4. **Ordering Sensitivity**: Policy order affects final header values when combined with other header manipulation policies.
+5. **Header Constraints Apply**: Header names and values must satisfy schema constraints (name pattern `^[a-zA-Z0-9-_]+$`, name max length 256, value max length 8192).
+
+
+## Notes
+
+**Security and Data Handling**
+
+Avoid placing secrets, credentials, or personally identifiable data in headers unless strictly necessary, since headers can be logged or forwarded across multiple intermediaries. Validate and sanitize dynamic header values before injecting them to reduce header injection risks. For response headers exposed to clients, ensure values do not reveal sensitive internal topology or implementation details.
+
+**Performance and Operational Impact**
+
+Header setting is lightweight and local, but excessive or oversized headers increase request/response size and can impact proxy or load balancer limits. Keep header sets minimal and purposeful, especially on high-throughput APIs. Monitor for rejected requests caused by upstream or intermediary header-size constraints.
+
+**Operational Best Practices**
+
+Use clear naming conventions and document which headers are enforced at API level versus operation level to avoid conflicts. Apply route-specific policies when different operations require different header contracts. Test overwrite behavior explicitly—especially for standard headers like `content-type`, `cache-control`, and `server`—to ensure downstream systems and clients behave as expected.

--- a/docs/set-headers/v1.0/metadata.json
+++ b/docs/set-headers/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "set-headers",
+  "displayName": "Set Headers",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation",
+    "MCP"
+  ],
+  "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
+}

--- a/docs/subscription-validation/v1.0/docs/subscription-validation.md
+++ b/docs/subscription-validation/v1.0/docs/subscription-validation.md
@@ -1,0 +1,190 @@
+---
+title: "Overview"
+---
+# Subscription Validation
+
+## Overview
+
+The Subscription Validation policy ensures that incoming requests are associated with an active subscription for the target API. It primarily validates a subscription token provided in the request, with support for both header and cookie sources. When subscription plans include throttle limits, this policy also enforces per-subscription rate limits.
+
+## Features
+
+- Validates subscriptions per API using subscription tokens.
+- Supports subscription tokens from a configurable HTTP header
+- Optional lookup of subscription tokens from a configurable cookie
+- Enforces plan-based throttling (rate limiting) when a subscription plan defines limits and `StopOnQuotaReach` is enabled
+
+## Configuration
+
+This policy uses a single-level configuration model where all parameters are configured per API or route in the API definition YAML.
+
+### User Parameters (API Definition)
+
+These parameters are configured per API or route by the API developer:
+
+| Parameter               | Type    | Required | Default            | Description |
+|-------------------------|---------|----------|--------------------|-------------|
+| `subscriptionKeyHeader` | string  | No       | `Subscription-Key` | Name of the HTTP request header that carries the subscription token. This is the primary source and is checked before cookie fallback. |
+| `subscriptionKeyCookie` | string  | No       | `""`               | Optional cookie name that can carry the subscription token. When non-empty, the cookie value is checked only if the header does not contain a token. |
+
+At runtime the policy behaves as follows:
+
+1. It first attempts to read the subscription token from `subscriptionKeyHeader`.
+2. If no header token is present and `subscriptionKeyCookie` is non-empty, it attempts to read the token from the named cookie.
+3. If a token is found, it is validated against the subscription store for the target API.
+4. If a matching active subscription is not found, the request is rejected.
+5. When the matched subscription plan includes throttle limits, the policy enforces per-subscription rate limits and can block requests when the quota is exceeded.
+
+### System Parameters
+
+This policy does not require explicit system-level configuration; it relies on the gateway's subscription store, which is managed by the platform.
+
+## Error Responses
+
+When validation fails, the policy returns an immediate JSON error response and stops further processing.
+
+- **Forbidden / No Active Subscription**
+  - **Status code:** `403`
+  - **Body (example):**
+    ```json
+    {
+      "error": "forbidden",
+      "message": "Subscription required for this API"
+    }
+    ```
+
+- **Rate Limit Exceeded**
+  - When a subscription has a throttle plan with `StopOnQuotaReach=true` and the quota is exceeded:
+  - **Status code:** `429`
+  - **Body (example):**
+    ```json
+    {
+      "error": "rate_limit_exceeded",
+      "message": "Subscription quota exceeded"
+    }
+    ```
+
+## Adding the Policy Module
+
+Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
+
+```yaml
+- name: subscription-validation
+  gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Subscription Token Validation (Header Only)
+
+Require a subscription token from the default `Subscription-Key` header:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: subscription-validation
+      version: v0
+      params:
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /plans/{planId}
+```
+
+In this configuration, requests must include a valid subscription token:
+
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Subscription-Key: tok-1
+```
+
+### Example 2: Custom Header Name
+
+Use a custom header name for the subscription token:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: subscription-validation
+      version: v0
+      params:
+        subscriptionKeyHeader: X-Subscription-Token
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+```
+
+Requests must now send the token in `X-Subscription-Token`:
+
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+X-Subscription-Token: tok-1
+```
+
+### Example 3: Cookie-Based Subscription Token
+
+Read the subscription token from a cookie when the header is not present:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: subscription-validation
+      version: v0
+      params:
+        subscriptionKeyHeader: Subscription-Key
+        subscriptionKeyCookie: sub-key
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+```
+
+If the `Subscription-Key` header is missing, the policy will look for a cookie:
+
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Cookie: sub-key=tok-1
+```
+
+### Example 4: Plan-Based Rate Limiting
+
+When a subscription has a throttle plan configured (for example, request limits per minute) and `StopOnQuotaReach` is enabled, the policy enforces rate limits per subscription:
+
+- Requests within the allowed quota are passed through.
+- Once the configured limit is exceeded, additional requests are rejected with `429 Too Many Requests` and a `rate_limit_exceeded` error.
+
+This allows you to combine subscription validation with fine-grained quota enforcement for different subscription tiers.
+

--- a/docs/subscription-validation/v1.0/metadata.json
+++ b/docs/subscription-validation/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "subscription-validation",
+  "displayName": "Subscription Validation",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security"
+  ],
+  "description": "Validates that incoming requests are associated with an active subscription for the target API. Supports subscription tokens from a configurable header or cookie, and enforces per-subscription rate limits based on the configured subscription plan."
+}

--- a/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
+++ b/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
@@ -1,0 +1,411 @@
+---
+title: "Overview"
+---
+# Token Based Rate Limiting
+
+## Overview
+
+The Token Based Rate Limiting policy controls LLM API usage by enforcing rate limits based on token counts rather than request counts. It enables you to set independent quotas for prompt tokens, completion tokens, and total tokens, ensuring fine-grained control over how much LLM capacity is consumed within a given time window.
+
+Token counts are automatically extracted from LLM provider responses using provider-specific templates. This means you only need to define the token limits — the policy handles the extraction of actual token usage from each response automatically.
+
+Use this policy when you need to:
+
+- Limit LLM API usage based on actual token consumption.
+- Apply separate quotas for prompt (input) and completion (output) tokens.
+- Enforce total token budgets across time windows.
+- Protect against excessive LLM costs by capping token usage per provider path.
+
+## Features
+
+- **Token-Level Rate Limiting**: Enforce rate limits based on actual token consumption instead of request counts.
+- **Independent Token Quotas**: Configure separate limits for prompt tokens, completion tokens, and total tokens.
+- **Automatic Token Extraction**: Token counts are extracted automatically from LLM provider responses using provider-specific templates — no manual cost configuration required.
+- **Multiple Time Windows**: Define multiple concurrent limits per token type (for example, 1000 tokens per minute AND 50000 tokens per day).
+- **Multiple Algorithms**: Supports GCRA (smooth rate limiting with burst support) and Fixed Window (simple counter per time window).
+- **Dual Backends**: Choose between in-memory storage (single instance) or Redis (distributed rate limiting across multiple gateway instances).
+- **Comprehensive Rate Limit Headers**: Responses include standard rate limit headers (X-RateLimit-*, IETF RateLimit, Retry-After) for client-side visibility.
+- **Pre-Flight Quota Check**: Requests are blocked upfront when the token quota is already exhausted, preventing unnecessary upstream calls.
+
+## Configuration
+
+This policy uses a two-level configuration: system parameters configured by administrators and user parameters configured per LLM provider.
+
+### User Parameters (LLM Provider Definition)
+
+These parameters are configured per LLM provider path by the API developer:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `promptTokenLimits` | `Limit` array | No | Rate limits for prompt (input) tokens. |
+| `completionTokenLimits` | `Limit` array | No | Rate limits for completion (output) tokens. |
+| `totalTokenLimits` | `Limit` array | No | Rate limits for total (prompt + completion) tokens. |
+
+> **Note:** At least one of `promptTokenLimits`, `completionTokenLimits`, or `totalTokenLimits` should be configured for the policy to enforce any limits.
+
+#### Limit Configuration
+
+Each limit entry defines a quota for a specific time window:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `count` | integer | Yes | Maximum number of tokens allowed in the duration. Minimum value is 1. |
+| `duration` | string | Yes | Time window for the limit in Go duration format (for example, `"1m"`, `"1h"`, `"24h"`). |
+
+### System Parameters (From config.toml)
+
+These parameters are set by the administrator and apply globally:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `algorithm` | string | No | `"fixed-window"` | Rate limiting algorithm: `"gcra"` (smooth rate limiting with burst support) or `"fixed-window"` (simple counter per time window). |
+| `backend` | string | No | `"memory"` | Storage backend: `"memory"` for single-instance or `"redis"` for distributed rate limiting. |
+| `redis` | `Redis` object | No | - | Redis configuration. Used when `backend=redis`. |
+| `memory` | `Memory` object | No | - | In-memory storage configuration. Used when `backend=memory`. |
+
+#### Redis Configuration
+
+When using Redis as the backend, configure the following under `redis`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `host` | string | No | `"localhost"` | Redis server hostname or IP address. |
+| `port` | integer | No | `6379` | Redis server port. |
+| `password` | string | No | `""` | Redis authentication password (optional). |
+| `username` | string | No | `""` | Redis ACL username (optional, Redis 6+). |
+| `db` | integer | No | `0` | Redis database index (0-15). |
+| `keyPrefix` | string | No | `"ratelimit:v1:"` | Prefix for Redis keys to avoid collisions with other applications. |
+| `failureMode` | string | No | `"open"` | Behavior when Redis is unavailable: `"open"` allows traffic, `"closed"` blocks traffic. |
+| `connectionTimeout` | string | No | `"5s"` | Redis connection timeout (Go duration format). |
+| `readTimeout` | string | No | `"3s"` | Redis read timeout (Go duration format). |
+| `writeTimeout` | string | No | `"3s"` | Redis write timeout (Go duration format). |
+
+#### Memory Configuration
+
+When using in-memory backend, configure the following under `memory`:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `maxEntries` | integer | No | `10000` | Maximum number of rate limit entries stored in memory. Old entries are evicted when this limit is reached. |
+| `cleanupInterval` | string | No | `"5m"` | Interval for cleaning up expired entries (Go duration format). Use `"0"` to disable periodic cleanup. |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "fixed-window"
+backend = "memory"
+
+[policy_configurations.ratelimit_v0.memory]
+max_entries = 10000
+cleanup_interval = "5m"
+```
+
+For distributed rate limiting across multiple gateway instances:
+
+```toml
+[policy_configurations.ratelimit_v0]
+algorithm = "fixed-window"
+backend = "redis"
+
+[policy_configurations.ratelimit_v0.redis]
+host = "redis.example.com"
+port = 6379
+password = "your-redis-password"
+db = 0
+key_prefix = "ratelimit:v1:"
+failure_mode = "open"
+connection_timeout = "5s"
+read_timeout = "3s"
+write_timeout = "3s"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: token-based-ratelimit
+  gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v0
+```
+
+## Reference Scenarios
+
+This policy is designed to be attached to an `LlmProvider`. Before attaching the policy, you must create an `LlmProviderTemplate` that defines the token extraction paths for your LLM backend.
+
+### LLM Provider Template
+
+The `LlmProviderTemplate` tells the policy where to find token usage information in the LLM provider's response. Here is an example template for an OpenAI-compatible provider:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProviderTemplate
+metadata:
+  name: openai-template
+spec:
+  displayName: OpenAI Template
+  promptTokens:
+    location: payload
+    identifier: $.usage.prompt_tokens
+  completionTokens:
+    location: payload
+    identifier: $.usage.completion_tokens
+  totalTokens:
+    location: payload
+    identifier: $.usage.total_tokens
+  requestModel:
+    location: payload
+    identifier: $.model
+  responseModel:
+    location: payload
+    identifier: $.model
+```
+
+The `identifier` fields use JSONPath expressions to locate token counts in the response body. Adjust these paths to match the response format of your LLM provider.
+
+### Example 1: Limit Total Tokens Per Minute
+
+Apply a simple total token limit to an LLM provider:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  template: openai-template
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            totalTokenLimits:
+              - count: 10000
+                duration: "1m"
+```
+
+This limits the `/chat/completions` path to 10,000 total tokens per minute. Once the quota is exhausted, subsequent requests are rejected with a 429 response until the window resets.
+
+### Example 2: Separate Prompt and Completion Token Limits
+
+Apply independent limits for prompt (input) and completion (output) tokens:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  template: openai-template
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            promptTokenLimits:
+              - count: 5000
+                duration: "1m"
+            completionTokenLimits:
+              - count: 8000
+                duration: "1m"
+```
+
+This enforces 5,000 prompt tokens per minute and 8,000 completion tokens per minute independently. If either quota is exhausted, subsequent requests are rejected.
+
+### Example 3: Multiple Time Windows
+
+Enforce both short-term and long-term token budgets:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  template: openai-template
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            totalTokenLimits:
+              - count: 10000
+                duration: "1m"
+              - count: 500000
+                duration: "24h"
+```
+
+This enforces a burst limit of 10,000 total tokens per minute and a daily budget of 500,000 total tokens. Both limits are evaluated, and the most restrictive one is enforced.
+
+### Example 4: Comprehensive Token Limits
+
+Apply limits to all three token types with multiple time windows:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  template: openai-template
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            promptTokenLimits:
+              - count: 5000
+                duration: "1m"
+              - count: 200000
+                duration: "24h"
+            completionTokenLimits:
+              - count: 8000
+                duration: "1m"
+              - count: 300000
+                duration: "24h"
+            totalTokenLimits:
+              - count: 12000
+                duration: "1m"
+              - count: 500000
+                duration: "24h"
+```
+
+This applies per-minute and daily limits across all token types. Each token type is tracked and enforced independently. A request is rejected if any one of the configured limits is exceeded.
+
+### Example 5: Token Limits on Multiple Paths
+
+Apply different token limits to different paths within the same LLM provider:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  template: openai-template
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /completions
+        methods: [POST]
+  policies:
+    - name: token-based-ratelimit
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            totalTokenLimits:
+              - count: 50000
+                duration: "1h"
+        - path: /completions
+          methods: [POST]
+          params:
+            totalTokenLimits:
+              - count: 100000
+                duration: "1h"
+```
+
+Each path maintains its own independent token quota. The `/chat/completions` path is limited to 50,000 total tokens per hour, while `/completions` is limited to 100,000 total tokens per hour.
+
+## Notes
+
+When rate limiting is applied, the following headers may be included in responses:
+
+##### X-RateLimit Headers (Industry Standard)
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum tokens allowed in the current window |
+| `X-RateLimit-Remaining` | Remaining tokens in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the rate limit resets |
+
+##### IETF RateLimit Headers (Draft Standard)
+
+| Header | Description |
+|--------|-------------|
+| `RateLimit-Limit` | Maximum tokens allowed in the current window |
+| `RateLimit-Remaining` | Remaining tokens in the current window |
+| `RateLimit-Reset` | Seconds until the rate limit resets |
+| `RateLimit-Policy` | Rate limit policy description |
+
+##### Retry-After Header (RFC 7231)
+
+| Header | Description |
+|--------|-------------|
+| `Retry-After` | Seconds to wait before retrying (only on 429 responses) |

--- a/docs/token-based-ratelimit/v1.0/metadata.json
+++ b/docs/token-based-ratelimit/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "token-based-ratelimit",
+  "displayName": "Token Based Ratelimit",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "A specialized rate limiting policy for LLM APIs that enforces usage quotas based on token counts. Supports independent limits for prompt tokens, completion tokens, and total tokens. Token counts are automatically extracted from LLM provider responses using provider-specific templates, enabling accurate usage-based rate limiting without manual cost configuration."
+}

--- a/docs/url-guardrail/v1.0/docs/url.md
+++ b/docs/url-guardrail/v1.0/docs/url.md
@@ -1,0 +1,267 @@
+---
+title: "Overview"
+---
+# URL Guardrail
+
+## Overview
+
+The URL Guardrail validates URLs found in request or response body content by checking their reachability and validity. This guardrail helps prevent broken links, malicious URLs, and ensures that referenced resources are accessible.
+
+This policy supports SSE streaming responses. When the upstream returns a streaming response (`stream: true`), the guardrail extracts URLs from accumulated SSE delta content and validates them, using a configurable `streamingJsonPath` to extract content from each SSE event.
+
+## Features
+
+- Validates URLs via DNS resolution or HTTP HEAD requests
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable timeout for URL validation
+- Supports independent request and response phase configuration
+- Optional detailed assessment information including invalid URLs in error responses
+- SSE streaming support with intelligent URL boundary detection to avoid validating incomplete URLs
+- Configurable `streamingJsonPath` for extracting content from SSE delta chunks
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request-phase URL validation. |
+| `response` | object | No* | - | Configuration for response-phase URL validation. |
+
+*At least one of `request` or `response` must be provided.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the request flow. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from JSON payload. Set to `""` to validate the entire payload as a string. |
+| `onlyDNS` | boolean | No | `false` | If `true`, validates URLs only via DNS resolution (faster, less reliable). If `false`, validates URLs via HTTP HEAD request (slower, more reliable). |
+| `timeout` | integer | No | `3000` | Timeout in milliseconds for DNS lookup or HTTP HEAD request. Minimum: 0. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information including invalid URLs in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the response flow. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from JSON payload. Set to `""` to validate the entire payload as a string. |
+| `streamingJsonPath` | string | No | `"$.choices[0].delta.content"` | JSONPath expression to extract content from SSE streaming delta chunks. Used when the upstream returns a streaming (`stream: true`) response. |
+| `onlyDNS` | boolean | No | `false` | If `true`, validates URLs only via DNS resolution (faster, less reliable). If `false`, validates URLs via HTTP HEAD request (slower, more reliable). |
+| `timeout` | integer | No | `3000` | Timeout in milliseconds for DNS lookup or HTTP HEAD request. Minimum: 0. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information including invalid URLs in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages[-1].content` - Extracts content from the last message in a messages array (default for request)
+- `$.choices[0].message.content` - Extracts content from the first choice message (default for response)
+- `$.choices[0].delta.content` - Extracts content from SSE delta chunks (default for streaming)
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+
+Set `jsonPath` to `""` to validate the entire payload as a string.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: url-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/url-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic URL Validation
+
+Deploy an LLM provider that validates URLs in request content using HTTP HEAD requests:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: url-guardrail-provider
+spec:
+  displayName: URL Guardrail Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: url-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              enabled: true
+              jsonPath: "$.messages[-1].content"
+              onlyDNS: false
+              timeout: 5000
+
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Visit https://www.example.com for more information"
+      }
+    ]
+  }'
+
+# Invalid request - invalid URL (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Visit https://invalid-url-that-does-not-exist-12345.com"
+      }
+    ]
+  }'
+```
+
+**In Case of Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "URL_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "url-guardrail",
+    "actionReason": "Violation of url validity detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details including invalid URLs are included:
+
+```json
+{
+  "type": "URL_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "url-guardrail",
+    "actionReason": "Violation of url validity detected.",
+    "assessments": {
+      "invalidUrls": [
+        "http://example.com/suspicious-link",
+        "https://foo.bar.baz"
+      ],
+      "message": "One or more URLs in the payload failed validation."
+    },
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Response Streaming URL Validation
+
+Validate URLs in streaming LLM responses using a custom streaming JSONPath:
+
+```yaml
+  policies:
+    - name: url-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            response:
+              enabled: true
+              jsonPath: "$.choices[0].message.content"
+              streamingJsonPath: "$.choices[0].delta.content"
+              onlyDNS: true
+              timeout: 3000
+```
+
+When the upstream returns an SSE streaming response, the guardrail accumulates delta content from each SSE event and validates URLs once they are fully received. The guardrail detects incomplete URLs at the end of accumulated content and continues buffering until the URL is complete before validating. If an invalid URL is found, an SSE error event replaces the offending chunk in the stream.
+
+## How it Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **URL Detection**: Finds all URLs in the extracted content using pattern matching.
+3. **Validation Execution**: Validates each detected URL using either DNS-only lookup or DNS + HTTP HEAD request based on `onlyDNS`.
+4. **Timeout Enforcement**: Applies the configured `timeout` to each validation operation.
+5. **Intervention on Violation**: If any URL is invalid, returns HTTP `422` and blocks further processing.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload. For SSE streaming responses, delta content is extracted using `streamingJsonPath` instead.
+2. **URL Detection**: Finds all URLs in the extracted content using pattern matching.
+3. **Validation Execution**: Validates each detected URL using the configured mode (`onlyDNS`).
+4. **Timeout Enforcement**: Applies the configured `timeout` to each validation operation.
+5. **Intervention on Violation**: If any URL is invalid, returns HTTP `422` to the client. For streaming responses, an SSE error event replaces the offending chunk.
+
+#### Streaming (SSE) Behavior
+
+When the upstream returns an SSE streaming response, each SSE event arrives as a `data:` line containing a JSON payload, for example:
+
+```
+data: {"choices":[{"delta":{"content":"token"}}]}
+```
+
+The URL guardrail uses a **smart boundary detection pattern** for streaming. `NeedsMoreResponseData` conditionally buffers chunks only when an incomplete URL is detected at the end of the accumulated content:
+
+1. **Delta Content Extraction**: Content is extracted from each SSE event using `streamingJsonPath` (default: `$.choices[0].delta.content`).
+2. **Incomplete URL Detection**: `NeedsMoreResponseData` checks whether the accumulated delta content ends with an incomplete URL -- anything from a bare protocol token (`http`, `https`, `https:`, `https:/`) through a URL body that has started past `://` but has no terminating whitespace (`https://example.com/path`). This prevents false positives from URLs split across SSE chunk boundaries.
+3. **Conditional Buffering**: If an incomplete URL is detected, `NeedsMoreResponseData` returns `true` and the kernel continues accumulating chunks. Once all URLs are complete (terminated by whitespace or end of text), or the stream ends (`data: [DONE]`), the accumulated chunks are flushed for validation.
+4. **URL Validation**: Once chunks are released, all complete URLs in the delta content are validated using the configured mode (`onlyDNS` or HTTP HEAD request).
+5. **Error Handling**: Since HTTP response headers are already committed when streaming begins, violations cannot be reported via HTTP status codes. Instead, an SSE error event replaces the offending chunk in the stream.
+6. **Plain JSON Chunks**: For non-SSE chunked responses (e.g., `Transfer-Encoding: chunked` without SSE), chunks are accumulated until end of stream and validated as a complete body via JSONPath.
+
+#### URL Validation Modes
+
+- **DNS-Only Validation (`onlyDNS: true`)**: Faster method that checks whether the domain resolves via DNS, without confirming HTTP/HTTPS accessibility.
+- **HTTP HEAD Request Validation (`onlyDNS: false`)**: More thorough method that performs DNS lookup and HTTP HEAD checks to verify URL reachability.
+
+## Notes
+
+- URL validation extracts all URLs from the content using pattern matching.
+- DNS-only validation is faster but less reliable than HTTP HEAD validation.
+- Use `request` and `response` independently to validate one or both directions.
+- Timeout values should be set based on network conditions and acceptable latency.
+- HTTP HEAD requests may fail for URLs that require specific headers or authentication.
+- Some URLs may be temporarily unavailable; consider retry logic for production use.
+- When using JSONPath, if the path does not exist or the extracted value is not a string, validation will fail.
+- The guardrail validates all URLs found in the content; if any URL is invalid, validation fails.
+- The `streamingJsonPath` parameter is only used during SSE streaming responses. For non-streaming responses, the standard `jsonPath` is used.

--- a/docs/url-guardrail/v1.0/metadata.json
+++ b/docs/url-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "url-guardrail",
+  "displayName": "URL Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates URLs found in request or response body content.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan validate URLs via DNS resolution only or HTTP HEAD request reachability.\nSupports separate configuration for request and response phases.\nSupports SSE streaming responses with configurable streaming JSONPath extraction."
+}

--- a/docs/word-count-guardrail/v1.0/docs/word-count.md
+++ b/docs/word-count-guardrail/v1.0/docs/word-count.md
@@ -1,0 +1,269 @@
+---
+title: "Overview"
+---
+# Word Count Guardrail
+
+## Overview
+
+The Word Count Guardrail validates the word count of request or response body content against configurable minimum and maximum thresholds. This guardrail is useful for enforcing content length policies, ensuring responses meet quality standards, or preventing excessively long inputs that could impact system performance.
+
+This policy supports SSE streaming responses. When the upstream returns a streaming response (`stream: true`), the guardrail accumulates SSE delta content and validates the word count across the full streamed output, using a configurable `streamingJsonPath` to extract content from each SSE event.
+
+## Features
+
+- Validates word count against minimum and maximum thresholds
+- Supports JSONPath extraction to validate specific fields within JSON payloads
+- Configurable inverted logic to pass when word count is outside the range
+- Supports independent request and response phase configuration
+- Optional detailed assessment information in error responses
+- **SSE Streaming Support**: Processes streaming responses in real time using a gate-then-stream pattern, buffering until minimum thresholds are met before releasing to the client
+- Configurable `streamingJsonPath` for extracting content from SSE delta chunks
+
+## Configuration
+
+This policy requires only a single-level configuration where all parameters are configured in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `request` | object | No* | - | Configuration for request-phase word count validation. |
+| `response` | object | No* | - | Configuration for response-phase word count validation. |
+
+*At least one of `request` or `response` must be provided.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `min` | integer | Conditional | - | Minimum allowed word count (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed word count (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from JSON payload. If empty, validates the entire payload as a string. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when word count is NOT within the min-max range. If `false`, validation passes when word count is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `min` | integer | Conditional | - | Minimum allowed word count (inclusive). Must be >= 0. Required when `enabled` is `true`. |
+| `max` | integer | Conditional | - | Maximum allowed word count (inclusive). Must be >= 1. Required when `enabled` is `true`. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from JSON payload. If empty, validates the entire payload as a string. |
+| `streamingJsonPath` | string | No | `"$.choices[0].delta.content"` | JSONPath expression to extract content from SSE streaming delta chunks. Used when the upstream returns a streaming (`stream: true`) response. |
+| `invert` | boolean | No | `false` | If `true`, validation passes when word count is NOT within the min-max range. If `false`, validation passes when word count is within the range. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages[-1].content` - Extracts content from the last message in a messages array (default for request)
+- `$.choices[0].message.content` - Extracts content from the first choice message (default for response)
+- `$.choices[0].delta.content` - Extracts content from SSE delta chunks (default for streaming)
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+
+If `jsonPath` is empty or not specified, the entire payload is treated as a string and validated.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: word-count-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/word-count-guardrail@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Word Count Validation
+
+Deploy an LLM provider that validates request messages contain between 10 and 500 words:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: word-count-provider
+spec:
+  displayName: Word Count Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+      - path: /models
+        methods: [GET]
+      - path: /models/{modelId}
+        methods: [GET]
+  policies:
+    - name: word-count-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            request:
+              min: 5
+              max: 500
+              jsonPath: "$.messages[-1].content"
+```
+
+**Test the guardrail:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file. or remove the vhost from the llm provider configuration and use localhost to invoke.
+
+```bash
+# Valid request (should pass)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Please explain artificial intelligence in simple terms for beginners"
+      }
+    ]
+  }'
+
+# Invalid request - too few words (should fail with HTTP 422)
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hi"
+      }
+    ]
+  }'
+```
+
+**In Case of Error Response:**
+
+When validation fails, the guardrail returns an HTTP 422 status code with the following structure:
+
+```json
+{
+  "type": "WORD_COUNT_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "word-count-guardrail",
+    "actionReason": "Violation of applied word count constraints detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "WORD_COUNT_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "word-count-guardrail",
+    "actionReason": "Violation of applied word count constraints detected.",
+    "assessments": "Violation of word count detected. Expected between 2 and 10 words.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+### Example 2: Response Streaming Validation
+
+Validate word count on streaming LLM responses using a custom streaming JSONPath:
+
+```yaml
+  policies:
+    - name: word-count-guardrail
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            response:
+              enabled: true
+              min: 10
+              max: 1000
+              jsonPath: "$.choices[0].message.content"
+              streamingJsonPath: "$.choices[0].delta.content"
+```
+
+When the upstream returns an SSE streaming response, the guardrail accumulates delta content from each SSE event and validates the total word count. For non-streaming responses, the standard `jsonPath` is used instead. If the word count exceeds the maximum during streaming, an SSE error event is injected into the stream. If the word count is below the minimum when the stream completes, an SSE error event is appended.
+
+## How it Works
+
+#### Request Phase
+
+1. **Content Extraction**: Extracts content from the request body using `jsonPath` (if configured) or uses the entire payload.
+2. **Word Counting**: Counts words in the extracted content after trimming whitespace.
+3. **Range Evaluation**: Validates whether the word count is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` and blocks further processing.
+
+#### Response Phase
+
+1. **Content Extraction**: Extracts content from the response body using `jsonPath` (if configured) or uses the entire payload. For SSE streaming responses, delta content is extracted using `streamingJsonPath` instead.
+2. **Word Counting**: Counts words in the extracted content after trimming whitespace.
+3. **Range Evaluation**: Validates whether the word count is within `min` and `max` bounds.
+4. **Invert Handling**: Applies `invert` logic when configured to validate outside-range behavior.
+5. **Intervention on Violation**: If validation fails, returns HTTP `422` to the client. For streaming responses, an SSE error event is injected into the stream.
+
+#### Streaming (SSE) Processing
+
+This guardrail supports **Server-Sent Events (SSE) streaming responses** commonly used by LLM providers (e.g., OpenAI with `stream: true`).
+
+**How SSE content extraction works:**
+
+- The `streamingJsonPath` parameter (default: `$.choices[0].delta.content`) specifies a JSONPath expression used to extract text content from each SSE `data:` event in the response stream.
+- Each SSE event is a JSON object like `data: {"choices":[{"delta":{"content":"token"}}]}`. The policy uses the JSONPath to extract the incremental token text.
+- The extracted text is accumulated across all SSE events to build the full response content for word count validation.
+
+**Gate-then-stream buffering (`NeedsMoreResponseData`):**
+
+- Before any response data reaches the client, the policy evaluates `NeedsMoreResponseData` on the accumulated content.
+- When `NeedsMoreResponseData` returns `true`, the gateway kernel **buffers SSE chunks silently** -- the client does not receive anything yet.
+- Once `NeedsMoreResponseData` returns `false` (e.g., the minimum word count threshold is met), the gateway **releases all buffered chunks** and begins streaming subsequent chunks to the client immediately.
+- This ensures the response meets the minimum word count threshold before any data is sent to the client.
+
+**Mode-specific gating behavior:**
+
+- **Normal mode (`invert: false`)**: The guardrail buffers SSE events silently until the accumulated word count reaches the configured `min`. Once the minimum is met, buffered chunks are flushed to the client. If the word count exceeds `max` at any point during streaming, an SSE error event replaces the offending chunk. If the stream completes (the `[DONE]` sentinel arrives) with the count below `min`, an SSE error event is appended.
+- **Inverted mode (`invert: true`)**: The guardrail buffers until the word count exceeds `max` (guaranteed outside the excluded range). At stream completion, if the count falls within the excluded `[min, max]` range, an SSE error event is appended.
+
+**Error handling in streaming:**
+
+- Since HTTP headers are already committed once streaming begins, the policy cannot return a traditional HTTP error response.
+- Instead, it injects an **SSE error event** into the stream (e.g., `data: {"type":"WORD_COUNT_GUARDRAIL","message":{...}}`) to notify the client of a violation.
+- Max violations are caught in real-time as chunks arrive. Min violations are caught when the `[DONE]` sentinel arrives (end of stream).
+
+#### Validation Behavior
+
+- **Normal Mode (`invert: false`)**: Validation passes only when the word count is within the configured `[min, max]` range.
+- **Inverted Mode (`invert: true`)**: Validation passes only when the word count is outside the configured `[min, max]` range.
+
+## Notes
+
+- Word counting is performed on the extracted or full content after trimming whitespace.
+- The validation is case-sensitive and counts all words separated by whitespace.
+- Use `request` and `response` independently to validate one or both directions.
+- When using JSONPath, if the path does not exist or the extracted value is not a string, validation will fail.
+- Inverted logic is useful for blocking content that falls outside acceptable ranges rather than within them.
+- The `streamingJsonPath` parameter is only used during SSE streaming responses. For non-streaming responses, the standard `jsonPath` is used.

--- a/docs/word-count-guardrail/v1.0/metadata.json
+++ b/docs/word-count-guardrail/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "word-count-guardrail",
+  "displayName": "Word Count Guardrail",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates the word count of request or response body content.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nCan be configured with min/max word count constraints and inverted logic.\nSupports separate configuration for request and response phases.\nSupports SSE streaming responses with configurable streaming JSONPath extraction."
+}

--- a/policies/advanced-ratelimit/cost_extractor.go
+++ b/policies/advanced-ratelimit/cost_extractor.go
@@ -284,11 +284,17 @@ func (e *CostExtractor) extractFromRequestSource(ctx *policy.RequestContext, sou
 }
 
 func (e *CostExtractor) extractFromRequestHeader(ctx *policy.RequestContext, headerName string) (float64, bool) {
-	if ctx.Headers == nil {
+	return extractCostFromHeaders(ctx.Headers, headerName)
+}
+
+// extractCostFromHeaders parses a numeric cost value from the named header.
+// Shared by both request-body-phase and request-header-phase extraction paths.
+func extractCostFromHeaders(headers *policy.Headers, headerName string) (float64, bool) {
+	if headers == nil {
 		return 0, false
 	}
 
-	values := ctx.Headers.Get(strings.ToLower(headerName))
+	values := headers.Get(strings.ToLower(headerName))
 	if len(values) == 0 || values[0] == "" {
 		return 0, false
 	}
@@ -303,6 +309,34 @@ func (e *CostExtractor) extractFromRequestHeader(ctx *policy.RequestContext, hea
 	}
 
 	return cost, true
+}
+
+// ExtractRequestHeaderOnlyCost extracts cost from request_header sources using the
+// header-phase context. Only called when HasHeaderOnlyCostSources() is true,
+// meaning all request-phase sources are request_header.
+func (e *CostExtractor) ExtractRequestHeaderOnlyCost(ctx *policy.RequestHeaderContext) (float64, bool) {
+	if !e.config.Enabled {
+		return e.config.Default, false
+	}
+
+	var total float64
+	var found bool
+
+	for _, source := range e.config.Sources {
+		if source.Type != CostSourceRequestHeader {
+			continue
+		}
+		val, ok := extractCostFromHeaders(ctx.Headers, source.Key)
+		if ok {
+			found = true
+			total += val * source.Multiplier
+		}
+	}
+
+	if !found {
+		return e.config.Default, false
+	}
+	return total, true
 }
 
 func (e *CostExtractor) extractFromRequestMetadata(ctx *policy.RequestContext, key string) (float64, bool) {
@@ -462,23 +496,72 @@ func (e *CostExtractor) RequiresResponseBody() bool {
 	return false
 }
 
-// RequiresRequestBody returns true if any source requires the OnRequestBody phase.
-// request_header and request_metadata are available in the header phase but their
-// cost consumption is deferred to OnRequestBody, so those also require buffering.
-func (e *CostExtractor) RequiresRequestBody() bool {
+// HasRequestBodyPhase returns true if any source requires the OnRequestBody phase.
+// request_body and request_cel need body content. request_metadata is also deferred
+// to the body phase because metadata may be mutated by earlier policies before that phase.
+// request_header is consumed directly in OnRequestHeaders and does not require buffering.
+func (e *CostExtractor) HasRequestBodyPhase() bool {
 	if !e.config.Enabled {
 		return false
 	}
 	for _, source := range e.config.Sources {
-		// request_body and request_cel need body buffering; request_header and
-		// request_metadata are available in header phase but consumption is
-		// deferred to OnRequestBody, so they also require buffering.
 		if source.Type == CostSourceRequestBody || source.Type == CostSourceRequestCEL ||
-			source.Type == CostSourceRequestHeader || source.Type == CostSourceRequestMetadata {
+			source.Type == CostSourceRequestMetadata {
 			return true
 		}
 	}
 	return false
+}
+
+// HasResponseHeaderOnlyCostSources returns true if cost extraction is enabled,
+// no source requires the response body phase (no response_body or response_cel),
+// and all response-phase sources are response_header.
+// response_metadata is excluded — it may be populated by upstream response-phase
+// policies that haven't run yet in OnResponseHeaders.
+// Request-phase sources are irrelevant and are ignored.
+// When true, cost can be fully consumed in OnResponseHeaders with no body buffering.
+func (e *CostExtractor) HasResponseHeaderOnlyCostSources() bool {
+	if !e.config.Enabled || e.RequiresResponseBody() {
+		return false
+	}
+	hasHeader := false
+	for _, source := range e.config.Sources {
+		if source.Type == CostSourceResponseHeader {
+			hasHeader = true
+			continue
+		}
+		// Any other response-phase source disqualifies response-header-only consumption.
+		// Request-phase sources are irrelevant — skip them.
+		if isResponsePhaseSource(source.Type) {
+			return false
+		}
+	}
+	return hasHeader
+}
+
+// HasRequestHeaderOnlyCostSources returns true if cost extraction is enabled,
+// no source requires the request body phase (no request_body, request_cel, or
+// request_metadata), and at least one request_header source exists.
+// Response-phase sources (response_header, response_body, etc.) are ignored —
+// only request-phase sources are evaluated to determine header-only eligibility.
+// When true, cost can be fully consumed in OnRequestHeaders with no body buffering.
+func (e *CostExtractor) HasRequestHeaderOnlyCostSources() bool {
+	if !e.config.Enabled || e.HasRequestBodyPhase() {
+		return false
+	}
+	hasHeader := false
+	for _, source := range e.config.Sources {
+		if source.Type == CostSourceRequestHeader {
+			hasHeader = true
+			continue
+		}
+		// Any other request-phase source disqualifies header-only consumption.
+		// Response-phase sources are irrelevant — skip them.
+		if isRequestPhaseSource(source.Type) {
+			return false
+		}
+	}
+	return hasHeader
 }
 
 // HasRequestPhaseSources returns true if any source is available during request phase

--- a/policies/advanced-ratelimit/cost_extractor.go
+++ b/policies/advanced-ratelimit/cost_extractor.go
@@ -314,7 +314,7 @@ func extractCostFromHeaders(headers *policy.Headers, headerName string) (float64
 // ExtractRequestHeaderOnlyCost extracts cost from request_header sources using the
 // header-phase context. Only called when HasHeaderOnlyCostSources() is true,
 // meaning all request-phase sources are request_header.
-func (e *CostExtractor) ExtractRequestHeaderOnlyCost(ctx *policy.RequestHeaderContext) (float64, bool) {
+func (e *CostExtractor) ExtractRequestHeaderOnlyCost(reqCtx *policy.RequestHeaderContext) (float64, bool) {
 	if !e.config.Enabled {
 		return e.config.Default, false
 	}
@@ -326,7 +326,7 @@ func (e *CostExtractor) ExtractRequestHeaderOnlyCost(ctx *policy.RequestHeaderCo
 		if source.Type != CostSourceRequestHeader {
 			continue
 		}
-		val, ok := extractCostFromHeaders(ctx.Headers, source.Key)
+		val, ok := extractCostFromHeaders(reqCtx.Headers, source.Key)
 		if ok {
 			found = true
 			total += val * source.Multiplier

--- a/policies/advanced-ratelimit/cost_extractor_test.go
+++ b/policies/advanced-ratelimit/cost_extractor_test.go
@@ -161,3 +161,427 @@ func TestExtractFromBodyBytes_PlainJSON_StillWorks(t *testing.T) {
 		t.Fatalf("expected 42, got %v", cost)
 	}
 }
+
+// anthropicSSEBody is the full buffered Anthropic SSE response used across multiple tests.
+// The message_delta event carries usage: input_tokens=10, output_tokens=20.
+var anthropicSSEBody = "event: message_start\n" +
+	"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-sonnet-20241022\",\"stop_reason\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n" +
+	"\n" +
+	"event: content_block_start\n" +
+	"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n" +
+	"\n" +
+	"event: message_delta\n" +
+	"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n" +
+	"\n" +
+	"event: message_stop\n" +
+	"data: {\"type\":\"message_stop\"}\n"
+
+func TestCostExtractor_AnthropicSSE_InputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.input_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"text/event-stream"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected input_tokens=10, got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_OutputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.output_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"text/event-stream"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected output_tokens=20, got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_WithMultiplier(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.output_tokens",
+				Multiplier: 2,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	// 20 * 2 = 40
+	if cost != 40 {
+		t.Fatalf("expected output_tokens=20 * multiplier=2 = 40, got %v", cost)
+	}
+}
+
+// ─── Amazon Bedrock ───────────────────────────────────────────────────────────
+
+// bedrockStreamingBody is a buffered Bedrock streaming response.
+// Bedrock does NOT embed usage in the body — usage comes from response headers.
+var bedrockStreamingBody = "data: {\"chunk\":{\"bytes\":\"Hello\"}}\n" +
+	"data: {\"chunk\":{\"bytes\":\" world\"}}\n" +
+	"data: {\"chunk\":{\"bytes\":\"!\"}}\n"
+
+// TestCostExtractor_BedrockStreaming_InputTokensFromHeader verifies that
+// x-amzn-bedrock-input-token-count is extracted via CostSourceResponseHeader.
+func TestCostExtractor_BedrockStreaming_InputTokensFromHeader(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-input-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response header to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected input_token_count=10, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_OutputTokensFromHeader verifies that
+// x-amzn-bedrock-output-token-count is extracted via CostSourceResponseHeader.
+func TestCostExtractor_BedrockStreaming_OutputTokensFromHeader(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response header to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected output_token_count=20, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_CombinedHeaderCost verifies that
+// input + output token counts are summed when both header sources are configured.
+func TestCostExtractor_BedrockStreaming_CombinedHeaderCost(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-input-token-count",
+				Multiplier: 1,
+			},
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response headers to succeed")
+	}
+	// 10 + 20 = 30
+	if cost != 30 {
+		t.Fatalf("expected combined cost=30, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_WithMultiplier verifies that the multiplier
+// is applied to the header-sourced token count.
+func TestCostExtractor_BedrockStreaming_WithMultiplier(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 2,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction to succeed")
+	}
+	// 20 * 2 = 40
+	if cost != 40 {
+		t.Fatalf("expected 20 * 2 = 40, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_BodyYieldsNoMatch confirms that the Bedrock
+// streaming body (chunk format) does not match a usage JSONPath.
+// Usage must be sourced from response headers, not the body.
+func TestCostExtractor_BedrockStreaming_BodyYieldsNoMatch(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:     CostSourceResponseBody,
+				JSONPath: "$.usage.inputTokens",
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	_, extracted := extractor.ExtractResponseCost(ctx)
+	if extracted {
+		t.Error("expected no extraction: Bedrock streaming body carries no usage field")
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_InputTokens verifies extraction of inputTokens
+// from a Bedrock non-streaming JSON response body.
+func TestCostExtractor_BedrockNonStream_InputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.inputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from non-stream response body to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected inputTokens=10, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_OutputTokens verifies extraction of outputTokens
+// from a Bedrock non-streaming JSON response body.
+func TestCostExtractor_BedrockNonStream_OutputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.outputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from non-stream response body to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected outputTokens=20, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_CombinedCost verifies that inputTokens and
+// outputTokens are summed when both body sources are configured.
+func TestCostExtractor_BedrockNonStream_CombinedCost(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.inputTokens",
+				Multiplier: 1,
+			},
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.outputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction to succeed")
+	}
+	// 10 + 20 = 30
+	if cost != 30 {
+		t.Fatalf("expected combined cost=30 (10+20), got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_OnlyMessageDeltaMatches(t *testing.T) {
+	// content_block_delta events have a "delta" field but no "usage" — they must not match.
+	_, ok := extractFromSSEBodyBytes([]byte(anthropicSSEBody), "$.usage.output_tokens")
+	if !ok {
+		t.Fatal("expected a match from message_delta event")
+	}
+
+	// Verify that a body with only content_block_delta events (no message_delta) yields no match.
+	noUsageBody := "event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+		"\n" +
+		"event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n"
+
+	_, ok = extractFromSSEBodyBytes([]byte(noUsageBody), "$.usage.output_tokens")
+	if ok {
+		t.Error("expected no match when no event carries $.usage.output_tokens")
+	}
+}

--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v0.10.2
+version: v1.0.0
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1117,7 +1117,7 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 			if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
 				// request_header sources only — all values are available now, consume immediately.
 				// No body buffering needed.
-				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(ctx)
+				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(reqCtx)
 				if !extracted {
 					slog.Debug("Header cost extraction failed, using default",
 						"quota", quotaName, "key", key, "defaultCost", requestCost)
@@ -1325,7 +1325,7 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 		// Retrieve results stored by OnRequestHeaders so header-only quota results
 		// (consumed in OnRequestHeaders) can be carried forward.
 		storedResultsMap := make(map[string]quotaResult)
-		if prev, ok := ctx.Metadata[rateLimitResultKey].([]quotaResult); ok {
+		if prev, ok := reqCtx.Metadata[rateLimitResultKey].([]quotaResult); ok {
 			for _, r := range prev {
 				storedResultsMap[r.QuotaName] = r
 			}
@@ -1652,7 +1652,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 
 	// Store updated results so OnResponseBody can carry forward response_header
 	// quota results and avoid re-consuming them.
-	ctx.Metadata[rateLimitResultKey] = allQuotaResults
+	respCtx.Metadata[rateLimitResultKey] = allQuotaResults
 
 	// Only build rate limit headers here if OnResponseBody will not run.
 	// If body/metadata sources exist, OnResponseBody will process those quotas

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -425,7 +425,7 @@ func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
 	if p.requiresRequestBody() {
 		requestBodyMode = policy.BodyModeBuffer
 	}
-	if p.requiresResponseBody() {
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
 		responseBodyMode = policy.BodyModeBuffer
 	}
 
@@ -916,7 +916,7 @@ func getDurationParam(params map[string]interface{}, key string, defaultVal time
 func (p *RateLimitPolicy) requiresRequestBody() bool {
 	for _, q := range p.quotas {
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			if q.CostExtractor.RequiresRequestBody() {
+			if q.CostExtractor.HasRequestBodyPhase() {
 				return true
 			}
 		}
@@ -941,15 +941,18 @@ func (p *RateLimitPolicy) requiresResponseBody() bool {
 	return false
 }
 
-// hasNonBodyResponsePhaseSources returns true if any quota has response-phase cost
-// sources that do not require the response body (e.g. response_metadata,
-// response_header). These sources cannot be resolved in OnResponseHeaders because
-// upstream policies that populate the metadata (e.g. llm-cost writing x-llm-cost)
-// run in the response-body phase. OnResponseBody must therefore also process them,
-// after those upstream policies have had a chance to set the metadata.
-func (p *RateLimitPolicy) hasNonBodyResponsePhaseSources() bool {
+// hasNonHeaderResponsePhaseSources returns true if any quota has response-phase cost
+// sources that are not response_header (e.g. response_metadata, response_body,
+// response_cel). These require OnResponseBody to run — either because they need
+// the body content, or because the metadata they read is populated by upstream
+// policies that execute in the response-body phase.
+func (p *RateLimitPolicy) hasNonHeaderResponsePhaseSources() bool {
 	for _, q := range p.quotas {
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
+			// response_header-only quotas are consumed in OnResponseHeaders — exclude them.
+			if q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+				continue
+			}
 			if q.CostExtractor.HasResponsePhaseSources() && !q.CostExtractor.RequiresResponseBody() {
 				return true
 			}
@@ -1111,32 +1114,80 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx *policy.RequestHeaderContext, par
 		quotaKeys[quotaName] = key
 
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			// Cost extraction configured — only pre-check quota availability; actual
-			// consumption remains in OnRequest (request-phase sources) or OnResponse
-			// (response-phase sources).
-			available, err := q.Limiter.GetAvailable(context.Background(), key)
-			if err != nil {
-				if p.backend == "redis" && p.redisFailOpen {
-					slog.Warn("Rate limit pre-check failed (fail-open)", "error", err, "quota", quotaName)
-					continue
+			if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
+				// request_header sources only — all values are available now, consume immediately.
+				// No body buffering needed.
+				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(ctx)
+				if !extracted {
+					slog.Debug("Header cost extraction failed, using default",
+						"quota", quotaName, "key", key, "defaultCost", requestCost)
+				} else {
+					slog.Debug("Header cost extracted",
+						"quota", quotaName, "key", key, "cost", requestCost)
 				}
-				slog.Error("Rate limit pre-check failed (fail-closed)", "error", err, "quota", quotaName)
-				return p.buildRateLimitResponse(nil, quotaName, quotaResults)
-			}
-			if available <= 0 {
-				slog.Debug("Cost extraction mode: quota exhausted in header phase",
-					"quota", quotaName, "key", key)
-				duration := getDurationFromQuota(q)
-				result := &limiter.Result{
-					Allowed:   false,
-					Limit:     getLimitFromQuota(q),
-					Remaining: 0,
-					Reset:     time.Now().Add(duration),
-					Duration:  duration,
+				if requestCost < 0 {
+					requestCost = 0
 				}
-				return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				cost := int64(requestCost)
+				result, err := q.Limiter.AllowN(context.Background(), key, cost)
+				if err != nil {
+					if p.backend == "redis" && p.redisFailOpen {
+						slog.Warn("Rate limit check failed (fail-open)", "error", err, "quota", quotaName)
+						continue
+					}
+					slog.Error("Rate limit check failed (fail-closed)", "error", err, "quota", quotaName)
+					return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+				}
+				if !result.Allowed {
+					slog.Debug("Rate limit exceeded in header phase",
+						"quota", quotaName, "key", key, "cost", cost)
+					return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				}
+				slog.Debug("Rate limit check passed",
+					"quota", quotaName, "key", key, "cost", cost, "remaining", result.Remaining)
+
+				quotaResults = append(quotaResults, quotaResult{
+					QuotaName: quotaName,
+					Result:    result,
+					Key:       key,
+					Duration:  result.Duration,
+				})
+				handledQuotas[quotaName] = true
+			} else {
+				// body/metadata/CEL/response sources — pre-check availability only;
+				// actual consumption is deferred to OnRequestBody or OnResponse.
+				available, err := q.Limiter.GetAvailable(context.Background(), key)
+				if err != nil {
+					if p.backend == "redis" && p.redisFailOpen {
+						slog.Warn("Rate limit pre-check failed (fail-open)", "error", err, "quota", quotaName)
+						continue
+					}
+					slog.Error("Rate limit pre-check failed (fail-closed)", "error", err, "quota", quotaName)
+					return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+				}
+				if available <= 0 {
+					slog.Debug("Cost extraction mode: quota exhausted in header phase",
+						"quota", quotaName, "key", key)
+					duration := getDurationFromQuota(q)
+					result := &limiter.Result{
+						Allowed:   false,
+						Limit:     getLimitFromQuota(q),
+						Remaining: 0,
+						Reset:     time.Now().Add(duration),
+						Duration:  duration,
+					}
+					return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				}
+				// Store a placeholder so the response phase can find this quota in
+				// storedResultsMap. Actual consumption and result are populated in
+				// OnRequestBody or OnResponse.
+				quotaResults = append(quotaResults, quotaResult{
+					QuotaName: quotaName,
+					Result:    nil,
+					Key:       key,
+					Duration:  getDurationFromQuota(q),
+				})
 			}
-			// Not exhausted — defer full consumption to OnRequest/OnResponse
 		} else {
 			// Standard mode (no cost extraction): consume 1 token in header phase
 			result, err := q.Limiter.AllowN(context.Background(), key, 1)
@@ -1245,6 +1296,8 @@ func (p *RateLimitPolicy) extractKeyComponentFromHeaderCtx(ctx *policy.RequestHe
 		return p.routeName
 
 	case "cel":
+		// extractQuotaKeyFromHeaderCtx is never called for a quota with CEL key extraction
+		// Only a defensive fallback in case that invariant is ever violated
 		// CEL key extraction is not supported in the header phase. OnRequestHeaders always
 		// defers quotas with CEL keys to the body phase, so this case is unreachable.
 		slog.Warn("CEL key extraction reached in header phase unexpectedly, returning placeholder",
@@ -1270,6 +1323,15 @@ func (p *RateLimitPolicy) OnRequestBody(
 			"quotaCount", len(p.quotas),
 			"backend", p.backend)
 
+		// Retrieve results stored by OnRequestHeaders so header-only quota results
+		// (consumed in OnRequestHeaders) can be carried forward.
+		storedResultsMap := make(map[string]quotaResult)
+		if prev, ok := ctx.Metadata[rateLimitResultKey].([]quotaResult); ok {
+			for _, r := range prev {
+				storedResultsMap[r.QuotaName] = r
+			}
+		}
+
 		var quotaResults []quotaResult
 		var quotaKeys = make(map[string]string) // Store keys for response phase
 
@@ -1291,6 +1353,14 @@ func (p *RateLimitPolicy) OnRequestBody(
 
 			// If cost extraction is enabled, handle based on whether we have request-phase or response-phase sources
 			if q.CostExtractionEnabled && q.CostExtractor != nil {
+				// request_header-only quotas are fully consumed in OnRequestHeaders —
+				// carry forward the stored result for response-phase header building.
+				if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
+					if stored, ok := storedResultsMap[quotaName]; ok {
+						quotaResults = append(quotaResults, stored)
+					}
+					continue
+				}
 				// Check if this quota has request-phase sources (can be processed now)
 				if q.CostExtractor.HasRequestPhaseSources() {
 					slog.Debug("Processing request-phase cost extraction",
@@ -1477,8 +1547,9 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx *policy.ResponseHeaderContext, p
 		// Handle post-response cost extraction for quotas that have it enabled.
 		// Skip quotas that require the response body — those are handled exclusively
 		// in OnResponseBody to avoid double consumption.
-		if q.CostExtractionEnabled && q.CostExtractor != nil && q.CostExtractor.HasResponsePhaseSources() && !q.CostExtractor.RequiresResponseBody() {
-			slog.Debug("Processing response-phase cost extraction",
+		if q.CostExtractionEnabled && q.CostExtractor != nil &&
+			 q.CostExtractor.HasResponsePhaseSources() && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+			slog.Debug("Processing response-header-phase cost extraction",
 				"quota", quotaName)
 
 			key := quotaKeys[quotaName]
@@ -1580,7 +1651,18 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx *policy.ResponseHeaderContext, p
 		}
 	}
 
-	// Build headers for all quotas using the new multi-quota function
+	// Store updated results so OnResponseBody can carry forward response_header
+	// quota results and avoid re-consuming them.
+	ctx.Metadata[rateLimitResultKey] = allQuotaResults
+
+	// Only build rate limit headers here if OnResponseBody will not run.
+	// If body/metadata sources exist, OnResponseBody will process those quotas
+	// and emit the final complete headers — building partial headers here would
+	// be incorrect and they would be overwritten anyway.
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
+		return nil
+	}
+
 	if len(allQuotaResults) == 0 {
 		return nil
 	}
@@ -1611,7 +1693,7 @@ func (p *RateLimitPolicy) OnResponseBody(
 	ctx *policy.ResponseContext,
 	_ map[string]interface{},
 ) policy.ResponseAction {
-	if p.requiresResponseBody() || p.hasNonBodyResponsePhaseSources() {
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
 		slog.Debug("Processing rate limit response phase",
 			"route", p.routeName,
 			"status", ctx.ResponseStatus,
@@ -1650,6 +1732,15 @@ func (p *RateLimitPolicy) OnResponseBody(
 			quotaName := q.Name
 			if quotaName == "" {
 				quotaName = fmt.Sprintf("quota-%d", i)
+			}
+
+			// response_header-only quotas are fully consumed in OnResponseHeaders —
+			// carry forward the stored result to avoid re-consumption.
+			if q.CostExtractionEnabled && q.CostExtractor != nil && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+				if stored, ok := storedResultsMap[quotaName]; ok {
+					allQuotaResults = append(allQuotaResults, stored)
+				}
+				continue
 			}
 
 			// Handle post-response cost extraction for quotas that have it enabled

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1189,8 +1189,9 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				})
 			}
 		} else {
-			// Standard mode (no cost extraction): consume 1 token in header phase
-			result, err := q.Limiter.AllowN(context.Background(), key, 1)
+			// Standard mode (no cost extraction): consume 1 token per request
+			cost := int64(1)
+			result, err := q.Limiter.AllowN(context.Background(), key, cost)
 			if err != nil {
 				if p.backend == "redis" && p.redisFailOpen {
 					slog.Warn("Rate limit check failed (fail-open)", "error", err, "quota", quotaName)
@@ -1199,10 +1200,12 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				slog.Error("Rate limit check failed (fail-closed)", "error", err, "quota", quotaName)
 				return p.buildRateLimitResponse(nil, quotaName, quotaResults)
 			}
+
 			if !result.Allowed {
-				slog.Debug("Rate limit exceeded in header phase", "quota", quotaName, "key", key)
+				slog.Debug("Rate limit exceeded", "key", key, "quota", quotaName)
 				return p.buildRateLimitResponse(result, quotaName, quotaResults)
 			}
+
 			quotaResults = append(quotaResults, quotaResult{
 				QuotaName: quotaName,
 				Result:    result,

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1360,6 +1360,15 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 			}
 		}
 
+		// Load the set of quotas fully consumed in OnRequestHeaders (standard-mode and
+		// request_header-only cost quotas). Standard-mode quotas call AllowN(1) in the
+		// header phase unconditionally, so if OnRequestBody also runs (because another
+		// quota needs the body), they must not be charged again.
+		handledInHeaderPhase := make(map[string]bool)
+		if prev, ok := reqCtx.Metadata[rateLimitHeaderHandledKey].(map[string]bool); ok {
+			handledInHeaderPhase = prev
+		}
+
 		var quotaResults []quotaResult
 		var quotaKeys = make(map[string]string) // Store keys for response phase
 
@@ -1517,7 +1526,15 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 				continue
 			}
 
-			// Standard mode (no cost extraction): consume 1 token per request
+			// Standard mode (no cost extraction): consume 1 token per request.
+			// Guard against double-charging: OnRequestHeaders always calls AllowN(1)
+			// for standard-mode quotas, so skip re-consumption if that already happened.
+			if handledInHeaderPhase[quotaName] {
+				if stored, ok := storedResultsMap[quotaName]; ok {
+					quotaResults = append(quotaResults, stored)
+				}
+				continue
+			}
 			cost := int64(1)
 
 			result, err := q.Limiter.AllowN(context.Background(), key, cost)

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -410,13 +410,6 @@ func GetPolicy(
 	}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
 	requestBodyMode := policy.BodyModeSkip

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1128,6 +1128,32 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				if requestCost < 0 {
 					requestCost = 0
 				}
+				if requestCost == 0 {
+					available, err := q.Limiter.GetAvailable(context.Background(), key)
+					if err != nil {
+						if p.backend == "redis" && p.redisFailOpen {
+							slog.Warn("Rate limit state lookup failed (fail-open)", "error", err, "quota", quotaName)
+							continue
+						}
+						slog.Error("Rate limit state lookup failed (fail-closed)", "error", err, "quota", quotaName)
+						return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+					}
+					duration := getDurationFromQuota(q)
+					quotaResults = append(quotaResults, quotaResult{
+						QuotaName: quotaName,
+						Result: &limiter.Result{
+							Allowed:   available > 0,
+							Limit:     getLimitFromQuota(q),
+							Remaining: available,
+							Reset:     time.Now().Add(duration),
+							Duration:  duration,
+						},
+						Key:      key,
+						Duration: duration,
+					})
+					handledQuotas[quotaName] = true
+					continue
+				}
 				cost := int64(requestCost)
 				result, err := q.Limiter.AllowN(context.Background(), key, cost)
 				if err != nil {
@@ -1387,6 +1413,31 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 							"quota", quotaName,
 							"originalCost", requestCost)
 						requestCost = 0
+					}
+					if requestCost == 0 {
+						available, err := q.Limiter.GetAvailable(context.Background(), key)
+						if err != nil {
+							if p.backend == "redis" && p.redisFailOpen {
+								slog.Warn("Rate limit state lookup failed (fail-open)", "error", err, "quota", quotaName)
+								continue
+							}
+							slog.Error("Rate limit state lookup failed (fail-closed)", "error", err, "quota", quotaName)
+							return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+						}
+						duration := getDurationFromQuota(q)
+						quotaResults = append(quotaResults, quotaResult{
+							QuotaName: quotaName,
+							Result: &limiter.Result{
+								Allowed:   available > 0,
+								Limit:     getLimitFromQuota(q),
+								Remaining: available,
+								Reset:     time.Now().Add(duration),
+								Duration:  duration,
+							},
+							Key:      key,
+							Duration: duration,
+						})
+						continue
 					}
 
 					// Consume tokens based on extracted request cost

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -695,6 +695,30 @@ func TestModeBehavior(t *testing.T) {
 			wantReqBody: policy.BodyModeSkip,
 			wantResBody: policy.BodyModeSkip,
 		},
+		{
+			name:        "request header only source skips body buffering",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceRequestHeader, Key: "x-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "response header only source skips body buffering",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseHeader, Key: "x-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "request metadata source requires request body phase",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceRequestMetadata, Key: "tokens"}})},
+			wantReqBody: policy.BodyModeBuffer,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "response metadata source requires response body phase",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeBuffer,
+		},
 	}
 
 	for _, tt := range tests {
@@ -709,6 +733,138 @@ func TestModeBehavior(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCostExtractorMethods(t *testing.T) {
+	enabled := func(sources []CostSource) *CostExtractor {
+		return NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: sources})
+	}
+
+	tests := []struct {
+		name                  string
+		sources               []CostSource
+		wantReqHeaderOnly     bool
+		wantRespHeaderOnly    bool
+		wantReqBodyPhase      bool
+		wantRequiresRespBody  bool
+	}{
+		{
+			name:               "request_header only",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}},
+			wantReqHeaderOnly:  true,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: true,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "request_metadata only",
+			sources:            []CostSource{{Type: CostSourceRequestMetadata, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_metadata only",
+			sources:            []CostSource{{Type: CostSourceResponseMetadata, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "request_body only",
+			sources:            []CostSource{{Type: CostSourceRequestBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_body only",
+			sources:            []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: true,
+		},
+		{
+			name:               "request_header + request_metadata disqualifies request header only",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceRequestMetadata, Key: "y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_header + response_body disqualifies response header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseBody, JSONPath: "$.y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: true,
+		},
+		{
+			name:               "response_header + response_metadata disqualifies response header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseMetadata, Key: "y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			// Response-phase sources are ignored when evaluating request-header-only,
+			// and request-phase sources are ignored when evaluating response-header-only.
+			name:               "request_header + response_header both qualify for their respective header-only paths",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceResponseHeader, Key: "y"}},
+			wantReqHeaderOnly:  true,
+			wantRespHeaderOnly: true,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ce := enabled(tt.sources)
+			if got := ce.HasRequestHeaderOnlyCostSources(); got != tt.wantReqHeaderOnly {
+				t.Errorf("HasRequestHeaderOnlyCostSources() = %v, want %v", got, tt.wantReqHeaderOnly)
+			}
+			if got := ce.HasResponseHeaderOnlyCostSources(); got != tt.wantRespHeaderOnly {
+				t.Errorf("HasResponseHeaderOnlyCostSources() = %v, want %v", got, tt.wantRespHeaderOnly)
+			}
+			if got := ce.HasRequestBodyPhase(); got != tt.wantReqBodyPhase {
+				t.Errorf("HasRequestBodyPhase() = %v, want %v", got, tt.wantReqBodyPhase)
+			}
+			if got := ce.RequiresResponseBody(); got != tt.wantRequiresRespBody {
+				t.Errorf("RequiresResponseBody() = %v, want %v", got, tt.wantRequiresRespBody)
+			}
+		})
+	}
+
+	t.Run("disabled extractor always returns false for all predicates", func(t *testing.T) {
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: false, Sources: []CostSource{{Type: CostSourceRequestHeader, Key: "x"}}})
+		if ce.HasRequestHeaderOnlyCostSources() {
+			t.Error("HasRequestHeaderOnlyCostSources() should be false when disabled")
+		}
+		if ce.HasResponseHeaderOnlyCostSources() {
+			t.Error("HasResponseHeaderOnlyCostSources() should be false when disabled")
+		}
+		if ce.HasRequestBodyPhase() {
+			t.Error("HasRequestBodyPhase() should be false when disabled")
+		}
+		if ce.RequiresResponseBody() {
+			t.Error("RequiresResponseBody() should be false when disabled")
+		}
+	})
 }
 
 func TestKeyExtractionBehavior(t *testing.T) {
@@ -981,9 +1137,9 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		ctx := newRequestCtx(map[string][]string{"x-cost": {"7"}}, nil)
-
-		_ = p.OnRequestBody(ctx, nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, nil)
+		_ = p.OnRequestHeaders(hctx, nil)
 		if lim.lastCost != 7 {
 			t.Fatalf("expected extracted request cost 7, got %d", lim.lastCost)
 		}
@@ -1004,9 +1160,9 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		ctx := newRequestCtx(map[string][]string{"x-cost": {"-5"}}, nil)
-
-		_ = p.OnRequestBody(ctx, nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"-5"}}, nil)
+		_ = p.OnRequestHeaders(hctx, nil)
 		if lim.lastCost != 0 {
 			t.Fatalf("expected clamped request cost 0, got %d", lim.lastCost)
 		}
@@ -1027,7 +1183,8 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		_ = p.OnRequestBody(newRequestCtx(nil, nil), nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		_ = p.OnRequestHeaders(newRequestHeaderCtx(nil, nil), nil)
 		if lim.lastCost != 5 {
 			t.Fatalf("expected default request cost 5, got %d", lim.lastCost)
 		}
@@ -1111,6 +1268,56 @@ func TestOnRequestBehavior(t *testing.T) {
 		_ = assertImmediateResponse(t, p.OnRequestHeaders(newRequestHeaderCtx(nil, nil), nil), 429)
 	})
 
+	t.Run("request body carries forward request header quota result without re-consuming", func(t *testing.T) {
+		limHdr := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 100, 93, 0, time.Minute), nil
+		}}
+		limBody := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 50, 47, 0, time.Minute), nil
+		}}
+		ceHdr := NewCostExtractor(CostExtractionConfig{
+			Enabled: true, Default: 1,
+			Sources: []CostSource{{Type: CostSourceRequestHeader, Key: "x-cost", Multiplier: 1}},
+		})
+		ceBody := NewCostExtractor(CostExtractionConfig{
+			Enabled: true, Default: 1,
+			Sources: []CostSource{{Type: CostSourceRequestMetadata, Key: "tokens", Multiplier: 1}},
+		})
+		p := basePolicy([]QuotaRuntime{
+			{Name: "hdr", KeyExtraction: []KeyComponent{{Type: "constant", Key: "k1"}}, Limiter: limHdr, Limits: []LimitConfig{{Limit: 100, Duration: time.Minute}}, CostExtractor: ceHdr, CostExtractionEnabled: true},
+			{Name: "body", KeyExtraction: []KeyComponent{{Type: "constant", Key: "k2"}}, Limiter: limBody, Limits: []LimitConfig{{Limit: 50, Duration: time.Minute}}, CostExtractor: ceBody, CostExtractionEnabled: true},
+		})
+
+		// OnRequestHeaders: consumes hdr quota (request_header only), stores placeholder for body quota
+		sharedMeta := map[string]interface{}{"tokens": float64(3)}
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
+		_ = p.OnRequestHeaders(hctx, nil)
+		if limHdr.allowNCalls != 1 || limHdr.lastCost != 7 {
+			t.Fatalf("expected header quota consumed once with cost 7, calls=%d cost=%d", limHdr.allowNCalls, limHdr.lastCost)
+		}
+
+		// Copy stored metadata into a RequestContext for OnRequestBody
+		sharedMeta[rateLimitResultKey] = hctx.Metadata[rateLimitResultKey]
+		sharedMeta[rateLimitKeysKey] = hctx.Metadata[rateLimitKeysKey]
+		sharedMeta[rateLimitHeaderHandledKey] = hctx.Metadata[rateLimitHeaderHandledKey]
+		reqCtx := newRequestCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
+		_ = p.OnRequestBody(reqCtx, nil)
+
+		// hdr quota must NOT be re-consumed in body phase
+		if limHdr.allowNCalls != 1 {
+			t.Fatalf("expected header quota consumed only once, got %d calls", limHdr.allowNCalls)
+		}
+		// body quota must be consumed in body phase with cost from metadata
+		if limBody.allowNCalls != 1 || limBody.lastCost != 3 {
+			t.Fatalf("expected body quota consumed once with cost 3, calls=%d cost=%d", limBody.allowNCalls, limBody.lastCost)
+		}
+		// Both quota results must be present in final output
+		results, ok := reqCtx.Metadata[rateLimitResultKey].([]quotaResult)
+		if !ok || len(results) != 2 {
+			t.Fatalf("expected 2 quota results after body phase, got %#v", reqCtx.Metadata[rateLimitResultKey])
+		}
+	})
+
 	t.Run("mixed quotas standard consumed response key stored", func(t *testing.T) {
 		limStandard := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
 			return newResult(true, 10, 9, 0, time.Minute), nil
@@ -1125,11 +1332,14 @@ func TestOnRequestBehavior(t *testing.T) {
 		hctx := newRequestHeaderCtx(nil, nil)
 		_ = p.OnRequestHeaders(hctx, nil)
 		results, ok := hctx.Metadata[rateLimitResultKey].([]quotaResult)
-		if !ok || len(results) != 1 {
-			t.Fatalf("expected 1 stored quota result (standard only), got %#v", hctx.Metadata[rateLimitResultKey])
+		if !ok || len(results) != 2 {
+			t.Fatalf("expected 2 stored quota results (standard + post placeholder), got %#v", hctx.Metadata[rateLimitResultKey])
 		}
 		if results[0].QuotaName != "standard" || results[0].Result == nil {
 			t.Fatalf("expected standard quota result with non-nil Result, got %+v", results[0])
+		}
+		if results[1].QuotaName != "post" || results[1].Result != nil {
+			t.Fatalf("expected post quota placeholder with nil Result, got %+v", results[1])
 		}
 		keys, ok := hctx.Metadata[rateLimitKeysKey].(map[string]string)
 		if !ok || keys["post"] == "" {
@@ -1319,6 +1529,103 @@ func TestOnResponseBehavior(t *testing.T) {
 		}
 		if !strings.Contains(mods.HeadersToSet["ratelimit"], `"q1"`) || !strings.Contains(mods.HeadersToSet["ratelimit"], `"q2"`) {
 			t.Fatalf("expected consolidated ratelimit, got %q", mods.HeadersToSet["ratelimit"])
+		}
+	})
+
+	t.Run("OnResponseHeaders returns nil when response metadata source present", func(t *testing.T) {
+		lim := &fakeLimiter{}
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{{Name: "meta", Limiter: lim, Limits: []LimitConfig{{Limit: 10, Duration: time.Minute}}, CostExtractor: ce, CostExtractionEnabled: true}})
+		hctx := newResponseHeaderCtx(nil, nil, map[string]interface{}{
+			rateLimitResultKey: []quotaResult{{QuotaName: "meta", Key: "k1", Duration: time.Minute, Result: nil}},
+			rateLimitKeysKey:   map[string]string{"meta": "k1"},
+		}, 200)
+		// response_metadata is populated by upstream policies in the body phase — must defer
+		if action := p.OnResponseHeaders(hctx, nil); action != nil {
+			t.Fatalf("expected nil action when response metadata source present, got %T", action)
+		}
+		// Results must still be written back so OnResponseBody can use them
+		if _, ok := hctx.Metadata[rateLimitResultKey]; !ok {
+			t.Fatalf("expected %s to remain in metadata after OnResponseHeaders returned nil", rateLimitResultKey)
+		}
+	})
+
+	t.Run("response metadata source consumed in OnResponseBody", func(t *testing.T) {
+		lim := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 100, 88, 0, time.Minute), nil
+		}}
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{{Name: "meta", Limiter: lim, Limits: []LimitConfig{{Limit: 100, Duration: time.Minute}}, CostExtractor: ce, CostExtractionEnabled: true}})
+
+		respCtx := newResponseCtx(nil, nil, map[string]interface{}{
+			rateLimitResultKey: []quotaResult{{QuotaName: "meta", Key: "k1", Duration: time.Minute, Result: nil}},
+			rateLimitKeysKey:   map[string]string{"meta": "k1"},
+			"x-llm-cost":       float64(12),
+		}, 200)
+
+		action := p.OnResponseBody(respCtx, nil)
+		mods, ok := action.(policy.DownstreamResponseModifications)
+		if !ok {
+			t.Fatalf("expected DownstreamResponseModifications, got %T", action)
+		}
+		if mods.HeadersToSet["x-ratelimit-remaining"] != "88" {
+			t.Fatalf("expected remaining=88, got %q", mods.HeadersToSet["x-ratelimit-remaining"])
+		}
+		if lim.consumeNCalls != 1 || lim.lastCost != 12 {
+			t.Fatalf("expected ConsumeN once with cost 12, calls=%d cost=%d", lim.consumeNCalls, lim.lastCost)
+		}
+	})
+
+	t.Run("response header quota result carried forward in OnResponseBody without re-consumption", func(t *testing.T) {
+		limHdr := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 20, 15, 0, time.Minute), nil
+		}}
+		limBody := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 10, 7, 0, time.Minute), nil
+		}}
+		ceHdr := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseHeader, Key: "x-hdr-cost", Multiplier: 1}}})
+		ceBody := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.tokens", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{
+			{Name: "hdr", Limiter: limHdr, Limits: []LimitConfig{{Limit: 20, Duration: time.Minute}}, CostExtractor: ceHdr, CostExtractionEnabled: true},
+			{Name: "body", Limiter: limBody, Limits: []LimitConfig{{Limit: 10, Duration: time.Minute}}, CostExtractor: ceBody, CostExtractionEnabled: true},
+		})
+
+		// OnResponseHeaders: consumes hdr quota, defers body quota, returns nil (because body phase will run)
+		sharedMeta := map[string]interface{}{
+			rateLimitResultKey: []quotaResult{
+				{QuotaName: "hdr", Key: "k1", Duration: time.Minute, Result: nil},
+				{QuotaName: "body", Key: "k2", Duration: time.Minute, Result: nil},
+			},
+			rateLimitKeysKey: map[string]string{"hdr": "k1", "body": "k2"},
+		}
+		hctx := newResponseHeaderCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
+		if action := p.OnResponseHeaders(hctx, nil); action != nil {
+			t.Fatalf("expected nil from OnResponseHeaders (body phase will run), got %T", action)
+		}
+		if limHdr.consumeNCalls != 1 || limHdr.lastCost != 5 {
+			t.Fatalf("expected hdr quota consumed once with cost 5, calls=%d cost=%d", limHdr.consumeNCalls, limHdr.lastCost)
+		}
+
+		// OnResponseBody: must carry forward hdr result, consume body quota only
+		respCtx := newResponseCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
+		respCtx.ResponseBody = &policy.Body{Present: true, Content: []byte(`{"tokens": 3}`)}
+		action := p.OnResponseBody(respCtx, nil)
+		mods, ok := action.(policy.DownstreamResponseModifications)
+		if !ok {
+			t.Fatalf("expected DownstreamResponseModifications from OnResponseBody, got %T", action)
+		}
+
+		// hdr quota must NOT be re-consumed
+		if limHdr.consumeNCalls != 1 {
+			t.Fatalf("expected hdr quota consumed only once (not re-consumed in body phase), got %d calls", limHdr.consumeNCalls)
+		}
+		// body quota must be consumed with correct cost
+		if limBody.consumeNCalls != 1 || limBody.lastCost != 3 {
+			t.Fatalf("expected body quota consumed once with cost 3, calls=%d cost=%d", limBody.consumeNCalls, limBody.lastCost)
+		}
+		// Headers must reflect both quotas
+		if !strings.Contains(mods.HeadersToSet["ratelimit-policy"], `"hdr"`) || !strings.Contains(mods.HeadersToSet["ratelimit-policy"], `"body"`) {
+			t.Fatalf("expected consolidated ratelimit-policy with both quotas, got %q", mods.HeadersToSet["ratelimit-policy"])
 		}
 	})
 

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -1139,7 +1139,7 @@ func TestOnRequestBehavior(t *testing.T) {
 		}})
 		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
 		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, nil)
-		_ = p.OnRequestHeaders(hctx, nil)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		if lim.lastCost != 7 {
 			t.Fatalf("expected extracted request cost 7, got %d", lim.lastCost)
 		}
@@ -1162,7 +1162,7 @@ func TestOnRequestBehavior(t *testing.T) {
 		}})
 		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
 		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"-5"}}, nil)
-		_ = p.OnRequestHeaders(hctx, nil)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		if lim.lastCost != 0 {
 			t.Fatalf("expected clamped request cost 0, got %d", lim.lastCost)
 		}
@@ -1184,7 +1184,7 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractionEnabled: true,
 		}})
 		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
-		_ = p.OnRequestHeaders(newRequestHeaderCtx(nil, nil), nil)
+		_ = p.OnRequestHeaders(context.Background(), newRequestHeaderCtx(nil, nil), nil)
 		if lim.lastCost != 5 {
 			t.Fatalf("expected default request cost 5, got %d", lim.lastCost)
 		}
@@ -1291,7 +1291,7 @@ func TestOnRequestBehavior(t *testing.T) {
 		// OnRequestHeaders: consumes hdr quota (request_header only), stores placeholder for body quota
 		sharedMeta := map[string]interface{}{"tokens": float64(3)}
 		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
-		_ = p.OnRequestHeaders(hctx, nil)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		if limHdr.allowNCalls != 1 || limHdr.lastCost != 7 {
 			t.Fatalf("expected header quota consumed once with cost 7, calls=%d cost=%d", limHdr.allowNCalls, limHdr.lastCost)
 		}
@@ -1301,7 +1301,7 @@ func TestOnRequestBehavior(t *testing.T) {
 		sharedMeta[rateLimitKeysKey] = hctx.Metadata[rateLimitKeysKey]
 		sharedMeta[rateLimitHeaderHandledKey] = hctx.Metadata[rateLimitHeaderHandledKey]
 		reqCtx := newRequestCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
-		_ = p.OnRequestBody(reqCtx, nil)
+		_ = p.OnRequestBody(context.Background(), reqCtx, nil)
 
 		// hdr quota must NOT be re-consumed in body phase
 		if limHdr.allowNCalls != 1 {
@@ -1541,7 +1541,7 @@ func TestOnResponseBehavior(t *testing.T) {
 			rateLimitKeysKey:   map[string]string{"meta": "k1"},
 		}, 200)
 		// response_metadata is populated by upstream policies in the body phase — must defer
-		if action := p.OnResponseHeaders(hctx, nil); action != nil {
+		if action := p.OnResponseHeaders(context.Background(), hctx, nil); action != nil {
 			t.Fatalf("expected nil action when response metadata source present, got %T", action)
 		}
 		// Results must still be written back so OnResponseBody can use them
@@ -1563,7 +1563,7 @@ func TestOnResponseBehavior(t *testing.T) {
 			"x-llm-cost":       float64(12),
 		}, 200)
 
-		action := p.OnResponseBody(respCtx, nil)
+		action := p.OnResponseBody(context.Background(), respCtx, nil)
 		mods, ok := action.(policy.DownstreamResponseModifications)
 		if !ok {
 			t.Fatalf("expected DownstreamResponseModifications, got %T", action)
@@ -1599,7 +1599,7 @@ func TestOnResponseBehavior(t *testing.T) {
 			rateLimitKeysKey: map[string]string{"hdr": "k1", "body": "k2"},
 		}
 		hctx := newResponseHeaderCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
-		if action := p.OnResponseHeaders(hctx, nil); action != nil {
+		if action := p.OnResponseHeaders(context.Background(), hctx, nil); action != nil {
 			t.Fatalf("expected nil from OnResponseHeaders (body phase will run), got %T", action)
 		}
 		if limHdr.consumeNCalls != 1 || limHdr.lastCost != 5 {
@@ -1609,7 +1609,7 @@ func TestOnResponseBehavior(t *testing.T) {
 		// OnResponseBody: must carry forward hdr result, consume body quota only
 		respCtx := newResponseCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
 		respCtx.ResponseBody = &policy.Body{Present: true, Content: []byte(`{"tokens": 3}`)}
-		action := p.OnResponseBody(respCtx, nil)
+		action := p.OnResponseBody(context.Background(), respCtx, nil)
 		mods, ok := action.(policy.DownstreamResponseModifications)
 		if !ok {
 			t.Fatalf("expected DownstreamResponseModifications from OnResponseBody, got %T", action)

--- a/policies/analytics-header-filter/analyticsheaderfilter.go
+++ b/policies/analytics-header-filter/analyticsheaderfilter.go
@@ -37,13 +37,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *AnalyticsHeaderFilterPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/analytics-header-filter/policy-definition.yaml
+++ b/policies/analytics-header-filter/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: analytics-header-filter
-version: v0.10.0
+version: v1.0.0
 description: |
   Filters request and response headers from analytics data using configurable allow or deny lists.
 

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -51,13 +51,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *APIKeyPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v0.10.1
+version: v1.0.0
 description: |
   Secures APIs by validating API keys in incoming requests. API keys can be
   provided through a configured HTTP header or query parameter.

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -170,13 +170,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the AWS Bedrock guardrail policy.
 func (p *AWSBedrockGuardrailPolicy) Mode() policy.ProcessingMode {

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: aws-bedrock-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
@@ -122,13 +122,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the Azure Content Safety content moderation policy.
 func (p *AzureContentSafetyContentModerationPolicy) Mode() policy.ProcessingMode {

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: azure-content-safety-content-moderation
-version: v0.10.0
+version: v1.0.0
 description: |
   Validates request and response content with Azure Content Safety moderation
   checks.

--- a/policies/basic-auth/basicauth.go
+++ b/policies/basic-auth/basicauth.go
@@ -45,13 +45,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *BasicAuthPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/basic-auth/policy-definition.yaml
+++ b/policies/basic-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-auth
-version: v0.10.0
+version: v1.0.0
 description: |
   Protects APIs using Basic Authentication by validating username and password credentials.
 

--- a/policies/basic-ratelimit/basic_ratelimit.go
+++ b/policies/basic-ratelimit/basic_ratelimit.go
@@ -143,20 +143,6 @@ func (p *BasicRateLimitPolicy) OnRequestHeaders(
 	return policy.UpstreamRequestHeaderModifications{}
 }
 
-// OnRequestBody delegates to the core ratelimit policy's OnRequestBody method if available.
-func (p *BasicRateLimitPolicy) OnRequestBody(
-	ctx *policy.RequestContext,
-	params map[string]interface{},
-) policy.RequestAction {
-	type requestBodyPolicer interface {
-		OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction
-	}
-	if rl, ok := p.delegate.(requestBodyPolicer); ok {
-		return rl.OnRequestBody(ctx, params)
-	}
-	return policy.UpstreamRequestModifications{}
-}
-
 // OnResponseHeaders delegates to the core ratelimit policy's OnResponseHeaders method if available.
 func (p *BasicRateLimitPolicy) OnResponseHeaders(
 	ctx *policy.ResponseHeaderContext,
@@ -169,18 +155,4 @@ func (p *BasicRateLimitPolicy) OnResponseHeaders(
 		return rl.OnResponseHeaders(ctx, params)
 	}
 	return policy.DownstreamResponseHeaderModifications{}
-}
-
-// OnResponseBody delegates to the core ratelimit policy's OnResponseBody method if available.
-func (p *BasicRateLimitPolicy) OnResponseBody(
-	ctx *policy.ResponseContext,
-	params map[string]interface{},
-) policy.ResponseAction {
-	type responseBodyPolicer interface {
-		OnResponseBody(*policy.ResponseContext, map[string]interface{}) policy.ResponseAction
-	}
-	if rl, ok := p.delegate.(responseBodyPolicer); ok {
-		return rl.OnResponseBody(ctx, params)
-	}
-	return policy.DownstreamResponseModifications{}
 }

--- a/policies/basic-ratelimit/basic_ratelimit.go
+++ b/policies/basic-ratelimit/basic_ratelimit.go
@@ -49,13 +49,6 @@ func GetPolicy(
 	return &BasicRateLimitPolicy{delegate: delegate}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *BasicRateLimitPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 )
 
 require (

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-ratelimit
-version: v0.10.1
+version: v1.0.0
 description: |
   Limits request rates by restricting the number of requests allowed within one
   or more defined time windows.

--- a/policies/content-length-guardrail/contentlengthguardrail.go
+++ b/policies/content-length-guardrail/contentlengthguardrail.go
@@ -103,13 +103,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *ContentLengthGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: content-length-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate content byte lengths in request or response payloads using min/max limits.
 

--- a/policies/cors/cors.go
+++ b/policies/cors/cors.go
@@ -118,13 +118,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *CorsPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/cors/policy-definition.yaml
+++ b/policies/cors/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: cors
-version: v0.10.0
+version: v1.0.0
 description: |
   Applies Cross-Origin Resource Sharing (CORS) rules by handling preflight
   requests and adding CORS headers to responses. Controls cross-origin access

--- a/policies/dynamic-endpoint/dynamicendpoint.go
+++ b/policies/dynamic-endpoint/dynamicendpoint.go
@@ -28,13 +28,6 @@ func GetPolicy(
 	}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *DynamicEndpointPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/dynamic-endpoint/policy-definition.yaml
+++ b/policies/dynamic-endpoint/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: dynamic-endpoint
-version: v0.10.0
+version: v1.0.0
 description: |
   Routes requests to a dynamically specified upstream definition.
   This policy reads an upstream name from parameters and routes the request to that upstream.

--- a/policies/json-schema-guardrail/jsonschemaguardrail.go
+++ b/policies/json-schema-guardrail/jsonschemaguardrail.go
@@ -89,13 +89,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *JSONSchemaGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/json-schema-guardrail/policy-definition.yaml
+++ b/policies/json-schema-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-schema-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate request or response content against a JSON Schema.
 

--- a/policies/json-xml-mediator/jsonxmlmediation.go
+++ b/policies/json-xml-mediator/jsonxmlmediation.go
@@ -69,13 +69,6 @@ func GetPolicy(
 	}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *JSONXMLMediationPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/json-xml-mediator/policy-definition.yaml
+++ b/policies/json-xml-mediator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-xml-mediator
-version: v0.10.0
+version: v1.0.0
 description: |
   Mediates request and response payloads between downstream and upstream JSON/XML formats
 

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -123,13 +123,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *JwtAuthPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v0.10.0
+version: v1.0.0
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -70,13 +70,6 @@ func GetPolicy(
 	}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for this policy.
 // ResponseBodyMode is Buffer so that OnResponseBody is called after llm-cost

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v0.10.2
+version: v1.0.0
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -81,13 +81,6 @@ func GetPolicy(
 	return instance, instanceErr
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode declares the SDK processing requirements:
 //   - RequestBodyMode=Buffer: buffer the request so ctx.RequestBody is available

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v0.10.1
+version: v1.0.0
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").

--- a/policies/log-message/logmessage.go
+++ b/policies/log-message/logmessage.go
@@ -55,13 +55,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *LogMessagePolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/log-message/policy-definition.yaml
+++ b/policies/log-message/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: log-message
-version: v0.10.0
+version: v1.0.0
 description: |
   Log request and response payloads and headers for observability without changing traffic.
 

--- a/policies/mcp-acl-list/mcp-acl-list.go
+++ b/policies/mcp-acl-list/mcp-acl-list.go
@@ -99,13 +99,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *McpAclListPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/mcp-acl-list/policy-definition.yaml
+++ b/policies/mcp-acl-list/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-acl-list
-version: v0.10.0
+version: v1.0.0
 description: |
   Control MCP tool, resource, and prompt access with allow/deny mode plus exceptions, apply the same rules to requests and list responses, and avoid rewriting capability names or entry fields.
 

--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -105,13 +105,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // parseAuthority extracts host and port from an authority string (e.g., "example.com:8080")
 func parseAuthority(authority string) (host string, port int) {

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v0.10.0
+version: v1.0.0
 description: |
   Secure Model Context Protocol traffic by validating bearer access tokens for MCP resources using the underlying JWT authentication runtime.
 

--- a/policies/mcp-authz/mcp-authz.go
+++ b/policies/mcp-authz/mcp-authz.go
@@ -96,13 +96,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // parseRules extracts and validates rules from the 4 top-level arrays: tools, resources, prompts, methods
 func parseRules(params map[string]any) ([]Rule, error) {

--- a/policies/mcp-authz/policy-definition.yaml
+++ b/policies/mcp-authz/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-authz
-version: v0.10.0
+version: v1.0.0
 description: |
   Authorize MCP tools, resources, prompts, and methods using claim/scope rules after `mcp-auth`; evaluate rules by specificity, require all matching rules to pass, and allow access when no rule matches.
 

--- a/policies/mcp-rewrite/mcp-rewrite.go
+++ b/policies/mcp-rewrite/mcp-rewrite.go
@@ -102,13 +102,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // parseCapabilityConfig parses capability-specific configuration entries.
 func parseCapabilityConfig(params map[string]any, capabilityType string) (CapabilityConfig, error) {

--- a/policies/mcp-rewrite/policy-definition.yaml
+++ b/policies/mcp-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-rewrite
-version: v0.10.0
+version: v1.0.0
 description: |
   Rewrite MCP tool, resource, and prompt names between client-facing and backend values, and optionally filter list responses to configured entries (omit to allow all, set `[]` to deny all).
 

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v0.10.0
+version: v1.0.0
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.

--- a/policies/model-round-robin/roundrobin.go
+++ b/policies/model-round-robin/roundrobin.go
@@ -87,13 +87,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *ModelRoundRobinPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-weighted-round-robin
-version: v0.10.0
+version: v1.0.0
 description: |
   Distribute requests across models using weighted round-robin so higher-weight models receive proportionally more traffic.
 

--- a/policies/model-weighted-round-robin/weightedroundrobin.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin.go
@@ -100,13 +100,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *ModelWeightedRoundRobinPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/pii-masking-regex/piimaskingregex.go
+++ b/policies/pii-masking-regex/piimaskingregex.go
@@ -80,13 +80,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the PII masking regex policy.
 func (p *PIIMaskingRegexPolicy) Mode() policy.ProcessingMode {

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: pii-masking-regex
-version: v0.10.0
+version: v1.0.0
 description: |
   Masks or redacts Personally Identifiable Information (PII) in request and
   response payloads.

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-decorator
-version: v0.10.0
+version: v1.0.0
 description: |
   Applies configured prompt decorations to request payloads before upstream processing.
 

--- a/policies/prompt-decorator/promptdecorator.go
+++ b/policies/prompt-decorator/promptdecorator.go
@@ -84,13 +84,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the prompt decorator policy.
 func (p *PromptDecoratorPolicy) Mode() policy.ProcessingMode {

--- a/policies/prompt-template/policy-definition.yaml
+++ b/policies/prompt-template/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-template
-version: v0.10.0
+version: v1.0.0
 description: |
   Applies configured prompt templates to request payloads to transform prompts
   before upstream processing.

--- a/policies/prompt-template/prompttemplate.go
+++ b/policies/prompt-template/prompttemplate.go
@@ -89,13 +89,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the prompt template policy.
 func (p *PromptTemplatePolicy) Mode() policy.ProcessingMode {

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: regex-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate request or response content against regex patterns using optional JSONPath extraction and optional inverted matching.
 

--- a/policies/regex-guardrail/regexguardrail.go
+++ b/policies/regex-guardrail/regexguardrail.go
@@ -98,13 +98,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *RegexGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/remove-headers/policy-definition.yaml
+++ b/policies/remove-headers/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: remove-headers
-version: v0.10.0
+version: v1.0.0
 description: |
   Removes configured headers from requests and/or responses. Header matching is
   case-insensitive, and removing a non-existent header is ignored.

--- a/policies/remove-headers/removeheaders.go
+++ b/policies/remove-headers/removeheaders.go
@@ -38,13 +38,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *RemoveHeadersPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/request-rewrite/policy-definition.yaml
+++ b/policies/request-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: request-rewrite
-version: v0.10.1
+version: v1.0.0
 description: |
   Rewrite request paths, query parameters, and HTTP methods before forwarding upstream, with optional header and query match conditions to apply rewrites only when criteria are met.
 

--- a/policies/request-rewrite/requestrewrite.go
+++ b/policies/request-rewrite/requestrewrite.go
@@ -58,13 +58,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *RequestRewritePolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/respond/policy-definition.yaml
+++ b/policies/respond/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: respond
-version: v0.10.0
+version: v1.0.0
 description: |
   Return a response directly to the client without forwarding the request to the upstream.
 

--- a/policies/respond/respond.go
+++ b/policies/respond/respond.go
@@ -51,13 +51,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *RespondPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/semantic-cache/policy-definition.yaml
+++ b/policies/semantic-cache/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-cache
-version: v0.10.0
+version: v1.0.0
 description: |
   Caches LLM responses using semantic similarity over request embeddings to
   reduce repeated upstream calls. Returns cached responses on similarity hits

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -94,13 +94,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the semantic cache policy.
 func (p *SemanticCachePolicy) Mode() policy.ProcessingMode {

--- a/policies/semantic-prompt-guard/policy-definition.yaml
+++ b/policies/semantic-prompt-guard/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-prompt-guard
-version: v0.10.0
+version: v1.0.0
 description: |
   Evaluates request prompts using embedding similarity against configured allow
   and deny phrases. Blocks prompts that match denied phrases or fail allow

--- a/policies/semantic-prompt-guard/semanticpromptguard.go
+++ b/policies/semantic-prompt-guard/semanticpromptguard.go
@@ -91,13 +91,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the semantic prompt guard policy.
 func (p *SemanticPromptGuardPolicy) Mode() policy.ProcessingMode {

--- a/policies/semantic-tool-filtering/policy-definition.yaml
+++ b/policies/semantic-tool-filtering/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-tool-filtering
-version: v0.10.0
+version: v1.0.0
 description: |
   Dynamically filters the tools provided within an API request based on their semantic relevance to the
   user query. This policy extracts both the query and the tool definitions from the incoming payload,

--- a/policies/semantic-tool-filtering/semantictoolfiltering.go
+++ b/policies/semantic-tool-filtering/semantictoolfiltering.go
@@ -237,13 +237,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // Mode returns the processing mode for the semantic tool filtering policy.
 func (p *SemanticToolFilteringPolicy) Mode() policy.ProcessingMode {

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: sentence-count-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate sentence counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -113,13 +113,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *SentenceCountGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/set-headers/policy-definition.yaml
+++ b/policies/set-headers/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: set-headers
-version: v0.10.0
+version: v1.0.0
 description: |
   Sets configured headers on requests and/or responses. If the same header is set
   multiple times, the latest configured value overwrites earlier values.

--- a/policies/set-headers/setheaders.go
+++ b/policies/set-headers/setheaders.go
@@ -44,13 +44,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *SetHeadersPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v0.10.0
+version: v1.0.0
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -96,13 +96,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 // mergeConfig merges raw parameters from the policy configuration into a base config.
 func mergeConfig(base PolicyConfig, params map[string]interface{}) PolicyConfig {

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 	golang.org/x/sync v0.20.0
 )
 

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v0.10.2
+version: v1.0.0
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -401,9 +401,6 @@ func (p *TokenBasedRateLimitPolicy) OnRequestHeaders(
 	type requestHeaderPolicer interface {
 		OnRequestHeaders(*policy.RequestHeaderContext, map[string]interface{}) policy.RequestHeaderAction
 	}
-	type requestBodyPolicer interface {
-		OnRequestBody(*policy.RequestContext, map[string]interface{}) policy.RequestAction
-	}
 
 	slog.Debug("OnRequestHeaders: processing token-based rate limit",
 		"route", p.metadata.RouteName)
@@ -435,27 +432,6 @@ func (p *TokenBasedRateLimitPolicy) OnRequestHeaders(
 	if rl, ok := delegate.(requestHeaderPolicer); ok {
 		if action := rl.OnRequestHeaders(ctx, params); isBlockingHeaderAction(action) {
 			return action
-		}
-	}
-
-	// Phase 2: request-phase cost extraction — extracts cost from headers (e.g. X-Token-Cost)
-	// and consumes tokens. Uses a synthetic RequestContext so no body buffering is needed.
-	// ImmediateResponse implements RequestHeaderAction, so a 429 can be returned directly.
-	if rl, ok := delegate.(requestBodyPolicer); ok {
-		reqCtx := &policy.RequestContext{
-			SharedContext: ctx.SharedContext,
-			Headers:       ctx.Headers,
-			Body:          &policy.Body{Present: false},
-			Path:          ctx.Path,
-			Method:        ctx.Method,
-			Authority:     ctx.Authority,
-			Scheme:        ctx.Scheme,
-			Vhost:         ctx.Vhost,
-		}
-		if action := rl.OnRequestBody(reqCtx, nil); action != nil {
-			if ir, ok := action.(policy.ImmediateResponse); ok {
-				return ir
-			}
 		}
 	}
 

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -58,13 +58,6 @@ func GetPolicy(
 	}, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *TokenBasedRateLimitPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: url-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate URLs in request or response content using JSONPath extraction with DNS-only or HTTP reachability checks.
 

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -121,13 +121,6 @@ func GetPolicy(
 	return p, nil
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *URLGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: word-count-guardrail
-version: v0.10.0
+version: v1.0.0
 description: |
   Validate word counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -78,13 +78,6 @@ func GetPolicy(
 	return newPolicy(params)
 }
 
-// GetPolicyV2 delegates to GetPolicy.
-func GetPolicyV2(
-	metadata policy.PolicyMetadata,
-	params map[string]interface{},
-) (policy.Policy, error) {
-	return GetPolicy(metadata, params)
-}
 
 func (p *WordCountGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{


### PR DESCRIPTION
## Purpose
$subject



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Header-only quotas are evaluated earlier, avoiding unnecessary request/response body buffering and preventing double consumption by carrying header-derived results forward.
  * Some rate-limit policies no longer delegate or perform body-phase handling during header processing, changing when immediate rate-limit responses may occur.

* **Tests**
  * Expanded coverage for header/body/metadata extraction, phase routing, carry‑forward behavior, and streaming/non‑streaming LLM token extraction.

* **Chores**
  * Updated internal policy module versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->