### PR TITLE
Add streaming support for Advanced rate limiter & handle SSE Error events

### DIFF
--- a/policies/advanced-ratelimit/cost_extractor.go
+++ b/policies/advanced-ratelimit/cost_extractor.go
@@ -482,6 +482,64 @@ func extractFromSSEBodyBytes(bodyBytes []byte, jsonPath string) (float64, bool) 
 	return lastVal, found
 }
 
+// parseSSEChunk scans buf for complete SSE lines (newline-delimited) and applies
+// jsonPath to the JSON payload of each data: or event: line.
+//
+// It returns:
+//   - lastCost:  the numeric value from the last line that matched jsonPath
+//   - found:     true if at least one line yielded a value
+//   - remaining: any bytes after the last newline (an incomplete line); the caller
+//                must prepend these to the next chunk before calling parseSSEChunk
+//                again to guard against JSON payloads split across chunk boundaries
+//
+// last-match-wins is intentional: LLM providers send the authoritative token count
+// in the final usage event, so overwriting on each match naturally yields the right
+// value without needing to know which event is "last" in advance.
+func parseSSEChunk(buf []byte, jsonPath string) (lastCost float64, found bool, remaining []byte) {
+	s := string(buf)
+	for {
+		idx := strings.IndexByte(s, '\n')
+		if idx < 0 {
+			// No complete line remaining — return the fragment so the caller
+			// can prepend it to the next chunk.
+			return lastCost, found, []byte(s)
+		}
+		line := strings.TrimRight(s[:idx], "\r") // strip optional \r from CRLF line endings
+		s = s[idx+1:]
+
+		var value string
+		switch {
+		case strings.HasPrefix(line, sseDataPrefix):
+			value = strings.TrimPrefix(line, sseDataPrefix)
+		case strings.HasPrefix(line, sseEventPrefix):
+			// event: lines carry the event type name, not a JSON payload —
+			// included here for completeness but rarely contain the usage field.
+			value = strings.TrimSpace(strings.TrimPrefix(line, sseEventPrefix))
+		default:
+			// comment (: ...), id:, retry:, or blank separator line — ignore
+			continue
+		}
+
+		if value == sseDone || value == "" {
+			// Stream terminator or empty data field — nothing to extract.
+			continue
+		}
+
+		valueStr, err := utils.ExtractStringValueFromJsonpath([]byte(value), jsonPath)
+		if err != nil {
+			// jsonPath not present in this event. Expected for content chunks
+			// (e.g. delta text events) — only trailing usage events carry the field.
+			continue
+		}
+		cost, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			continue
+		}
+		lastCost = cost
+		found = true // will be overwritten if a later line also matches (last-match-wins)
+	}
+}
+
 // RequiresResponseBody returns true if any source requires response body access
 func (e *CostExtractor) RequiresResponseBody() bool {
 	if !e.config.Enabled {

--- a/policies/advanced-ratelimit/cost_extractor_test.go
+++ b/policies/advanced-ratelimit/cost_extractor_test.go
@@ -585,3 +585,108 @@ func TestCostExtractor_AnthropicSSE_OnlyMessageDeltaMatches(t *testing.T) {
 		t.Error("expected no match when no event carries $.usage.output_tokens")
 	}
 }
+
+// ─── parseSSEChunk unit tests ─────────────────────────────────────────────────
+
+func TestParseSSEChunk_SingleChunkWithUsage(t *testing.T) {
+	buf := []byte("data: {\"usage\":{\"total_tokens\":75}}\n")
+	cost, found, remaining := parseSSEChunk(buf, "$.usage.total_tokens")
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if cost != 75 {
+		t.Fatalf("expected cost=75, got %v", cost)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected empty remaining, got %q", remaining)
+	}
+}
+
+func TestParseSSEChunk_PartialLineCarriedForward(t *testing.T) {
+	// First chunk ends mid-JSON — no newline, so the whole thing is returned as remaining.
+	chunk1 := []byte(`data: {"usage":{"total_tokens":`)
+	_, found1, rem1 := parseSSEChunk(chunk1, "$.usage.total_tokens")
+	if found1 {
+		t.Fatal("expected found=false for incomplete line")
+	}
+	if string(rem1) != string(chunk1) {
+		t.Fatalf("expected remaining=%q, got %q", chunk1, rem1)
+	}
+
+	// Second chunk completes the line. Prepend remaining to simulate the caller's behaviour.
+	chunk2 := append(rem1, []byte("42}}\n")...)
+	cost, found2, _ := parseSSEChunk(chunk2, "$.usage.total_tokens")
+	if !found2 {
+		t.Fatal("expected found=true after combining partial remainder with next chunk")
+	}
+	if cost != 42 {
+		t.Fatalf("expected cost=42, got %v", cost)
+	}
+}
+
+func TestParseSSEChunk_LastMatchWins(t *testing.T) {
+	// Two data: lines both contain the jsonPath — the second value must win.
+	buf := []byte("data: {\"usage\":{\"total_tokens\":10}}\n" +
+		"data: {\"usage\":{\"total_tokens\":99}}\n")
+	cost, found, _ := parseSSEChunk(buf, "$.usage.total_tokens")
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if cost != 99 {
+		t.Fatalf("expected 99 (last-match-wins), got %v", cost)
+	}
+}
+
+func TestParseSSEChunk_NoMatchingField(t *testing.T) {
+	// data: line exists but jsonPath is absent — found must be false.
+	buf := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n")
+	_, found, remaining := parseSSEChunk(buf, "$.usage.total_tokens")
+	if found {
+		t.Fatal("expected found=false when jsonPath absent from payload")
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected empty remaining after complete line, got %q", remaining)
+	}
+}
+
+func TestParseSSEChunk_DoneTerminatorSkipped(t *testing.T) {
+	buf := []byte("data: [DONE]\n")
+	_, found, _ := parseSSEChunk(buf, "$.usage.total_tokens")
+	if found {
+		t.Fatal("expected found=false for [DONE] terminator")
+	}
+}
+
+func TestParseSSEChunk_BlankAndCommentLinesSkipped(t *testing.T) {
+	// Blank separator lines and comment lines must be ignored; the data: line must match.
+	buf := []byte("\n: this is a comment\ndata: {\"usage\":{\"total_tokens\":5}}\n")
+	cost, found, _ := parseSSEChunk(buf, "$.usage.total_tokens")
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if cost != 5 {
+		t.Fatalf("expected cost=5, got %v", cost)
+	}
+}
+
+func TestParseSSEChunk_CRLFLineEndings(t *testing.T) {
+	// Some providers send CRLF line endings — \r must be stripped.
+	buf := []byte("data: {\"usage\":{\"total_tokens\":37}}\r\n")
+	cost, found, _ := parseSSEChunk(buf, "$.usage.total_tokens")
+	if !found {
+		t.Fatal("expected found=true with CRLF line endings")
+	}
+	if cost != 37 {
+		t.Fatalf("expected cost=37, got %v", cost)
+	}
+}
+
+func TestParseSSEChunk_EmptyChunk(t *testing.T) {
+	_, found, remaining := parseSSEChunk([]byte{}, "$.usage.total_tokens")
+	if found {
+		t.Fatal("expected found=false for empty chunk")
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected empty remaining for empty chunk")
+	}
+}

--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v1.0.0
+version: v1.0.1
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -462,12 +462,14 @@ type quotaResult struct {
 // response body is being processed chunk-by-chunk in streaming mode.
 // A separate instance is stored per quota name inside rateLimitStreamStateKey so
 // that multiple quotas on the same request track their state independently.
+//
+// Raw response bytes are accumulated once per chunk (regardless of how many
+// response-phase sources the quota configures) and cost extraction runs once at
+// EOS via ExtractResponseCost. extractFromBodyBytes already handles both plain
+// JSON and SSE bodies transparently, so no per-format or per-source tracking is
+// needed here.
 type streamQuotaState struct {
-	lastCost    float64 // most recently extracted cost value; overwritten on each matching chunk (last-match-wins)
-	found       bool    // true once at least one chunk yielded a value for the configured jsonPath
-	isSSE       *bool   // nil = format not yet determined; set on first non-empty chunk and fixed for the stream lifetime
-	partialLine []byte  // SSE mode: bytes after the last newline in the current chunk, carried forward to the next
-	accumulated []byte  // JSON mode: raw body bytes gathered across all chunks; extracted once at EOS
+	accumulated []byte // raw body bytes gathered across all chunks; extracted once at EOS
 }
 
 // quotaNameFor returns the display/lookup name for a quota.
@@ -2157,17 +2159,12 @@ func (p *RateLimitPolicy) getOrInitStreamState(metadata map[string]interface{}) 
 // OnResponseBodyChunk is called by the kernel for every response body chunk when the
 // chain runs in FULL_DUPLEX_STREAMED mode (every policy returned BodyModeStream).
 //
-// It handles two formats transparently — detection happens on the first non-empty chunk
-// and is fixed for the lifetime of the stream:
-//
-//   - SSE  (data:/event: prefix detected): parse complete lines per chunk using
-//     parseSSEChunk; any bytes after the last newline are held in partialLine and
-//     prepended to the next chunk to guard against payloads split across boundaries.
-//     lastCost is overwritten on each matching event (last-match-wins), so the final
-//     usage value written by the LLM provider is what gets consumed at EOS.
-//
-//   - JSON (no SSE prefix): accumulate raw bytes in streamQuotaState.accumulated
-//     across all chunks; extract the jsonPath value once at EOS.
+// Raw bytes are accumulated once per quota per chunk into streamQuotaState.accumulated.
+// All cost extraction — both plain JSON (JSONPath) and SSE (last-match-wins via the
+// extractFromBodyBytes SSE fallback) — is deferred to EOS inside
+// finalizeAndConsumeStreamingCosts. Accumulating once per quota (rather than once
+// per source) ensures that quotas with multiple response_body/response_cel sources
+// always receive the correct, un-duplicated body bytes.
 //
 // The chunk is always passed through unmodified — this policy only observes the stream.
 // Token consumption happens in finalizeAndConsumeStreamingCosts at EOS.
@@ -2184,63 +2181,20 @@ func (p *RateLimitPolicy) OnResponseBodyChunk(
 		if !q.CostExtractionEnabled || q.CostExtractor == nil {
 			continue
 		}
+		// Only accumulate bytes for quotas that need body content. Quotas whose
+		// sources are exclusively response_header or response_metadata need no
+		// per-chunk work — they are handled in OnResponseHeaders or read directly
+		// from shared metadata at EOS.
+		if !q.CostExtractor.RequiresResponseBody() {
+			continue
+		}
 
 		quotaName := quotaNameFor(q, i)
 		qs := state[quotaName]
-
-		for _, src := range q.CostExtractor.GetConfig().Sources {
-			switch src.Type {
-			case CostSourceResponseBody:
-				// Detect SSE vs JSON on the first non-empty chunk.
-				// SSE streams always open with "data:" or "event:" on the first content line.
-				// Once set, isSSE stays fixed — we do not re-evaluate mid-stream.
-				if qs.isSSE == nil && len(chunk.Chunk) > 0 {
-					trimmed := strings.TrimLeft(string(chunk.Chunk), " \r\n")
-					isSSE := strings.HasPrefix(trimmed, "data:") || strings.HasPrefix(trimmed, "event:")
-					qs.isSSE = &isSSE
-					slog.Debug("Response body format detected",
-						"quota", quotaName, "isSSE", isSSE)
-				}
-
-				if qs.isSSE != nil && *qs.isSSE {
-					// SSE mode: parse this chunk for complete lines.
-					// Prepend any leftover bytes from the previous chunk so that a JSON
-					// payload split across a boundary is always evaluated as a whole line.
-					combined := append(qs.partialLine, chunk.Chunk...)
-					lastCost, found, remaining := parseSSEChunk(combined, src.JSONPath)
-					qs.partialLine = remaining
-					if found {
-						// Overwrite on each match: the provider's final usage event
-						// (which carries the authoritative token count) will be last.
-						qs.lastCost = lastCost * src.Multiplier
-						qs.found = true
-					}
-				} else {
-					// JSON mode: chunked transfer encoding splits the body arbitrarily.
-					// Accumulate all bytes; extraction runs once at EOS.
-					qs.accumulated = append(qs.accumulated, chunk.Chunk...)
-				}
-
-			case CostSourceResponseCEL:
-				// CEL expressions are evaluated against the complete response body,
-				// so we accumulate all bytes here and evaluate once at EOS —
-				// the same strategy as JSON response_body.
-				qs.accumulated = append(qs.accumulated, chunk.Chunk...)
-
-			case CostSourceResponseMetadata:
-				// Metadata is written to SharedContext by upstream policies during the
-				// stream. No per-chunk work is needed; the value is read at EOS from
-				// the synthetic ResponseContext built in finalizeAndConsumeStreamingCosts.
-
-			default:
-				// response_header sources are handled in OnResponseHeaders; skip.
-			}
-		}
-
+		qs.accumulated = append(qs.accumulated, chunk.Chunk...)
 		state[quotaName] = qs
 	}
-	// Persist updated state so the next chunk call sees the latest partialLine /
-	// accumulated bytes / lastCost for each quota.
+	// Persist updated state so the next chunk call sees the accumulated bytes for each quota.
 	respCtx.Metadata[rateLimitStreamStateKey] = state
 
 	// EOS: all chunks have arrived. Finalize JSON extraction (SSE values are
@@ -2253,21 +2207,22 @@ func (p *RateLimitPolicy) OnResponseBodyChunk(
 }
 
 // NeedsMoreResponseData always returns false.
-// For SSE we extract inline per chunk; for JSON we accumulate manually in
-// streamQuotaState.accumulated and extract at EOS. In neither case do we need
-// the kernel to buffer a minimum number of bytes before invoking OnResponseBodyChunk.
+// Raw bytes are accumulated manually in streamQuotaState.accumulated and
+// extracted at EOS. The kernel does not need to buffer a minimum number of
+// bytes before invoking OnResponseBodyChunk.
 func (p *RateLimitPolicy) NeedsMoreResponseData(_ []byte) bool {
 	return false
 }
 
 // finalizeAndConsumeStreamingCosts is called once when chunk.EndOfStream is true.
 //
-// For response_body SSE quotas the cost is already in streamQuotaState.lastCost from
-// per-chunk parsing. For all other source types — response_body JSON, response_cel, and
-// response_metadata — a synthetic ResponseContext is built from the stream context plus
-// the accumulated bytes, then the existing ExtractResponseCost is called. This reuses
-// the full extraction dispatch (JSONPath, CEL evaluation, metadata lookup) without
-// duplicating any logic.
+// A synthetic ResponseContext is built from the stream context plus the bytes
+// accumulated in streamQuotaState.accumulated, then ExtractResponseCost is called for
+// each quota. ExtractResponseCost dispatches to the appropriate handler for each
+// source type (JSONPath, CEL, metadata lookup) and its extractFromBodyBytes helper
+// transparently handles both plain JSON bodies and SSE streams — for SSE it falls back
+// to extractFromSSEBodyBytes which applies last-match-wins semantics over the buffered
+// events, identical to what per-chunk SSE parsing previously achieved.
 //
 // Note: response headers are already committed to the client before the first chunk
 // arrives, so rate-limit headers cannot be updated here. The pre-request availability
@@ -2301,43 +2256,40 @@ func (p *RateLimitPolicy) finalizeAndConsumeStreamingCosts(
 			extracted  bool
 		)
 
-		if qs != nil && qs.isSSE != nil && *qs.isSSE && qs.found {
-			// SSE response_body: cost was extracted per-chunk; use it directly.
-			// There is no accumulated body to parse — the per-chunk path is authoritative.
-			actualCost = qs.lastCost
-			extracted = true
-		} else {
-			// JSON response_body, response_cel, response_metadata:
-			// Build a synthetic ResponseContext so that ExtractResponseCost can dispatch
-			// to the correct handler for each source type without duplicating logic here.
-			//
-			// ResponseBody.Content holds the bytes accumulated across all chunks.
-			// For response_metadata, Content will be empty — ExtractResponseCost reads
-			// from synthCtx.Metadata (which is the shared SharedContext.Metadata already
-			// populated by upstream policies during the stream).
-			bodyBytes := []byte(nil)
-			if qs != nil {
-				bodyBytes = qs.accumulated
-			}
-			synthCtx := &policy.ResponseContext{
-				SharedContext:   respCtx.SharedContext,
-				RequestHeaders:  respCtx.RequestHeaders,
-				RequestBody:     respCtx.RequestBody,
-				RequestPath:     respCtx.RequestPath,
-				RequestMethod:   respCtx.RequestMethod,
-				ResponseHeaders: respCtx.ResponseHeaders,
-				ResponseStatus:  respCtx.ResponseStatus,
-				ResponseBody: &policy.Body{
-					Content:     bodyBytes,
-					Present:     len(bodyBytes) > 0,
-					EndOfStream: true,
-				},
-			}
-			actualCost, extracted = q.CostExtractor.ExtractResponseCost(synthCtx)
-			if !extracted {
-				slog.Debug("Streaming EOS cost extraction failed, using default",
-					"quota", quotaName, "key", key, "default", actualCost)
-			}
+		// Build a synthetic ResponseContext so that ExtractResponseCost can dispatch
+		// to the correct handler for each source type without duplicating logic here.
+		//
+		// ResponseBody.Content holds the bytes accumulated across all chunks.
+		// extractFromBodyBytes (called inside ExtractResponseCost for response_body
+		// sources) tries JSONPath first; if the body is not valid JSON (e.g. SSE
+		// format), it falls back to extractFromSSEBodyBytes which applies
+		// last-match-wins over each buffered data: line — preserving the correct
+		// final usage value from the provider's last usage event.
+		// For response_metadata, Content will be empty — ExtractResponseCost reads
+		// from synthCtx.Metadata (which is the shared SharedContext.Metadata already
+		// populated by upstream policies during the stream).
+		bodyBytes := []byte(nil)
+		if qs != nil {
+			bodyBytes = qs.accumulated
+		}
+		synthCtx := &policy.ResponseContext{
+			SharedContext:   respCtx.SharedContext,
+			RequestHeaders:  respCtx.RequestHeaders,
+			RequestBody:     respCtx.RequestBody,
+			RequestPath:     respCtx.RequestPath,
+			RequestMethod:   respCtx.RequestMethod,
+			ResponseHeaders: respCtx.ResponseHeaders,
+			ResponseStatus:  respCtx.ResponseStatus,
+			ResponseBody: &policy.Body{
+				Content:     bodyBytes,
+				Present:     len(bodyBytes) > 0,
+				EndOfStream: true,
+			},
+		}
+		actualCost, extracted = q.CostExtractor.ExtractResponseCost(synthCtx)
+		if !extracted {
+			slog.Debug("Streaming EOS cost extraction failed, using default",
+				"quota", quotaName, "key", key, "default", actualCost)
 		}
 
 		if actualCost < 0 {
@@ -2379,7 +2331,6 @@ func (p *RateLimitPolicy) finalizeAndConsumeStreamingCosts(
 		slog.Debug("Streaming EOS cost consumed",
 			"quota", quotaName,
 			"key", key,
-			"cost", actualCost,
-			"isSSE", qs != nil && qs.isSSE != nil && *qs.isSSE)
+			"cost", actualCost)
 	}
 }

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -418,8 +418,8 @@ func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
 	if p.requiresRequestBody() {
 		requestBodyMode = policy.BodyModeBuffer
 	}
-	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
-		responseBodyMode = policy.BodyModeBuffer
+	if p.requiresAnyResponseBodyMode() {
+		responseBodyMode = policy.BodyModeStream
 	}
 
 	return policy.ProcessingMode{
@@ -435,6 +435,7 @@ const (
 	rateLimitResultKey        = "ratelimit:result"
 	rateLimitKeysKey          = "ratelimit:keys"           // Store extracted keys for post-response cost extraction
 	rateLimitHeaderHandledKey = "ratelimit:header_handled" // Quota names fully handled in header phase
+	rateLimitStreamStateKey   = "ratelimit:stream_state"   // Per-request SSE/JSON streaming accumulation state
 )
 
 // quotaResult stores the result of checking a single quota
@@ -443,6 +444,27 @@ type quotaResult struct {
 	Result    *limiter.Result
 	Key       string
 	Duration  time.Duration // Window duration for IETF RateLimit-Policy header
+}
+
+// streamQuotaState holds per-request accumulation state for one quota while the
+// response body is being processed chunk-by-chunk in streaming mode.
+// A separate instance is stored per quota name inside rateLimitStreamStateKey so
+// that multiple quotas on the same request track their state independently.
+type streamQuotaState struct {
+	lastCost    float64 // most recently extracted cost value; overwritten on each matching chunk (last-match-wins)
+	found       bool    // true once at least one chunk yielded a value for the configured jsonPath
+	isSSE       *bool   // nil = format not yet determined; set on first non-empty chunk and fixed for the stream lifetime
+	partialLine []byte  // SSE mode: bytes after the last newline in the current chunk, carried forward to the next
+	accumulated []byte  // JSON mode: raw body bytes gathered across all chunks; extracted once at EOS
+}
+
+// quotaNameFor returns the display/lookup name for a quota.
+// Used consistently across streaming methods to avoid duplicating the fallback logic.
+func quotaNameFor(q *QuotaRuntime, index int) string {
+	if q.Name != "" {
+		return q.Name
+	}
+	return fmt.Sprintf("quota-%d", index)
 }
 
 // buildMultiQuotaHeaders creates rate limit headers for all quotas.
@@ -922,36 +944,44 @@ func (p *RateLimitPolicy) requiresRequestBody() bool {
 	return false
 }
 
-// requiresResponseBody returns true if any quota requires response body processing.
-func (p *RateLimitPolicy) requiresResponseBody() bool {
+
+// requiresAnyResponseBodyMode returns true if any quota has a response-phase cost
+// source that is not response_header. This is the single gating check used by
+// Mode() to request BodyModeStream and by OnResponseBody to guard the buffered
+// fallback path.
+//
+// response_header-only quotas are fully handled in OnResponseHeaders and are
+// excluded here to avoid requesting an unnecessary body phase.
+func (p *RateLimitPolicy) requiresAnyResponseBodyMode() bool {
 	for _, q := range p.quotas {
-		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			if q.CostExtractor.RequiresResponseBody() {
-				return true
-			}
+		if !q.CostExtractionEnabled || q.CostExtractor == nil {
+			continue
+		}
+		// Skip quotas whose only response sources are response_header — those are
+		// consumed entirely in OnResponseHeaders with no body involvement.
+		if q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+			continue
+		}
+		if q.CostExtractor.HasResponsePhaseSources() {
+			return true
 		}
 	}
 	return false
 }
 
-// hasNonHeaderResponsePhaseSources returns true if any quota has response-phase cost
-// sources that are not response_header (e.g. response_metadata, response_body,
-// response_cel). These require OnResponseBody to run — either because they need
-// the body content, or because the metadata they read is populated by upstream
-// policies that execute in the response-body phase.
-func (p *RateLimitPolicy) hasNonHeaderResponsePhaseSources() bool {
-	for _, q := range p.quotas {
-		if q.CostExtractionEnabled && q.CostExtractor != nil {
-			// response_header-only quotas are consumed in OnResponseHeaders — exclude them.
-			if q.CostExtractor.HasResponseHeaderOnlyCostSources() {
-				continue
-			}
-			if q.CostExtractor.HasResponsePhaseSources() && !q.CostExtractor.RequiresResponseBody() {
-				return true
-			}
-		}
+// hasStreamingResponseSourceForQuota returns true if the given quota has any
+// response-phase cost source that should be processed in the streaming path
+// (i.e. anything other than response_header, which is handled earlier).
+// Used in finalizeAndConsumeStreamingCosts to skip quotas that were already
+// fully consumed in OnResponseHeaders.
+func (p *RateLimitPolicy) hasStreamingResponseSourceForQuota(q *QuotaRuntime) bool {
+	if q.CostExtractor == nil {
+		return false
 	}
-	return false
+	if q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+		return false
+	}
+	return q.CostExtractor.HasResponsePhaseSources()
 }
 
 // getLimitFromQuota returns the limit from a quota's first limit config, or 0 if none
@@ -1722,7 +1752,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 	// If body/metadata sources exist, OnResponseBody will process those quotas
 	// and emit the final complete headers — building partial headers here would
 	// be incorrect and they would be overwritten anyway.
-	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
+	if p.requiresAnyResponseBodyMode() {
 		return nil
 	}
 
@@ -1755,7 +1785,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.ResponseContext,
 	_ map[string]interface{},
 ) policy.ResponseAction {
-	if p.requiresResponseBody() || p.hasNonHeaderResponsePhaseSources() {
+	if p.requiresAnyResponseBodyMode() {
 		slog.Debug("Processing rate limit response phase",
 			"route", p.routeName,
 			"status", respCtx.ResponseStatus,
@@ -2030,4 +2060,251 @@ func (p *RateLimitPolicy) extractIPAddress(headers *policy.Headers) string {
 
 	slog.Warn("Could not extract IP address for rate limit key, using 'unknown'")
 	return "unknown"
+}
+
+// ─── Streaming response body (StreamingResponsePolicy) ───────────────────────
+
+// getOrInitStreamState loads the per-request streaming state map from shared metadata,
+// creating and storing it if this is the first chunk of the request.
+// Each quota gets its own streamQuotaState entry keyed by quota name.
+func (p *RateLimitPolicy) getOrInitStreamState(metadata map[string]interface{}) map[string]*streamQuotaState {
+	if existing, ok := metadata[rateLimitStreamStateKey].(map[string]*streamQuotaState); ok {
+		return existing
+	}
+	state := make(map[string]*streamQuotaState, len(p.quotas))
+	for i := range p.quotas {
+		state[quotaNameFor(&p.quotas[i], i)] = &streamQuotaState{}
+	}
+	metadata[rateLimitStreamStateKey] = state
+	return state
+}
+
+// OnResponseBodyChunk is called by the kernel for every response body chunk when the
+// chain runs in FULL_DUPLEX_STREAMED mode (every policy returned BodyModeStream).
+//
+// It handles two formats transparently — detection happens on the first non-empty chunk
+// and is fixed for the lifetime of the stream:
+//
+//   - SSE  (data:/event: prefix detected): parse complete lines per chunk using
+//     parseSSEChunk; any bytes after the last newline are held in partialLine and
+//     prepended to the next chunk to guard against payloads split across boundaries.
+//     lastCost is overwritten on each matching event (last-match-wins), so the final
+//     usage value written by the LLM provider is what gets consumed at EOS.
+//
+//   - JSON (no SSE prefix): accumulate raw bytes in streamQuotaState.accumulated
+//     across all chunks; extract the jsonPath value once at EOS.
+//
+// The chunk is always passed through unmodified — this policy only observes the stream.
+// Token consumption happens in finalizeAndConsumeStreamingCosts at EOS.
+func (p *RateLimitPolicy) OnResponseBodyChunk(
+	ctx context.Context,
+	respCtx *policy.ResponseStreamContext,
+	chunk *policy.StreamBody,
+	_ map[string]interface{},
+) policy.ResponseChunkAction {
+	state := p.getOrInitStreamState(respCtx.Metadata)
+
+	for i := range p.quotas {
+		q := &p.quotas[i]
+		if !q.CostExtractionEnabled || q.CostExtractor == nil {
+			continue
+		}
+
+		quotaName := quotaNameFor(q, i)
+		qs := state[quotaName]
+
+		for _, src := range q.CostExtractor.GetConfig().Sources {
+			switch src.Type {
+			case CostSourceResponseBody:
+				// Detect SSE vs JSON on the first non-empty chunk.
+				// SSE streams always open with "data:" or "event:" on the first content line.
+				// Once set, isSSE stays fixed — we do not re-evaluate mid-stream.
+				if qs.isSSE == nil && len(chunk.Chunk) > 0 {
+					trimmed := strings.TrimLeft(string(chunk.Chunk), " \r\n")
+					isSSE := strings.HasPrefix(trimmed, "data:") || strings.HasPrefix(trimmed, "event:")
+					qs.isSSE = &isSSE
+					slog.Debug("Response body format detected",
+						"quota", quotaName, "isSSE", isSSE)
+				}
+
+				if qs.isSSE != nil && *qs.isSSE {
+					// SSE mode: parse this chunk for complete lines.
+					// Prepend any leftover bytes from the previous chunk so that a JSON
+					// payload split across a boundary is always evaluated as a whole line.
+					combined := append(qs.partialLine, chunk.Chunk...)
+					lastCost, found, remaining := parseSSEChunk(combined, src.JSONPath)
+					qs.partialLine = remaining
+					if found {
+						// Overwrite on each match: the provider's final usage event
+						// (which carries the authoritative token count) will be last.
+						qs.lastCost = lastCost * src.Multiplier
+						qs.found = true
+					}
+				} else {
+					// JSON mode: chunked transfer encoding splits the body arbitrarily.
+					// Accumulate all bytes; extraction runs once at EOS.
+					qs.accumulated = append(qs.accumulated, chunk.Chunk...)
+				}
+
+			case CostSourceResponseCEL:
+				// CEL expressions are evaluated against the complete response body,
+				// so we accumulate all bytes here and evaluate once at EOS —
+				// the same strategy as JSON response_body.
+				qs.accumulated = append(qs.accumulated, chunk.Chunk...)
+
+			case CostSourceResponseMetadata:
+				// Metadata is written to SharedContext by upstream policies during the
+				// stream. No per-chunk work is needed; the value is read at EOS from
+				// the synthetic ResponseContext built in finalizeAndConsumeStreamingCosts.
+
+			default:
+				// response_header sources are handled in OnResponseHeaders; skip.
+			}
+		}
+
+		state[quotaName] = qs
+	}
+	// Persist updated state so the next chunk call sees the latest partialLine /
+	// accumulated bytes / lastCost for each quota.
+	respCtx.Metadata[rateLimitStreamStateKey] = state
+
+	// EOS: all chunks have arrived. Finalize JSON extraction (SSE values are
+	// already up-to-date from per-chunk parsing) and consume tokens.
+	if chunk.EndOfStream {
+		p.finalizeAndConsumeStreamingCosts(ctx, respCtx, state)
+	}
+
+	return policy.ResponseChunkAction{} // passthrough — do not modify the chunk
+}
+
+// NeedsMoreResponseData always returns false.
+// For SSE we extract inline per chunk; for JSON we accumulate manually in
+// streamQuotaState.accumulated and extract at EOS. In neither case do we need
+// the kernel to buffer a minimum number of bytes before invoking OnResponseBodyChunk.
+func (p *RateLimitPolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
+}
+
+// finalizeAndConsumeStreamingCosts is called once when chunk.EndOfStream is true.
+//
+// For response_body SSE quotas the cost is already in streamQuotaState.lastCost from
+// per-chunk parsing. For all other source types — response_body JSON, response_cel, and
+// response_metadata — a synthetic ResponseContext is built from the stream context plus
+// the accumulated bytes, then the existing ExtractResponseCost is called. This reuses
+// the full extraction dispatch (JSONPath, CEL evaluation, metadata lookup) without
+// duplicating any logic.
+//
+// Note: response headers are already committed to the client before the first chunk
+// arrives, so rate-limit headers cannot be updated here. The pre-request availability
+// check in OnRequestHeaders still blocks requests when the quota is fully exhausted.
+func (p *RateLimitPolicy) finalizeAndConsumeStreamingCosts(
+	ctx context.Context,
+	respCtx *policy.ResponseStreamContext,
+	state map[string]*streamQuotaState,
+) {
+	// quotaKeys were written to metadata during the request phase (OnRequestHeaders /
+	// OnRequestBody) and carry the rate-limit key for each quota into the response phase.
+	quotaKeys, _ := respCtx.Metadata[rateLimitKeysKey].(map[string]string)
+
+	for i := range p.quotas {
+		q := &p.quotas[i]
+		if !q.CostExtractionEnabled || q.CostExtractor == nil {
+			continue
+		}
+		// Only process quotas with non-header response sources. response_header quotas
+		// are fully consumed in OnResponseHeaders and must not be charged again.
+		if !p.hasStreamingResponseSourceForQuota(q) {
+			continue
+		}
+
+		quotaName := quotaNameFor(q, i)
+		key := quotaKeys[quotaName]
+		qs := state[quotaName]
+
+		var (
+			actualCost float64
+			extracted  bool
+		)
+
+		if qs != nil && qs.isSSE != nil && *qs.isSSE && qs.found {
+			// SSE response_body: cost was extracted per-chunk; use it directly.
+			// There is no accumulated body to parse — the per-chunk path is authoritative.
+			actualCost = qs.lastCost
+			extracted = true
+		} else {
+			// JSON response_body, response_cel, response_metadata:
+			// Build a synthetic ResponseContext so that ExtractResponseCost can dispatch
+			// to the correct handler for each source type without duplicating logic here.
+			//
+			// ResponseBody.Content holds the bytes accumulated across all chunks.
+			// For response_metadata, Content will be empty — ExtractResponseCost reads
+			// from synthCtx.Metadata (which is the shared SharedContext.Metadata already
+			// populated by upstream policies during the stream).
+			bodyBytes := []byte(nil)
+			if qs != nil {
+				bodyBytes = qs.accumulated
+			}
+			synthCtx := &policy.ResponseContext{
+				SharedContext:   respCtx.SharedContext,
+				RequestHeaders:  respCtx.RequestHeaders,
+				RequestBody:     respCtx.RequestBody,
+				RequestPath:     respCtx.RequestPath,
+				RequestMethod:   respCtx.RequestMethod,
+				ResponseHeaders: respCtx.ResponseHeaders,
+				ResponseStatus:  respCtx.ResponseStatus,
+				ResponseBody: &policy.Body{
+					Content:     bodyBytes,
+					Present:     len(bodyBytes) > 0,
+					EndOfStream: true,
+				},
+			}
+			actualCost, extracted = q.CostExtractor.ExtractResponseCost(synthCtx)
+			if !extracted {
+				slog.Debug("Streaming EOS cost extraction failed, using default",
+					"quota", quotaName, "key", key, "default", actualCost)
+			}
+		}
+
+		if actualCost < 0 {
+			actualCost = 0
+		}
+		if actualCost == 0 {
+			// Zero cost: skip the limiter call entirely to avoid unnecessary overhead.
+			continue
+		}
+
+		// Consume tokens against the limiter.
+		// ConsumeN (CostTracker) tracks overflow and consumed metrics accurately.
+		// ConsumeOrClampN is the safe fallback for limiters that do not implement
+		// CostTracker; it clamps the deduction to the available balance.
+		if tracker, ok := q.Limiter.(limiter.CostTracker); ok {
+			if _, err := tracker.ConsumeN(ctx, key, int64(actualCost)); err != nil {
+				if p.backend == "redis" && p.redisFailOpen {
+					slog.Warn("Streaming EOS cost consumption failed (fail-open)",
+						"error", err, "quota", quotaName, "key", key, "cost", actualCost)
+					continue
+				}
+				slog.Error("Streaming EOS cost consumption failed (fail-closed)",
+					"error", err, "quota", quotaName, "key", key, "cost", actualCost)
+				continue
+			}
+		} else {
+			if _, err := q.Limiter.ConsumeOrClampN(ctx, key, int64(actualCost)); err != nil {
+				if p.backend == "redis" && p.redisFailOpen {
+					slog.Warn("Streaming EOS cost consumption failed (fail-open)",
+						"error", err, "quota", quotaName, "key", key, "cost", actualCost)
+					continue
+				}
+				slog.Error("Streaming EOS cost consumption failed (fail-closed)",
+					"error", err, "quota", quotaName, "key", key, "cost", actualCost)
+				continue
+			}
+		}
+
+		slog.Debug("Streaming EOS cost consumed",
+			"quota", quotaName,
+			"key", key,
+			"cost", actualCost,
+			"isSSE", qs != nil && qs.isSSE != nil && *qs.isSSE)
+	}
 }

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -438,6 +438,18 @@ const (
 	rateLimitStreamStateKey   = "ratelimit:stream_state"   // Per-request SSE/JSON streaming accumulation state
 )
 
+// upstreamRateLimitHeaders are provider-specific rate-limit headers that should
+// never be forwarded to API consumers. They leak upstream quota details, conflict
+// with gateway-issued ratelimit headers, and pollute the x-ratelimit-* namespace.
+var upstreamRateLimitHeaders = []string{
+	"x-ratelimit-limit-requests",
+	"x-ratelimit-limit-tokens",
+	"x-ratelimit-remaining-requests",
+	"x-ratelimit-remaining-tokens",
+	"x-ratelimit-reset-requests",
+	"x-ratelimit-reset-tokens",
+}
+
 // quotaResult stores the result of checking a single quota
 type quotaResult struct {
 	QuotaName string
@@ -982,6 +994,28 @@ func (p *RateLimitPolicy) hasStreamingResponseSourceForQuota(q *QuotaRuntime) bo
 		return false
 	}
 	return q.CostExtractor.HasResponsePhaseSources()
+}
+
+// isStreamingResponse returns true if the upstream response headers indicate a streaming
+// body — either Server-Sent Events (content-type: text/event-stream) or chunked transfer
+// encoding. These are the same signals the kernel uses to activate FULL_DUPLEX_STREAMED
+// mode, which routes body data through OnResponseBodyChunk instead of OnResponseBody and
+// commits response headers before the first chunk arrives.
+func isStreamingResponse(headers *policy.Headers) bool {
+	if headers == nil {
+		return false
+	}
+	ct := headers.Get("content-type")
+	if len(ct) > 0 && strings.Contains(ct[0], "text/event-stream") {
+		return true
+	}
+	te := headers.Get("transfer-encoding")
+	for _, v := range te {
+		if strings.Contains(strings.ToLower(v), "chunked") {
+			return true
+		}
+	}
+	return false
 }
 
 // getLimitFromQuota returns the limit from a quota's first limit config, or 0 if none
@@ -1611,6 +1645,12 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 		}
 	}
 
+	// Detect whether the upstream response is streaming (SSE or chunked transfer).
+	// The kernel activates FULL_DUPLEX_STREAMED mode under the same conditions, which
+	// means OnResponseBodyChunk will be used instead of OnResponseBody, and response
+	// headers will be committed before any body chunks arrive.
+	isStreaming := isStreamingResponse(respCtx.ResponseHeaders)
+
 	// Retrieve stored results from request phase
 	resultsRaw, hasResults := respCtx.Metadata[rateLimitResultKey]
 	var storedResults []quotaResult
@@ -1737,9 +1777,39 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 				Duration:  result.Duration,
 			})
 		} else {
-			// Use stored result from request phase
+			// Use stored result from request phase.
 			if stored, ok := storedResultsMap[quotaName]; ok && stored.Result != nil {
 				allQuotaResults = append(allQuotaResults, stored)
+			} else if isStreaming {
+				// stored.Result is nil (pre-check placeholder) AND the response is
+				// streaming (SSE / chunked). Response headers are committed to the client
+				// before the first body chunk arrives, so OnResponseBodyChunk /
+				// finalizeAndConsumeStreamingCosts cannot update them. Use GetAvailable
+				// to produce a pre-consumption snapshot so the client sees useful
+				// rate-limit information. The value reflects remaining BEFORE this
+				// request's token cost is deducted; it decreases correctly across
+				// successive requests as each EOS deduction is applied.
+				// For buffered responses this branch is intentionally skipped —
+				// OnResponseBody will set accurate post-consumption values instead.
+				key := quotaKeys[quotaName]
+				if key != "" {
+					available, err := q.Limiter.GetAvailable(context.Background(), key)
+					if err == nil {
+						duration := getDurationFromQuota(q)
+						allQuotaResults = append(allQuotaResults, quotaResult{
+							QuotaName: quotaName,
+							Result: &limiter.Result{
+								Allowed:   available > 0,
+								Limit:     getLimitFromQuota(q),
+								Remaining: available,
+								Reset:     time.Now().Add(duration),
+								Duration:  duration,
+							},
+							Key:      key,
+							Duration: duration,
+						})
+					}
+				}
 			}
 		}
 	}
