### PR TITLE
Add streaming cost calculation for SSE and plain JSON responses in LLM Cost Policy

### DIFF
--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -54,6 +54,16 @@ const (
 	// accumulated across streaming chunks. Gives O(1) access to the first and
 	// last event without re-scanning raw bytes at EndOfStream.
 	metaKeySSEEvents = "x-llm-cost-sse-events"
+
+	// metaKeyIsSSE is set to true once the first SSE chunk is detected. It persists
+	// SSE mode across subsequent chunks that may not start with "data: " (e.g. the
+	// second half of an event split across two network packets).
+	metaKeyIsSSE = "x-llm-cost-is-sse"
+
+	// metaKeyLineRemainder stores an incomplete SSE line fragment from the previous
+	// chunk. It is prepended to the next chunk so that events split mid-line across
+	// network packets are reconstructed before JSON parsing.
+	metaKeyLineRemainder = "x-llm-cost-line-remainder"
 )
 
 // LLMCostPolicy calculates the cost of an LLM API call from the response body
@@ -112,23 +122,57 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 
 	responseBody := respCtx.ResponseBody.Content
 
-	// If the response body is buffered SSE events rather than a single JSON
-	// object, merge all events into one JSON blob so the downstream calculators
-	// can parse it with a regular json.Unmarshal.
+	// If the response body is buffered SSE events, use the same event-array
+	// approach as OnResponseBodyChunk so that Anthropic's split usage
+	// (input_tokens in message_start, output_tokens in message_delta) is
+	// correctly merged by buildAnthropicSSEBody rather than lost by a
+	// shallow merge.
 	if isSSEContent(responseBody) {
-		merged, err := mergeSSEEvents(responseBody)
-		if err != nil {
-			slog.Warn("llm-cost: failed to merge SSE events", "error", err)
+		meta := make(map[string]interface{})
+		appendSSEEvents(meta, responseBody)
+		events, _ := meta[metaKeySSEEvents].([]json.RawMessage)
+		if len(events) == 0 {
+			slog.Warn("llm-cost: no valid SSE events found in response body")
 			return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
 		}
-		responseBody = merged
+		// Determine provider from the model in events[0] so buildSSEResponseBody
+		// can choose the right merge strategy (Anthropic vs others).
+		var sseProbe struct {
+			Model        string `json:"model"`
+			ModelVersion string `json:"modelVersion"`
+			Message      *struct {
+				Model string `json:"model"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(events[0], &sseProbe); err != nil {
+			slog.Warn("llm-cost: could not parse first SSE event", "error", err)
+			return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+		}
+		sseModel := sseProbe.Model
+		if sseModel == "" {
+			sseModel = sseProbe.ModelVersion
+		}
+		if sseModel == "" && sseProbe.Message != nil {
+			sseModel = sseProbe.Message.Model
+		}
+		provider := ""
+		if sseModel != "" {
+			if entry, ok := lookupPricing(p.pricingMap, sseModel); ok {
+				provider = entry.Provider
+			}
+		}
+		built, err := buildSSEResponseBody(events, provider)
+		if err != nil {
+			slog.Warn("llm-cost: failed to build response body from SSE events", "error", err)
+			return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+		}
+		responseBody = built
 	}
 
 	// Extract model name from response body.
 	// Providers place the model name in different locations:
-	//   $.model (OpenAI, Anthropic non-streaming, Mistral)
-	//   $.modelVersion (Gemini)
-	//   $.message.model (Anthropic streaming after SSE merge)
+	//   $.model        — OpenAI, Anthropic, Mistral (all paths)
+	//   $.modelVersion — Gemini
 	var probe struct {
 		Model        string `json:"model"`
 		ModelVersion string `json:"modelVersion"`
@@ -237,7 +281,15 @@ func (p *LLMCostPolicy) OnResponseBodyChunk(_ context.Context, respCtx *policy.R
 	}
 
 	if len(chunk.Chunk) > 0 {
-		if isSSEContent(chunk.Chunk) {
+		// Persist SSE mode once detected: a continuation chunk that starts mid-line
+		// (e.g. the second half of an event split across two TCP packets) won't begin
+		// with "data: " and would be misrouted to the raw-bytes path without this flag.
+		isSSE, _ := respCtx.Metadata[metaKeyIsSSE].(bool)
+		if !isSSE && isSSEContent(chunk.Chunk) {
+			isSSE = true
+			respCtx.Metadata[metaKeyIsSSE] = true
+		}
+		if isSSE {
 			appendSSEEvents(respCtx.Metadata, chunk.Chunk)
 		} else {
 			prev, _ := respCtx.Metadata[metaKeyAccBody].([]byte)
@@ -247,6 +299,12 @@ func (p *LLMCostPolicy) OnResponseBodyChunk(_ context.Context, respCtx *policy.R
 
 	if !chunk.EndOfStream {
 		return policy.ResponseChunkAction{}
+	}
+
+	// Flush any line fragment buffered from the last chunk (e.g. a stream that ends
+	// without a trailing newline, or an event whose newline arrives in a later packet).
+	if remainder, _ := respCtx.Metadata[metaKeyLineRemainder].(string); remainder != "" {
+		appendSSEEvents(respCtx.Metadata, []byte("\n"))
 	}
 
 	var requestBody []byte
@@ -462,9 +520,30 @@ func mergeSSEEvents(body []byte) ([]byte, error) {
 
 // appendSSEEvents parses the SSE lines in chunk, validates each as JSON, and
 // appends them to the []json.RawMessage slice stored at metadata[metaKeySSEEvents].
+//
+// It maintains a line-remainder buffer so that SSE events split mid-line across
+// network packets are reconstructed before JSON parsing. A chunk that does not end
+// with '\n' leaves the trailing fragment in metadata[metaKeyLineRemainder]; that
+// fragment is prepended to the next call's data automatically.
 func appendSSEEvents(metadata map[string]interface{}, chunk []byte) {
+	// Reconstruct any fragment that was left over from the previous chunk.
+	remainder, _ := metadata[metaKeyLineRemainder].(string)
+	data := remainder + string(chunk)
+
 	events, _ := metadata[metaKeySSEEvents].([]json.RawMessage)
-	for _, line := range strings.Split(string(chunk), "\n") {
+
+	lines := strings.Split(data, "\n")
+
+	// If data doesn't end with '\n' the last element is an incomplete line;
+	// save it for the next chunk rather than attempting to parse it now.
+	newRemainder := ""
+	completeLines := lines
+	if !strings.HasSuffix(data, "\n") && len(lines) > 0 {
+		newRemainder = lines[len(lines)-1]
+		completeLines = lines[:len(lines)-1]
+	}
+
+	for _, line := range completeLines {
 		line = strings.TrimRight(line, "\r")
 		var value string
 		if strings.HasPrefix(line, sseDataPrefix) {
@@ -482,7 +561,9 @@ func appendSSEEvents(metadata map[string]interface{}, chunk []byte) {
 			events = append(events, json.RawMessage(value))
 		}
 	}
+
 	metadata[metaKeySSEEvents] = events
+	metadata[metaKeyLineRemainder] = newRemainder
 }
 
 // buildSSEResponseBody constructs a JSON body suitable for the provider's

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -45,6 +45,15 @@ const (
 
 	costStatusCalculated    = "calculated"
 	costStatusNotCalculated = "not_calculated"
+
+	// metaKeyAccBody is the metadata key used to accumulate raw bytes for plain
+	// JSON (non-SSE) responses delivered via chunked transfer encoding.
+	metaKeyAccBody = "x-llm-cost-acc-body"
+
+	// metaKeySSEEvents holds a []json.RawMessage of every parsed SSE event JSON
+	// accumulated across streaming chunks. Gives O(1) access to the first and
+	// last event without re-scanning raw bytes at EndOfStream.
+	metaKeySSEEvents = "x-llm-cost-sse-events"
 )
 
 // LLMCostPolicy calculates the cost of an LLM API call from the response body
@@ -81,16 +90,15 @@ func GetPolicy(
 	return instance, instanceErr
 }
 
-
 // Mode declares the SDK processing requirements:
 //   - RequestBodyMode=Buffer: buffer the request so ctx.RequestBody is available
-//     in OnResponseBody (needed for Anthropic speed parameter).
-//   - ResponseBodyMode=Buffer: buffer the full response body so we can parse
-//     the usage object and model name.
+//     in OnResponseBody/OnResponseBodyChunk (needed for Anthropic speed parameter).
+//   - ResponseBodyMode=Stream: pass each chunk through to the client without
+//     kernel-level buffering; we accumulate in metadata and calculate at EndOfStream.
 func (p *LLMCostPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestBodyMode:  policy.BodyModeBuffer,
-		ResponseBodyMode: policy.BodyModeBuffer,
+		ResponseBodyMode: policy.BodyModeStream,
 	}
 }
 
@@ -188,6 +196,203 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 	return setCostMetadata(respCtx, finalCost, costStatusCalculated)
 }
 
+// setCostMetadata writes x-llm-cost and x-llm-cost-status into SharedContext.Metadata
+// for the v1alpha2 engine path.
+func setCostMetadata(respCtx *policy.ResponseContext, costUSD float64, status string) policy.ResponseAction {
+	if respCtx.SharedContext == nil {
+		slog.Warn("llm-cost: SharedContext is nil, cannot set cost metadata")
+		return policy.DownstreamResponseModifications{}
+	}
+	if respCtx.Metadata == nil {
+		respCtx.Metadata = make(map[string]interface{})
+	}
+	respCtx.Metadata[MetadataLLMCost] = fmt.Sprintf("%.10f", costUSD)
+	respCtx.Metadata[MetadataLLMCostStatus] = status
+	return policy.DownstreamResponseModifications{
+		AnalyticsMetadata: map[string]interface{}{
+			MetadataLLMCost: costUSD,
+		},
+	}
+}
+
+// NeedsMoreResponseData implements StreamingResponsePolicy.
+// Always returns false — chunks are accumulated in respCtx.Metadata rather than
+// held by the kernel, so each chunk flows to the client immediately.
+func (p *LLMCostPolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
+}
+
+// OnResponseBodyChunk implements StreamingResponsePolicy.
+// For SSE responses, each chunk's events are parsed and appended to a
+// []json.RawMessage in metadata so the first and last events are cheaply
+// accessible at EndOfStream. For plain JSON chunked responses, raw bytes
+// are accumulated as usual.
+func (p *LLMCostPolicy) OnResponseBodyChunk(_ context.Context, respCtx *policy.ResponseStreamContext, chunk *policy.StreamBody, _ map[string]interface{}) policy.ResponseChunkAction {
+	if chunk == nil {
+		return policy.ResponseChunkAction{}
+	}
+
+	if respCtx.Metadata == nil {
+		respCtx.Metadata = make(map[string]interface{})
+	}
+
+	if len(chunk.Chunk) > 0 {
+		if isSSEContent(chunk.Chunk) {
+			appendSSEEvents(respCtx.Metadata, chunk.Chunk)
+		} else {
+			prev, _ := respCtx.Metadata[metaKeyAccBody].([]byte)
+			respCtx.Metadata[metaKeyAccBody] = append(prev, chunk.Chunk...)
+		}
+	}
+
+	if !chunk.EndOfStream {
+		return policy.ResponseChunkAction{}
+	}
+
+	var requestBody []byte
+	if respCtx.RequestBody != nil && respCtx.RequestBody.Present {
+		requestBody = respCtx.RequestBody.Content
+	}
+
+	events, _ := respCtx.Metadata[metaKeySSEEvents].([]json.RawMessage)
+	if len(events) > 0 {
+		return p.calculateCostFromSSE(respCtx, events, requestBody)
+	}
+
+	// Plain JSON path: fall back to raw accumulated bytes.
+	responseBody, _ := respCtx.Metadata[metaKeyAccBody].([]byte)
+	if len(responseBody) == 0 {
+		slog.Warn("llm-cost: empty response body, skipping cost calculation")
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+	return p.calculateCostFromBody(respCtx, responseBody, requestBody)
+}
+
+// calculateCostFromSSE handles the streaming (SSE) path at EndOfStream.
+// It extracts the model name from the event array, uses the provider to build
+// the appropriate response body from the relevant events, then delegates to
+// the shared compute path.
+//
+// Per-provider event strategy:
+//   - OpenAI / Mistral: last event carries model + usage → passed directly.
+//   - Gemini / Vertex AI: last event carries modelVersion + usageMetadata → passed directly.
+//   - Anthropic: first event (message_start) has model + input tokens inside
+//     message envelope; last usage event (message_delta) has output_tokens at
+//     top level → merged into a single body.
+func (p *LLMCostPolicy) calculateCostFromSSE(respCtx *policy.ResponseStreamContext, events []json.RawMessage, requestBody []byte) policy.ResponseChunkAction {
+	// Model name is always present in the first SSE event for all providers:
+	//   $.model        — OpenAI, Mistral (every chunk)
+	//   $.modelVersion — Gemini (every chunk)
+	//   $.message.model — Anthropic message_start (first chunk)
+	var probe struct {
+		Model        string `json:"model"`
+		ModelVersion string `json:"modelVersion"`
+		Message      *struct {
+			Model string `json:"model"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(events[0], &probe); err != nil {
+		slog.Warn("llm-cost: could not parse first SSE event", "error", err)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+	modelName := probe.Model
+	if modelName == "" {
+		modelName = probe.ModelVersion
+	}
+	if modelName == "" && probe.Message != nil {
+		modelName = probe.Message.Model
+	}
+	if modelName == "" {
+		slog.Warn("llm-cost: no model name found in SSE events")
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	pricing, found := lookupPricing(p.pricingMap, modelName)
+	if !found {
+		slog.Warn("llm-cost: no pricing entry for model, setting cost to 0", "model", modelName)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	calc := selectCalculator(pricing.Provider)
+	if calc == nil {
+		slog.Warn("llm-cost: unsupported provider, skipping cost calculation", "provider", pricing.Provider, "model", modelName)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	responseBody, err := buildSSEResponseBody(events, pricing.Provider)
+	if err != nil {
+		slog.Warn("llm-cost: failed to build response body from SSE events", "error", err)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	return p.computeAndSetCost(respCtx, responseBody, requestBody, modelName, pricing, calc)
+}
+
+// calculateCostFromBody handles the plain JSON (non-SSE) path at EndOfStream.
+// Extracts the model name from the body, looks up pricing, and delegates to the
+// shared compute path.
+func (p *LLMCostPolicy) calculateCostFromBody(respCtx *policy.ResponseStreamContext, responseBody []byte, requestBody []byte) policy.ResponseChunkAction {
+	var probe struct {
+		Model        string `json:"model"`
+		ModelVersion string `json:"modelVersion"`
+		Message      *struct {
+			Model string `json:"model"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(responseBody, &probe); err != nil {
+		slog.Warn("llm-cost: could not parse response body", "error", err)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+	modelName := probe.Model
+	if modelName == "" {
+		modelName = probe.ModelVersion
+	}
+	if modelName == "" && probe.Message != nil {
+		modelName = probe.Message.Model
+	}
+	if modelName == "" {
+		slog.Warn("llm-cost: no model name found in response body")
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	pricing, found := lookupPricing(p.pricingMap, modelName)
+	if !found {
+		slog.Warn("llm-cost: no pricing entry for model, setting cost to 0", "model", modelName)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	calc := selectCalculator(pricing.Provider)
+	if calc == nil {
+		slog.Warn("llm-cost: unsupported provider, skipping cost calculation", "provider", pricing.Provider, "model", modelName)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	return p.computeAndSetCost(respCtx, responseBody, requestBody, modelName, pricing, calc)
+}
+
+// computeAndSetCost normalizes usage from responseBody, calculates the final
+// cost, and stores the result in SharedContext.Metadata.
+func (p *LLMCostPolicy) computeAndSetCost(respCtx *policy.ResponseStreamContext, responseBody []byte, requestBody []byte, modelName string, pricing ModelPricing, calc providerCalculator) policy.ResponseChunkAction {
+	usage, err := calc.Normalize(responseBody, requestBody)
+	if err != nil {
+		slog.Warn("llm-cost: failed to normalize usage", "model", modelName, "error", err)
+		return setStreamCostMetadata(respCtx, 0.0, costStatusNotCalculated)
+	}
+
+	baseCost := genericCalculateCost(usage, pricing)
+	finalCost := calc.Adjust(baseCost, usage, pricing)
+
+	slog.Debug("llm-cost: calculated cost",
+		"model", modelName,
+		"provider", pricing.Provider,
+		"prompt_tokens", usage.PromptTokens,
+		"completion_tokens", usage.CompletionTokens,
+		"cost_usd", finalCost,
+	)
+
+	return setStreamCostMetadata(respCtx, finalCost, costStatusCalculated)
+}
+
 // isSSEContent reports whether the body looks like buffered SSE data (has at
 // least one "data: " line).
 func isSSEContent(b []byte) bool {
@@ -255,19 +460,106 @@ func mergeSSEEvents(body []byte) ([]byte, error) {
 	return json.Marshal(merged)
 }
 
-// setCostMetadata writes x-llm-cost and x-llm-cost-status into SharedContext.Metadata
-// for the v1alpha2 engine path.
-func setCostMetadata(respCtx *policy.ResponseContext, costUSD float64, status string) policy.ResponseAction {
+// appendSSEEvents parses the SSE lines in chunk, validates each as JSON, and
+// appends them to the []json.RawMessage slice stored at metadata[metaKeySSEEvents].
+func appendSSEEvents(metadata map[string]interface{}, chunk []byte) {
+	events, _ := metadata[metaKeySSEEvents].([]json.RawMessage)
+	for _, line := range strings.Split(string(chunk), "\n") {
+		line = strings.TrimRight(line, "\r")
+		var value string
+		if strings.HasPrefix(line, sseDataPrefix) {
+			value = strings.TrimPrefix(line, sseDataPrefix)
+		} else if strings.HasPrefix(line, sseEventPrefix) {
+			value = strings.TrimSpace(strings.TrimPrefix(line, sseEventPrefix))
+		} else {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == sseDone || value == "" {
+			continue
+		}
+		if json.Valid([]byte(value)) {
+			events = append(events, json.RawMessage(value))
+		}
+	}
+	metadata[metaKeySSEEvents] = events
+}
+
+// buildSSEResponseBody constructs a JSON body suitable for the provider's
+// Normalize() method from the accumulated SSE events.
+//
+//   - OpenAI / Mistral / Gemini / Vertex AI: the last event already contains
+//     model + usage (or usageMetadata), so it is returned as-is.
+//   - Anthropic: usage is split across events — input tokens are inside the
+//     message envelope of the first event, output tokens are at the top level
+//     of the last message_delta event. buildAnthropicSSEBody merges them.
+func buildSSEResponseBody(events []json.RawMessage, provider string) ([]byte, error) {
+	if provider == "anthropic" {
+		return buildAnthropicSSEBody(events)
+	}
+	// OpenAI, Mistral, Gemini, Vertex AI: last event has everything needed.
+	return events[len(events)-1], nil
+}
+
+// buildAnthropicSSEBody constructs the body for AnthropicCalculator.Normalize()
+// from the event array. It seeds the usage map from the first event's
+// message.usage (input_tokens, cache tokens) and then overlays the last
+// event that carries a top-level usage key (message_delta's output_tokens).
+func buildAnthropicSSEBody(events []json.RawMessage) ([]byte, error) {
+	// First event (message_start) carries model + input usage inside message envelope.
+	var startEvent struct {
+		Message *struct {
+			Model string          `json:"model"`
+			Usage json.RawMessage `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(events[0], &startEvent); err != nil || startEvent.Message == nil {
+		return nil, fmt.Errorf("anthropic: missing or unparseable message_start event")
+	}
+
+	// Seed usage from message_start.message.usage (input_tokens, cache tokens, etc.).
+	usage := make(map[string]interface{})
+	if len(startEvent.Message.Usage) > 0 {
+		_ = json.Unmarshal(startEvent.Message.Usage, &usage)
+	}
+
+	// Overlay with the last event that has a non-empty top-level usage
+	// (message_delta carries output_tokens and optionally inference_geo).
+	for i := len(events) - 1; i >= 0; i-- {
+		var probe struct {
+			Usage json.RawMessage `json:"usage"`
+		}
+		if err := json.Unmarshal(events[i], &probe); err != nil || len(probe.Usage) <= 2 {
+			continue
+		}
+		var deltaUsage map[string]interface{}
+		if err := json.Unmarshal(probe.Usage, &deltaUsage); err == nil {
+			for k, v := range deltaUsage {
+				usage[k] = v
+			}
+		}
+		break
+	}
+
+	return json.Marshal(map[string]interface{}{
+		"model": startEvent.Message.Model,
+		"usage": usage,
+	})
+}
+
+// setStreamCostMetadata writes x-llm-cost and x-llm-cost-status into
+// SharedContext.Metadata and returns a ResponseChunkAction with AnalyticsMetadata.
+func setStreamCostMetadata(respCtx *policy.ResponseStreamContext, costUSD float64, status string) policy.ResponseChunkAction {
 	if respCtx.SharedContext == nil {
 		slog.Warn("llm-cost: SharedContext is nil, cannot set cost metadata")
-		return policy.DownstreamResponseModifications{}
+		return policy.ResponseChunkAction{}
 	}
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
 	respCtx.Metadata[MetadataLLMCost] = fmt.Sprintf("%.10f", costUSD)
 	respCtx.Metadata[MetadataLLMCostStatus] = status
-	return policy.DownstreamResponseModifications{
+	return policy.ResponseChunkAction{
 		AnalyticsMetadata: map[string]interface{}{
 			MetadataLLMCost: costUSD,
 		},

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -1885,6 +1885,47 @@ func TestOnResponseBody_SuccessStatus_Calculated(t *testing.T) {
 	}
 }
 
+// TestOnResponseBody_FullJSON_* — verify exact costs for plain JSON responses
+// (the path taken when Envoy buffers a non-streaming LLM response).
+
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBody_FullJSON_OpenAI(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"gpt-4o-mini-2024-07-18","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	ctx := makeResponseContext(body)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000045000")
+}
+
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBody_FullJSON_Anthropic(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_tokens":5}}`)
+	ctx := makeResponseContext(body)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000280000")
+}
+
+// gemini/gemini-1.5-flash: 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+func TestOnResponseBody_FullJSON_Gemini(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash"); !ok {
+		t.Skip("gemini/gemini-1.5-flash not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`)
+	ctx := makeResponseContext(body)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000022500")
+}
+
+// mistral-small-latest: 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBody_FullJSON_Mistral(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest"); !ok {
+		t.Skip("mistral/mistral-small-latest not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"mistral-small-latest","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	ctx := makeResponseContext(body)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000025000")
+}
+
 func TestOnResponseBody_EmptyBody_NotCalculated(t *testing.T) {
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
 	ctx := &policy.ResponseContext{
@@ -2311,6 +2352,26 @@ func TestOnResponseBody_SSE_OpenAI_Calculated(t *testing.T) {
 	}
 }
 
+// TestOnResponseBody_SSE_Anthropic_InputTokensNotLost is the regression test for
+// the mergeSSEEvents bug: Anthropic's input_tokens live inside message_start's
+// message.usage envelope, while output_tokens arrive later in message_delta's
+// top-level usage. The old shallow-merge silently dropped input_tokens when
+// output_tokens was non-zero. buildSSEResponseBody must produce the correct total.
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBody_SSE_Anthropic_InputTokensNotLost(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	sseBody := []byte(
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n" +
+			"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+			"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n" +
+			"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n" +
+			"data: {\"type\":\"message_stop\"}\n",
+	)
+	ctx := makeResponseContext(sseBody)
+	action := p.OnResponseBody(context.Background(), ctx, nil)
+	assertCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
+}
+
 func TestOnResponseBody_SSE_NoUsage_NotCalculated(t *testing.T) {
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
 	// SSE stream without any usage block (include_usage was not set)
@@ -2323,6 +2384,54 @@ func TestOnResponseBody_SSE_NoUsage_NotCalculated(t *testing.T) {
 	action := p.OnResponseBody(context.Background(), ctx, nil)
 	// Without usage data, cost should be calculated as 0 tokens (not a parse failure)
 	assertCostMetadata(t, ctx, action, costStatusCalculated, "0.0000000000")
+}
+
+// TestOnResponseBody_SSE_* — verify OnResponseBody handles buffered SSE correctly
+// for all providers. Envoy buffers the full SSE stream before calling OnResponseBody
+// when ResponseBodyMode=Buffer (not used in production but tested for completeness).
+
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBody_SSE_OpenAI_ExactCost(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	sseBody := []byte(
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx := makeResponseContext(sseBody)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000045000")
+}
+
+// gemini/gemini-1.5-flash: 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+func TestOnResponseBody_SSE_Gemini(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash"); !ok {
+		t.Skip("gemini/gemini-1.5-flash not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	// Gemini reports cumulative usageMetadata in every event; last event wins.
+	sseBody := []byte(
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":2,\"totalTokenCount\":12}}\n" +
+			"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n",
+	)
+	ctx := makeResponseContext(sseBody)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000022500")
+}
+
+// mistral-small-latest: 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBody_SSE_Mistral(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest"); !ok {
+		t.Skip("mistral/mistral-small-latest not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	sseBody := []byte(
+		"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n" +
+			"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx := makeResponseContext(sseBody)
+	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusCalculated, "0.0000025000")
 }
 
 func TestOnResponseBodyChunk_SSE_OpenAI_Calculated(t *testing.T) {
@@ -2353,138 +2462,283 @@ func TestOnResponseBodyChunk_SSE_NoUsage_NotCalculated(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Multi-chunk SSE streaming tests — events sent one per OnResponseBodyChunk call
+// Multi-chunk SSE streaming tests — realistic Envoy delivery patterns
 // ---------------------------------------------------------------------------
+//
+// Envoy does not guarantee one SSE event per OnResponseBodyChunk call. It may:
+//   (a) coalesce many events into one large chunk
+//   (b) split a single event mid-line across two TCP packets
+//   (c) deliver an empty body chunk with EndOfStream=true
+//
+// The tests below cover these cases. The partial-line remainder buffer in
+// appendSSEEvents and the persisted metaKeyIsSSE flag handle (b) and (c).
 
-// sendSSEChunksOneByOne sends each SSE event JSON as a separate non-EOS chunk,
-// then sends a final EOS chunk with "data: [DONE]". This exercises the
-// accumulation logic in OnResponseBodyChunk across multiple network packets.
-func sendSSEChunksOneByOne(p *LLMCostPolicy, eventJSONs []string) (*policy.ResponseStreamContext, policy.ResponseChunkAction) {
+// sendChunks sends each byte slice as a separate non-EOS OnResponseBodyChunk call,
+// then sends a final EOS chunk (empty body). This is how Envoy delivers data —
+// the last HTTP/2 DATA frame with END_STREAM is often empty.
+func sendChunks(p *LLMCostPolicy, chunks [][]byte) (*policy.ResponseStreamContext, policy.ResponseChunkAction) {
 	ctx := makeStreamResponseContext()
 	var action policy.ResponseChunkAction
-	for i, eventJSON := range eventJSONs {
+	for i, c := range chunks {
 		action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
-			Chunk: []byte("data: " + eventJSON + "\n"),
+			Chunk: c,
 			Index: uint64(i),
 		}, nil)
 	}
-	// Final EOS chunk — triggers cost calculation.
 	action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
-		Chunk:       []byte("data: [DONE]\n"),
+		Chunk:       nil,
 		EndOfStream: true,
-		Index:       uint64(len(eventJSONs)),
+		Index:       uint64(len(chunks)),
 	}, nil)
 	return ctx, action
 }
 
 // TestOnResponseBodyChunk_SSE_IntermediateChunksDoNotSetCost verifies that
-// non-EOS chunks do not trigger cost calculation; only the final EOS chunk does.
+// non-EOS chunks never set cost metadata; only the EOS trigger does.
 func TestOnResponseBodyChunk_SSE_IntermediateChunksDoNotSetCost(t *testing.T) {
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
 	ctx := makeStreamResponseContext()
 
-	events := []string{
-		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
-		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
+	intermediates := [][]byte{
+		[]byte("data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n"),
+		[]byte("data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n"),
 	}
-
-	// Send intermediate chunks — cost metadata must NOT be set yet.
-	for i, ev := range events {
+	for i, c := range intermediates {
 		action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
-			Chunk: []byte("data: " + ev + "\n"),
+			Chunk: c,
 			Index: uint64(i),
 		}, nil)
 		if _, ok := ctx.Metadata[MetadataLLMCostStatus]; ok {
-			t.Fatalf("chunk %d: cost status was set before EndOfStream", i)
+			t.Fatalf("chunk %d: cost status set before EndOfStream", i)
 		}
 		if len(action.AnalyticsMetadata) != 0 {
 			t.Fatalf("chunk %d: unexpected analytics metadata on intermediate chunk", i)
 		}
 	}
 
-	// Final EOS chunk — cost must now be set.
+	// Final chunk carries usage + [DONE], EOS triggers calculation.
 	eosAction := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
-		Chunk:       []byte("data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\ndata: [DONE]\n"),
+		Chunk:       []byte("data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\ndata: [DONE]\n"),
 		EndOfStream: true,
-		Index:       uint64(len(events)),
+		Index:       2,
 	}, nil)
 	assertStreamCostMetadata(t, ctx, eosAction, costStatusCalculated, "0.0000045000")
 }
 
-// TestOnResponseBodyChunk_SSE_OpenAI_MultiChunk sends three OpenAI SSE events as
-// separate chunks and verifies the cost is calculated correctly at EndOfStream.
-// gpt-4o-mini-2024-07-18: input=1.5e-7, output=6e-7
-// 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
-func TestOnResponseBodyChunk_SSE_OpenAI_MultiChunk(t *testing.T) {
+// TestOnResponseBodyChunk_SSE_OpenAI_AllEventsInOneChunk simulates Envoy coalescing
+// the entire SSE stream into a single non-EOS chunk followed by an empty EOS frame.
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBodyChunk_SSE_OpenAI_AllEventsInOneChunk(t *testing.T) {
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
-	events := []string{
-		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
-		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
-		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
-	}
-	ctx, action := sendSSEChunksOneByOne(p, events)
+	bigChunk := []byte(
+		"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{bigChunk})
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000045000")
 }
 
-// TestOnResponseBodyChunk_SSE_Anthropic_MultiChunk sends six Anthropic SSE events
-// as separate chunks. This is the key cross-event merge test: input tokens arrive
-// in message_start (events[0].message.usage.input_tokens) while output tokens
-// arrive in message_delta (events[4].usage.output_tokens).
-// claude-3-5-haiku-20241022: input=8e-7, output=4e-6
-// 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
-func TestOnResponseBodyChunk_SSE_Anthropic_MultiChunk(t *testing.T) {
+// TestOnResponseBodyChunk_SSE_OpenAI_EventSplitAcrossChunks simulates a TCP packet
+// boundary inside the first SSE event line. The model field ("gpt-4o-mini-2024-07-")
+// straddles the boundary; the remainder buffer must reconstruct it.
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBodyChunk_SSE_OpenAI_EventSplitAcrossChunks(t *testing.T) {
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
-	events := []string{
-		`{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}`,
-		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
-		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
-		`{"type":"content_block_stop","index":0}`,
-		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`,
-		`{"type":"message_stop"}`,
+	chunks := [][]byte{
+		// First packet cuts the JSON mid-field — no trailing newline.
+		[]byte(`data: {"id":"chatcmpl-1","model":"gpt-4o-mini-2024-07-`),
+		// Second packet completes the first event and adds usage + done.
+		[]byte("18\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n"),
 	}
-	ctx, action := sendSSEChunksOneByOne(p, events)
+	ctx, action := sendChunks(p, chunks)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000045000")
+}
+
+// TestOnResponseBodyChunk_SSE_Anthropic_AllEventsInOneChunk verifies the Anthropic
+// cross-event merge (input from message_start, output from message_delta) works
+// when Envoy delivers the full stream as one coalesced chunk.
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBodyChunk_SSE_Anthropic_AllEventsInOneChunk(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	bigChunk := []byte(
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n" +
+			"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+			"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n" +
+			"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+			"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n" +
+			"data: {\"type\":\"message_stop\"}\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{bigChunk})
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
 }
 
-// TestOnResponseBodyChunk_SSE_Gemini_MultiChunk sends two Gemini SSE events as
-// separate chunks. Gemini reports cumulative usageMetadata in every chunk so the
-// last chunk's values are used. modelVersion is used instead of model.
-// gemini/gemini-1.5-flash: input=7.5e-8, output=3e-7
-// 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
-func TestOnResponseBodyChunk_SSE_Gemini_MultiChunk(t *testing.T) {
-	pricing, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash")
-	if !ok {
+// TestOnResponseBodyChunk_SSE_Anthropic_MessageStartSplitAcrossChunks is the
+// critical regression test: the message_start event (the only one carrying the
+// model name for Anthropic) is split across two TCP packets. Without the
+// remainder buffer + SSE-mode persistence this test produces not_calculated.
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBodyChunk_SSE_Anthropic_MessageStartSplitAcrossChunks(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	chunks := [][]byte{
+		// Packet 1: message_start cut mid-JSON (before closing braces).
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_01","model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_t`),
+		// Packet 2: rest of message_start + content events + message_delta with output_tokens.
+		[]byte("okens\":0}}}\n" +
+			"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+			"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n" +
+			"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n" +
+			"data: {\"type\":\"message_stop\"}\n"),
+	}
+	ctx, action := sendChunks(p, chunks)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
+}
+
+// TestOnResponseBodyChunk_SSE_Gemini_AllEventsInOneChunk verifies Gemini cumulative
+// usageMetadata handling when all events arrive in a single chunk.
+// gemini/gemini-1.5-flash: 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+func TestOnResponseBodyChunk_SSE_Gemini_AllEventsInOneChunk(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash"); !ok {
 		t.Skip("gemini/gemini-1.5-flash not in pricing map")
 	}
-	_ = pricing
-
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
-	events := []string{
-		`{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}],"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"totalTokenCount":12}}`,
-		`{"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"},"finishReason":"STOP"}],"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,
-	}
-	ctx, action := sendSSEChunksOneByOne(p, events)
+	bigChunk := []byte(
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":2,\"totalTokenCount\":12}}\n" +
+			"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{bigChunk})
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000022500")
 }
 
-// TestOnResponseBodyChunk_SSE_Mistral_MultiChunk sends three Mistral SSE events as
-// separate chunks. Mistral's format mirrors OpenAI: model in every chunk, usage
-// in the last chunk. lookupPricing auto-prepends "mistral/" for bare model names.
-// mistral-small-latest: input=1e-7, output=3e-7
-// 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
-func TestOnResponseBodyChunk_SSE_Mistral_MultiChunk(t *testing.T) {
-	pricing, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest")
-	if !ok {
+// TestOnResponseBodyChunk_SSE_Mistral_AllEventsInOneChunk verifies Mistral (OpenAI
+// wire format) when Envoy coalesces the full stream into one chunk.
+// mistral-small-latest: 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBodyChunk_SSE_Mistral_AllEventsInOneChunk(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest"); !ok {
 		t.Skip("mistral/mistral-small-latest not in pricing map")
 	}
-	_ = pricing
-
 	p := &LLMCostPolicy{pricingMap: testPricingMap}
-	events := []string{
-		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
-		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`,
-		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	bigChunk := []byte(
+		"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n" +
+			"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"cmpl-1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{bigChunk})
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000025000")
+}
+
+// ---------------------------------------------------------------------------
+// Full JSON (non-SSE) at EOS — all providers
+// ---------------------------------------------------------------------------
+// Envoy may deliver the full LLM JSON response as a single EOS chunk.
+// invokeWithBody models this: one chunk with EndOfStream=true.
+
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBodyChunk_FullJSON_OpenAI(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"gpt-4o-mini-2024-07-18","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	ctx, action := invokeWithBody(p, body)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000045000")
+}
+
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBodyChunk_FullJSON_Anthropic(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_tokens":5}}`)
+	ctx, action := invokeWithBody(p, body)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
+}
+
+// gemini/gemini-1.5-flash: 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+func TestOnResponseBodyChunk_FullJSON_Gemini(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash"); !ok {
+		t.Skip("gemini/gemini-1.5-flash not in pricing map")
 	}
-	ctx, action := sendSSEChunksOneByOne(p, events)
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`)
+	ctx, action := invokeWithBody(p, body)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000022500")
+}
+
+// mistral-small-latest: 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBodyChunk_FullJSON_Mistral(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest"); !ok {
+		t.Skip("mistral/mistral-small-latest not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{"model":"mistral-small-latest","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	ctx, action := invokeWithBody(p, body)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000025000")
+}
+
+// ---------------------------------------------------------------------------
+// Multiple SSE data chunks → EOS — all providers
+// ---------------------------------------------------------------------------
+// Events arrive across several non-EOS chunks; EOS triggers final calculation.
+// Uses sendChunks with 2-3 data chunks so the accumulator is exercised across
+// multiple calls before the empty EOS frame.
+
+// gpt-4o-mini-2024-07-18: 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBodyChunk_SSE_EOS_OpenAI(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := sendChunks(p, [][]byte{
+		[]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n"),
+		[]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n"),
+		[]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\ndata: [DONE]\n"),
+	})
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000045000")
+}
+
+// claude-3-5-haiku-20241022: 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+// Critical: message_start (input tokens) arrives in chunk 1, message_delta
+// (output tokens) arrives in chunk 2 — verifies cross-chunk accumulation.
+func TestOnResponseBodyChunk_SSE_EOS_Anthropic(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := sendChunks(p, [][]byte{
+		// Chunk 1: message_start (model + input tokens) + content events
+		[]byte(
+			"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n" +
+				"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+				"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n",
+		),
+		// Chunk 2: message_delta (output tokens) + message_stop
+		[]byte(
+			"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+				"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n" +
+				"data: {\"type\":\"message_stop\"}\n",
+		),
+	})
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
+}
+
+// gemini/gemini-1.5-flash: 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+// Gemini sends cumulative usageMetadata in every chunk; last chunk's values win.
+func TestOnResponseBodyChunk_SSE_EOS_Gemini(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash"); !ok {
+		t.Skip("gemini/gemini-1.5-flash not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := sendChunks(p, [][]byte{
+		[]byte("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":2,\"totalTokenCount\":12}}\n"),
+		[]byte("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini/gemini-1.5-flash\",\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n"),
+	})
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000022500")
+}
+
+// mistral-small-latest: 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBodyChunk_SSE_EOS_Mistral(t *testing.T) {
+	if _, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest"); !ok {
+		t.Skip("mistral/mistral-small-latest not in pricing map")
+	}
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := sendChunks(p, [][]byte{
+		[]byte("data: {\"id\":\"c1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n"),
+		[]byte("data: {\"id\":\"c1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n"),
+		[]byte("data: {\"id\":\"c1\",\"model\":\"mistral-small-latest\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\ndata: [DONE]\n"),
+	})
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000025000")
 }

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -1807,6 +1807,36 @@ func TestSetCostMetadataV2_Formatting(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// setStreamCostMetadata formatting
+// ---------------------------------------------------------------------------
+
+func TestSetStreamCostMetadata_Formatting(t *testing.T) {
+	cases := []struct {
+		cost     float64
+		expected string
+	}{
+		{0.0, "0.0000000000"},
+		{0.00004231, "0.0000423100"},
+		{1.23456789012345, "1.2345678901"},
+	}
+	for _, tc := range cases {
+		ctx := makeStreamResponseContext()
+		action := setStreamCostMetadata(ctx, tc.cost, costStatusCalculated)
+		if action.AnalyticsMetadata == nil {
+			t.Fatalf("expected AnalyticsMetadata in ResponseChunkAction")
+		}
+		got, _ := ctx.Metadata[MetadataLLMCost].(string)
+		if got != tc.expected {
+			t.Errorf("cost=%.15f: expected metadata %q, got %q", tc.cost, tc.expected, got)
+		}
+		gotStatus, _ := ctx.Metadata[MetadataLLMCostStatus].(string)
+		if gotStatus != costStatusCalculated {
+			t.Errorf("expected status %q, got %q", costStatusCalculated, gotStatus)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // OnResponseBody -- cost status
 // ---------------------------------------------------------------------------
 
@@ -1882,6 +1912,76 @@ func TestOnResponseBody_UnknownModel_NotCalculated(t *testing.T) {
 	body := []byte(`{"model": "totally-unknown-model-xyz", "usage": {"prompt_tokens": 10}}`)
 	ctx := makeResponseContext(body)
 	assertCostMetadata(t, ctx, p.OnResponseBody(context.Background(), ctx, nil), costStatusNotCalculated, "0.0000000000")
+}
+
+// ---------------------------------------------------------------------------
+// OnResponseBodyChunk -- cost status
+// ---------------------------------------------------------------------------
+
+func makeStreamResponseContext() *policy.ResponseStreamContext {
+	return &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{
+			Metadata: make(map[string]interface{}),
+		},
+	}
+}
+
+func assertStreamCostMetadata(t *testing.T, respCtx *policy.ResponseStreamContext, action policy.ResponseChunkAction, wantStatus string, wantCost string) {
+	t.Helper()
+	gotStatus, _ := respCtx.Metadata[MetadataLLMCostStatus].(string)
+	if gotStatus != wantStatus {
+		t.Errorf("x-llm-cost-status: expected %q, got %q", wantStatus, gotStatus)
+	}
+	if wantCost != "" {
+		gotCost, _ := respCtx.Metadata[MetadataLLMCost].(string)
+		if gotCost != wantCost {
+			t.Errorf("x-llm-cost: expected %q, got %q", wantCost, gotCost)
+		}
+	}
+}
+
+func invokeWithBody(p *LLMCostPolicy, body []byte) (*policy.ResponseStreamContext, policy.ResponseChunkAction) {
+	ctx := makeStreamResponseContext()
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{Chunk: body, EndOfStream: true}, nil)
+	return ctx, action
+}
+
+func TestOnResponseBodyChunk_SuccessStatus_Calculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	body := []byte(`{
+		"model": "gpt-4o-mini-2024-07-18",
+		"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+	}`)
+	ctx, action := invokeWithBody(p, body)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "")
+	// Also verify the cost metadata is non-empty (exact value tested in calculator tests).
+	if gotCost, _ := ctx.Metadata[MetadataLLMCost].(string); gotCost == "" {
+		t.Error("expected non-empty x-llm-cost in metadata")
+	}
+}
+
+func TestOnResponseBodyChunk_EmptyBody_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := invokeWithBody(p, nil)
+	assertStreamCostMetadata(t, ctx, action, costStatusNotCalculated, "0.0000000000")
+}
+
+func TestOnResponseBodyChunk_UnparsableBody_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := invokeWithBody(p, []byte("not json"))
+	assertStreamCostMetadata(t, ctx, action, costStatusNotCalculated, "0.0000000000")
+}
+
+func TestOnResponseBodyChunk_NoModelName_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := invokeWithBody(p, []byte(`{"usage": {"prompt_tokens": 10}}`))
+	assertStreamCostMetadata(t, ctx, action, costStatusNotCalculated, "0.0000000000")
+}
+
+func TestOnResponseBodyChunk_UnknownModel_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx, action := invokeWithBody(p, []byte(`{"model": "totally-unknown-model-xyz", "usage": {"prompt_tokens": 10}}`))
+	assertStreamCostMetadata(t, ctx, action, costStatusNotCalculated, "0.0000000000")
 }
 
 // ---------------------------------------------------------------------------
@@ -2223,4 +2323,168 @@ func TestOnResponseBody_SSE_NoUsage_NotCalculated(t *testing.T) {
 	action := p.OnResponseBody(context.Background(), ctx, nil)
 	// Without usage data, cost should be calculated as 0 tokens (not a parse failure)
 	assertCostMetadata(t, ctx, action, costStatusCalculated, "0.0000000000")
+}
+
+func TestOnResponseBodyChunk_SSE_OpenAI_Calculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	sseBody := []byte(
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx, action := invokeWithBody(p, sseBody)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "")
+	if gotCost, _ := ctx.Metadata[MetadataLLMCost].(string); gotCost == "" {
+		t.Error("expected non-empty x-llm-cost for SSE OpenAI response")
+	}
+}
+
+func TestOnResponseBodyChunk_SSE_NoUsage_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	// SSE stream without any usage block (include_usage was not set)
+	sseBody := []byte(
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n" +
+			"data: [DONE]\n",
+	)
+	ctx, action := invokeWithBody(p, sseBody)
+	// Without usage data, cost should be calculated as 0 tokens (not a parse failure)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000000000")
+}
+
+// ---------------------------------------------------------------------------
+// Multi-chunk SSE streaming tests — events sent one per OnResponseBodyChunk call
+// ---------------------------------------------------------------------------
+
+// sendSSEChunksOneByOne sends each SSE event JSON as a separate non-EOS chunk,
+// then sends a final EOS chunk with "data: [DONE]". This exercises the
+// accumulation logic in OnResponseBodyChunk across multiple network packets.
+func sendSSEChunksOneByOne(p *LLMCostPolicy, eventJSONs []string) (*policy.ResponseStreamContext, policy.ResponseChunkAction) {
+	ctx := makeStreamResponseContext()
+	var action policy.ResponseChunkAction
+	for i, eventJSON := range eventJSONs {
+		action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+			Chunk: []byte("data: " + eventJSON + "\n"),
+			Index: uint64(i),
+		}, nil)
+	}
+	// Final EOS chunk — triggers cost calculation.
+	action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk:       []byte("data: [DONE]\n"),
+		EndOfStream: true,
+		Index:       uint64(len(eventJSONs)),
+	}, nil)
+	return ctx, action
+}
+
+// TestOnResponseBodyChunk_SSE_IntermediateChunksDoNotSetCost verifies that
+// non-EOS chunks do not trigger cost calculation; only the final EOS chunk does.
+func TestOnResponseBodyChunk_SSE_IntermediateChunksDoNotSetCost(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+
+	events := []string{
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
+	}
+
+	// Send intermediate chunks — cost metadata must NOT be set yet.
+	for i, ev := range events {
+		action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+			Chunk: []byte("data: " + ev + "\n"),
+			Index: uint64(i),
+		}, nil)
+		if _, ok := ctx.Metadata[MetadataLLMCostStatus]; ok {
+			t.Fatalf("chunk %d: cost status was set before EndOfStream", i)
+		}
+		if len(action.AnalyticsMetadata) != 0 {
+			t.Fatalf("chunk %d: unexpected analytics metadata on intermediate chunk", i)
+		}
+	}
+
+	// Final EOS chunk — cost must now be set.
+	eosAction := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk:       []byte("data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o-mini-2024-07-18\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\ndata: [DONE]\n"),
+		EndOfStream: true,
+		Index:       uint64(len(events)),
+	}, nil)
+	assertStreamCostMetadata(t, ctx, eosAction, costStatusCalculated, "0.0000045000")
+}
+
+// TestOnResponseBodyChunk_SSE_OpenAI_MultiChunk sends three OpenAI SSE events as
+// separate chunks and verifies the cost is calculated correctly at EndOfStream.
+// gpt-4o-mini-2024-07-18: input=1.5e-7, output=6e-7
+// 10 * 1.5e-7 + 5 * 6e-7 = 4.5e-6 → "0.0000045000"
+func TestOnResponseBodyChunk_SSE_OpenAI_MultiChunk(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	events := []string{
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4o-mini-2024-07-18","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	}
+	ctx, action := sendSSEChunksOneByOne(p, events)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000045000")
+}
+
+// TestOnResponseBodyChunk_SSE_Anthropic_MultiChunk sends six Anthropic SSE events
+// as separate chunks. This is the key cross-event merge test: input tokens arrive
+// in message_start (events[0].message.usage.input_tokens) while output tokens
+// arrive in message_delta (events[4].usage.output_tokens).
+// claude-3-5-haiku-20241022: input=8e-7, output=4e-6
+// 10 * 8e-7 + 5 * 4e-6 = 28e-6 → "0.0000280000"
+func TestOnResponseBodyChunk_SSE_Anthropic_MultiChunk(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	}
+	ctx, action := sendSSEChunksOneByOne(p, events)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000280000")
+}
+
+// TestOnResponseBodyChunk_SSE_Gemini_MultiChunk sends two Gemini SSE events as
+// separate chunks. Gemini reports cumulative usageMetadata in every chunk so the
+// last chunk's values are used. modelVersion is used instead of model.
+// gemini/gemini-1.5-flash: input=7.5e-8, output=3e-7
+// 10 * 7.5e-8 + 5 * 3e-7 = 2.25e-6 → "0.0000022500"
+func TestOnResponseBodyChunk_SSE_Gemini_MultiChunk(t *testing.T) {
+	pricing, ok := lookupPricing(testPricingMap, "gemini/gemini-1.5-flash")
+	if !ok {
+		t.Skip("gemini/gemini-1.5-flash not in pricing map")
+	}
+	_ = pricing
+
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	events := []string{
+		`{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}],"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"totalTokenCount":12}}`,
+		`{"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"},"finishReason":"STOP"}],"modelVersion":"gemini/gemini-1.5-flash","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,
+	}
+	ctx, action := sendSSEChunksOneByOne(p, events)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000022500")
+}
+
+// TestOnResponseBodyChunk_SSE_Mistral_MultiChunk sends three Mistral SSE events as
+// separate chunks. Mistral's format mirrors OpenAI: model in every chunk, usage
+// in the last chunk. lookupPricing auto-prepends "mistral/" for bare model names.
+// mistral-small-latest: input=1e-7, output=3e-7
+// 10 * 1e-7 + 5 * 3e-7 = 2.5e-6 → "0.0000025000"
+func TestOnResponseBodyChunk_SSE_Mistral_MultiChunk(t *testing.T) {
+	pricing, ok := lookupPricing(testPricingMap, "mistral/mistral-small-latest")
+	if !ok {
+		t.Skip("mistral/mistral-small-latest not in pricing map")
+	}
+	_ = pricing
+
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	events := []string{
+		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`,
+		`{"id":"cmpl-1","object":"chat.completion.chunk","model":"mistral-small-latest","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	}
+	ctx, action := sendSSEChunksOneByOne(p, events)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000025000")
 }


### PR DESCRIPTION
## Purpose
$subject
https://github.com/wso2/api-platform/issues/1386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streaming responses now enable incremental cost calculation, providing real-time cost updates instead of waiting for complete response buffering.

* **Bug Fixes**
  * Corrected token usage aggregation across multiple streaming events for accurate cost reporting.
  * Enhanced streaming cost calculation to properly handle provider-specific event formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->