### PR TITLE
Refactor Rate Limiting Related Policies

### DIFF
--- a/policies/advanced-ratelimit/cost_extractor.go
+++ b/policies/advanced-ratelimit/cost_extractor.go
@@ -284,11 +284,17 @@ func (e *CostExtractor) extractFromRequestSource(reqCtx *policy.RequestContext, 
 }
 
 func (e *CostExtractor) extractFromRequestHeader(reqCtx *policy.RequestContext, headerName string) (float64, bool) {
-	if reqCtx.Headers == nil {
+	return extractCostFromHeaders(reqCtx.Headers, headerName)
+}
+
+// extractCostFromHeaders parses a numeric cost value from the named header.
+// Shared by both request-body-phase and request-header-phase extraction paths.
+func extractCostFromHeaders(headers *policy.Headers, headerName string) (float64, bool) {
+	if headers == nil {
 		return 0, false
 	}
 
-	values := reqCtx.Headers.Get(strings.ToLower(headerName))
+	values := headers.Get(strings.ToLower(headerName))
 	if len(values) == 0 || values[0] == "" {
 		return 0, false
 	}
@@ -303,6 +309,34 @@ func (e *CostExtractor) extractFromRequestHeader(reqCtx *policy.RequestContext, 
 	}
 
 	return cost, true
+}
+
+// ExtractRequestHeaderOnlyCost extracts cost from request_header sources using the
+// header-phase context. Only called when HasHeaderOnlyCostSources() is true,
+// meaning all request-phase sources are request_header.
+func (e *CostExtractor) ExtractRequestHeaderOnlyCost(reqCtx *policy.RequestHeaderContext) (float64, bool) {
+	if !e.config.Enabled {
+		return e.config.Default, false
+	}
+
+	var total float64
+	var found bool
+
+	for _, source := range e.config.Sources {
+		if source.Type != CostSourceRequestHeader {
+			continue
+		}
+		val, ok := extractCostFromHeaders(reqCtx.Headers, source.Key)
+		if ok {
+			found = true
+			total += val * source.Multiplier
+		}
+	}
+
+	if !found {
+		return e.config.Default, false
+	}
+	return total, true
 }
 
 func (e *CostExtractor) extractFromRequestMetadata(reqCtx *policy.RequestContext, key string) (float64, bool) {
@@ -462,23 +496,72 @@ func (e *CostExtractor) RequiresResponseBody() bool {
 	return false
 }
 
-// RequiresRequestBody returns true if any source requires the OnRequestBody phase.
-// request_header and request_metadata are available in the header phase but their
-// cost consumption is deferred to OnRequestBody, so those also require buffering.
-func (e *CostExtractor) RequiresRequestBody() bool {
+// HasRequestBodyPhase returns true if any source requires the OnRequestBody phase.
+// request_body and request_cel need body content. request_metadata is also deferred
+// to the body phase because metadata may be mutated by earlier policies before that phase.
+// request_header is consumed directly in OnRequestHeaders and does not require buffering.
+func (e *CostExtractor) HasRequestBodyPhase() bool {
 	if !e.config.Enabled {
 		return false
 	}
 	for _, source := range e.config.Sources {
-		// request_body and request_cel need body buffering; request_header and
-		// request_metadata are available in header phase but consumption is
-		// deferred to OnRequestBody, so they also require buffering.
 		if source.Type == CostSourceRequestBody || source.Type == CostSourceRequestCEL ||
-			source.Type == CostSourceRequestHeader || source.Type == CostSourceRequestMetadata {
+			source.Type == CostSourceRequestMetadata {
 			return true
 		}
 	}
 	return false
+}
+
+// HasResponseHeaderOnlyCostSources returns true if cost extraction is enabled,
+// no source requires the response body phase (no response_body or response_cel),
+// and all response-phase sources are response_header.
+// response_metadata is excluded — it may be populated by upstream response-phase
+// policies that haven't run yet in OnResponseHeaders.
+// Request-phase sources are irrelevant and are ignored.
+// When true, cost can be fully consumed in OnResponseHeaders with no body buffering.
+func (e *CostExtractor) HasResponseHeaderOnlyCostSources() bool {
+	if !e.config.Enabled || e.RequiresResponseBody() {
+		return false
+	}
+	hasHeader := false
+	for _, source := range e.config.Sources {
+		if source.Type == CostSourceResponseHeader {
+			hasHeader = true
+			continue
+		}
+		// Any other response-phase source disqualifies response-header-only consumption.
+		// Request-phase sources are irrelevant — skip them.
+		if isResponsePhaseSource(source.Type) {
+			return false
+		}
+	}
+	return hasHeader
+}
+
+// HasRequestHeaderOnlyCostSources returns true if cost extraction is enabled,
+// no source requires the request body phase (no request_body, request_cel, or
+// request_metadata), and at least one request_header source exists.
+// Response-phase sources (response_header, response_body, etc.) are ignored —
+// only request-phase sources are evaluated to determine header-only eligibility.
+// When true, cost can be fully consumed in OnRequestHeaders with no body buffering.
+func (e *CostExtractor) HasRequestHeaderOnlyCostSources() bool {
+	if !e.config.Enabled || e.HasRequestBodyPhase() {
+		return false
+	}
+	hasHeader := false
+	for _, source := range e.config.Sources {
+		if source.Type == CostSourceRequestHeader {
+			hasHeader = true
+			continue
+		}
+		// Any other request-phase source disqualifies header-only consumption.
+		// Response-phase sources are irrelevant — skip them.
+		if isRequestPhaseSource(source.Type) {
+			return false
+		}
+	}
+	return hasHeader
 }
 
 // HasRequestPhaseSources returns true if any source is available during request phase

--- a/policies/advanced-ratelimit/cost_extractor_test.go
+++ b/policies/advanced-ratelimit/cost_extractor_test.go
@@ -161,3 +161,427 @@ func TestExtractFromBodyBytes_PlainJSON_StillWorks(t *testing.T) {
 		t.Fatalf("expected 42, got %v", cost)
 	}
 }
+
+// anthropicSSEBody is the full buffered Anthropic SSE response used across multiple tests.
+// The message_delta event carries usage: input_tokens=10, output_tokens=20.
+var anthropicSSEBody = "event: message_start\n" +
+	"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-sonnet-20241022\",\"stop_reason\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n" +
+	"\n" +
+	"event: content_block_start\n" +
+	"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n" +
+	"\n" +
+	"event: message_delta\n" +
+	"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n" +
+	"\n" +
+	"event: message_stop\n" +
+	"data: {\"type\":\"message_stop\"}\n"
+
+func TestCostExtractor_AnthropicSSE_InputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.input_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"text/event-stream"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected input_tokens=10, got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_OutputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.output_tokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"text/event-stream"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected output_tokens=20, got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_WithMultiplier(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.output_tokens",
+				Multiplier: 2,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(anthropicSSEBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from Anthropic SSE body to succeed")
+	}
+	// 20 * 2 = 40
+	if cost != 40 {
+		t.Fatalf("expected output_tokens=20 * multiplier=2 = 40, got %v", cost)
+	}
+}
+
+// ─── Amazon Bedrock ───────────────────────────────────────────────────────────
+
+// bedrockStreamingBody is a buffered Bedrock streaming response.
+// Bedrock does NOT embed usage in the body — usage comes from response headers.
+var bedrockStreamingBody = "data: {\"chunk\":{\"bytes\":\"Hello\"}}\n" +
+	"data: {\"chunk\":{\"bytes\":\" world\"}}\n" +
+	"data: {\"chunk\":{\"bytes\":\"!\"}}\n"
+
+// TestCostExtractor_BedrockStreaming_InputTokensFromHeader verifies that
+// x-amzn-bedrock-input-token-count is extracted via CostSourceResponseHeader.
+func TestCostExtractor_BedrockStreaming_InputTokensFromHeader(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-input-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response header to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected input_token_count=10, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_OutputTokensFromHeader verifies that
+// x-amzn-bedrock-output-token-count is extracted via CostSourceResponseHeader.
+func TestCostExtractor_BedrockStreaming_OutputTokensFromHeader(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response header to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected output_token_count=20, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_CombinedHeaderCost verifies that
+// input + output token counts are summed when both header sources are configured.
+func TestCostExtractor_BedrockStreaming_CombinedHeaderCost(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-input-token-count",
+				Multiplier: 1,
+			},
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-input-token-count":  {"10"},
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from response headers to succeed")
+	}
+	// 10 + 20 = 30
+	if cost != 30 {
+		t.Fatalf("expected combined cost=30, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_WithMultiplier verifies that the multiplier
+// is applied to the header-sourced token count.
+func TestCostExtractor_BedrockStreaming_WithMultiplier(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseHeader,
+				Key:        "x-amzn-bedrock-output-token-count",
+				Multiplier: 2,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"x-amzn-bedrock-output-token-count": {"20"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction to succeed")
+	}
+	// 20 * 2 = 40
+	if cost != 40 {
+		t.Fatalf("expected 20 * 2 = 40, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockStreaming_BodyYieldsNoMatch confirms that the Bedrock
+// streaming body (chunk format) does not match a usage JSONPath.
+// Usage must be sourced from response headers, not the body.
+func TestCostExtractor_BedrockStreaming_BodyYieldsNoMatch(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:     CostSourceResponseBody,
+				JSONPath: "$.usage.inputTokens",
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(bedrockStreamingBody),
+		},
+	}
+
+	_, extracted := extractor.ExtractResponseCost(ctx)
+	if extracted {
+		t.Error("expected no extraction: Bedrock streaming body carries no usage field")
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_InputTokens verifies extraction of inputTokens
+// from a Bedrock non-streaming JSON response body.
+func TestCostExtractor_BedrockNonStream_InputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.inputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from non-stream response body to succeed")
+	}
+	if cost != 10 {
+		t.Fatalf("expected inputTokens=10, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_OutputTokens verifies extraction of outputTokens
+// from a Bedrock non-streaming JSON response body.
+func TestCostExtractor_BedrockNonStream_OutputTokens(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.outputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction from non-stream response body to succeed")
+	}
+	if cost != 20 {
+		t.Fatalf("expected outputTokens=20, got %v", cost)
+	}
+}
+
+// TestCostExtractor_BedrockNonStream_CombinedCost verifies that inputTokens and
+// outputTokens are summed when both body sources are configured.
+func TestCostExtractor_BedrockNonStream_CombinedCost(t *testing.T) {
+	extractor := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 0,
+		Sources: []CostSource{
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.inputTokens",
+				Multiplier: 1,
+			},
+			{
+				Type:       CostSourceResponseBody,
+				JSONPath:   "$.usage.outputTokens",
+				Multiplier: 1,
+			},
+		},
+	})
+
+	ctx := &policy.ResponseContext{
+		ResponseHeaders: policy.NewHeaders(map[string][]string{
+			"content-type": {"application/json"},
+		}),
+		ResponseBody: &policy.Body{
+			Present: true,
+			Content: []byte(`{"completion":"Hello world","usage":{"inputTokens":10,"outputTokens":20}}`),
+		},
+	}
+
+	cost, extracted := extractor.ExtractResponseCost(ctx)
+	if !extracted {
+		t.Fatal("expected extraction to succeed")
+	}
+	// 10 + 20 = 30
+	if cost != 30 {
+		t.Fatalf("expected combined cost=30 (10+20), got %v", cost)
+	}
+}
+
+func TestCostExtractor_AnthropicSSE_OnlyMessageDeltaMatches(t *testing.T) {
+	// content_block_delta events have a "delta" field but no "usage" — they must not match.
+	_, ok := extractFromSSEBodyBytes([]byte(anthropicSSEBody), "$.usage.output_tokens")
+	if !ok {
+		t.Fatal("expected a match from message_delta event")
+	}
+
+	// Verify that a body with only content_block_delta events (no message_delta) yields no match.
+	noUsageBody := "event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+		"\n" +
+		"event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n"
+
+	_, ok = extractFromSSEBodyBytes([]byte(noUsageBody), "$.usage.output_tokens")
+	if ok {
+		t.Error("expected no match when no event carries $.usage.output_tokens")
+	}
+}

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -418,7 +418,7 @@ func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
 	if p.requiresRequestBody() {
 		requestBodyMode = policy.BodyModeBuffer
 	}
-	if p.requiresResponseBody() {
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
 		responseBodyMode = policy.BodyModeBuffer
 	}
 
@@ -909,7 +909,7 @@ func getDurationParam(params map[string]interface{}, key string, defaultVal time
 func (p *RateLimitPolicy) requiresRequestBody() bool {
 	for _, q := range p.quotas {
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			if q.CostExtractor.RequiresRequestBody() {
+			if q.CostExtractor.HasRequestBodyPhase() {
 				return true
 			}
 		}
@@ -934,15 +934,18 @@ func (p *RateLimitPolicy) requiresResponseBody() bool {
 	return false
 }
 
-// hasNonBodyResponsePhaseSources returns true if any quota has response-phase cost
-// sources that do not require the response body (e.g. response_metadata,
-// response_header). These sources cannot be resolved in OnResponseHeaders because
-// upstream policies that populate the metadata (e.g. llm-cost writing x-llm-cost)
-// run in the response-body phase. OnResponseBody must therefore also process them,
-// after those upstream policies have had a chance to set the metadata.
-func (p *RateLimitPolicy) hasNonBodyResponsePhaseSources() bool {
+// hasNonHeaderResponsePhaseSources returns true if any quota has response-phase cost
+// sources that are not response_header (e.g. response_metadata, response_body,
+// response_cel). These require OnResponseBody to run — either because they need
+// the body content, or because the metadata they read is populated by upstream
+// policies that execute in the response-body phase.
+func (p *RateLimitPolicy) hasNonHeaderResponsePhaseSources() bool {
 	for _, q := range p.quotas {
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
+			// response_header-only quotas are consumed in OnResponseHeaders — exclude them.
+			if q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+				continue
+			}
 			if q.CostExtractor.HasResponsePhaseSources() && !q.CostExtractor.RequiresResponseBody() {
 				return true
 			}
@@ -1104,32 +1107,80 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 		quotaKeys[quotaName] = key
 
 		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			// Cost extraction configured — only pre-check quota availability; actual
-			// consumption remains in OnRequest (request-phase sources) or OnResponse
-			// (response-phase sources).
-			available, err := q.Limiter.GetAvailable(context.Background(), key)
-			if err != nil {
-				if p.backend == "redis" && p.redisFailOpen {
-					slog.Warn("Rate limit pre-check failed (fail-open)", "error", err, "quota", quotaName)
-					continue
+			if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
+				// request_header sources only — all values are available now, consume immediately.
+				// No body buffering needed.
+				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(ctx)
+				if !extracted {
+					slog.Debug("Header cost extraction failed, using default",
+						"quota", quotaName, "key", key, "defaultCost", requestCost)
+				} else {
+					slog.Debug("Header cost extracted",
+						"quota", quotaName, "key", key, "cost", requestCost)
 				}
-				slog.Error("Rate limit pre-check failed (fail-closed)", "error", err, "quota", quotaName)
-				return p.buildRateLimitResponse(nil, quotaName, quotaResults)
-			}
-			if available <= 0 {
-				slog.Debug("Cost extraction mode: quota exhausted in header phase",
-					"quota", quotaName, "key", key)
-				duration := getDurationFromQuota(q)
-				result := &limiter.Result{
-					Allowed:   false,
-					Limit:     getLimitFromQuota(q),
-					Remaining: 0,
-					Reset:     time.Now().Add(duration),
-					Duration:  duration,
+				if requestCost < 0 {
+					requestCost = 0
 				}
-				return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				cost := int64(requestCost)
+				result, err := q.Limiter.AllowN(context.Background(), key, cost)
+				if err != nil {
+					if p.backend == "redis" && p.redisFailOpen {
+						slog.Warn("Rate limit check failed (fail-open)", "error", err, "quota", quotaName)
+						continue
+					}
+					slog.Error("Rate limit check failed (fail-closed)", "error", err, "quota", quotaName)
+					return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+				}
+				if !result.Allowed {
+					slog.Debug("Rate limit exceeded in header phase",
+						"quota", quotaName, "key", key, "cost", cost)
+					return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				}
+				slog.Debug("Rate limit check passed",
+					"quota", quotaName, "key", key, "cost", cost, "remaining", result.Remaining)
+
+				quotaResults = append(quotaResults, quotaResult{
+					QuotaName: quotaName,
+					Result:    result,
+					Key:       key,
+					Duration:  result.Duration,
+				})
+				handledQuotas[quotaName] = true
+			} else {
+				// body/metadata/CEL/response sources — pre-check availability only;
+				// actual consumption is deferred to OnRequestBody or OnResponse.
+				available, err := q.Limiter.GetAvailable(context.Background(), key)
+				if err != nil {
+					if p.backend == "redis" && p.redisFailOpen {
+						slog.Warn("Rate limit pre-check failed (fail-open)", "error", err, "quota", quotaName)
+						continue
+					}
+					slog.Error("Rate limit pre-check failed (fail-closed)", "error", err, "quota", quotaName)
+					return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+				}
+				if available <= 0 {
+					slog.Debug("Cost extraction mode: quota exhausted in header phase",
+						"quota", quotaName, "key", key)
+					duration := getDurationFromQuota(q)
+					result := &limiter.Result{
+						Allowed:   false,
+						Limit:     getLimitFromQuota(q),
+						Remaining: 0,
+						Reset:     time.Now().Add(duration),
+						Duration:  duration,
+					}
+					return p.buildRateLimitResponse(result, quotaName, quotaResults)
+				}
+				// Store a placeholder so the response phase can find this quota in
+				// storedResultsMap. Actual consumption and result are populated in
+				// OnRequestBody or OnResponse.
+				quotaResults = append(quotaResults, quotaResult{
+					QuotaName: quotaName,
+					Result:    nil,
+					Key:       key,
+					Duration:  getDurationFromQuota(q),
+				})
 			}
-			// Not exhausted — defer full consumption to OnRequest/OnResponse
 		} else {
 			// Standard mode (no cost extraction): consume 1 token in header phase
 			result, err := q.Limiter.AllowN(context.Background(), key, 1)
@@ -1238,6 +1289,8 @@ func (p *RateLimitPolicy) extractKeyComponentFromHeaderCtx(reqCtx *policy.Reques
 		return p.routeName
 
 	case "cel":
+		// extractQuotaKeyFromHeaderCtx is never called for a quota with CEL key extraction
+		// Only a defensive fallback in case that invariant is ever violated
 		// CEL key extraction is not supported in the header phase. OnRequestHeaders always
 		// defers quotas with CEL keys to the body phase, so this case is unreachable.
 		slog.Warn("CEL key extraction reached in header phase unexpectedly, returning placeholder",
@@ -1262,6 +1315,15 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 			"quotaCount", len(p.quotas),
 			"backend", p.backend)
 
+		// Retrieve results stored by OnRequestHeaders so header-only quota results
+		// (consumed in OnRequestHeaders) can be carried forward.
+		storedResultsMap := make(map[string]quotaResult)
+		if prev, ok := ctx.Metadata[rateLimitResultKey].([]quotaResult); ok {
+			for _, r := range prev {
+				storedResultsMap[r.QuotaName] = r
+			}
+		}
+
 		var quotaResults []quotaResult
 		var quotaKeys = make(map[string]string) // Store keys for response phase
 
@@ -1283,6 +1345,14 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 
 			// If cost extraction is enabled, handle based on whether we have request-phase or response-phase sources
 			if q.CostExtractionEnabled && q.CostExtractor != nil {
+				// request_header-only quotas are fully consumed in OnRequestHeaders —
+				// carry forward the stored result for response-phase header building.
+				if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
+					if stored, ok := storedResultsMap[quotaName]; ok {
+						quotaResults = append(quotaResults, stored)
+					}
+					continue
+				}
 				// Check if this quota has request-phase sources (can be processed now)
 				if q.CostExtractor.HasRequestPhaseSources() {
 					slog.Debug("Processing request-phase cost extraction",
@@ -1469,8 +1539,9 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 		// Handle post-response cost extraction for quotas that have it enabled.
 		// Skip quotas that require the response body — those are handled exclusively
 		// in OnResponseBody to avoid double consumption.
-		if q.CostExtractionEnabled && q.CostExtractor != nil && q.CostExtractor.HasResponsePhaseSources() && !q.CostExtractor.RequiresResponseBody() {
-			slog.Debug("Processing response-phase cost extraction",
+		if q.CostExtractionEnabled && q.CostExtractor != nil &&
+			 q.CostExtractor.HasResponsePhaseSources() && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+			slog.Debug("Processing response-header-phase cost extraction",
 				"quota", quotaName)
 
 			key := quotaKeys[quotaName]
@@ -1572,7 +1643,18 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 		}
 	}
 
-	// Build headers for all quotas using the new multi-quota function
+	// Store updated results so OnResponseBody can carry forward response_header
+	// quota results and avoid re-consuming them.
+	ctx.Metadata[rateLimitResultKey] = allQuotaResults
+
+	// Only build rate limit headers here if OnResponseBody will not run.
+	// If body/metadata sources exist, OnResponseBody will process those quotas
+	// and emit the final complete headers — building partial headers here would
+	// be incorrect and they would be overwritten anyway.
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
+		return nil
+	}
+
 	if len(allQuotaResults) == 0 {
 		return nil
 	}
@@ -1602,7 +1684,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.ResponseContext,
 	_ map[string]interface{},
 ) policy.ResponseAction {
-	if p.requiresResponseBody() || p.hasNonBodyResponsePhaseSources() {
+	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
 		slog.Debug("Processing rate limit response phase",
 			"route", p.routeName,
 			"status", respCtx.ResponseStatus,
@@ -1641,6 +1723,15 @@ func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Re
 			quotaName := q.Name
 			if quotaName == "" {
 				quotaName = fmt.Sprintf("quota-%d", i)
+			}
+
+			// response_header-only quotas are fully consumed in OnResponseHeaders —
+			// carry forward the stored result to avoid re-consumption.
+			if q.CostExtractionEnabled && q.CostExtractor != nil && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+				if stored, ok := storedResultsMap[quotaName]; ok {
+					allQuotaResults = append(allQuotaResults, stored)
+				}
+				continue
 			}
 
 			// Handle post-response cost extraction for quotas that have it enabled

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1182,8 +1182,9 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				})
 			}
 		} else {
-			// Standard mode (no cost extraction): consume 1 token in header phase
-			result, err := q.Limiter.AllowN(context.Background(), key, 1)
+			// Standard mode (no cost extraction): consume 1 token per request
+			cost := int64(1)
+			result, err := q.Limiter.AllowN(context.Background(), key, cost)
 			if err != nil {
 				if p.backend == "redis" && p.redisFailOpen {
 					slog.Warn("Rate limit check failed (fail-open)", "error", err, "quota", quotaName)
@@ -1192,10 +1193,12 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				slog.Error("Rate limit check failed (fail-closed)", "error", err, "quota", quotaName)
 				return p.buildRateLimitResponse(nil, quotaName, quotaResults)
 			}
+
 			if !result.Allowed {
-				slog.Debug("Rate limit exceeded in header phase", "quota", quotaName, "key", key)
+				slog.Debug("Rate limit exceeded", "key", key, "quota", quotaName)
 				return p.buildRateLimitResponse(result, quotaName, quotaResults)
 			}
+
 			quotaResults = append(quotaResults, quotaResult{
 				QuotaName: quotaName,
 				Result:    result,

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1110,7 +1110,7 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 			if q.CostExtractor.HasRequestHeaderOnlyCostSources() {
 				// request_header sources only — all values are available now, consume immediately.
 				// No body buffering needed.
-				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(ctx)
+				requestCost, extracted := q.CostExtractor.ExtractRequestHeaderOnlyCost(reqCtx)
 				if !extracted {
 					slog.Debug("Header cost extraction failed, using default",
 						"quota", quotaName, "key", key, "defaultCost", requestCost)
@@ -1318,7 +1318,7 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 		// Retrieve results stored by OnRequestHeaders so header-only quota results
 		// (consumed in OnRequestHeaders) can be carried forward.
 		storedResultsMap := make(map[string]quotaResult)
-		if prev, ok := ctx.Metadata[rateLimitResultKey].([]quotaResult); ok {
+		if prev, ok := reqCtx.Metadata[rateLimitResultKey].([]quotaResult); ok {
 			for _, r := range prev {
 				storedResultsMap[r.QuotaName] = r
 			}
@@ -1645,7 +1645,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 
 	// Store updated results so OnResponseBody can carry forward response_header
 	// quota results and avoid re-consuming them.
-	ctx.Metadata[rateLimitResultKey] = allQuotaResults
+	respCtx.Metadata[rateLimitResultKey] = allQuotaResults
 
 	// Only build rate limit headers here if OnResponseBody will not run.
 	// If body/metadata sources exist, OnResponseBody will process those quotas

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1353,6 +1353,15 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 			}
 		}
 
+		// Load the set of quotas fully consumed in OnRequestHeaders (standard-mode and
+		// request_header-only cost quotas). Standard-mode quotas call AllowN(1) in the
+		// header phase unconditionally, so if OnRequestBody also runs (because another
+		// quota needs the body), they must not be charged again.
+		handledInHeaderPhase := make(map[string]bool)
+		if prev, ok := reqCtx.Metadata[rateLimitHeaderHandledKey].(map[string]bool); ok {
+			handledInHeaderPhase = prev
+		}
+
 		var quotaResults []quotaResult
 		var quotaKeys = make(map[string]string) // Store keys for response phase
 
@@ -1510,7 +1519,15 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 				continue
 			}
 
-			// Standard mode (no cost extraction): consume 1 token per request
+			// Standard mode (no cost extraction): consume 1 token per request.
+			// Guard against double-charging: OnRequestHeaders always calls AllowN(1)
+			// for standard-mode quotas, so skip re-consumption if that already happened.
+			if handledInHeaderPhase[quotaName] {
+				if stored, ok := storedResultsMap[quotaName]; ok {
+					quotaResults = append(quotaResults, stored)
+				}
+				continue
+			}
 			cost := int64(1)
 
 			result, err := q.Limiter.AllowN(context.Background(), key, cost)

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -1121,6 +1121,32 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 				if requestCost < 0 {
 					requestCost = 0
 				}
+				if requestCost == 0 {
+					available, err := q.Limiter.GetAvailable(context.Background(), key)
+					if err != nil {
+						if p.backend == "redis" && p.redisFailOpen {
+							slog.Warn("Rate limit state lookup failed (fail-open)", "error", err, "quota", quotaName)
+							continue
+						}
+						slog.Error("Rate limit state lookup failed (fail-closed)", "error", err, "quota", quotaName)
+						return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+					}
+					duration := getDurationFromQuota(q)
+					quotaResults = append(quotaResults, quotaResult{
+						QuotaName: quotaName,
+						Result: &limiter.Result{
+							Allowed:   available > 0,
+							Limit:     getLimitFromQuota(q),
+							Remaining: available,
+							Reset:     time.Now().Add(duration),
+							Duration:  duration,
+						},
+						Key:      key,
+						Duration: duration,
+					})
+					handledQuotas[quotaName] = true
+					continue
+				}
 				cost := int64(requestCost)
 				result, err := q.Limiter.AllowN(context.Background(), key, cost)
 				if err != nil {
@@ -1380,6 +1406,31 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 							"quota", quotaName,
 							"originalCost", requestCost)
 						requestCost = 0
+					}
+					if requestCost == 0 {
+						available, err := q.Limiter.GetAvailable(context.Background(), key)
+						if err != nil {
+							if p.backend == "redis" && p.redisFailOpen {
+								slog.Warn("Rate limit state lookup failed (fail-open)", "error", err, "quota", quotaName)
+								continue
+							}
+							slog.Error("Rate limit state lookup failed (fail-closed)", "error", err, "quota", quotaName)
+							return p.buildRateLimitResponse(nil, quotaName, quotaResults)
+						}
+						duration := getDurationFromQuota(q)
+						quotaResults = append(quotaResults, quotaResult{
+							QuotaName: quotaName,
+							Result: &limiter.Result{
+								Allowed:   available > 0,
+								Limit:     getLimitFromQuota(q),
+								Remaining: available,
+								Reset:     time.Now().Add(duration),
+								Duration:  duration,
+							},
+							Key:      key,
+							Duration: duration,
+						})
+						continue
 					}
 
 					// Consume tokens based on extracted request cost

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -695,6 +695,30 @@ func TestModeBehavior(t *testing.T) {
 			wantReqBody: policy.BodyModeSkip,
 			wantResBody: policy.BodyModeSkip,
 		},
+		{
+			name:        "request header only source skips body buffering",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceRequestHeader, Key: "x-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "response header only source skips body buffering",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseHeader, Key: "x-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "request metadata source requires request body phase",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceRequestMetadata, Key: "tokens"}})},
+			wantReqBody: policy.BodyModeBuffer,
+			wantResBody: policy.BodyModeSkip,
+		},
+		{
+			name:        "response metadata source requires response body phase",
+			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost"}})},
+			wantReqBody: policy.BodyModeSkip,
+			wantResBody: policy.BodyModeBuffer,
+		},
 	}
 
 	for _, tt := range tests {
@@ -709,6 +733,138 @@ func TestModeBehavior(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCostExtractorMethods(t *testing.T) {
+	enabled := func(sources []CostSource) *CostExtractor {
+		return NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: sources})
+	}
+
+	tests := []struct {
+		name                  string
+		sources               []CostSource
+		wantReqHeaderOnly     bool
+		wantRespHeaderOnly    bool
+		wantReqBodyPhase      bool
+		wantRequiresRespBody  bool
+	}{
+		{
+			name:               "request_header only",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}},
+			wantReqHeaderOnly:  true,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: true,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "request_metadata only",
+			sources:            []CostSource{{Type: CostSourceRequestMetadata, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_metadata only",
+			sources:            []CostSource{{Type: CostSourceResponseMetadata, Key: "x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "request_body only",
+			sources:            []CostSource{{Type: CostSourceRequestBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_body only",
+			sources:            []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: true,
+		},
+		{
+			name:               "request_header + request_metadata disqualifies request header only",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceRequestMetadata, Key: "y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   true,
+			wantRequiresRespBody: false,
+		},
+		{
+			name:               "response_header + response_body disqualifies response header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseBody, JSONPath: "$.y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: true,
+		},
+		{
+			name:               "response_header + response_metadata disqualifies response header only",
+			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseMetadata, Key: "y"}},
+			wantReqHeaderOnly:  false,
+			wantRespHeaderOnly: false,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+		{
+			// Response-phase sources are ignored when evaluating request-header-only,
+			// and request-phase sources are ignored when evaluating response-header-only.
+			name:               "request_header + response_header both qualify for their respective header-only paths",
+			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceResponseHeader, Key: "y"}},
+			wantReqHeaderOnly:  true,
+			wantRespHeaderOnly: true,
+			wantReqBodyPhase:   false,
+			wantRequiresRespBody: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ce := enabled(tt.sources)
+			if got := ce.HasRequestHeaderOnlyCostSources(); got != tt.wantReqHeaderOnly {
+				t.Errorf("HasRequestHeaderOnlyCostSources() = %v, want %v", got, tt.wantReqHeaderOnly)
+			}
+			if got := ce.HasResponseHeaderOnlyCostSources(); got != tt.wantRespHeaderOnly {
+				t.Errorf("HasResponseHeaderOnlyCostSources() = %v, want %v", got, tt.wantRespHeaderOnly)
+			}
+			if got := ce.HasRequestBodyPhase(); got != tt.wantReqBodyPhase {
+				t.Errorf("HasRequestBodyPhase() = %v, want %v", got, tt.wantReqBodyPhase)
+			}
+			if got := ce.RequiresResponseBody(); got != tt.wantRequiresRespBody {
+				t.Errorf("RequiresResponseBody() = %v, want %v", got, tt.wantRequiresRespBody)
+			}
+		})
+	}
+
+	t.Run("disabled extractor always returns false for all predicates", func(t *testing.T) {
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: false, Sources: []CostSource{{Type: CostSourceRequestHeader, Key: "x"}}})
+		if ce.HasRequestHeaderOnlyCostSources() {
+			t.Error("HasRequestHeaderOnlyCostSources() should be false when disabled")
+		}
+		if ce.HasResponseHeaderOnlyCostSources() {
+			t.Error("HasResponseHeaderOnlyCostSources() should be false when disabled")
+		}
+		if ce.HasRequestBodyPhase() {
+			t.Error("HasRequestBodyPhase() should be false when disabled")
+		}
+		if ce.RequiresResponseBody() {
+			t.Error("RequiresResponseBody() should be false when disabled")
+		}
+	})
 }
 
 func TestKeyExtractionBehavior(t *testing.T) {
@@ -981,9 +1137,9 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		ctx := newRequestCtx(map[string][]string{"x-cost": {"7"}}, nil)
-
-		_ = p.OnRequestBody(context.Background(), ctx, nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, nil)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		if lim.lastCost != 7 {
 			t.Fatalf("expected extracted request cost 7, got %d", lim.lastCost)
 		}
@@ -1004,9 +1160,9 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		ctx := newRequestCtx(map[string][]string{"x-cost": {"-5"}}, nil)
-
-		_ = p.OnRequestBody(context.Background(), ctx, nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"-5"}}, nil)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		if lim.lastCost != 0 {
 			t.Fatalf("expected clamped request cost 0, got %d", lim.lastCost)
 		}
@@ -1027,7 +1183,8 @@ func TestOnRequestBehavior(t *testing.T) {
 			CostExtractor:         ce,
 			CostExtractionEnabled: true,
 		}})
-		_ = p.OnRequestBody(context.Background(), newRequestCtx(nil, nil), nil)
+		// request_header sources are consumed in OnRequestHeaders — no body buffering needed
+		_ = p.OnRequestHeaders(context.Background(), newRequestHeaderCtx(nil, nil), nil)
 		if lim.lastCost != 5 {
 			t.Fatalf("expected default request cost 5, got %d", lim.lastCost)
 		}
@@ -1111,6 +1268,56 @@ func TestOnRequestBehavior(t *testing.T) {
 		_ = assertImmediateResponse(t, p.OnRequestHeaders(context.Background(), newRequestHeaderCtx(nil, nil), nil), 429)
 	})
 
+	t.Run("request body carries forward request header quota result without re-consuming", func(t *testing.T) {
+		limHdr := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 100, 93, 0, time.Minute), nil
+		}}
+		limBody := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 50, 47, 0, time.Minute), nil
+		}}
+		ceHdr := NewCostExtractor(CostExtractionConfig{
+			Enabled: true, Default: 1,
+			Sources: []CostSource{{Type: CostSourceRequestHeader, Key: "x-cost", Multiplier: 1}},
+		})
+		ceBody := NewCostExtractor(CostExtractionConfig{
+			Enabled: true, Default: 1,
+			Sources: []CostSource{{Type: CostSourceRequestMetadata, Key: "tokens", Multiplier: 1}},
+		})
+		p := basePolicy([]QuotaRuntime{
+			{Name: "hdr", KeyExtraction: []KeyComponent{{Type: "constant", Key: "k1"}}, Limiter: limHdr, Limits: []LimitConfig{{Limit: 100, Duration: time.Minute}}, CostExtractor: ceHdr, CostExtractionEnabled: true},
+			{Name: "body", KeyExtraction: []KeyComponent{{Type: "constant", Key: "k2"}}, Limiter: limBody, Limits: []LimitConfig{{Limit: 50, Duration: time.Minute}}, CostExtractor: ceBody, CostExtractionEnabled: true},
+		})
+
+		// OnRequestHeaders: consumes hdr quota (request_header only), stores placeholder for body quota
+		sharedMeta := map[string]interface{}{"tokens": float64(3)}
+		hctx := newRequestHeaderCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
+		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
+		if limHdr.allowNCalls != 1 || limHdr.lastCost != 7 {
+			t.Fatalf("expected header quota consumed once with cost 7, calls=%d cost=%d", limHdr.allowNCalls, limHdr.lastCost)
+		}
+
+		// Copy stored metadata into a RequestContext for OnRequestBody
+		sharedMeta[rateLimitResultKey] = hctx.Metadata[rateLimitResultKey]
+		sharedMeta[rateLimitKeysKey] = hctx.Metadata[rateLimitKeysKey]
+		sharedMeta[rateLimitHeaderHandledKey] = hctx.Metadata[rateLimitHeaderHandledKey]
+		reqCtx := newRequestCtx(map[string][]string{"x-cost": {"7"}}, sharedMeta)
+		_ = p.OnRequestBody(context.Background(), reqCtx, nil)
+
+		// hdr quota must NOT be re-consumed in body phase
+		if limHdr.allowNCalls != 1 {
+			t.Fatalf("expected header quota consumed only once, got %d calls", limHdr.allowNCalls)
+		}
+		// body quota must be consumed in body phase with cost from metadata
+		if limBody.allowNCalls != 1 || limBody.lastCost != 3 {
+			t.Fatalf("expected body quota consumed once with cost 3, calls=%d cost=%d", limBody.allowNCalls, limBody.lastCost)
+		}
+		// Both quota results must be present in final output
+		results, ok := reqCtx.Metadata[rateLimitResultKey].([]quotaResult)
+		if !ok || len(results) != 2 {
+			t.Fatalf("expected 2 quota results after body phase, got %#v", reqCtx.Metadata[rateLimitResultKey])
+		}
+	})
+
 	t.Run("mixed quotas standard consumed response key stored", func(t *testing.T) {
 		limStandard := &fakeLimiter{allowNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
 			return newResult(true, 10, 9, 0, time.Minute), nil
@@ -1125,11 +1332,14 @@ func TestOnRequestBehavior(t *testing.T) {
 		hctx := newRequestHeaderCtx(nil, nil)
 		_ = p.OnRequestHeaders(context.Background(), hctx, nil)
 		results, ok := hctx.Metadata[rateLimitResultKey].([]quotaResult)
-		if !ok || len(results) != 1 {
-			t.Fatalf("expected 1 stored quota result (standard only), got %#v", hctx.Metadata[rateLimitResultKey])
+		if !ok || len(results) != 2 {
+			t.Fatalf("expected 2 stored quota results (standard + post placeholder), got %#v", hctx.Metadata[rateLimitResultKey])
 		}
 		if results[0].QuotaName != "standard" || results[0].Result == nil {
 			t.Fatalf("expected standard quota result with non-nil Result, got %+v", results[0])
+		}
+		if results[1].QuotaName != "post" || results[1].Result != nil {
+			t.Fatalf("expected post quota placeholder with nil Result, got %+v", results[1])
 		}
 		keys, ok := hctx.Metadata[rateLimitKeysKey].(map[string]string)
 		if !ok || keys["post"] == "" {
@@ -1319,6 +1529,103 @@ func TestOnResponseBehavior(t *testing.T) {
 		}
 		if !strings.Contains(mods.HeadersToSet["ratelimit"], `"q1"`) || !strings.Contains(mods.HeadersToSet["ratelimit"], `"q2"`) {
 			t.Fatalf("expected consolidated ratelimit, got %q", mods.HeadersToSet["ratelimit"])
+		}
+	})
+
+	t.Run("OnResponseHeaders returns nil when response metadata source present", func(t *testing.T) {
+		lim := &fakeLimiter{}
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{{Name: "meta", Limiter: lim, Limits: []LimitConfig{{Limit: 10, Duration: time.Minute}}, CostExtractor: ce, CostExtractionEnabled: true}})
+		hctx := newResponseHeaderCtx(nil, nil, map[string]interface{}{
+			rateLimitResultKey: []quotaResult{{QuotaName: "meta", Key: "k1", Duration: time.Minute, Result: nil}},
+			rateLimitKeysKey:   map[string]string{"meta": "k1"},
+		}, 200)
+		// response_metadata is populated by upstream policies in the body phase — must defer
+		if action := p.OnResponseHeaders(context.Background(), hctx, nil); action != nil {
+			t.Fatalf("expected nil action when response metadata source present, got %T", action)
+		}
+		// Results must still be written back so OnResponseBody can use them
+		if _, ok := hctx.Metadata[rateLimitResultKey]; !ok {
+			t.Fatalf("expected %s to remain in metadata after OnResponseHeaders returned nil", rateLimitResultKey)
+		}
+	})
+
+	t.Run("response metadata source consumed in OnResponseBody", func(t *testing.T) {
+		lim := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 100, 88, 0, time.Minute), nil
+		}}
+		ce := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{{Name: "meta", Limiter: lim, Limits: []LimitConfig{{Limit: 100, Duration: time.Minute}}, CostExtractor: ce, CostExtractionEnabled: true}})
+
+		respCtx := newResponseCtx(nil, nil, map[string]interface{}{
+			rateLimitResultKey: []quotaResult{{QuotaName: "meta", Key: "k1", Duration: time.Minute, Result: nil}},
+			rateLimitKeysKey:   map[string]string{"meta": "k1"},
+			"x-llm-cost":       float64(12),
+		}, 200)
+
+		action := p.OnResponseBody(context.Background(), respCtx, nil)
+		mods, ok := action.(policy.DownstreamResponseModifications)
+		if !ok {
+			t.Fatalf("expected DownstreamResponseModifications, got %T", action)
+		}
+		if mods.HeadersToSet["x-ratelimit-remaining"] != "88" {
+			t.Fatalf("expected remaining=88, got %q", mods.HeadersToSet["x-ratelimit-remaining"])
+		}
+		if lim.consumeNCalls != 1 || lim.lastCost != 12 {
+			t.Fatalf("expected ConsumeN once with cost 12, calls=%d cost=%d", lim.consumeNCalls, lim.lastCost)
+		}
+	})
+
+	t.Run("response header quota result carried forward in OnResponseBody without re-consumption", func(t *testing.T) {
+		limHdr := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 20, 15, 0, time.Minute), nil
+		}}
+		limBody := &fakeLimiter{consumeNFn: func(ctx context.Context, key string, n int64) (*limiter.Result, error) {
+			return newResult(true, 10, 7, 0, time.Minute), nil
+		}}
+		ceHdr := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseHeader, Key: "x-hdr-cost", Multiplier: 1}}})
+		ceBody := NewCostExtractor(CostExtractionConfig{Enabled: true, Default: 1, Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.tokens", Multiplier: 1}}})
+		p := mkPolicy([]QuotaRuntime{
+			{Name: "hdr", Limiter: limHdr, Limits: []LimitConfig{{Limit: 20, Duration: time.Minute}}, CostExtractor: ceHdr, CostExtractionEnabled: true},
+			{Name: "body", Limiter: limBody, Limits: []LimitConfig{{Limit: 10, Duration: time.Minute}}, CostExtractor: ceBody, CostExtractionEnabled: true},
+		})
+
+		// OnResponseHeaders: consumes hdr quota, defers body quota, returns nil (because body phase will run)
+		sharedMeta := map[string]interface{}{
+			rateLimitResultKey: []quotaResult{
+				{QuotaName: "hdr", Key: "k1", Duration: time.Minute, Result: nil},
+				{QuotaName: "body", Key: "k2", Duration: time.Minute, Result: nil},
+			},
+			rateLimitKeysKey: map[string]string{"hdr": "k1", "body": "k2"},
+		}
+		hctx := newResponseHeaderCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
+		if action := p.OnResponseHeaders(context.Background(), hctx, nil); action != nil {
+			t.Fatalf("expected nil from OnResponseHeaders (body phase will run), got %T", action)
+		}
+		if limHdr.consumeNCalls != 1 || limHdr.lastCost != 5 {
+			t.Fatalf("expected hdr quota consumed once with cost 5, calls=%d cost=%d", limHdr.consumeNCalls, limHdr.lastCost)
+		}
+
+		// OnResponseBody: must carry forward hdr result, consume body quota only
+		respCtx := newResponseCtx(nil, map[string][]string{"x-hdr-cost": {"5"}}, sharedMeta, 200)
+		respCtx.ResponseBody = &policy.Body{Present: true, Content: []byte(`{"tokens": 3}`)}
+		action := p.OnResponseBody(context.Background(), respCtx, nil)
+		mods, ok := action.(policy.DownstreamResponseModifications)
+		if !ok {
+			t.Fatalf("expected DownstreamResponseModifications from OnResponseBody, got %T", action)
+		}
+
+		// hdr quota must NOT be re-consumed
+		if limHdr.consumeNCalls != 1 {
+			t.Fatalf("expected hdr quota consumed only once (not re-consumed in body phase), got %d calls", limHdr.consumeNCalls)
+		}
+		// body quota must be consumed with correct cost
+		if limBody.consumeNCalls != 1 || limBody.lastCost != 3 {
+			t.Fatalf("expected body quota consumed once with cost 3, calls=%d cost=%d", limBody.consumeNCalls, limBody.lastCost)
+		}
+		// Headers must reflect both quotas
+		if !strings.Contains(mods.HeadersToSet["ratelimit-policy"], `"hdr"`) || !strings.Contains(mods.HeadersToSet["ratelimit-policy"], `"body"`) {
+			t.Fatalf("expected consolidated ratelimit-policy with both quotas, got %q", mods.HeadersToSet["ratelimit-policy"])
 		}
 	})
 