@@ -1748,11 +1818,12 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 	// quota results and avoid re-consuming them.
 	respCtx.Metadata[rateLimitResultKey] = allQuotaResults
 
-	// Only build rate limit headers here if OnResponseBody will not run.
-	// If body/metadata sources exist, OnResponseBody will process those quotas
-	// and emit the final complete headers — building partial headers here would
-	// be incorrect and they would be overwritten anyway.
-	if p.requiresAnyResponseBodyMode() {
+	// For buffered responses with body-phase sources, defer header emission to
+	// OnResponseBody which has the full body and can report accurate post-consumption
+	// remaining. For streaming responses, headers are already committed by the time
+	// chunks arrive so we must emit them here using the pre-consumption snapshot built
+	// above — skip the early return in that case.
+	if p.requiresAnyResponseBodyMode() && !isStreaming {
 		return nil
 	}
 
@@ -1766,7 +1837,8 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 	}
 
 	return policy.DownstreamResponseHeaderModifications{
-		HeadersToSet: headers,
+		HeadersToSet:    headers,
+		HeadersToRemove: upstreamRateLimitHeaders,
 	}
 }
 
@@ -1939,10 +2011,13 @@ func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Re
 		}
 
 		return policy.DownstreamResponseModifications{
-			HeadersToSet: headers,
+			HeadersToSet:    headers,
+			HeadersToRemove: upstreamRateLimitHeaders,
 		}
 	}
