### PR TITLE
test(semantic-cache): fix threshold assertion for cosine baseline scaling

### DIFF
--- a/policies/semantic-cache/semanticcache_test.go
+++ b/policies/semantic-cache/semanticcache_test.go
@@ -368,7 +368,7 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 					if filter["api_id"] != "Books:v1" {
 						t.Fatalf("unexpected api_id in filter: %v", filter["api_id"])
 					}
-					if filter["threshold"] != "0.70" {
+					if filter["threshold"] != "0.8800" {
 						t.Fatalf("unexpected threshold in filter: %v", filter["threshold"])
 					}
 					if _, ok := filter["ctx"].(context.Context); !ok {


### PR DESCRIPTION
## Purpose

The OnRequestBody handler applies a cosine similarity baseline transformation (effectiveThreshold = 0.6 + threshold * 0.4) before passing the threshold to the vector DB filter. The test was asserting the raw threshold "0.70" instead of the scaled value "0.8800" for a 0.7 input threshold, causing the test to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated semantic cache policy test assertions to verify correct threshold handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->