--- a/policies/basic-ratelimit/basic_ratelimit.go
+++ b/policies/basic-ratelimit/basic_ratelimit.go
@@ -137,19 +137,6 @@ func (p *BasicRateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *pol
 	return policy.UpstreamRequestHeaderModifications{}
 }
 
-// OnRequestBody delegates to the core ratelimit policy's OnRequestBody method if available.
-func (p *BasicRateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.RequestContext,
-	params map[string]interface{},
-) policy.RequestAction {
-	type requestBodyPolicer interface {
-		OnRequestBody(context.Context, *policy.RequestContext, map[string]interface{}) policy.RequestAction
-	}
-	if rl, ok := p.delegate.(requestBodyPolicer); ok {
-		return rl.OnRequestBody(ctx, reqCtx, params)
-	}
-	return policy.UpstreamRequestModifications{}
-}
-
 // OnResponseHeaders delegates to the core ratelimit policy's OnResponseHeaders method if available.
 func (p *BasicRateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy.ResponseHeaderContext,
 	params map[string]interface{},
@@ -161,17 +148,4 @@ func (p *BasicRateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *p
 		return rl.OnResponseHeaders(ctx, respCtx, params)
 	}
 	return policy.DownstreamResponseHeaderModifications{}
-}
-
-// OnResponseBody delegates to the core ratelimit policy's OnResponseBody method if available.
-func (p *BasicRateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.ResponseContext,
-	params map[string]interface{},
-) policy.ResponseAction {
-	type responseBodyPolicer interface {
-		OnResponseBody(context.Context, *policy.ResponseContext, map[string]interface{}) policy.ResponseAction
-	}
-	if rl, ok := p.delegate.(responseBodyPolicer); ok {
-		return rl.OnResponseBody(ctx, respCtx, params)
-	}
-	return policy.DownstreamResponseModifications{}
 }

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 )
 
 require (

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1
 )
 
 require (

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1 h1:JOJkA34ACG3N5BkWp/Fdv1/e9h9Cb2KHCZQCAynNahQ=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1 h1:JOJkA34ACG3N5BkWp/Fdv1/e9h9Cb2KHCZQCAynNahQ=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
 	golang.org/x/sync v0.20.0
 )
 

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.0
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1
 	golang.org/x/sync v0.20.0
 )
 

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4 h1:zqprAMNwu4fB42PjRkwwGYnf2lS1tKSKs/InDqniWRo=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.4/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
 github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7 h1:fKt+T+jZZGBUVhFfdHY00U+iAQLdd9DxIydk4NFVu14=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.10.7/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1 h1:JOJkA34ACG3N5BkWp/Fdv1/e9h9Cb2KHCZQCAynNahQ=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v0.11.1/go.mod h1:IB+HLLADI3of9MuMf80PzMuRpwvfYuTZ1mCMUfpNu5E=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -394,9 +394,6 @@ func (p *TokenBasedRateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx
 	type requestHeaderPolicer interface {
 		OnRequestHeaders(context.Context, *policy.RequestHeaderContext, map[string]interface{}) policy.RequestHeaderAction
 	}
-	type requestBodyPolicer interface {
-		OnRequestBody(context.Context, *policy.RequestContext, map[string]interface{}) policy.RequestAction
-	}
 
 	slog.Debug("OnRequestHeaders: processing token-based rate limit",
 		"route", p.metadata.RouteName)
@@ -428,27 +425,6 @@ func (p *TokenBasedRateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx
 	if rl, ok := delegate.(requestHeaderPolicer); ok {
 		if action := rl.OnRequestHeaders(ctx, reqCtx, params); isBlockingHeaderAction(action) {
 			return action
-		}
-	}
-
-	// Phase 2: request-phase cost extraction — extracts cost from headers (e.g. X-Token-Cost)
-	// and consumes tokens. Uses a synthetic RequestContext so no body buffering is needed.
-	// ImmediateResponse implements RequestHeaderAction, so a 429 can be returned directly.
-	if rl, ok := delegate.(requestBodyPolicer); ok {
-		reqCtxDel := &policy.RequestContext{
-			SharedContext: reqCtx.SharedContext,
-			Headers:       reqCtx.Headers,
-			Body:          &policy.Body{Present: false},
-			Path:          reqCtx.Path,
-			Method:        reqCtx.Method,
-			Authority:     reqCtx.Authority,
-			Scheme:        reqCtx.Scheme,
-			Vhost:         reqCtx.Vhost,
-		}
-		if action := rl.OnRequestBody(ctx, reqCtxDel, nil); action != nil {
-			if ir, ok := action.(policy.ImmediateResponse); ok {
-				return ir
-			}
 		}
 	}
 


### PR DESCRIPTION
## Purpose
$subject
https://github.com/wso2/api-platform/issues/1386

  This PR refactors rate limiting policy logic across the gateway-controllers repo with three main goals:

  **1. Phase-Aware Cost Extraction**

  Rate limiting costs that can be determined from headers alone are now extracted immediately in the header phase, without needing to buffer the full request/response body. This avoids
   unnecessary overhead.

  **2. Preventing Double-Charging**

  Improved cross-phase state tracking ensures that if a cost is already extracted in the header phase, it is not charged again when the body phase runs.

  **3. New Streaming Format Support**

  Adds token count extraction from Anthropic SSE and Bedrock streaming response formats.

  ---
  The key architectural improvement is that rate limiting now correctly identifies whether a cost is determinable at the header phase vs. requiring the body to be buffered, making the
  system both more efficient and more correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated header-only cost extraction paths for request and response headers
  * Support for extracting token counts from Anthropic SSE, Bedrock streaming, and non-streaming JSON

* **Improvements**
  * Smarter phase handling and buffering to avoid double-charging and optimize header/body processing
  * Cross-phase state carry-forward to preserve quota results between phases

* **Tests**
  * Expanded integration and unit tests covering header/body extraction and streaming scenarios

* **Chores**
  * Updated module dependency versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->