-	return policy.DownstreamResponseModifications{}
+	return policy.DownstreamResponseModifications{
+		HeadersToRemove: upstreamRateLimitHeaders,
+	}
 }
 
 func (p *RateLimitPolicy) extractQuotaKey(reqCtx *policy.RequestContext, q *QuotaRuntime) string {

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -2792,6 +2792,429 @@ func TestOnResponseBodyChunk_EmptyFirstChunkDeferrsSSEDetection(t *testing.T) {
 	}
 }
 
+func TestOnResponseBodyChunk_MultipleResponseBodySources_Summed(t *testing.T) {
+	// Regression test for the multi-source bug: when a quota has two response_body
+	// sources (e.g. prompt_tokens + completion_tokens), both values must be extracted
+	// and summed. The old per-chunk per-source path overwrote qs.lastCost on each
+	// source, so only the last source's value was charged.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.prompt_tokens", Multiplier: 1},
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.completion_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-multisource",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "ms-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// OpenAI-style stream: content deltas carry no usage; only the final event does.
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n"),
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n"),
+		// Final event: prompt_tokens=25, completion_tokens=50 → expected total=75
+		[]byte("data: {\"usage\":{\"prompt_tokens\":25,\"completion_tokens\":50,\"total_tokens\":75}}\n"),
+		[]byte("data: [DONE]\n"),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	// Both sources must be summed: 25 + 50 = 75
+	if lim.lastCost != 75 {
+		t.Fatalf("expected cost=75 (prompt_tokens+completion_tokens), got %d — multi-source accumulation broken", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_MultipleResponseBodySources_WithMultipliers(t *testing.T) {
+	// Two sources with different multipliers: prompt_tokens * 1.0, completion_tokens * 2.0
+	// prompt=25, completion=50 → 25*1 + 50*2 = 125
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.prompt_tokens", Multiplier: 1.0},
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.completion_tokens", Multiplier: 2.0},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-multimul",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "mm-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n"),
+		[]byte("data: {\"usage\":{\"prompt_tokens\":25,\"completion_tokens\":50,\"total_tokens\":75}}\n"),
+		[]byte("data: [DONE]\n"),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	// 25*1 + 50*2 = 125
+	if lim.lastCost != 125 {
+		t.Fatalf("expected cost=125 (25×1 + 50×2), got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_OpenAISSE_ManyChunks(t *testing.T) {
+	// Realistic OpenAI stream: 10 content delta events followed by a usage event
+	// and [DONE]. Verifies that last-match-wins correctly picks the final usage value
+	// even when many intermediate chunks contain no usage field.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-many",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "many-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// 10 content-only delta chunks (no usage field), then a usage-only chunk, then [DONE].
+	words := []string{"The", " quick", " brown", " fox", " jumps", " over", " the", " lazy", " dog", "."}
+	chunks := make([][]byte, 0, len(words)+2)
+	for _, w := range words {
+		chunks = append(chunks, []byte(`data: {"id":"chatcmpl-x","choices":[{"delta":{"content":"`+w+`"}}]}`+"\n"))
+	}
+	// Final usage event — prompt_tokens=12, completion_tokens=10, total_tokens=22
+	chunks = append(chunks, []byte("data: {\"id\":\"chatcmpl-x\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":10,\"total_tokens\":22}}\n"))
+	chunks = append(chunks, []byte("data: [DONE]\n"))
+
+	sendChunks(t, p, respCtx, chunks)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 22 {
+		t.Fatalf("expected cost=22 from final usage event, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_AnthropicSSE_MultiChunk_SplitAcrossBoundary(t *testing.T) {
+	// Anthropic SSE stream delivered as many small chunks — including a split mid-line —
+	// to verify that byte accumulation correctly reconstructs the body at EOS.
+	// The authoritative usage is in the message_delta event: input_tokens=10, output_tokens=20.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.output_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-anthropic-split",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "as-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Split the anthropicSSEBody into individual lines (one chunk per line).
+	// This simulates each SSE event arriving as a separate chunk and exercises
+	// the accumulation path across many boundary crossings.
+	lines := strings.Split(anthropicSSEBody, "\n")
+	chunks := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			chunks = append(chunks, []byte("\n"))
+		} else {
+			chunks = append(chunks, []byte(line+"\n"))
+		}
+	}
+	// Remove trailing empty chunk if present
+	for len(chunks) > 0 && len(chunks[len(chunks)-1]) == 0 {
+		chunks = chunks[:len(chunks)-1]
+	}
+
+	sendChunks(t, p, respCtx, chunks)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 20 {
+		t.Fatalf("expected cost=20 from message_delta usage.output_tokens, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_AnthropicSSE_TwoSources_InputPlusOutput(t *testing.T) {
+	// Two response_body sources extracting input and output tokens separately from
+	// the Anthropic message_delta event. Both must be summed: 10 + 20 = 30.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.input_tokens", Multiplier: 1},
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.output_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-anthropic-both",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "ab-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Deliver the Anthropic SSE body line-by-line to exercise multi-chunk accumulation.
+	lines := strings.Split(anthropicSSEBody, "\n")
+	chunks := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			chunks = append(chunks, []byte("\n"))
+		} else {
+			chunks = append(chunks, []byte(line+"\n"))
+		}
+	}
+	for len(chunks) > 0 && len(chunks[len(chunks)-1]) == 0 {
+		chunks = chunks[:len(chunks)-1]
+	}
+
+	sendChunks(t, p, respCtx, chunks)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	// input_tokens=10 + output_tokens=20 = 30
+	if lim.lastCost != 30 {
+		t.Fatalf("expected cost=30 (input_tokens+output_tokens), got %d — multi-source accumulation broken", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_OpenAISSE_BufferedAndIndividualChunks(t *testing.T) {
+	// Simulates what happens when another policy in the chain returns NeedsMoreData=true:
+	// the kernel buffers several SSE events and delivers them together as one large chunk,
+	// while the remaining events arrive individually. The rate-limit policy must still
+	// extract the correct final usage value from the complete accumulated body.
+	//
+	// Stream layout:
+	//   chunk 0 (buffered — 4 events merged): 4 content delta events
+	//   chunk 1 (individual):                 1 more content delta
+	//   chunk 2 (individual):                 final usage event
+	//   chunk 3 (individual + EOS):           [DONE]
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-buffered",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "buf-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Four events merged into one chunk by the kernel (simulating upstream buffering).
+	buffered := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"The"}}]}`,
+		`data: {"choices":[{"delta":{"content":" quick"}}]}`,
+		`data: {"choices":[{"delta":{"content":" brown"}}]}`,
+		`data: {"choices":[{"delta":{"content":" fox"}}]}`,
+		"",
+	}, "\n")
+
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte(buffered),                                       // chunk 0: 4 events buffered together
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\" jumps\"}}]}\n"), // chunk 1: individual
+		[]byte("data: {\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":5,\"total_tokens\":13}}\n"), // chunk 2: usage
+		[]byte("data: [DONE]\n"),                              // chunk 3: EOS
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 13 {
+		t.Fatalf("expected cost=13 from final usage event, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_OpenAISSE_BufferedAndIndividual_MultiSource(t *testing.T) {
+	// Same mixed-buffering scenario but with two response_body sources
+	// (prompt_tokens + completion_tokens). Verifies that multi-source summing
+	// is not affected by whether events arrive individually or batched.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.prompt_tokens", Multiplier: 1},
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.completion_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-buffered-multi",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "bm-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// First two events arrive buffered together; the usage event arrives alone.
+	buffered := "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n"
+
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte(buffered),
+		// prompt_tokens=30, completion_tokens=45 → expected 30+45=75
+		[]byte("data: {\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":45,\"total_tokens\":75}}\n"),
+		[]byte("data: [DONE]\n"),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 75 {
+		t.Fatalf("expected cost=75 (30+45), got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_AnthropicSSE_BufferedEventsWithIndividualUsage(t *testing.T) {
+	// Anthropic stream where the bulk of content events are buffered into one chunk
+	// by an upstream policy, but the authoritative message_delta (with usage) and
+	// message_stop arrive as individual chunks.
+	//
+	// input_tokens=10, output_tokens=20 in the message_delta event.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.input_tokens", Multiplier: 1},
+			{Type: CostSourceResponseBody, JSONPath: "$.usage.output_tokens", Multiplier: 1},
+		},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name:                  "tokens",
+			Limiter:               lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-anthropic-buffered",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "ab2-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Chunk 0 (buffered): message_start + content_block_start + two content_block_delta events
+	bufferedStart := "event: message_start\n" +
+		"data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n" +
+		"\n" +
+		"event: content_block_start\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"\n" +
+		"event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+		"\n" +
+		"event: content_block_delta\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n" +
+		"\n"
+
+	// Chunk 1 (individual): the authoritative message_delta with usage
+	messageDelta := "event: message_delta\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n" +
+		"\n"
+
+	// Chunk 2 (individual + EOS): message_stop
+	messageStop := "event: message_stop\n" +
+		"data: {\"type\":\"message_stop\"}\n"
+
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte(bufferedStart),
+		[]byte(messageDelta),
+		[]byte(messageStop),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	// input_tokens=10 + output_tokens=20 = 30
+	if lim.lastCost != 30 {
+		t.Fatalf("expected cost=30 (input_tokens+output_tokens from message_delta), got %d", lim.lastCost)
+	}
+}
+
 func TestOnResponseBodyChunk_NoCostExtractionEnabled_NoConsume(t *testing.T) {
 	// Quotas without cost extraction enabled must not call ConsumeN.
 	lim := &fakeLimiter{}

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -678,16 +678,21 @@ func TestModeBehavior(t *testing.T) {
 			wantResBody: policy.BodyModeSkip,
 		},
 		{
+			// response_body uses BodyModeStream so the policy can process SSE events
+			// per-chunk and avoid buffering the entire LLM response in memory.
+			// OnResponseBody remains as the buffered fallback when another policy in
+			// the chain forces BodyModeBuffer.
 			name:        "response body source",
 			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.total"}})},
 			wantReqBody: policy.BodyModeSkip,
-			wantResBody: policy.BodyModeBuffer,
+			wantResBody: policy.BodyModeStream,
 		},
 		{
+			// request_body buffers the request; response_body streams the response.
 			name:        "mixed body sources",
 			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceRequestBody, JSONPath: "$.in"}, {Type: CostSourceResponseBody, JSONPath: "$.out"}})},
 			wantReqBody: policy.BodyModeBuffer,
-			wantResBody: policy.BodyModeBuffer,
+			wantResBody: policy.BodyModeStream,
 		},
 		{
 			name:        "configured but effectively disabled",
@@ -714,10 +719,13 @@ func TestModeBehavior(t *testing.T) {
 			wantResBody: policy.BodyModeSkip,
 		},
 		{
+			// response_metadata uses BodyModeStream: metadata written by upstream policies
+			// is available in SharedContext at EOS, read via the synthetic ResponseContext
+			// built in finalizeAndConsumeStreamingCosts.
 			name:        "response metadata source requires response body phase",
 			quotas:      []QuotaRuntime{mkQuota(true, []CostSource{{Type: CostSourceResponseMetadata, Key: "x-llm-cost"}})},
 			wantReqBody: policy.BodyModeSkip,
-			wantResBody: policy.BodyModeBuffer,
+			wantResBody: policy.BodyModeStream,
 		},
 	}
 
@@ -2508,6 +2516,307 @@ func TestBugHunt_MultiplierTypeShouldBeValidated(t *testing.T) {
 	}
 }
 */
+
+// newResponseStreamCtx builds a ResponseStreamContext for use in OnResponseBodyChunk tests.
+// metadata should contain at least rateLimitKeysKey so EOS cost consumption can resolve quota keys.
+func newResponseStreamCtx(reqHeaders, respHeaders map[string][]string, metadata map[string]interface{}, status int) *policy.ResponseStreamContext {
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	if reqHeaders == nil {
+		reqHeaders = map[string][]string{}
+	}
+	if respHeaders == nil {
+		respHeaders = map[string][]string{}
+	}
+	return &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{
+			Metadata:   metadata,
+			APIName:    "petstore",
+			APIVersion: "v1",
+			APIId:      "api-id",
+			APIContext: "/petstore",
+		},
+		RequestHeaders:  policy.NewHeaders(reqHeaders),
+		ResponseHeaders: policy.NewHeaders(respHeaders),
+		ResponseStatus:  status,
+	}
+}
+
+// sendChunks is a test helper that calls OnResponseBodyChunk for each provided byte slice.
+// The last slice is delivered with EndOfStream=true. It uses the same respCtx for all calls
+// so that the per-request streaming state in Metadata accumulates correctly.
+func sendChunks(t *testing.T, p *RateLimitPolicy, respCtx *policy.ResponseStreamContext, chunks [][]byte) {
+	t.Helper()
+	for i, c := range chunks {
+		eos := i == len(chunks)-1
+		chunk := &policy.StreamBody{Chunk: c, EndOfStream: eos, Index: uint64(i)}
+		p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+	}
+}
+
+// ─── OnResponseBodyChunk integration tests ───────────────────────────────────
+
+func TestOnResponseBodyChunk_OpenAISSE_MultiChunk(t *testing.T) {
+	// Simulate an OpenAI SSE stream split across three chunks.
+	// The final data: line before [DONE] carries usage — last-match-wins gives total_tokens=75.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 1}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-openai",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "openai-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	chunks := [][]byte{
+		// Chunk 0: first content delta — no usage field
+		[]byte("data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n"),
+		// Chunk 1: final delta with usage (stream_options: {include_usage: true})
+		[]byte("data: {\"id\":\"chatcmpl-1\",\"usage\":{\"prompt_tokens\":25,\"completion_tokens\":50,\"total_tokens\":75}}\n"),
+		// Chunk 2: [DONE] terminator with EOS
+		[]byte("data: [DONE]\n"),
+	}
+	sendChunks(t, p, respCtx, chunks)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 75 {
+		t.Fatalf("expected cost=75 from usage.total_tokens, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_AnthropicSSE_OutputTokens(t *testing.T) {
+	// Anthropic streams usage in the message_delta event. The message_stop event that
+	// follows has no usage field, so last-match-wins returns output_tokens=20.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.output_tokens", Multiplier: 1}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-anthropic",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "anthropic-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Deliver the full Anthropic SSE body as a single chunk with EOS.
+	// anthropicSSEBody has message_delta with usage.output_tokens=20.
+	chunk := &policy.StreamBody{
+		Chunk:       []byte(anthropicSSEBody),
+		EndOfStream: true,
+		Index:       0,
+	}
+	p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 20 {
+		t.Fatalf("expected cost=20 from usage.output_tokens, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_PlainJSONChunked_AccumulateAndExtractAtEOS(t *testing.T) {
+	// Plain JSON response delivered as two chunks (chunked transfer encoding).
+	// The policy must accumulate both chunks and extract the jsonPath only at EOS.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.tokens", Multiplier: 1}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-json",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "json-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// Split the JSON body across two chunks so the parser cannot extract mid-stream.
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte(`{"result":"ok","tok`),
+		[]byte(`ens":42}`),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once at EOS, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 42 {
+		t.Fatalf("expected cost=42 from $.tokens, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_NoUsageField_FallsBackToDefault(t *testing.T) {
+	// When the jsonPath is absent from all SSE events, the configured default cost is used.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 5, // fallback
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 1}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 1000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-nofield",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "nf-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// SSE body where no data: line carries $.usage.total_tokens.
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n"),
+		[]byte("data: [DONE]\n"),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once (with default), got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 5 {
+		t.Fatalf("expected cost=5 (default), got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_MultiplierApplied(t *testing.T) {
+	// Extracted value is multiplied before consumption.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 0.5}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-multiplier",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "mul-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	// total_tokens=100, multiplier=0.5 → expected cost=50
+	chunk := &policy.StreamBody{
+		Chunk:       []byte("data: {\"usage\":{\"total_tokens\":100}}\n"),
+		EndOfStream: true,
+		Index:       0,
+	}
+	p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 50 {
+		t.Fatalf("expected cost=50 (100 × 0.5), got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_EmptyFirstChunkDeferrsSSEDetection(t *testing.T) {
+	// The first chunk may be a keep-alive (empty bytes). SSE detection must be deferred
+	// until the first non-empty chunk to avoid misidentifying the stream as JSON.
+	lim := &fakeLimiter{}
+	ce := NewCostExtractor(CostExtractionConfig{
+		Enabled: true,
+		Default: 1,
+		Sources: []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.usage.total_tokens", Multiplier: 1}},
+	})
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "tokens", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10000, Duration: time.Minute}},
+			CostExtractor:         ce,
+			CostExtractionEnabled: true,
+		}},
+		routeName: "route-keepalive",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"tokens": "ka-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	sendChunks(t, p, respCtx, [][]byte{
+		{},  // empty keep-alive — must not trigger JSON mode
+		[]byte("data: {\"usage\":{\"total_tokens\":33}}\n"),
+		[]byte("data: [DONE]\n"),
+	})
+
+	if lim.consumeNCalls != 1 {
+		t.Fatalf("expected ConsumeN called once, got %d", lim.consumeNCalls)
+	}
+	if lim.lastCost != 33 {
+		t.Fatalf("expected cost=33 after deferred SSE detection, got %d", lim.lastCost)
+	}
+}
+
+func TestOnResponseBodyChunk_NoCostExtractionEnabled_NoConsume(t *testing.T) {
+	// Quotas without cost extraction enabled must not call ConsumeN.
+	lim := &fakeLimiter{}
+	p := &RateLimitPolicy{
+		quotas: []QuotaRuntime{{
+			Name: "basic", Limiter: lim,
+			Limits:                []LimitConfig{{Limit: 10, Duration: time.Minute}},
+			CostExtractionEnabled: false,
+		}},
+		routeName: "route-nocost",
+	}
+
+	meta := map[string]interface{}{
+		rateLimitKeysKey: map[string]string{"basic": "basic-key"},
+	}
+	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
+
+	sendChunks(t, p, respCtx, [][]byte{
+		[]byte("data: {\"usage\":{\"total_tokens\":99}}\n"),
+	})
+
+	if lim.consumeNCalls != 0 {
+		t.Fatalf("expected ConsumeN not called, got %d calls", lim.consumeNCalls)
+	}
+}
 
 // clearCaches resets all global caches for test isolation.
 func clearCaches() {

--- a/policies/content-length-guardrail/contentlengthguardrail.go
+++ b/policies/content-length-guardrail/contentlengthguardrail.go
@@ -410,12 +410,6 @@ func (p *ContentLengthGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 
 	chunkStr := string(chunk.Chunk)
 
-	// If a preceding policy already emitted a guardrail SSE error event, pass it
-	// through unchanged — a second guardrail must not validate or override it.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
-
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -454,7 +448,7 @@ func (p *ContentLengthGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 		reason := fmt.Sprintf("content length %d bytes is outside the allowed range %d-%d bytes", running, rp.Min, rp.Max)
 		slog.Debug("ContentLengthGuardrail: streaming max violation",
 			"runningBytes", running, "max", rp.Max)
-		return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp.ShowAssessment, rp.Min, rp.Max)}
+		return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp.ShowAssessment, rp.Min, rp.Max), TerminateStream: true}
 	}
 
 	// At end of stream: perform the complete min/max/invert validation.
@@ -473,35 +467,11 @@ func (p *ContentLengthGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 			}
 			slog.Debug("ContentLengthGuardrail: streaming validation failed",
 				"runningBytes", running, "min", rp.Min, "max", rp.Max, "invert", rp.Invert)
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp.ShowAssessment, rp.Min, rp.Max)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp.ShowAssessment, rp.Min, rp.Max), TerminateStream: true}
 		}
 	}
 
 	return policy.ResponseChunkAction{}
-}
-
-// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
-// event emitted by a preceding policy in the chain. Such a chunk has an SSE
-// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
-// These chunks must be passed through unchanged so the upstream error is
-// preserved and not overwritten by a subsequent guardrail.
-func isGuardrailSSEErrorEvent(s string) bool {
-	for _, line := range strings.SplitN(s, "\n", 5) {
-		line = strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/content-length-guardrail/contentlengthguardrail.go
+++ b/policies/content-length-guardrail/contentlengthguardrail.go
@@ -409,6 +409,13 @@ func (p *ContentLengthGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 	}
 
 	chunkStr := string(chunk.Chunk)
+
+	// If a preceding policy already emitted a guardrail SSE error event, pass it
+	// through unchanged — a second guardrail must not validate or override it.
+	if isGuardrailSSEErrorEvent(chunkStr) {
+		return policy.ResponseChunkAction{}
+	}
+
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -471,6 +478,30 @@ func (p *ContentLengthGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 	}
 
 	return policy.ResponseChunkAction{}
+}
+
+// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
+// event emitted by a preceding policy in the chain. Such a chunk has an SSE
+// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
+// These chunks must be passed through unchanged so the upstream error is
+// preserved and not overwritten by a subsequent guardrail.
+func isGuardrailSSEErrorEvent(s string) bool {
+	for _, line := range strings.SplitN(s, "\n", 5) {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/content-length-guardrail/go.mod
+++ b/policies/content-length-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/content-length-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/content-length-guardrail/go.sum
+++ b/policies/content-length-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: content-length-guardrail
-version: v1.0.0
+version: v1.0.1
 description: |
   Validate content byte lengths in request or response payloads using min/max limits.
 

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -72,15 +72,15 @@ func GetPolicy(
 
 
 // Mode returns the processing mode for this policy.
-// ResponseBodyMode is Buffer so that OnResponseBody is called after llm-cost
-// sets x-llm-cost in SharedContext.Metadata; response headers phase runs before
-// that metadata is populated so cost extraction there would always return 0.
+// ResponseBodyMode is Stream so that OnResponseBodyChunk is called for each chunk,
+// delegating to the advanced-ratelimit instance which reads x-llm-cost from
+// SharedContext.Metadata at end-of-stream (set by the llm-cost system policy).
 func (p *LLMCostRateLimitPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeSkip,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeStream,
 	}
 }
 
@@ -203,6 +203,53 @@ func (p *LLMCostRateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx 
 		"route", p.metadata.RouteName,
 		"provider", providerName)
 	return policy.DownstreamResponseHeaderModifications{}
+}
+
+// OnResponseBodyChunk processes each streaming response chunk by delegating to the
+// provider-specific advanced-ratelimit instance. The delegate reads x-llm-cost from
+// SharedContext.Metadata at end-of-stream (set by the llm-cost system policy) and
+// consumes the cost quota. Dollar-denominated headers are set during OnResponseHeaders.
+func (p *LLMCostRateLimitPolicy) OnResponseBodyChunk(
+	ctx context.Context,
+	respCtx *policy.ResponseStreamContext,
+	chunk *policy.StreamBody,
+	params map[string]interface{},
+) policy.ResponseChunkAction {
+	type responseChunkPolicer interface {
+		OnResponseBodyChunk(context.Context, *policy.ResponseStreamContext, *policy.StreamBody, map[string]interface{}) policy.ResponseChunkAction
+	}
+
+	// First, try the delegate pinned during OnRequestHeaders.
+	if delegate, ok := respCtx.Metadata[MetadataKeyDelegate].(policy.Policy); ok {
+		if rl, ok := delegate.(responseChunkPolicer); ok {
+			return rl.OnResponseBodyChunk(ctx, respCtx, chunk, params)
+		}
+		return policy.ResponseChunkAction{}
+	}
+
+	// Fallback: look up by provider name (for cases where OnRequestHeaders didn't run).
+	providerName, ok := respCtx.Metadata[MetadataKeyProviderName].(string)
+	if !ok || providerName == "" {
+		slog.Debug("OnResponseBodyChunk: provider name not found in metadata; skipping",
+			"route", p.metadata.RouteName)
+		return policy.ResponseChunkAction{}
+	}
+
+	if entry, ok := p.delegates.Load(providerName); ok {
+		if de, ok := entry.(*delegateEntry); ok && de.delegate != nil {
+			if rl, ok := de.delegate.(responseChunkPolicer); ok {
+				return rl.OnResponseBodyChunk(ctx, respCtx, chunk, params)
+			}
+		}
+	}
+
+	return policy.ResponseChunkAction{}
+}
+
+// NeedsMoreResponseData returns false because the delegate (advanced-ratelimit) manages
+// all state internally — x-llm-cost metadata is read at end-of-stream from SharedContext.
+func (p *LLMCostRateLimitPolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
 }
 
 // OnResponseBody processes the response body phase by delegating to the same

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
@@ -20,6 +20,7 @@ package llmcostratelimit
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -424,5 +425,111 @@ func TestLLMCostRateLimitPolicy_Integration_NoBudgetLimits(t *testing.T) {
 
 	if _, ok := action.(policy.UpstreamRequestHeaderModifications); !ok {
 		t.Errorf("Expected UpstreamRequestHeaderModifications when no budget limits configured, got %T", action)
+	}
+}
+
+// stubCostChunkPolicer is a minimal delegate stub that records OnResponseBodyChunk calls.
+type stubCostChunkPolicer struct {
+	chunkCalls int
+}
+
+func (s *stubCostChunkPolicer) Mode() policy.ProcessingMode { return policy.ProcessingMode{} }
+func (s *stubCostChunkPolicer) OnRequestHeaders(context.Context, *policy.RequestHeaderContext, map[string]interface{}) policy.RequestHeaderAction {
+	return nil
+}
+func (s *stubCostChunkPolicer) OnResponseHeaders(context.Context, *policy.ResponseHeaderContext, map[string]interface{}) policy.ResponseHeaderAction {
+	return nil
+}
+func (s *stubCostChunkPolicer) OnResponseBody(context.Context, *policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+	return nil
+}
+func (s *stubCostChunkPolicer) OnResponseBodyChunk(_ context.Context, _ *policy.ResponseStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.ResponseChunkAction {
+	s.chunkCalls++
+	return policy.ResponseChunkAction{}
+}
+func (s *stubCostChunkPolicer) NeedsMoreResponseData(_ []byte) bool { return false }
+
+func newCostStreamCtx(providerName string, pinnedDelegate policy.Policy) *policy.ResponseStreamContext {
+	metadata := map[string]interface{}{}
+	if providerName != "" {
+		metadata[MetadataKeyProviderName] = providerName
+	}
+	if pinnedDelegate != nil {
+		metadata[MetadataKeyDelegate] = pinnedDelegate
+	}
+	return &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{
+			Metadata: metadata,
+		},
+		ResponseHeaders: policy.NewHeaders(map[string][]string{}),
+	}
+}
+
+// TestLLMCostRateLimitPolicy_Mode_ReturnsStream verifies that Mode reports BodyModeStream.
+func TestLLMCostRateLimitPolicy_Mode_ReturnsStream(t *testing.T) {
+	p := &LLMCostRateLimitPolicy{}
+	mode := p.Mode()
+	if mode.ResponseBodyMode != policy.BodyModeStream {
+		t.Errorf("expected ResponseBodyMode=BodyModeStream, got %v", mode.ResponseBodyMode)
+	}
+}
+
+// TestLLMCostRateLimitPolicy_NeedsMoreResponseData_ReturnsFalse verifies the streaming
+// buffer hint is always false (metadata is read at EOS, no buffering needed).
+func TestLLMCostRateLimitPolicy_NeedsMoreResponseData_ReturnsFalse(t *testing.T) {
+	p := &LLMCostRateLimitPolicy{}
+	if p.NeedsMoreResponseData([]byte("anything")) {
+		t.Error("expected NeedsMoreResponseData to return false")
+	}
+}
+
+// TestLLMCostRateLimitPolicy_OnResponseBodyChunk_NoProvider verifies that a missing
+// provider name and no pinned delegate is handled gracefully.
+func TestLLMCostRateLimitPolicy_OnResponseBodyChunk_NoProvider(t *testing.T) {
+	p := &LLMCostRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	respCtx := newCostStreamCtx("", nil)
+	chunk := &policy.StreamBody{Chunk: []byte("data: {}"), EndOfStream: true}
+
+	action := p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+	if !reflect.DeepEqual(action, policy.ResponseChunkAction{}) {
+		t.Errorf("expected empty ResponseChunkAction, got %v", action)
+	}
+}
+
+// TestLLMCostRateLimitPolicy_OnResponseBodyChunk_UsesPinnedDelegate verifies that the
+// delegate pinned in metadata during OnRequestHeaders takes precedence.
+func TestLLMCostRateLimitPolicy_OnResponseBodyChunk_UsesPinnedDelegate(t *testing.T) {
+	stub := &stubCostChunkPolicer{}
+	p := &LLMCostRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	respCtx := newCostStreamCtx("", stub)
+
+	chunks := [][]byte{
+		[]byte("data: {\"usage\":{}}\n"),
+		[]byte("data: [DONE]\n"),
+	}
+	for i, c := range chunks {
+		eos := i == len(chunks)-1
+		p.OnResponseBodyChunk(context.Background(), respCtx, &policy.StreamBody{Chunk: c, EndOfStream: eos, Index: uint64(i)}, nil)
+	}
+
+	if stub.chunkCalls != 2 {
+		t.Errorf("expected pinned delegate OnResponseBodyChunk called 2 times, got %d", stub.chunkCalls)
+	}
+}
+
+// TestLLMCostRateLimitPolicy_OnResponseBodyChunk_FallsBackToDelegatesMap verifies the
+// fallback lookup by provider name when no delegate is pinned in metadata.
+func TestLLMCostRateLimitPolicy_OnResponseBodyChunk_FallsBackToDelegatesMap(t *testing.T) {
+	stub := &stubCostChunkPolicer{}
+	p := &LLMCostRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	p.delegates.Store("anthropic", &delegateEntry{cacheKey: "k", delegate: stub})
+
+	respCtx := newCostStreamCtx("anthropic", nil)
+	chunk := &policy.StreamBody{Chunk: []byte("data: [DONE]\n"), EndOfStream: true}
+
+	p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+
+	if stub.chunkCalls != 1 {
+		t.Errorf("expected delegate OnResponseBodyChunk called 1 time via fallback, got %d", stub.chunkCalls)
 	}
 }

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v1.0.0
+version: v1.0.1
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -31,6 +31,11 @@ const (
 	sseDataPrefix  = "data: "
 	sseDone        = "[DONE]"
 	sseEventPrefix = "event:"
+
+	// llmCostStreamAccumKey is the per-request metadata key used to accumulate
+	// streaming response body chunks. It is written by OnResponseBodyChunk and
+	// deleted at end-of-stream once the cost has been calculated.
+	llmCostStreamAccumKey = "llm-cost:stream-accum"
 )
 
 const (
@@ -85,13 +90,19 @@ func GetPolicy(
 // Mode declares the SDK processing requirements:
 //   - RequestBodyMode=Buffer: buffer the request so ctx.RequestBody is available
 //     in OnResponseBody (needed for Anthropic speed parameter).
-//   - ResponseBodyMode=Buffer: buffer the full response body so we can parse
-//     the usage object and model name.
+//   - ResponseBodyMode=Stream: receive body data via OnResponseBodyChunk for both
+//     streaming (SSE) and buffered responses. Chunks are accumulated and processed
+//     at end-of-stream, which covers the buffered path too (single chunk, EOS=true).
 func (p *LLMCostPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestBodyMode:  policy.BodyModeBuffer,
-		ResponseBodyMode: policy.BodyModeBuffer,
+		ResponseBodyMode: policy.BodyModeStream,
 	}
+}
+
+// NeedsMoreResponseData always returns false; the policy accumulates chunks manually.
+func (p *LLMCostPolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
 }
 
 // OnResponseBody reads the LLM response, looks up model pricing, calculates cost,
@@ -186,6 +197,138 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 	)
 
 	return setCostMetadata(respCtx, finalCost, costStatusCalculated)
+}
+
+// OnResponseBodyChunk accumulates streaming response chunks and, at end-of-stream,
+// computes the LLM cost and writes it to SharedContext.Metadata so that downstream
+// policies (e.g. llm-cost-based-ratelimit) can read x-llm-cost at EOS.
+// This method is called for both SSE streaming responses and buffered responses
+// (the kernel delivers the full body as a single chunk with EndOfStream=true).
+func (p *LLMCostPolicy) OnResponseBodyChunk(
+	_ context.Context,
+	respCtx *policy.ResponseStreamContext,
+	chunk *policy.StreamBody,
+	_ map[string]interface{},
+) policy.ResponseChunkAction {
+	if len(chunk.Chunk) > 0 {
+		if respCtx.Metadata == nil {
+			respCtx.Metadata = make(map[string]interface{})
+		}
+		existing, _ := respCtx.Metadata[llmCostStreamAccumKey].([]byte)
+		respCtx.Metadata[llmCostStreamAccumKey] = append(existing, chunk.Chunk...)
+	}
+
+	if !chunk.EndOfStream {
+		return policy.ResponseChunkAction{}
+	}
+
+	// EOS: extract accumulated bytes and clean up the temporary key.
+	var accumulated []byte
+	if respCtx.Metadata != nil {
+		accumulated, _ = respCtx.Metadata[llmCostStreamAccumKey].([]byte)
+		delete(respCtx.Metadata, llmCostStreamAccumKey)
+	}
+
+	var requestBody []byte
+	if respCtx.RequestBody != nil && respCtx.RequestBody.Present {
+		requestBody = respCtx.RequestBody.Content
+	}
+
+	p.computeAndSetStreamingCost(respCtx.SharedContext, accumulated, requestBody)
+	return policy.ResponseChunkAction{}
+}
+
+// computeAndSetStreamingCost parses the accumulated response bytes, calculates the
+// LLM cost, and writes x-llm-cost / x-llm-cost-status into SharedContext.Metadata.
+func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedContext, body, requestBody []byte) {
+	if sharedCtx == nil {
+		slog.Warn("llm-cost: SharedContext is nil in streaming mode, cannot set cost metadata")
+		return
+	}
+	if sharedCtx.Metadata == nil {
+		sharedCtx.Metadata = make(map[string]interface{})
+	}
+
+	setMeta := func(cost float64, status string) {
+		sharedCtx.Metadata[MetadataLLMCost] = fmt.Sprintf("%.10f", cost)
+		sharedCtx.Metadata[MetadataLLMCostStatus] = status
+	}
+
+	if len(body) == 0 {
+		slog.Warn("llm-cost: empty accumulated stream body, skipping cost calculation")
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+
+	responseBody := body
+	if isSSEContent(body) {
+		merged, err := mergeSSEEvents(body)
+		if err != nil {
+			slog.Warn("llm-cost: failed to merge SSE events in streaming mode", "error", err)
+			setMeta(0.0, costStatusNotCalculated)
+			return
+		}
+		responseBody = merged
+	}
+
+	var probe struct {
+		Model        string `json:"model"`
+		ModelVersion string `json:"modelVersion"`
+		Message      *struct {
+			Model string `json:"model"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(responseBody, &probe); err != nil {
+		slog.Warn("llm-cost: could not parse streaming response body", "error", err)
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+	modelName := probe.Model
+	if modelName == "" {
+		modelName = probe.ModelVersion
+	}
+	if modelName == "" && probe.Message != nil {
+		modelName = probe.Message.Model
+	}
+	if modelName == "" {
+		slog.Warn("llm-cost: no model name found in streaming response body")
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+
+	pricing, found := lookupPricing(p.pricingMap, modelName)
+	if !found {
+		slog.Warn("llm-cost: no pricing entry for model, setting cost to 0", "model", modelName)
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+
+	calc := selectCalculator(pricing.Provider)
+	if calc == nil {
+		slog.Warn("llm-cost: unsupported provider in streaming mode", "provider", pricing.Provider, "model", modelName)
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+
+	usage, err := calc.Normalize(responseBody, requestBody)
+	if err != nil {
+		slog.Warn("llm-cost: failed to normalize streaming usage", "model", modelName, "error", err)
+		setMeta(0.0, costStatusNotCalculated)
+		return
+	}
+
+	baseCost := genericCalculateCost(usage, pricing)
+	finalCost := calc.Adjust(baseCost, usage, pricing)
+
+	slog.Debug("llm-cost: calculated streaming cost",
+		"model", modelName,
+		"provider", pricing.Provider,
+		"prompt_tokens", usage.PromptTokens,
+		"completion_tokens", usage.CompletionTokens,
+		"cost_usd", finalCost,
+	)
+
+	setMeta(finalCost, costStatusCalculated)
 }
 
 // isSSEContent reports whether the body looks like buffered SSE data (has at

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v1.0.0
+version: v1.0.1
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").

--- a/policies/pii-masking-regex/go.mod
+++ b/policies/pii-masking-regex/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/pii-masking-regex
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/pii-masking-regex/go.sum
+++ b/policies/pii-masking-regex/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/pii-masking-regex/piimaskingregex.go
+++ b/policies/pii-masking-regex/piimaskingregex.go
@@ -527,12 +527,6 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 
 	chunkStr := string(chunk.Chunk)
 
-	// If a preceding guardrail already emitted an error SSE event, pass it through
-	// unchanged — do not attempt PII restoration on the error payload.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
-
 	// maskedPIIMap is keyed original→placeholder (set by maskPIIFromContent).
 	// The restore helpers expect placeholder→original, so invert before use.
 	restoreMap := invertStringMap(maskedPIIMap)
@@ -547,26 +541,6 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 }
 
 // ─── SSE / Streaming helpers ─────────────────────────────────────────────────
-
-// isGuardrailSSEErrorEvent reports whether the chunk is an SSE error event emitted by
-// a preceding guardrail (identified by message.action == "GUARDRAIL_INTERVENED").
-func isGuardrailSSEErrorEvent(chunk string) bool {
-	for _, line := range strings.Split(chunk, "\n") {
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
-}
 
 // isSSEChunk reports whether the chunk looks like SSE data (has at least one "data: " or "event:" line).
 func isSSEChunk(s string) bool {

--- a/policies/pii-masking-regex/piimaskingregex.go
+++ b/policies/pii-masking-regex/piimaskingregex.go
@@ -527,6 +527,12 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 
 	chunkStr := string(chunk.Chunk)
 
+	// If a preceding guardrail already emitted an error SSE event, pass it through
+	// unchanged — do not attempt PII restoration on the error payload.
+	if isGuardrailSSEErrorEvent(chunkStr) {
+		return policy.ResponseChunkAction{}
+	}
+
 	// maskedPIIMap is keyed original→placeholder (set by maskPIIFromContent).
 	// The restore helpers expect placeholder→original, so invert before use.
 	restoreMap := invertStringMap(maskedPIIMap)
@@ -541,6 +547,26 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 }
 
 // ─── SSE / Streaming helpers ─────────────────────────────────────────────────
+
+// isGuardrailSSEErrorEvent reports whether the chunk is an SSE error event emitted by
+// a preceding guardrail (identified by message.action == "GUARDRAIL_INTERVENED").
+func isGuardrailSSEErrorEvent(chunk string) bool {
+	for _, line := range strings.Split(chunk, "\n") {
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
+}
 
 // isSSEChunk reports whether the chunk looks like SSE data (has at least one "data: " or "event:" line).
 func isSSEChunk(s string) bool {

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: pii-masking-regex
-version: v1.0.0
+version: v1.0.1
 description: |
   Masks or redacts Personally Identifiable Information (PII) in request and
   response payloads.

--- a/policies/regex-guardrail/go.mod
+++ b/policies/regex-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/regex-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/regex-guardrail/go.sum
+++ b/policies/regex-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: regex-guardrail
-version: v1.0.0
+version: v1.0.1
 description: |
   Validate request or response content against regex patterns using optional JSONPath extraction and optional inverted matching.
 

--- a/policies/regex-guardrail/regexguardrail.go
+++ b/policies/regex-guardrail/regexguardrail.go
@@ -334,12 +334,6 @@ func (p *RegexGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx 
 
 	chunkStr := string(chunk.Chunk)
 
-	// If a preceding policy already emitted a guardrail SSE error event, pass it
-	// through unchanged — a second guardrail must not validate or override it.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
-
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -393,34 +387,10 @@ func (p *RegexGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx 
 	if violated {
 		slog.Debug("RegexGuardrail: streaming validation failed",
 			"regex", rp.Regex, "invert", rp.Invert, "chunkIndex", chunk.Index)
-		return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(rp)}
+		return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(rp), TerminateStream: true}
 	}
 
 	return policy.ResponseChunkAction{}
-}
-
-// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
-// event emitted by a preceding policy in the chain. Such a chunk has an SSE
-// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
-// These chunks must be passed through unchanged so the upstream error is
-// preserved and not overwritten by a subsequent guardrail.
-func isGuardrailSSEErrorEvent(s string) bool {
-	for _, line := range strings.SplitN(s, "\n", 5) {
-		line = strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/regex-guardrail/regexguardrail.go
+++ b/policies/regex-guardrail/regexguardrail.go
@@ -333,6 +333,13 @@ func (p *RegexGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx 
 	}
 
 	chunkStr := string(chunk.Chunk)
+
+	// If a preceding policy already emitted a guardrail SSE error event, pass it
+	// through unchanged — a second guardrail must not validate or override it.
+	if isGuardrailSSEErrorEvent(chunkStr) {
+		return policy.ResponseChunkAction{}
+	}
+
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -390,6 +397,30 @@ func (p *RegexGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx 
 	}
 
 	return policy.ResponseChunkAction{}
+}
+
+// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
+// event emitted by a preceding policy in the chain. Such a chunk has an SSE
+// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
+// These chunks must be passed through unchanged so the upstream error is
+// preserved and not overwritten by a subsequent guardrail.
+func isGuardrailSSEErrorEvent(s string) bool {
+	for _, line := range strings.SplitN(s, "\n", 5) {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/sentence-count-guardrail/go.mod
+++ b/policies/sentence-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/sentence-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/sentence-count-guardrail/go.sum
+++ b/policies/sentence-count-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: sentence-count-guardrail
-version: v1.0.0
+version: v1.0.1
 description: |
   Validate sentence counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -44,7 +44,6 @@ const (
 	sseEventPrefix           = "event:"
 	metaKeyAccContent        = "sentencecountguardrail:accumulated_content"
 	metaKeyAccJsonBody       = "sentencecountguardrail:json_body"
-	metaKeyViolated          = "sentencecountguardrail:violated"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
 )
 
@@ -577,16 +576,6 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
-	// If a preceding policy already emitted a guardrail SSE error event, pass it
-	// through unchanged — a second guardrail must not validate or override it.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
-	// If a violation was already reported, suppress all subsequent chunks so the
-	// client does not receive real content after the error + [DONE] already sent.
-	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
-		return policy.ResponseChunkAction{Body: []byte{}}
-	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -607,11 +596,11 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 			if !rp.Invert {
 				if count < rp.Min {
 					reason := fmt.Sprintf("sentence count %d is below minimum of %d sentences", count, rp.Min)
-					return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+					return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 				}
 			} else if count >= rp.Min && count <= rp.Max {
 				reason := fmt.Sprintf("sentence count %d is within the excluded range %d-%d sentences", count, rp.Min, rp.Max)
-				return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+				return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 			}
 			return policy.ResponseChunkAction{}
 		}
@@ -644,16 +633,13 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 			slog.Debug("SentenceCountGuardrail: max exceeded",
 				"count", count, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("sentence count %d exceeded maximum of %d sentences", count, rp.Max)
-			respCtx.Metadata[metaKeyViolated] = true
-			errorEvent := p.buildSSEErrorEvent(reason, rp)
-			done := []byte(sseDataPrefix + sseDone + "\n\n")
-			return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 		}
 		if isDone && count < rp.Min {
 			slog.Debug("SentenceCountGuardrail: below min at stream end",
 				"count", count, "min", rp.Min, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("sentence count %d is below minimum of %d sentences", count, rp.Min)
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 		}
 		return policy.ResponseChunkAction{}
 	}
@@ -664,34 +650,10 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 			slog.Debug("SentenceCountGuardrail: invert violation at stream end",
 				"count", count, "min", rp.Min, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("sentence count %d is within the excluded range %d-%d sentences", count, rp.Min, rp.Max)
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 		}
 	}
 	return policy.ResponseChunkAction{}
-}
-
-// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
-// event emitted by a preceding policy in the chain. Such a chunk has an SSE
-// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
-// These chunks must be passed through unchanged so the upstream error is
-// preserved and not overwritten by a subsequent guardrail.
-func isGuardrailSSEErrorEvent(s string) bool {
-	for _, line := range strings.SplitN(s, "\n", 5) {
-		line = strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -44,6 +44,7 @@ const (
 	sseEventPrefix           = "event:"
 	metaKeyAccContent        = "sentencecountguardrail:accumulated_content"
 	metaKeyAccJsonBody       = "sentencecountguardrail:json_body"
+	metaKeyViolated          = "sentencecountguardrail:violated"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
 )
 
@@ -576,6 +577,16 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
+	// If a preceding policy already emitted a guardrail SSE error event, pass it
+	// through unchanged — a second guardrail must not validate or override it.
+	if isGuardrailSSEErrorEvent(chunkStr) {
+		return policy.ResponseChunkAction{}
+	}
+	// If a violation was already reported, suppress all subsequent chunks so the
+	// client does not receive real content after the error + [DONE] already sent.
+	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
+		return policy.ResponseChunkAction{Body: []byte{}}
+	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -633,7 +644,10 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 			slog.Debug("SentenceCountGuardrail: max exceeded",
 				"count", count, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("sentence count %d exceeded maximum of %d sentences", count, rp.Max)
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+			respCtx.Metadata[metaKeyViolated] = true
+			errorEvent := p.buildSSEErrorEvent(reason, rp)
+			done := []byte(sseDataPrefix + sseDone + "\n\n")
+			return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
 		}
 		if isDone && count < rp.Min {
 			slog.Debug("SentenceCountGuardrail: below min at stream end",
@@ -654,6 +668,30 @@ func (p *SentenceCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, 
 		}
 	}
 	return policy.ResponseChunkAction{}
+}
+
+// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
+// event emitted by a preceding policy in the chain. Such a chunk has an SSE
+// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
+// These chunks must be passed through unchanged so the upstream error is
+// preserved and not overwritten by a subsequent guardrail.
+func isGuardrailSSEErrorEvent(s string) bool {
+	for _, line := range strings.SplitN(s, "\n", 5) {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/sentence-count-guardrail/sentencecountguardrail_test.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail_test.go
@@ -675,29 +675,11 @@ func newStreamingRespCtx() *policy.ResponseStreamContext {
 	return &policy.ResponseStreamContext{SharedContext: &policy.SharedContext{}}
 }
 
-// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
-// preceding policy in the chain has already emitted a guardrail SSE error event,
-// the sentence-count guardrail passes it through unchanged without attempting
-// validation or overwriting the error with its own.
-func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
-	p := newStreamingPolicy(1, 100)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	precedingError := "data: " + `{"type":"URL_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"url-guardrail"}}` + "\n\ndata: [DONE]\n\n"
-	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
-	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
-
-	if got.Body != nil {
-		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
-	}
-}
-
-// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE verifies that when the
-// accumulated sentence count exceeds max mid-stream, OnResponseBodyChunk replaces
-// the offending chunk with an SSE error event immediately followed by
-// data: [DONE] so the client receives a clean stream termination.
-func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
+// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndTerminates verifies that
+// when the accumulated sentence count exceeds max mid-stream, OnResponseBodyChunk
+// returns an SSE error event with TerminateStream set so the engine closes the
+// stream cleanly.
+func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndTerminates(t *testing.T) {
 	p := newStreamingPolicy(1, 2)
 	ctx := context.Background()
 	respCtx := newStreamingRespCtx()
@@ -711,51 +693,25 @@ func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
 		}
 	}
 
-	// Third sentence pushes count to 3, exceeding max=2 — must emit error + [DONE].
+	// Third sentence pushes count to 3, exceeding max=2 — must emit error with TerminateStream.
 	chunk := &policy.StreamBody{Chunk: []byte(sseEvent(" Bye."))}
 	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
 
 	if got.Body == nil {
 		t.Fatal("expected error body on max violation, got nil")
 	}
+	if !got.TerminateStream {
+		t.Fatal("expected TerminateStream=true on max violation")
+	}
 	if !strings.Contains(string(got.Body), "SENTENCE_COUNT_GUARDRAIL") {
 		t.Fatalf("expected SENTENCE_COUNT_GUARDRAIL in error body, got: %s", got.Body)
 	}
-	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
-		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
-	}
-	// Parse the first SSE event and verify guardrail action fields.
-	parts := strings.SplitN(string(got.Body), "\n\n", 2)
-	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	// Parse the SSE event and verify guardrail action fields.
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(strings.TrimSuffix(string(got.Body), "\n\n"), "data: ")))
 	if msg["action"] != "GUARDRAIL_INTERVENED" {
 		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
 	}
 	if msg["interveningGuardrail"] != "sentence-count-guardrail" {
 		t.Fatalf("expected interveningGuardrail=sentence-count-guardrail, got %#v", msg["interveningGuardrail"])
-	}
-}
-
-// TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed verifies that
-// after a max-violation error is emitted, all subsequent chunks are suppressed
-// (Body is non-nil but empty) rather than passed through to the client.
-func TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed(t *testing.T) {
-	p := newStreamingPolicy(1, 1)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	// Trigger violation: 2 sentences exceed max=1.
-	chunk := &policy.StreamBody{Chunk: []byte(sseEvent("Hello. World."))}
-	p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
-
-	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
-	for i, sentence := range []string{" Bye.", " See you.", " Later."} {
-		next := &policy.StreamBody{Chunk: []byte(sseEvent(sentence))}
-		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
-		if got.Body == nil {
-			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, sentence)
-		}
-		if len(got.Body) != 0 {
-			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, sentence, got.Body)
-		}
 	}
 }

--- a/policies/sentence-count-guardrail/sentencecountguardrail_test.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail_test.go
@@ -651,3 +651,111 @@ func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }
+
+// ─── OnResponseBodyChunk stream-stop tests ───────────────────────────────────
+
+func sseEvent(content string) string {
+	quoted, _ := json.Marshal(content)
+	return `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":` + string(quoted) + `},"logprobs":null,"finish_reason":null}],"obfuscation":"test"}` + "\n\n"
+}
+
+func newStreamingPolicy(min, max int) *SentenceCountGuardrailPolicy {
+	return &SentenceCountGuardrailPolicy{
+		hasResponseParams: true,
+		responseParams: SentenceCountGuardrailPolicyParams{
+			Enabled:           true,
+			Min:               min,
+			Max:               max,
+			StreamingJsonPath: DefaultStreamingJsonPath,
+		},
+	}
+}
+
+func newStreamingRespCtx() *policy.ResponseStreamContext {
+	return &policy.ResponseStreamContext{SharedContext: &policy.SharedContext{}}
+}
+
+// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
+// preceding policy in the chain has already emitted a guardrail SSE error event,
+// the sentence-count guardrail passes it through unchanged without attempting
+// validation or overwriting the error with its own.
+func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
+	p := newStreamingPolicy(1, 100)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	precedingError := "data: " + `{"type":"URL_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"url-guardrail"}}` + "\n\ndata: [DONE]\n\n"
+	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body != nil {
+		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
+	}
+}
+
+// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE verifies that when the
+// accumulated sentence count exceeds max mid-stream, OnResponseBodyChunk replaces
+// the offending chunk with an SSE error event immediately followed by
+// data: [DONE] so the client receives a clean stream termination.
+func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
+	p := newStreamingPolicy(1, 2)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// First two sentences (count == max) pass through unmodified.
+	for _, sentence := range []string{"Hello.", " World."} {
+		chunk := &policy.StreamBody{Chunk: []byte(sseEvent(sentence))}
+		got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+		if got.Body != nil {
+			t.Fatalf("sentence %q: expected passthrough (Body=nil), got %q", sentence, got.Body)
+		}
+	}
+
+	// Third sentence pushes count to 3, exceeding max=2 — must emit error + [DONE].
+	chunk := &policy.StreamBody{Chunk: []byte(sseEvent(" Bye."))}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body == nil {
+		t.Fatal("expected error body on max violation, got nil")
+	}
+	if !strings.Contains(string(got.Body), "SENTENCE_COUNT_GUARDRAIL") {
+		t.Fatalf("expected SENTENCE_COUNT_GUARDRAIL in error body, got: %s", got.Body)
+	}
+	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
+		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
+	}
+	// Parse the first SSE event and verify guardrail action fields.
+	parts := strings.SplitN(string(got.Body), "\n\n", 2)
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	if msg["action"] != "GUARDRAIL_INTERVENED" {
+		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
+	}
+	if msg["interveningGuardrail"] != "sentence-count-guardrail" {
+		t.Fatalf("expected interveningGuardrail=sentence-count-guardrail, got %#v", msg["interveningGuardrail"])
+	}
+}
+
+// TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed verifies that
+// after a max-violation error is emitted, all subsequent chunks are suppressed
+// (Body is non-nil but empty) rather than passed through to the client.
+func TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed(t *testing.T) {
+	p := newStreamingPolicy(1, 1)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// Trigger violation: 2 sentences exceed max=1.
+	chunk := &policy.StreamBody{Chunk: []byte(sseEvent("Hello. World."))}
+	p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
+	for i, sentence := range []string{" Bye.", " See you.", " Later."} {
+		next := &policy.StreamBody{Chunk: []byte(sseEvent(sentence))}
+		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
+		if got.Body == nil {
+			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, sentence)
+		}
+		if len(got.Body) != 0 {
+			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, sentence, got.Body)
+		}
+	}
+}

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v1.0.0
+version: v1.0.1
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -64,7 +64,7 @@ func (p *TokenBasedRateLimitPolicy) Mode() policy.ProcessingMode {
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeSkip,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeStream,
 	}
 }
 
@@ -464,6 +464,42 @@ func (p *TokenBasedRateLimitPolicy) OnResponseHeaders(ctx context.Context, respC
 	}
 
 	return policy.DownstreamResponseHeaderModifications{}
+}
+
+// OnResponseBodyChunk processes each streaming response chunk by delegating to the
+// provider-specific advanced-ratelimit instance. The delegate accumulates SSE or JSON
+// chunks and consumes the token quota at end-of-stream.
+func (p *TokenBasedRateLimitPolicy) OnResponseBodyChunk(
+	ctx context.Context,
+	respCtx *policy.ResponseStreamContext,
+	chunk *policy.StreamBody,
+	params map[string]interface{},
+) policy.ResponseChunkAction {
+	type responseChunkPolicer interface {
+		OnResponseBodyChunk(context.Context, *policy.ResponseStreamContext, *policy.StreamBody, map[string]interface{}) policy.ResponseChunkAction
+	}
+
+	providerName, ok := respCtx.Metadata[MetadataKeyProviderName].(string)
+	if !ok || providerName == "" {
+		slog.Debug("OnResponseBodyChunk: provider name not found in metadata; skipping",
+			"route", p.metadata.RouteName)
+		return policy.ResponseChunkAction{}
+	}
+
+	if delegate, ok := p.delegates.Load(providerName); ok {
+		if rl, ok := delegate.(responseChunkPolicer); ok {
+			return rl.OnResponseBodyChunk(ctx, respCtx, chunk, params)
+		}
+	}
+
+	return policy.ResponseChunkAction{}
+}
+
+// NeedsMoreResponseData returns false because the delegate (advanced-ratelimit) manages
+// all buffering internally — SSE costs are extracted per-chunk and JSON bytes are
+// accumulated in the delegate's per-request stream state.
+func (p *TokenBasedRateLimitPolicy) NeedsMoreResponseData(_ []byte) bool {
+	return false
 }
 
 // OnResponseBody processes the response body phase by delegating to the provider-specific instance.

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -490,7 +490,12 @@ func (p *TokenBasedRateLimitPolicy) OnResponseBodyChunk(
 		if rl, ok := delegate.(responseChunkPolicer); ok {
 			return rl.OnResponseBodyChunk(ctx, respCtx, chunk, params)
 		}
+		return policy.ResponseChunkAction{}
 	}
+
+	slog.Debug("OnResponseBody: no delegate found for provider",
+		"route", p.metadata.RouteName,
+		"provider", providerName)
 
 	return policy.ResponseChunkAction{}
 }

--- a/policies/token-based-ratelimit/token_based_ratelimit_test.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit_test.go
@@ -19,10 +19,46 @@
 package tokenbasedratelimit
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
+
+// stubChunkPolicer is a minimal delegate stub that records chunk calls.
+type stubChunkPolicer struct {
+	chunkCalls int
+}
+
+func (s *stubChunkPolicer) Mode() policy.ProcessingMode { return policy.ProcessingMode{} }
+func (s *stubChunkPolicer) OnRequestHeaders(context.Context, *policy.RequestHeaderContext, map[string]interface{}) policy.RequestHeaderAction {
+	return nil
+}
+func (s *stubChunkPolicer) OnResponseHeaders(context.Context, *policy.ResponseHeaderContext, map[string]interface{}) policy.ResponseHeaderAction {
+	return nil
+}
+func (s *stubChunkPolicer) OnResponseBody(context.Context, *policy.ResponseContext, map[string]interface{}) policy.ResponseAction {
+	return nil
+}
+func (s *stubChunkPolicer) OnResponseBodyChunk(_ context.Context, _ *policy.ResponseStreamContext, _ *policy.StreamBody, _ map[string]interface{}) policy.ResponseChunkAction {
+	s.chunkCalls++
+	return policy.ResponseChunkAction{}
+}
+func (s *stubChunkPolicer) NeedsMoreResponseData(_ []byte) bool { return false }
+
+func newTokenStreamCtx(providerName string) *policy.ResponseStreamContext {
+	metadata := map[string]interface{}{}
+	if providerName != "" {
+		metadata[MetadataKeyProviderName] = providerName
+	}
+	return &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{
+			Metadata: metadata,
+		},
+		ResponseHeaders: policy.NewHeaders(map[string][]string{}),
+	}
+}
 
 // TestTokenBasedRateLimitPolicy_GetPolicy tests policy creation
 func TestTokenBasedRateLimitPolicy_GetPolicy(t *testing.T) {
@@ -371,5 +407,72 @@ func TestTokenBasedRateLimitPolicy_TransformToRatelimitParams_TemplateLocationMa
 	totalSource := getSource("total_tokens")
 	if totalSource["type"] != "metadata" || totalSource["key"] != "usage.total_tokens" {
 		t.Fatalf("Unexpected total source mapping: %v", totalSource)
+	}
+}
+
+// TestTokenBasedRateLimitPolicy_Mode_ReturnsStream verifies that Mode reports BodyModeStream.
+func TestTokenBasedRateLimitPolicy_Mode_ReturnsStream(t *testing.T) {
+	p := &TokenBasedRateLimitPolicy{}
+	mode := p.Mode()
+	if mode.ResponseBodyMode != policy.BodyModeStream {
+		t.Errorf("expected ResponseBodyMode=BodyModeStream, got %v", mode.ResponseBodyMode)
+	}
+}
+
+// TestTokenBasedRateLimitPolicy_NeedsMoreResponseData_ReturnsFalse verifies the streaming
+// buffer hint is always false (the delegate manages its own accumulation).
+func TestTokenBasedRateLimitPolicy_NeedsMoreResponseData_ReturnsFalse(t *testing.T) {
+	p := &TokenBasedRateLimitPolicy{}
+	if p.NeedsMoreResponseData([]byte("data: hello")) {
+		t.Error("expected NeedsMoreResponseData to return false")
+	}
+}
+
+// TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_NoProvider verifies that a missing
+// provider name in metadata is handled gracefully without panic.
+func TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_NoProvider(t *testing.T) {
+	p := &TokenBasedRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	respCtx := newTokenStreamCtx("")
+	chunk := &policy.StreamBody{Chunk: []byte("data: {}"), EndOfStream: true}
+
+	action := p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+	if !reflect.DeepEqual(action, policy.ResponseChunkAction{}) {
+		t.Errorf("expected empty ResponseChunkAction, got %v", action)
+	}
+}
+
+// TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_NoDelegateFound verifies that a
+// provider name with no cached delegate is handled gracefully.
+func TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_NoDelegateFound(t *testing.T) {
+	p := &TokenBasedRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	respCtx := newTokenStreamCtx("unknown-provider")
+	chunk := &policy.StreamBody{Chunk: []byte("data: {}"), EndOfStream: true}
+
+	action := p.OnResponseBodyChunk(context.Background(), respCtx, chunk, nil)
+	if !reflect.DeepEqual(action, policy.ResponseChunkAction{}) {
+		t.Errorf("expected empty ResponseChunkAction, got %v", action)
+	}
+}
+
+// TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_DelegateCalled verifies that
+// OnResponseBodyChunk forwards to the cached delegate when one exists.
+func TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_DelegateCalled(t *testing.T) {
+	stub := &stubChunkPolicer{}
+	p := &TokenBasedRateLimitPolicy{metadata: policy.PolicyMetadata{RouteName: "r"}}
+	p.delegates.Store("openai", stub)
+
+	respCtx := newTokenStreamCtx("openai")
+	chunks := [][]byte{
+		[]byte("data: {\"usage\":{\"total_tokens\":50}}\n"),
+		[]byte("data: [DONE]\n"),
+	}
+
+	for i, c := range chunks {
+		eos := i == len(chunks)-1
+		p.OnResponseBodyChunk(context.Background(), respCtx, &policy.StreamBody{Chunk: c, EndOfStream: eos, Index: uint64(i)}, nil)
+	}
+
+	if stub.chunkCalls != 2 {
+		t.Errorf("expected delegate OnResponseBodyChunk called 2 times, got %d", stub.chunkCalls)
 	}
 }

--- a/policies/url-guardrail/go.mod
+++ b/policies/url-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/url-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/url-guardrail/go.sum
+++ b/policies/url-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/url-guardrail/policy-definition.yaml
+++ b/policies/url-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: url-guardrail
-version: v1.0.0
+version: v1.0.1
 description: |
   Validate URLs in request or response content using JSONPath extraction with DNS-only or HTTP reachability checks.
 

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -48,7 +48,6 @@ const (
 	sseEventPrefix           = "event:"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
 	metaKeyAccJsonBody = "urlguardrail:json_body"
-	metaKeyViolated   = "urlguardrail:violated"
 )
 
 var (
@@ -497,19 +496,8 @@ func (p *URLGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx *p
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
-	// Violation already reported — suppress all subsequent chunks so the client
-	// does not receive real content after the error + [DONE] we already sent.
-	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
-		return policy.ResponseChunkAction{Body: []byte{}}
-	}
 
 	chunkStr := string(chunk.Chunk)
-
-	// If a preceding policy already emitted a guardrail SSE error event, pass it
-	// through unchanged — a second guardrail must not validate or override it.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
 
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
@@ -552,37 +540,10 @@ func (p *URLGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx *p
 	if len(invalidURLs) > 0 {
 		slog.Debug("URLGuardrail: streaming validation failed",
 			"invalidURLCount", len(invalidURLs), "totalURLCount", len(urls))
-		respCtx.Metadata[metaKeyViolated] = true
-		errorEvent := p.buildSSEErrorEvent(invalidURLs, p.responseParams.ShowAssessment)
-		done := []byte(sseDataPrefix + sseDone + "\n\n")
-		return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
+		return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(invalidURLs, p.responseParams.ShowAssessment), TerminateStream: true}
 	}
 
 	return policy.ResponseChunkAction{} // all URLs valid — pass through
-}
-
-// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
-// event emitted by a preceding policy in the chain. Such a chunk has an SSE
-// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
-// These chunks must be passed through unchanged so the upstream error is
-// preserved and not overwritten by a subsequent guardrail.
-func isGuardrailSSEErrorEvent(s string) bool {
-	for _, line := range strings.SplitN(s, "\n", 5) {
-		line = strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/url-guardrail/urlguardrail.go
+++ b/policies/url-guardrail/urlguardrail.go
@@ -47,7 +47,8 @@ const (
 	sseDone                  = "[DONE]"
 	sseEventPrefix           = "event:"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
-	metaKeyAccJsonBody       = "urlguardrail:json_body"
+	metaKeyAccJsonBody = "urlguardrail:json_body"
+	metaKeyViolated   = "urlguardrail:violated"
 )
 
 var (
@@ -58,7 +59,13 @@ var (
 	// way through a URL body that has started past "://" but has no terminating
 	// whitespace yet ("https://example.com/path"). A single regex covers both
 	// cases: https?  optionally followed by  :  and any non-whitespace chars.
-	incompleteURLAtEnd = regexp.MustCompile(`(?:^|[\s])https?(?::[^\s]*)?$`)
+	//
+	// [^\w] (instead of [\s]) is intentional: URLs can appear directly after
+	// non-whitespace punctuation such as backticks, parentheses, or quotes
+	// (e.g. `http://example.com`).  Using [^\w] accepts any non-alphanumeric
+	// predecessor while still rejecting embedded substrings like "webhttps"
+	// where a word character (b) immediately precedes the protocol.
+	incompleteURLAtEnd = regexp.MustCompile(`(?:^|[^\w])https?(?::[^\s]*)?$`)
 )
 
 // URLGuardrailPolicy implements URL validation guardrail
@@ -487,14 +494,26 @@ func (p *URLGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx *p
 		return policy.ResponseChunkAction{}
 	}
 
+	if respCtx.Metadata == nil {
+		respCtx.Metadata = make(map[string]interface{})
+	}
+	// Violation already reported — suppress all subsequent chunks so the client
+	// does not receive real content after the error + [DONE] we already sent.
+	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
+		return policy.ResponseChunkAction{Body: []byte{}}
+	}
+
 	chunkStr := string(chunk.Chunk)
+
+	// If a preceding policy already emitted a guardrail SSE error event, pass it
+	// through unchanged — a second guardrail must not validate or override it.
+	if isGuardrailSSEErrorEvent(chunkStr) {
+		return policy.ResponseChunkAction{}
+	}
 
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
-		if respCtx.Metadata == nil {
-			respCtx.Metadata = make(map[string]interface{})
-		}
 		prev, _ := respCtx.Metadata[metaKeyAccJsonBody].(string)
 		full := prev + chunkStr
 		respCtx.Metadata[metaKeyAccJsonBody] = full
@@ -533,12 +552,37 @@ func (p *URLGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, respCtx *p
 	if len(invalidURLs) > 0 {
 		slog.Debug("URLGuardrail: streaming validation failed",
 			"invalidURLCount", len(invalidURLs), "totalURLCount", len(urls))
-		return policy.ResponseChunkAction{
-			Body: p.buildSSEErrorEvent(invalidURLs, p.responseParams.ShowAssessment),
-		}
+		respCtx.Metadata[metaKeyViolated] = true
+		errorEvent := p.buildSSEErrorEvent(invalidURLs, p.responseParams.ShowAssessment)
+		done := []byte(sseDataPrefix + sseDone + "\n\n")
+		return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
 	}
 
 	return policy.ResponseChunkAction{} // all URLs valid — pass through
+}
+
+// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
+// event emitted by a preceding policy in the chain. Such a chunk has an SSE
+// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
+// These chunks must be passed through unchanged so the upstream error is
+// preserved and not overwritten by a subsequent guardrail.
+func isGuardrailSSEErrorEvent(s string) bool {
+	for _, line := range strings.SplitN(s, "\n", 5) {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).

--- a/policies/url-guardrail/urlguardrail_test.go
+++ b/policies/url-guardrail/urlguardrail_test.go
@@ -484,25 +484,6 @@ func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 
 // ─── OnResponseBodyChunk non-SSE (plain JSON chunked transfer) tests ─────────
 
-// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
-// preceding policy in the chain has already emitted a guardrail SSE error event,
-// the URL guardrail passes it through unchanged without attempting validation or
-// overwriting the error with its own.
-func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
-	p := newStreamingURLPolicy(200)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	// Construct the SSE error event as it would arrive from a preceding guardrail.
-	precedingError := "data: " + `{"type":"SENTENCE_COUNT_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"sentence-count-guardrail"}}` + "\n\ndata: [DONE]\n\n"
-	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
-	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
-
-	if got.Body != nil {
-		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
-	}
-}
-
 // TestOnResponseBodyChunk_NonSSE_InvalidURL_ReturnsError verifies that the
 // non-SSE path correctly detects and blocks invalid URLs when JSONPath extraction
 // succeeds and the extracted text contains an unreachable URL.
@@ -545,10 +526,10 @@ func newStreamingURLPolicy(timeout int) *URLGuardrailPolicy {
 	}
 }
 
-// TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndDONE verifies that when a
-// chunk contains an invalid URL, OnResponseBodyChunk replaces it with an SSE
-// error event immediately followed by data: [DONE] for clean stream termination.
-func TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndDONE(t *testing.T) {
+// TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndTerminates verifies that when
+// a chunk contains an invalid URL, OnResponseBodyChunk returns an SSE error
+// event with TerminateStream set so the engine closes the stream cleanly.
+func TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndTerminates(t *testing.T) {
 	p := newStreamingURLPolicy(200)
 	ctx := context.Background()
 	respCtx := newStreamingRespCtx()
@@ -567,44 +548,18 @@ func TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndDONE(t *testing.T) {
 	if got.Body == nil {
 		t.Fatal("expected error body on invalid URL, got nil")
 	}
+	if !got.TerminateStream {
+		t.Fatal("expected TerminateStream=true on invalid URL violation")
+	}
 	if !strings.Contains(string(got.Body), "URL_GUARDRAIL") {
 		t.Fatalf("expected URL_GUARDRAIL in error body, got: %s", got.Body)
 	}
-	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
-		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
-	}
-	// Parse the first SSE event and verify guardrail action fields.
-	parts := strings.SplitN(string(got.Body), "\n\n", 2)
-	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	// Parse the SSE event and verify guardrail action fields.
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(strings.TrimSuffix(string(got.Body), "\n\n"), "data: ")))
 	if msg["action"] != "GUARDRAIL_INTERVENED" {
 		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
 	}
 	if msg["interveningGuardrail"] != "url-guardrail" {
 		t.Fatalf("expected interveningGuardrail=url-guardrail, got %#v", msg["interveningGuardrail"])
-	}
-}
-
-// TestOnResponseBodyChunk_InvalidURL_SubsequentChunksSuppressed verifies that
-// after an invalid-URL error is emitted, all subsequent chunks are suppressed
-// (Body is non-nil but empty) rather than passed through to the client.
-func TestOnResponseBodyChunk_InvalidURL_SubsequentChunksSuppressed(t *testing.T) {
-	p := newStreamingURLPolicy(200)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	// Trigger violation.
-	invalid := &policy.StreamBody{Chunk: sseContentChunk("see http://127.0.0.1:1")}
-	p.OnResponseBodyChunk(ctx, respCtx, invalid, nil)
-
-	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
-	for i, content := range []string{"more text", "even more", "the end"} {
-		next := &policy.StreamBody{Chunk: sseContentChunk(content)}
-		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
-		if got.Body == nil {
-			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, content)
-		}
-		if len(got.Body) != 0 {
-			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, content, got.Body)
-		}
 	}
 }

--- a/policies/url-guardrail/urlguardrail_test.go
+++ b/policies/url-guardrail/urlguardrail_test.go
@@ -481,3 +481,130 @@ func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }
+
+// ─── OnResponseBodyChunk non-SSE (plain JSON chunked transfer) tests ─────────
+
+// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
+// preceding policy in the chain has already emitted a guardrail SSE error event,
+// the URL guardrail passes it through unchanged without attempting validation or
+// overwriting the error with its own.
+func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
+	p := newStreamingURLPolicy(200)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// Construct the SSE error event as it would arrive from a preceding guardrail.
+	precedingError := "data: " + `{"type":"SENTENCE_COUNT_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"sentence-count-guardrail"}}` + "\n\ndata: [DONE]\n\n"
+	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body != nil {
+		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
+	}
+}
+
+// TestOnResponseBodyChunk_NonSSE_InvalidURL_ReturnsError verifies that the
+// non-SSE path correctly detects and blocks invalid URLs when JSONPath extraction
+// succeeds and the extracted text contains an unreachable URL.
+func TestOnResponseBodyChunk_NonSSE_InvalidURL_ReturnsError(t *testing.T) {
+	p := newStreamingURLPolicy(200)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	body := []byte(`{"choices":[{"message":{"content":"visit http://127.0.0.1:1 for info"}}]}`)
+	chunk := &policy.StreamBody{Chunk: body, EndOfStream: true}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body == nil {
+		t.Fatal("expected error body for invalid URL in non-SSE chunk, got nil")
+	}
+	if !strings.Contains(string(got.Body), "URL_GUARDRAIL") {
+		t.Fatalf("expected URL_GUARDRAIL in error body, got: %s", got.Body)
+	}
+}
+
+// ─── OnResponseBodyChunk stream-stop tests ───────────────────────────────────
+
+func sseContentChunk(content string) []byte {
+	quoted, _ := json.Marshal(content)
+	return []byte(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":` + string(quoted) + `},"finish_reason":null}]}` + "\n\n")
+}
+
+func newStreamingRespCtx() *policy.ResponseStreamContext {
+	return &policy.ResponseStreamContext{SharedContext: &policy.SharedContext{}}
+}
+
+func newStreamingURLPolicy(timeout int) *URLGuardrailPolicy {
+	return &URLGuardrailPolicy{
+		hasResponseParams: true,
+		responseParams: URLGuardrailPolicyParams{
+			Enabled:           true,
+			StreamingJsonPath: DefaultStreamingJsonPath,
+			Timeout:           timeout,
+		},
+	}
+}
+
+// TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndDONE verifies that when a
+// chunk contains an invalid URL, OnResponseBodyChunk replaces it with an SSE
+// error event immediately followed by data: [DONE] for clean stream termination.
+func TestOnResponseBodyChunk_InvalidURL_EmitsErrorAndDONE(t *testing.T) {
+	p := newStreamingURLPolicy(200)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// Chunk with no URL passes through unmodified.
+	plain := &policy.StreamBody{Chunk: sseContentChunk("no urls here")}
+	got := p.OnResponseBodyChunk(ctx, respCtx, plain, nil)
+	if got.Body != nil {
+		t.Fatalf("expected passthrough for chunk with no URL, got %q", got.Body)
+	}
+
+	// Chunk containing an unreachable URL triggers the guardrail.
+	invalid := &policy.StreamBody{Chunk: sseContentChunk("visit http://127.0.0.1:1 for info")}
+	got = p.OnResponseBodyChunk(ctx, respCtx, invalid, nil)
+
+	if got.Body == nil {
+		t.Fatal("expected error body on invalid URL, got nil")
+	}
+	if !strings.Contains(string(got.Body), "URL_GUARDRAIL") {
+		t.Fatalf("expected URL_GUARDRAIL in error body, got: %s", got.Body)
+	}
+	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
+		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
+	}
+	// Parse the first SSE event and verify guardrail action fields.
+	parts := strings.SplitN(string(got.Body), "\n\n", 2)
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	if msg["action"] != "GUARDRAIL_INTERVENED" {
+		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
+	}
+	if msg["interveningGuardrail"] != "url-guardrail" {
+		t.Fatalf("expected interveningGuardrail=url-guardrail, got %#v", msg["interveningGuardrail"])
+	}
+}
+
+// TestOnResponseBodyChunk_InvalidURL_SubsequentChunksSuppressed verifies that
+// after an invalid-URL error is emitted, all subsequent chunks are suppressed
+// (Body is non-nil but empty) rather than passed through to the client.
+func TestOnResponseBodyChunk_InvalidURL_SubsequentChunksSuppressed(t *testing.T) {
+	p := newStreamingURLPolicy(200)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// Trigger violation.
+	invalid := &policy.StreamBody{Chunk: sseContentChunk("see http://127.0.0.1:1")}
+	p.OnResponseBodyChunk(ctx, respCtx, invalid, nil)
+
+	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
+	for i, content := range []string{"more text", "even more", "the end"} {
+		next := &policy.StreamBody{Chunk: sseContentChunk(content)}
+		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
+		if got.Body == nil {
+			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, content)
+		}
+		if len(got.Body) != 0 {
+			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, content, got.Body)
+		}
+	}
+}

--- a/policies/word-count-guardrail/go.mod
+++ b/policies/word-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/word-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.0
+require github.com/wso2/api-platform/sdk/core v0.2.2

--- a/policies/word-count-guardrail/go.sum
+++ b/policies/word-count-guardrail/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.0 h1:nv4Xa4l0cRZYdk5GU1d1gZkxLk5czb7tBjp4zKI3aCU=
-github.com/wso2/api-platform/sdk/core v0.2.0/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.2 h1:8oTspH3n3T450tIB8qCE/Y5BcFnlkwp7euMygtWsiTQ=
+github.com/wso2/api-platform/sdk/core v0.2.2/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: word-count-guardrail
-version: v1.0.0
+version: v1.0.1
 description: |
   Validate word counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -44,7 +44,6 @@ const (
 	sseEventPrefix           = "event:"
 	metaKeyAccContent        = "wordcountguardrail:accumulated_content"
 	metaKeyAccJsonBody       = "wordcountguardrail:json_body"
-	metaKeyViolated          = "wordcountguardrail:violated"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
 )
 
@@ -417,30 +416,6 @@ func (p *WordCountGuardrailPolicy) OnResponseBody(ctx context.Context, respCtx *
 	return p.validatePayload(content, p.responseParams, true).(policy.ResponseAction)
 }
 
-// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
-// event emitted by a preceding policy in the chain. Such a chunk has an SSE
-// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
-// These chunks must be passed through unchanged so the upstream error is
-// preserved and not overwritten by a subsequent guardrail.
-func isGuardrailSSEErrorEvent(s string) bool {
-	for _, line := range strings.SplitN(s, "\n", 5) {
-		line = strings.TrimRight(line, "\r")
-		if !strings.HasPrefix(line, sseDataPrefix) {
-			continue
-		}
-		data := strings.TrimPrefix(line, sseDataPrefix)
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(data), &m) != nil {
-			continue
-		}
-		msg, _ := m["message"].(map[string]interface{})
-		if msg["action"] == "GUARDRAIL_INTERVENED" {
-			return true
-		}
-	}
-	return false
-}
-
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).
 func isSSEChunk(s string) bool {
 	for _, line := range strings.SplitN(s, "\n", 5) {
@@ -713,16 +688,6 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
-	// If a preceding policy already emitted a guardrail SSE error event, pass it
-	// through unchanged — a second guardrail must not validate or override it.
-	if isGuardrailSSEErrorEvent(chunkStr) {
-		return policy.ResponseChunkAction{}
-	}
-	// If a violation was already reported, suppress all subsequent chunks so the
-	// client does not receive real content after the error + [DONE] already sent.
-	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
-		return policy.ResponseChunkAction{Body: []byte{}}
-	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -742,11 +707,11 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 			if !rp.Invert {
 				if count < rp.Min {
 					reason := fmt.Sprintf("word count %d is below minimum of %d words", count, rp.Min)
-					return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+					return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 				}
 			} else if count >= rp.Min && count <= rp.Max {
 				reason := fmt.Sprintf("word count %d is within the excluded range %d-%d words", count, rp.Min, rp.Max)
-				return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+				return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 			}
 			return policy.ResponseChunkAction{}
 		}
@@ -779,16 +744,13 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 			slog.Debug("WordCountGuardrail: max exceeded",
 				"count", count, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("word count %d exceeded maximum of %d words", count, rp.Max)
-			respCtx.Metadata[metaKeyViolated] = true
-			errorEvent := p.buildSSEErrorEvent(reason, rp)
-			done := []byte(sseDataPrefix + sseDone + "\n\n")
-			return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 		}
 		if isDone && count < rp.Min {
 			slog.Debug("WordCountGuardrail: below min at stream end",
 				"count", count, "min", rp.Min, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("word count %d is below minimum of %d words", count, rp.Min)
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp), TerminateStream: true}
 		}
 		return policy.ResponseChunkAction{}
 	}

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -44,6 +44,7 @@ const (
 	sseEventPrefix           = "event:"
 	metaKeyAccContent        = "wordcountguardrail:accumulated_content"
 	metaKeyAccJsonBody       = "wordcountguardrail:json_body"
+	metaKeyViolated          = "wordcountguardrail:violated"
 	DefaultStreamingJsonPath = "$.choices[0].delta.content"
 )
 
@@ -688,6 +689,10 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
+	// If a violation was already reported, drop all subsequent chunks silently.
+	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
+		return policy.ResponseChunkAction{}
+	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
 		// Accumulate all chunks and validate the complete body at end of stream.
@@ -744,6 +749,7 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 			slog.Debug("WordCountGuardrail: max exceeded",
 				"count", count, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("word count %d exceeded maximum of %d words", count, rp.Max)
+			respCtx.Metadata[metaKeyViolated] = true
 			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
 		}
 		if isDone && count < rp.Min {

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -417,6 +417,30 @@ func (p *WordCountGuardrailPolicy) OnResponseBody(ctx context.Context, respCtx *
 	return p.validatePayload(content, p.responseParams, true).(policy.ResponseAction)
 }
 
+// isGuardrailSSEErrorEvent returns true when the chunk is a guardrail SSE error
+// event emitted by a preceding policy in the chain. Such a chunk has an SSE
+// data line whose JSON payload carries a "type" field ending with "_GUARDRAIL".
+// These chunks must be passed through unchanged so the upstream error is
+// preserved and not overwritten by a subsequent guardrail.
+func isGuardrailSSEErrorEvent(s string) bool {
+	for _, line := range strings.SplitN(s, "\n", 5) {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, sseDataPrefix) {
+			continue
+		}
+		data := strings.TrimPrefix(line, sseDataPrefix)
+		var m map[string]interface{}
+		if json.Unmarshal([]byte(data), &m) != nil {
+			continue
+		}
+		msg, _ := m["message"].(map[string]interface{})
+		if msg["action"] == "GUARDRAIL_INTERVENED" {
+			return true
+		}
+	}
+	return false
+}
+
 // isSSEChunk reports whether s looks like SSE data (has at least one "data: " or "event:" line).
 func isSSEChunk(s string) bool {
 	for _, line := range strings.SplitN(s, "\n", 5) {
@@ -689,9 +713,15 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 	if respCtx.Metadata == nil {
 		respCtx.Metadata = make(map[string]interface{})
 	}
-	// If a violation was already reported, drop all subsequent chunks silently.
-	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
+	// If a preceding policy already emitted a guardrail SSE error event, pass it
+	// through unchanged — a second guardrail must not validate or override it.
+	if isGuardrailSSEErrorEvent(chunkStr) {
 		return policy.ResponseChunkAction{}
+	}
+	// If a violation was already reported, suppress all subsequent chunks so the
+	// client does not receive real content after the error + [DONE] already sent.
+	if violated, _ := respCtx.Metadata[metaKeyViolated].(bool); violated {
+		return policy.ResponseChunkAction{Body: []byte{}}
 	}
 	if !isSSEChunk(chunkStr) {
 		// Plain JSON via chunked transfer (e.g. OpenAI stream:false with Transfer-Encoding: chunked).
@@ -750,7 +780,9 @@ func (p *WordCountGuardrailPolicy) OnResponseBodyChunk(ctx context.Context, resp
 				"count", count, "max", rp.Max, "chunkIndex", chunk.Index)
 			reason := fmt.Sprintf("word count %d exceeded maximum of %d words", count, rp.Max)
 			respCtx.Metadata[metaKeyViolated] = true
-			return policy.ResponseChunkAction{Body: p.buildSSEErrorEvent(reason, rp)}
+			errorEvent := p.buildSSEErrorEvent(reason, rp)
+			done := []byte(sseDataPrefix + sseDone + "\n\n")
+			return policy.ResponseChunkAction{Body: append(errorEvent, done...)}
 		}
 		if isDone && count < rp.Min {
 			slog.Debug("WordCountGuardrail: below min at stream end",

--- a/policies/word-count-guardrail/wordcountguardrail_test.go
+++ b/policies/word-count-guardrail/wordcountguardrail_test.go
@@ -1038,29 +1038,11 @@ func newStreamingRespCtx() *policy.ResponseStreamContext {
 	return &policy.ResponseStreamContext{SharedContext: &policy.SharedContext{}}
 }
 
-// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
-// preceding policy in the chain has already emitted a guardrail SSE error event,
-// the word-count guardrail passes it through unchanged without attempting
-// validation or overwriting the error with its own.
-func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
-	p := newStreamingPolicy(1, 100)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	precedingError := "data: " + `{"type":"URL_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"url-guardrail"}}` + "\n\ndata: [DONE]\n\n"
-	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
-	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
-
-	if got.Body != nil {
-		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
-	}
-}
-
-// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE verifies that when the
-// accumulated word count exceeds max mid-stream, OnResponseBodyChunk replaces
-// the offending chunk with an SSE error event immediately followed by
-// data: [DONE] so the client receives a clean stream termination.
-func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
+// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndTerminates verifies that
+// when the accumulated word count exceeds max mid-stream, OnResponseBodyChunk
+// returns an SSE error event with TerminateStream set so the engine closes the
+// stream cleanly.
+func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndTerminates(t *testing.T) {
 	p := newStreamingPolicy(1, 3)
 	ctx := context.Background()
 	respCtx := newStreamingRespCtx()
@@ -1074,51 +1056,25 @@ func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
 		}
 	}
 
-	// Fourth word pushes count to 4, exceeding max=3 — must emit error + [DONE].
+	// Fourth word pushes count to 4, exceeding max=3 — must emit error with TerminateStream.
 	chunk := &policy.StreamBody{Chunk: []byte(sseEvent(" four"))}
 	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
 
 	if got.Body == nil {
 		t.Fatal("expected error body on max violation, got nil")
 	}
+	if !got.TerminateStream {
+		t.Fatal("expected TerminateStream=true on max violation")
+	}
 	if !strings.Contains(string(got.Body), "WORD_COUNT_GUARDRAIL") {
 		t.Fatalf("expected WORD_COUNT_GUARDRAIL in error body, got: %s", got.Body)
 	}
-	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
-		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
-	}
-	// Parse the first SSE event and verify guardrail action fields.
-	parts := strings.SplitN(string(got.Body), "\n\n", 2)
-	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	// Parse the SSE event and verify guardrail action fields.
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(strings.TrimSuffix(string(got.Body), "\n\n"), "data: ")))
 	if msg["action"] != "GUARDRAIL_INTERVENED" {
 		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
 	}
 	if msg["interveningGuardrail"] != "word-count-guardrail" {
 		t.Fatalf("expected interveningGuardrail=word-count-guardrail, got %#v", msg["interveningGuardrail"])
-	}
-}
-
-// TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed verifies that
-// after a max-violation error is emitted, all subsequent chunks are suppressed
-// (Body is non-nil but empty) rather than passed through to the client.
-func TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed(t *testing.T) {
-	p := newStreamingPolicy(1, 2)
-	ctx := context.Background()
-	respCtx := newStreamingRespCtx()
-
-	// Trigger violation: 3 words exceed max=2.
-	chunk := &policy.StreamBody{Chunk: []byte(sseEvent("one two three"))}
-	p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
-
-	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
-	for i, word := range []string{" four", " five", " six"} {
-		next := &policy.StreamBody{Chunk: []byte(sseEvent(word))}
-		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
-		if got.Body == nil {
-			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, word)
-		}
-		if len(got.Body) != 0 {
-			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, word, got.Body)
-		}
 	}
 }

--- a/policies/word-count-guardrail/wordcountguardrail_test.go
+++ b/policies/word-count-guardrail/wordcountguardrail_test.go
@@ -1031,3 +1031,94 @@ func TestOnRequestBodyAndOnResponseBody(t *testing.T) {
 		t.Fatalf("expected response no-op when response.enabled=false, got %T", respDisabled)
 	}
 }
+
+// ─── OnResponseBodyChunk stream-stop tests ───────────────────────────────────
+
+func newStreamingRespCtx() *policy.ResponseStreamContext {
+	return &policy.ResponseStreamContext{SharedContext: &policy.SharedContext{}}
+}
+
+// TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough verifies that when a
+// preceding policy in the chain has already emitted a guardrail SSE error event,
+// the word-count guardrail passes it through unchanged without attempting
+// validation or overwriting the error with its own.
+func TestOnResponseBodyChunk_GuardrailSSEError_PassesThrough(t *testing.T) {
+	p := newStreamingPolicy(1, 100)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	precedingError := "data: " + `{"type":"URL_GUARDRAIL","message":{"action":"GUARDRAIL_INTERVENED","interveningGuardrail":"url-guardrail"}}` + "\n\ndata: [DONE]\n\n"
+	chunk := &policy.StreamBody{Chunk: []byte(precedingError)}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body != nil {
+		t.Fatalf("expected passthrough (Body=nil) for guardrail SSE error event, got %q", got.Body)
+	}
+}
+
+// TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE verifies that when the
+// accumulated word count exceeds max mid-stream, OnResponseBodyChunk replaces
+// the offending chunk with an SSE error event immediately followed by
+// data: [DONE] so the client receives a clean stream termination.
+func TestOnResponseBodyChunk_MaxViolation_EmitsErrorAndDONE(t *testing.T) {
+	p := newStreamingPolicy(1, 3)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// First three words (count == max) pass through unmodified.
+	for _, word := range []string{"one", " two", " three"} {
+		chunk := &policy.StreamBody{Chunk: []byte(sseEvent(word))}
+		got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+		if got.Body != nil {
+			t.Fatalf("word %q: expected passthrough (Body=nil), got %q", word, got.Body)
+		}
+	}
+
+	// Fourth word pushes count to 4, exceeding max=3 — must emit error + [DONE].
+	chunk := &policy.StreamBody{Chunk: []byte(sseEvent(" four"))}
+	got := p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	if got.Body == nil {
+		t.Fatal("expected error body on max violation, got nil")
+	}
+	if !strings.Contains(string(got.Body), "WORD_COUNT_GUARDRAIL") {
+		t.Fatalf("expected WORD_COUNT_GUARDRAIL in error body, got: %s", got.Body)
+	}
+	if !strings.HasSuffix(string(got.Body), "data: [DONE]\n\n") {
+		t.Fatalf("expected body to end with 'data: [DONE]\\n\\n', got: %q", got.Body)
+	}
+	// Parse the first SSE event and verify guardrail action fields.
+	parts := strings.SplitN(string(got.Body), "\n\n", 2)
+	msg := mustMessageMap(t, []byte(strings.TrimPrefix(parts[0], "data: ")))
+	if msg["action"] != "GUARDRAIL_INTERVENED" {
+		t.Fatalf("expected action=GUARDRAIL_INTERVENED, got %#v", msg["action"])
+	}
+	if msg["interveningGuardrail"] != "word-count-guardrail" {
+		t.Fatalf("expected interveningGuardrail=word-count-guardrail, got %#v", msg["interveningGuardrail"])
+	}
+}
+
+// TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed verifies that
+// after a max-violation error is emitted, all subsequent chunks are suppressed
+// (Body is non-nil but empty) rather than passed through to the client.
+func TestOnResponseBodyChunk_MaxViolation_SubsequentChunksSuppressed(t *testing.T) {
+	p := newStreamingPolicy(1, 2)
+	ctx := context.Background()
+	respCtx := newStreamingRespCtx()
+
+	// Trigger violation: 3 words exceed max=2.
+	chunk := &policy.StreamBody{Chunk: []byte(sseEvent("one two three"))}
+	p.OnResponseBodyChunk(ctx, respCtx, chunk, nil)
+
+	// All subsequent chunks must be suppressed — Body must be []byte{}, not nil.
+	for i, word := range []string{" four", " five", " six"} {
+		next := &policy.StreamBody{Chunk: []byte(sseEvent(word))}
+		got := p.OnResponseBodyChunk(ctx, respCtx, next, nil)
+		if got.Body == nil {
+			t.Fatalf("chunk %d %q: expected suppression (Body=[]byte{}), got nil (passthrough)", i, word)
+		}
+		if len(got.Body) != 0 {
+			t.Fatalf("chunk %d %q: expected empty suppressed body, got %q", i, word, got.Body)
+		}
+	}
+}


### PR DESCRIPTION
$subject

- https://github.com/wso2/api-platform/issues/1563
- https://github.com/wso2/api-platform/issues/1548
- https://github.com/wso2/api-platform/issues/1386
- 
#### SSE Streaming Support for Advanced Rate Limiter — Design

## Overview

The SDK (`v0.2.0`) already defines `StreamingResponsePolicy` with `OnResponseBodyChunk` /
`NeedsMoreResponseData` and `BodyModeStream`. The work is entirely in the policy itself.

**Core principle:** The operator does not choose between streaming and non-streaming. The
`response_body` source type handles both transparently. LLM providers always use
`Transfer-Encoding: chunked`, so `OnResponseBodyChunk` fires regardless of whether the
client requested SSE or a plain JSON response. The policy detects which format it is on the
first chunk and adapts automatically.

---

## 1. No New Source Type

The existing `response_body` source type is used for both cases. No `response_body_stream`
type is needed. Configuration stays the same as today:

```yaml
costExtraction:
  enabled: true
  sources:
    - type: response_body
      jsonPath: usage.total_tokens  # same path for both SSE and plain JSON responses
      multiplier: 0.000002          # applied to the extracted numeric value
  default: 1                        # fallback cost when extraction finds nothing
```

---

## 2. Updated `Mode()` — Stream Instead of Buffer for `response_body`

```go
// ratelimit.go

func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
    requestBodyMode  := policy.BodyModeSkip
    responseBodyMode := policy.BodyModeSkip

    if p.requiresRequestBody() {
        requestBodyMode = policy.BodyModeBuffer
    }

    if p.hasResponseBodySource() {
        // Switch to BodyModeStream for response_body cost sources.
        // The kernel enters FULL_DUPLEX_STREAMED mode only when every policy in the
        // chain agrees on BodyModeStream. If any other policy requests BodyModeBuffer,
        // the kernel falls back to buffered mode and calls OnResponseBody instead —
        // which already handles both SSE and plain JSON via extractFromBodyBytes.
        responseBodyMode = policy.BodyModeStream
    }

    return policy.ProcessingMode{
        RequestHeaderMode:  policy.HeaderModeProcess,
        RequestBodyMode:    requestBodyMode,
        ResponseHeaderMode: policy.HeaderModeProcess,
        ResponseBodyMode:   responseBodyMode,
    }
}

// hasResponseBodySource returns true if any quota has a response_body cost source.
// This is used by Mode() to decide whether to request BodyModeStream for the response.
func (p *RateLimitPolicy) hasResponseBodySource() bool {
    for _, q := range p.quotas {
        if q.CostExtractionEnabled && q.CostExtractor != nil {
            for _, src := range q.CostExtractor.GetConfig().Sources {
                if src.Type == CostSourceResponseBody {
                    return true
                }
            }
        }
    }
    return false
}
```

**Kernel behavior:**
- If every policy in the chain returns `BodyModeStream` (or `BodyModeSkip`), the kernel enters
  `FULL_DUPLEX_STREAMED` mode and calls `OnResponseBodyChunk` per chunk.
- If any other policy requires `BodyModeBuffer`, the kernel falls back to buffered mode and
  calls `OnResponseBody` instead. The existing `extractFromBodyBytes` / `extractFromSSEBodyBytes`
  fallback already handles both SSE and JSON in that path — no changes needed there.

---

## 3. Per-Request Streaming State

Since `RateLimitPolicy` is a singleton shared across all requests, per-stream state must live
in `SharedContext.Metadata` (which is per-request and persists across all chunk calls for the
same request).

```go
// ratelimit.go

const rateLimitStreamStateKey = "ratelimit:stream_state"

// streamQuotaState holds per-stream accumulation state for one quota.
// A separate instance is kept per quota name inside the metadata map so that
// multiple quotas on the same request track their state independently.
type streamQuotaState struct {
    lastCost    float64 // most recently extracted cost value (updated on each matching chunk)
    found       bool    // true once at least one chunk yielded a value for the jsonPath
    isSSE       *bool   // nil = format not yet determined; true = SSE, false = plain JSON
    partialLine []byte  // SSE mode only: bytes from the current chunk with no trailing newline,
                        // carried forward and prepended to the next chunk
    accumulated []byte  // JSON mode only: full body bytes gathered across all chunks until EOS
}
```

---

## 4. `OnResponseBodyChunk` — Auto-Detect SSE vs JSON

```go
// OnResponseBodyChunk is called by the kernel for every response body chunk when the chain
// runs in FULL_DUPLEX_STREAMED mode. It handles both SSE and plain JSON responses:
//   - SSE  → parse each chunk line-by-line; extract jsonPath per event; last match wins at EOS.
//   - JSON → accumulate raw bytes across chunks; extract jsonPath once at EOS.
// Format detection happens on the first non-empty chunk and is fixed for the lifetime of
// the stream. The chunk itself is always passed through unmodified.
func (p *RateLimitPolicy) OnResponseBodyChunk(
    ctx context.Context,
    respCtx *policy.ResponseStreamContext,
    chunk *policy.StreamBody,
    _ map[string]interface{},
) policy.ResponseChunkAction {

    // Load (or lazily create) the per-request state map from shared metadata.
    state := p.getOrInitStreamState(respCtx.Metadata)

    for i := range p.quotas {
        q := &p.quotas[i]
        if !q.CostExtractionEnabled || q.CostExtractor == nil {
            continue
        }

        quotaName := quotaNameFor(q, i)
        qs := state[quotaName]

        for _, src := range q.CostExtractor.GetConfig().Sources {
            if src.Type != CostSourceResponseBody {
                continue
            }

            // Detect SSE vs JSON on the first non-empty chunk.
            // SSE streams always begin with "data:" or "event:" on the first content line.
            // This detection is done once and stays fixed for the rest of the stream.
            if qs.isSSE == nil && len(chunk.Chunk) > 0 {
                trimmed := strings.TrimLeft(string(chunk.Chunk), " \r\n")
                isSSE := strings.HasPrefix(trimmed, "data:") || strings.HasPrefix(trimmed, "event:")
                qs.isSSE = &isSSE
                slog.Debug("Detected response body format",
                    "quota", quotaName, "isSSE", isSSE)
            }

            if qs.isSSE != nil && *qs.isSSE {
                // SSE mode: parse whatever complete lines exist in this chunk.
                // Any bytes after the last newline are incomplete and held in partialLine
                // to be prepended to the next chunk — guarding against a JSON payload
                // being split across a chunk boundary.
                combined := append(qs.partialLine, chunk.Chunk...)
                lastCost, found, remaining := parseSSEChunk(combined, src.JSONPath)
                qs.partialLine = remaining
                if found {
                    // Overwrite on each match: last-match-wins gives the final/EOS value,
                    // which is what LLM providers populate with the complete token count.
                    qs.lastCost = lastCost * src.Multiplier
                    qs.found = true
                }
            } else {
                // JSON mode: the full body arrives as multiple chunks due to chunked
                // transfer encoding. Accumulate all bytes and defer extraction to EOS.
                qs.accumulated = append(qs.accumulated, chunk.Chunk...)
            }
        }

        state[quotaName] = qs
    }
    // Write state back so it is visible to the next chunk call for this request.
    respCtx.Metadata[rateLimitStreamStateKey] = state

    // EOS: all chunks received. Finalize JSON extraction (SSE values are already
    // up-to-date from per-chunk parsing) and consume tokens against each quota.
    if chunk.EndOfStream {
        p.finalizeAndConsumeStreamingCosts(ctx, respCtx, state)
    }

    return policy.ResponseChunkAction{} // passthrough — chunk bytes unmodified
}

// NeedsMoreResponseData always returns false because we process each chunk as it arrives
// rather than waiting to accumulate a minimum number of bytes first.
// For SSE: we extract per-event inline.
// For JSON: we accumulate manually in streamQuotaState.accumulated and only extract at EOS.
func (p *RateLimitPolicy) NeedsMoreResponseData(_ []byte) bool {
    return false
}
```

---

## 5. EOS Finalization and Cost Consumption

```go
// finalizeAndConsumeStreamingCosts is called once at EOS (chunk.EndOfStream == true).
// For SSE quotas the cost is already in streamQuotaState from per-chunk parsing.
// For JSON quotas the accumulated bytes are extracted here for the first time.
// Tokens are consumed via ConsumeN (preferred) or ConsumeOrClampN (fallback) — the
// same pattern used in OnResponseBody for the buffered path.
func (p *RateLimitPolicy) finalizeAndConsumeStreamingCosts(
    ctx context.Context,
    respCtx *policy.ResponseStreamContext,
    state map[string]*streamQuotaState,
) {
    // quotaKeys were stored in metadata during the request phase (OnRequestHeaders /
    // OnRequestBody) so we can resolve the rate-limit key for each quota here.
    quotaKeys, _ := respCtx.Metadata[rateLimitKeysKey].(map[string]string)

    for i := range p.quotas {
        q := &p.quotas[i]
        if !q.CostExtractionEnabled || q.CostExtractor == nil {
            continue
        }
        // Only process quotas that use response_body sources; other source types
        // (response_header, response_metadata, response_cel) are handled elsewhere.
        if !p.hasResponseBodySourceForQuota(q) {
            continue
        }

        quotaName := quotaNameFor(q, i)
        key := quotaKeys[quotaName]
        qs := state[quotaName]

        var actualCost float64

        if qs != nil {
            if qs.isSSE == nil || !*qs.isSSE {
                // JSON mode: all bytes are in qs.accumulated — extract now.
                // Re-uses extractFromBodyBytes which handles standard JSONPath evaluation.
                for _, src := range q.CostExtractor.GetConfig().Sources {
                    if src.Type != CostSourceResponseBody {
                        continue
                    }
                    if cost, ok := extractFromBodyBytes(qs.accumulated, src.JSONPath); ok {
                        qs.lastCost = cost * src.Multiplier
                        qs.found = true
                    }
                }
            }
            // SSE mode: qs.lastCost was populated incrementally during OnResponseBodyChunk.
            if qs.found {
                actualCost = qs.lastCost
            } else {
                // No chunk matched the jsonPath — fall back to the configured default.
                actualCost = q.CostExtractor.GetConfig().Default
            }
        } else {
            // State was never initialised (e.g. all chunks were empty). Use default.
            actualCost = q.CostExtractor.GetConfig().Default
        }

        if actualCost < 0 {
            actualCost = 0
        }
        if actualCost == 0 {
            // Zero cost: nothing to consume. Skip to avoid unnecessary limiter calls.
            continue
        }

        // Consume tokens. ConsumeN (CostTracker) records accurate overflow/consumed
        // metrics. ConsumeOrClampN is the safe fallback for limiters that don't implement
        // CostTracker — it clamps the deduction to the available balance.
        if tracker, ok := q.Limiter.(limiter.CostTracker); ok {
            tracker.ConsumeN(ctx, key, int64(actualCost))
        } else {
            q.Limiter.ConsumeOrClampN(ctx, key, int64(actualCost))
        }

        slog.Debug("Streaming EOS cost consumed",
            "quota", quotaName, "key", key, "cost", actualCost,
            "isSSE", qs != nil && qs.isSSE != nil && *qs.isSSE)
    }
}
```

---

## 6. SSE Chunk Parser (Partial-Line Safe)

Added to `cost_extractor.go`. Reuses the existing `sseDataPrefix`, `sseEventPrefix`, `sseDone`
constants.

```go
// parseSSEChunk scans buf for complete SSE lines (delimited by '\n') and applies
// jsonPath to the JSON payload of each data:/event: line.
//
// It returns:
//   - lastCost: the numeric value from the last line that matched jsonPath
//   - found:    true if at least one line matched
//   - remaining: any bytes after the last '\n' (an incomplete line); the caller must
//                prepend these to the next chunk before calling parseSSEChunk again
//
// last-match-wins is intentional: LLM providers send the authoritative token count in
// the final usage event, so overwriting on each match naturally yields the right value.
func parseSSEChunk(buf []byte, jsonPath string) (lastCost float64, found bool, remaining []byte) {
    s := string(buf)
    for {
        idx := strings.IndexByte(s, '\n')
        if idx < 0 {
            // No complete line remaining — return the fragment so the caller can
            // prepend it to the next chunk.
            return lastCost, found, []byte(s)
        }
        line := strings.TrimRight(s[:idx], "\r") // strip optional \r from CRLF
        s = s[idx+1:]

        var value string
        if strings.HasPrefix(line, sseDataPrefix) {
            value = strings.TrimPrefix(line, sseDataPrefix)
        } else if strings.HasPrefix(line, sseEventPrefix) {
            value = strings.TrimSpace(strings.TrimPrefix(line, sseEventPrefix))
        } else {
            continue // comment, id:, retry:, or blank separator line — ignore
        }

        if value == sseDone || value == "" {
            continue // stream terminator or empty data field — skip
        }

        valueStr, err := utils.ExtractStringValueFromJsonpath([]byte(value), jsonPath)
        if err != nil {
            // jsonPath not present in this event (e.g. content chunk with no usage field).
            // This is expected for most SSE events — only trailing events carry usage.
            continue
        }
        cost, err := strconv.ParseFloat(valueStr, 64)
        if err != nil {
            continue
        }
        lastCost = cost
        found = true // will be overwritten if a later line also matches
    }
}
```

---

## 7. `OnResponseBody` — Buffered Fallback (No Changes)

When the kernel falls back to buffered mode (another policy in the chain requires
`BodyModeBuffer`), `OnResponseBody` is called with the complete buffered body.
`extractFromBodyBytes` already tries plain JSON first, then `extractFromSSEBodyBytes`
as a fallback — no changes required.

---

## 8. Rate Limit Headers in Streaming Mode

Response headers are already committed to the client before the first chunk arrives.
`X-RateLimit-*` headers set inside `OnResponseBodyChunk` are ignored by Envoy. This is
a hard constraint of the streaming protocol.

**Mitigations:**
- The `OnRequestHeaders` pre-check still blocks requests when the quota is already exhausted.
- Rate limit headers from the request phase reflect the pre-request quota state, which is
  the closest approximation possible.
- Post-stream token state is reflected accurately on the *next* request.

---

## 9. Metadata & CEL

At EOS in `finalizeAndConsumeStreamingCosts`, write the extracted value into
`SharedContext.Metadata` (e.g. `ratelimit:stream_usage:{quotaName}`) so downstream
analytics policies can read it.

`response_cel` sources are unaffected — they continue using buffered mode (`requiresResponseBody()`
remains true for `response_cel`) and evaluate against the full body in `OnResponseBody`.

---

## 10. Provider Compatibility

| Provider | Format | `jsonPath` |
|---|---|---|
| **OpenAI** | SSE; last `data:` before `data: [DONE]` has `usage.total_tokens` | `usage.total_tokens` |
| **Anthropic** | SSE; `event: message_delta` has `usage.output_tokens` | `usage.output_tokens` |
| **AWS Bedrock** | SSE; final chunk has `amazon-bedrock-invocationMetrics.totalTokenCount` | `amazon-bedrock-invocationMetrics.totalTokenCount` |
| **Any non-streaming LLM** | Chunked JSON; accumulated and extracted at EOS | same `jsonPath` as before |

The last-match-wins strategy works for all SSE providers: usage appears only in trailing events.
For plain JSON sent as chunked transfer, bytes are accumulated and extracted at EOS identically
to the current buffered path.

---

## 11. Edge Case Handling

| Case | Handling |
|---|---|
| Usage field absent in all chunks | `found == false` → use `costExtraction.default` |
| Partial JSON spanning two chunks | `parseSSEChunk` holds remainder in `partialLine`; prepended to next chunk |
| Multiple `data:` lines with usage | Last match wins — correct for all known providers |
| Keep-alive / blank lines | Skipped (`value == ""` check) |
| `data: [DONE]` terminator | Skipped (`value == sseDone` check) |
| First chunk is empty (keep-alive) | Detection deferred until first non-empty chunk |
| Mixed SSE + JSON in same response | Not expected; detection on first non-empty chunk is authoritative for the stream |
| `response_cel` source alongside `response_body` | `response_cel` forces `BodyModeBuffer`; kernel calls `OnResponseBody`; `extractFromBodyBytes` SSE fallback handles both |

---

## 12. Files to Change

| File | Change |
|---|---|
| `ratelimit.go` | `hasResponseBodySource()`, updated `Mode()`, `streamQuotaState`, `getOrInitStreamState`, `OnResponseBodyChunk`, `NeedsMoreResponseData`, `finalizeAndConsumeStreamingCosts` |
| `cost_extractor.go` | Add `parseSSEChunk` (reuses existing SSE constants) |
| `cost_extractor_test.go` | Tests for `parseSSEChunk`: partial lines, multi-chunk, missing field, plain JSON accumulation |
| `ratelimit_integration_test.go` | End-to-end: mock SSE stream → verify EOS consumption; mock chunked JSON → verify accumulation |
| `policy-definition.yaml` | No schema change — `response_body` already exists |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming response support with incremental SSE/JSON parsing for per-chunk cost extraction and interim availability snapshots
  * Delegation hooks so provider-specific handlers can process response chunks
  * Upstream rate-limit headers are removed/sanitized
  * Guardrails now pass through upstream guardrail errors, append stream terminators on intervention, and suppress subsequent chunks after a violation

* **Tests**
  * Added unit and integration tests covering multi-chunk SSE, chunked JSON accumulation, edge cases, multiplier handling, and delegate behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->