### PR TITLE
Fix JSON path isse of semantic tool filtering policy

### DIFF
--- a/docs/semantic-tool-filtering/v0.1/docs/semantic-tool-filtering.md
+++ b/docs/semantic-tool-filtering/v0.1/docs/semantic-tool-filtering.md
@@ -27,7 +27,7 @@ This policy helps reduce token consumption and improve LLM response quality by s
 | limit | integer | No | `5` | The number of most relevant tools to include (used if selectionMode is `By Rank`). |
 | threshold | number | No | `0.7` | Similarity threshold for filtering (0.0 to 1.0). Only tools with a score above this value are included (used if selectionMode is `By Threshold`). |
 | queryJSONPath | string | No | `$.messages[-1].content` | JSONPath expression to extract the user's query from the request body. |
-| toolsJSONPath | string | No | `$.tools` | JSONPath expression to extract the tools array from the request body (used when `toolsIsJson` is true). |
+| toolsJSONPath | string | No | `$.tools` | JSONPath expression to extract the tools definition from the request body. It can point to the array itself, such as `$.tools`, or to the iterated object inside each array item, such as `$.tools[*].function`. |
 | userQueryIsJson | boolean | No | `true` | Specifies format of user query. `true`: use `queryJSONPath`. `false`: extract from text using `<userq>` tags. |
 | toolsIsJson | boolean | No | `true` | Specifies format of tools definition. `true`: use `toolsJSONPath`. `false`: extract from text using `<toolname>`/`<tooldescription>` tags. |
 
@@ -124,6 +124,55 @@ policies:
 ```
 
 The policy will interpret the request, calculate embeddings, and filter the `tools` array to include only the top 3 matches (e.g., `get_weather`, `book_venue`, `send_email`).
+
+### Scenario 1b: OpenAI/Mistral-style Function Wrappers
+
+If the request wraps each tool as an object with a nested `function`, configure the iterator path so the policy reads `name` and `description` from the nested object while still filtering the parent `tools` array.
+
+**Configuration:**
+
+```yaml
+type: http
+policies:
+  - policy:
+      name: semantic-tool-filtering
+      parameters:
+        selectionMode: "By Rank"
+        limit: 3
+        queryJSONPath: "$.messages[-1].content"
+        toolsJSONPath: "$.tools[*].function"
+        userQueryIsJson: true
+        toolsIsJson: true
+```
+
+**Request:**
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What tools can help me check the weather?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather"
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Send an email notification"
+      }
+    }
+  ]
+}
+```
 
 ### Scenario 2: Filtering Tools by Threshold
 

--- a/docs/semantic-tool-filtering/v0.1/docs/semantic-tool-filtering.md
+++ b/docs/semantic-tool-filtering/v0.1/docs/semantic-tool-filtering.md
@@ -26,10 +26,10 @@ This policy helps reduce token consumption and improve LLM response quality by s
 | selectionMode | string | Yes | `By Rank` | Method used to filter tools: `By Rank` (selects top-K) or `By Threshold` (selects based on score). |
 | limit | integer | No | `5` | The number of most relevant tools to include (used if selectionMode is `By Rank`). |
 | threshold | number | No | `0.7` | Similarity threshold for filtering (0.0 to 1.0). Only tools with a score above this value are included (used if selectionMode is `By Threshold`). |
-| queryJSONPath | string | No | `$.messages[-1].content` | JSONPath expression to extract the user's query from the request body. |
-| toolsJSONPath | string | No | `$.tools` | JSONPath expression to extract the tools definition from the request body. It can point to the array itself, such as `$.tools`, or to the iterated object inside each array item, such as `$.tools[*].function`. |
-| userQueryIsJson | boolean | No | `true` | Specifies format of user query. `true`: use `queryJSONPath`. `false`: extract from text using `<userq>` tags. |
-| toolsIsJson | boolean | No | `true` | Specifies format of tools definition. `true`: use `toolsJSONPath`. `false`: extract from text using `<toolname>`/`<tooldescription>` tags. |
+| queryJSONPath | string | Yes | `$.messages[-1].content` | JSONPath expression to extract the user's query from the request body. |
+| toolsJSONPath | string | Yes | `$.tools` | JSONPath expression to extract the tools array from the request body (used when `toolsIsJson` is true). |
+| userQueryIsJson | boolean | Yes | `true` | Specifies format of user query. `true`: use `queryJSONPath`. `false`: extract from text using `<userq>` tags. |
+| toolsIsJson | boolean | Yes | `true` | Specifies format of tools definition. `true`: use `toolsJSONPath`. `false`: extract from text using `<toolname>`/`<tooldescription>` tags. |
 
 ### System Parameters (From config.toml)
 
@@ -124,55 +124,6 @@ policies:
 ```
 
 The policy will interpret the request, calculate embeddings, and filter the `tools` array to include only the top 3 matches (e.g., `get_weather`, `book_venue`, `send_email`).
-
-### Scenario 1b: OpenAI/Mistral-style Function Wrappers
-
-If the request wraps each tool as an object with a nested `function`, configure the iterator path so the policy reads `name` and `description` from the nested object while still filtering the parent `tools` array.
-
-**Configuration:**
-
-```yaml
-type: http
-policies:
-  - policy:
-      name: semantic-tool-filtering
-      parameters:
-        selectionMode: "By Rank"
-        limit: 3
-        queryJSONPath: "$.messages[-1].content"
-        toolsJSONPath: "$.tools[*].function"
-        userQueryIsJson: true
-        toolsIsJson: true
-```
-
-**Request:**
-
-```json
-{
-  "messages": [
-    {
-      "role": "user",
-      "content": "What tools can help me check the weather?"
-    }
-  ],
-  "tools": [
-    {
-      "type": "function",
-      "function": {
-        "name": "get_weather",
-        "description": "Get current weather"
-      }
-    },
-    {
-      "type": "function",
-      "function": {
-        "name": "send_email",
-        "description": "Send an email notification"
-      }
-    }
-  ]
-}
-```
 
 ### Scenario 2: Filtering Tools by Threshold
 

--- a/docs/semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md
+++ b/docs/semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md
@@ -26,10 +26,10 @@ This policy helps reduce token consumption and improve LLM response quality by s
 | selectionMode | string | Yes | `By Rank` | Method used to filter tools: `By Rank` (selects top-K) or `By Threshold` (selects based on score). |
 | limit | integer | No | `5` | The number of most relevant tools to include (used if selectionMode is `By Rank`). |
 | threshold | number | No | `0.7` | Similarity threshold for filtering (0.0 to 1.0). Only tools with a score above this value are included (used if selectionMode is `By Threshold`). |
-| queryJSONPath | string | No | `$.messages[-1].content` | JSONPath expression to extract the user's query from the request body. |
-| toolsJSONPath | string | No | `$.tools` | JSONPath expression to extract the tools array from the request body (used when `toolsIsJson` is true). |
-| userQueryIsJson | boolean | No | `true` | Specifies format of user query. `true`: use `queryJSONPath`. `false`: extract from text using `<userq>` tags. |
-| toolsIsJson | boolean | No | `true` | Specifies format of tools definition. `true`: use `toolsJSONPath`. `false`: extract from text using `<toolname>`/`<tooldescription>` tags. |
+| queryJSONPath | string | Yes | `$.messages[-1].content` | JSONPath expression to extract the user's query from the request body. |
+| toolsJSONPath | string | Yes | `$.tools` | JSONPath expression to extract the tools definition from the request body. It can point to the array itself, such as `$.tools`, or to the iterated object inside each array item, such as `$.tools[*].function`. |
+| userQueryIsJson | boolean | Yes | `true` | Specifies format of user query. `true`: use `queryJSONPath`. `false`: extract from text using `<userq>` tags. |
+| toolsIsJson | boolean | Yes | `true` | Specifies format of tools definition. `true`: use `toolsJSONPath`. `false`: extract from text using `<toolname>`/`<tooldescription>` tags. |
 
 ### System Parameters (From config.toml)
 
@@ -125,25 +125,9 @@ policies:
 
 The policy will interpret the request, calculate embeddings, and filter the `tools` array to include only the top 3 matches (e.g., `get_weather`, `book_venue`, `send_email`).
 
-### Scenario 2: Filtering Tools by Threshold
+### Scenario 1b: OpenAI/Mistral-style Function Wrappers
 
-In this scenario, only tools with a semantic similarity score of 0.7 or higher are included.
-
-**Configuration:**
-
-```yaml
-type: http
-policies:
-  - policy:
-      name: semantic-tool-filtering
-      parameters:
-        selectionMode: "By Threshold"
-        threshold: 0.7
-```
-
-### Scenario 3: Text Format (XML-like Tags)
-
-This scenario handles cases where the user query and tool definitions are embedded in a text payload using custom tags.
+If the request wraps each tool as an object with a nested `function`, configure the iterator path so the policy reads `name` and `description` from the nested object while still filtering the parent `tools` array.
 
 **Configuration:**
 
@@ -155,8 +139,75 @@ policies:
       parameters:
         selectionMode: "By Rank"
         limit: 3
+        queryJSONPath: "$.messages[-1].content"
+        toolsJSONPath: "$.tools[*].function"
+        userQueryIsJson: true
+        toolsIsJson: true
+```
+
+**Request:**
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What tools can help me check the weather?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather"
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Send an email notification"
+      }
+    }
+  ]
+}
+```
+
+### Scenario 2: Filtering Tools by Threshold
+
+In this scenario, only tools with a semantic similarity score of 0.7 or higher are included.
+
+**Configuration:**
+
+```yaml
+policies:
+  - policy:
+      name: semantic-tool-filtering
+      parameters:
+        selectionMode: "By Threshold"
+        threshold: 0.7
+        # Rest of the parameters
+```
+
+### Scenario 3: Text Format (XML-like Tags)
+
+This scenario handles cases where the user query and tool definitions are embedded in a text payload using custom tags.
+
+**Configuration:**
+
+```yaml
+policies:
+  - policy:
+      name: semantic-tool-filtering
+      parameters:
+        selectionMode: "By Rank"
+        limit: 3
         userQueryIsJson: false
         toolsIsJson: false
+        queryJSONPath: "$.messages[-1].content.text"
+        toolsJSONPath: "$.messages[-1].content.text"
+
 ```
 
 **Request Body:**

--- a/policies/semantic-tool-filtering/go.mod
+++ b/policies/semantic-tool-filtering/go.mod
@@ -1,4 +1,4 @@
-module github.com/NaveenSandaruwan/gateway-controllers/policies/semantic-tool-filtering
+module github.com/wso2/gateway-controllers/policies/semantic-tool-filtering
 
 go 1.26.1
 

--- a/policies/semantic-tool-filtering/go.mod
+++ b/policies/semantic-tool-filtering/go.mod
@@ -1,4 +1,4 @@
-module github.com/wso2/gateway-controllers/policies/semantic-tool-filtering
+module github.com/NaveenSandaruwan/gateway-controllers/policies/semantic-tool-filtering
 
 go 1.26.1
 

--- a/policies/semantic-tool-filtering/methodsforv1alpha2.go
+++ b/policies/semantic-tool-filtering/methodsforv1alpha2.go
@@ -28,6 +28,84 @@ import (
 	utils "github.com/wso2/api-platform/sdk/core/utils"
 )
 
+type jsonToolEntry struct {
+	original map[string]interface{}
+	inspect  map[string]interface{}
+}
+
+func parseJSONArray(value interface{}) ([]interface{}, error) {
+	var items []interface{}
+	var itemsBytes []byte
+
+	switch v := value.(type) {
+	case []byte:
+		itemsBytes = v
+	case string:
+		itemsBytes = []byte(v)
+	default:
+		var err error
+		itemsBytes, err = json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := json.Unmarshal(itemsBytes, &items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+func extractJSONToolEntries(requestBody map[string]interface{}, toolsPath string) ([]jsonToolEntry, string, error) {
+	spec, err := parseToolsJSONPath(toolsPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	toolsJSON, err := utils.ExtractValueFromJsonpath(requestBody, spec.arrayPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	items, err := parseJSONArray(toolsJSON)
+	if err != nil {
+		return nil, "", err
+	}
+
+	entries := make([]jsonToolEntry, 0, len(items))
+	for _, item := range items {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		inspectMap := itemMap
+		if spec.iteratedObjectSubpath != "" {
+			inspectValue, err := extractValueFromRelativePath(itemMap, spec.iteratedObjectSubpath)
+			if err != nil {
+				return nil, "", err
+			}
+			if inspectValue == nil {
+				continue
+			}
+
+			nestedMap, ok := inspectValue.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			inspectMap = nestedMap
+		}
+
+		entries = append(entries, jsonToolEntry{
+			original: itemMap,
+			inspect:  inspectMap,
+		})
+	}
+
+	return entries, spec.arrayPath, nil
+}
+
 // OnRequestBody is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
 func (p *SemanticToolFilteringPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.RequestContext, _ map[string]interface{}) policy.RequestAction {
 	return p.processRequestBody(reqCtx)
@@ -76,32 +154,12 @@ func (p *SemanticToolFilteringPolicy) handleJSONRequest(reqCtx *policy.RequestCo
 		return policy.UpstreamRequestModifications{}
 	}
 
-	// Extract tools array using JSONPath
-	toolsJSON, err := utils.ExtractValueFromJsonpath(requestBody, p.toolsJSONPath)
+	toolEntries, updatePath, err := extractJSONToolEntries(requestBody, p.toolsJSONPath)
 	if err != nil {
 		return p.buildErrorResponse("Error extracting tools from JSONPath", err)
 	}
 
-	// Parse tools array
-	var tools []interface{}
-	var toolsBytes []byte
-	switch v := toolsJSON.(type) {
-	case []byte:
-		toolsBytes = v
-	case string:
-		toolsBytes = []byte(v)
-	default:
-		var err error
-		toolsBytes, err = json.Marshal(v)
-		if err != nil {
-			return p.buildErrorResponse("Invalid tools format in request", err)
-		}
-	}
-	if err := json.Unmarshal(toolsBytes, &tools); err != nil {
-		return p.buildErrorResponse("Invalid tools format in request", err)
-	}
-
-	if len(tools) == 0 {
+	if len(toolEntries) == 0 {
 		slog.Debug("SemanticToolFiltering: No tools to filter")
 		return policy.UpstreamRequestModifications{}
 	}
@@ -121,24 +179,17 @@ func (p *SemanticToolFilteringPolicy) handleJSONRequest(reqCtx *policy.RequestCo
 
 	// Prepare embedding requests for all valid tools
 	var embeddingRequests []toolEmbeddingRequest
-	toolDescMap := make(map[string]string)                   // hashKey -> toolDesc for similarity calculation
 	toolMapByHash := make(map[string]map[string]interface{}) // hashKey -> toolMap
 
-	for _, toolRaw := range tools {
-		toolMap, ok := toolRaw.(map[string]interface{})
-		if !ok {
-			slog.Warn("SemanticToolFiltering: Invalid tool format, skipping")
-			continue
-		}
-
-		toolDesc := extractToolDescription(toolMap)
+	for _, entry := range toolEntries {
+		toolName, toolDescription := extractToolNameAndDescription(entry.inspect)
+		toolDesc := buildToolEmbeddingText(toolName, toolDescription)
 		if toolDesc == "" {
 			slog.Warn("SemanticToolFiltering: No description found for tool, skipping",
-				"toolName", toolMap["name"])
+				"toolName", toolName)
 			continue
 		}
 
-		toolName, _ := toolMap["name"].(string)
 		descHash := p.getCacheKey(toolDesc)
 
 		embeddingRequests = append(embeddingRequests, toolEmbeddingRequest{
@@ -146,8 +197,7 @@ func (p *SemanticToolFilteringPolicy) handleJSONRequest(reqCtx *policy.RequestCo
 			Description: toolDesc,
 			HashKey:     descHash,
 		})
-		toolDescMap[descHash] = toolDesc
-		toolMapByHash[descHash] = toolMap
+		toolMapByHash[descHash] = entry.original
 	}
 
 	// Process embeddings with proper cache management (avoids cascade evictions)
@@ -183,12 +233,12 @@ func (p *SemanticToolFilteringPolicy) handleJSONRequest(reqCtx *policy.RequestCo
 	filteredTools := p.filterTools(toolsWithScores)
 
 	slog.Debug("SemanticToolFiltering: Filtered tools",
-		"originalCount", len(tools),
+		"originalCount", len(toolEntries),
 		"filteredCount", len(filteredTools),
 		"selectionMode", p.selectionMode)
 
 	// Update request body with filtered tools
-	if err := updateToolsInRequestBody(&requestBody, p.toolsJSONPath, filteredTools); err != nil {
+	if err := updateToolsInRequestBody(&requestBody, updatePath, filteredTools); err != nil {
 		return p.buildErrorResponse("Error updating request body with filtered tools", err)
 	}
 
@@ -382,30 +432,12 @@ func (p *SemanticToolFilteringPolicy) handleMixedRequest(reqCtx *policy.RequestC
 			return p.buildErrorResponse("Invalid JSON in request body", err)
 		}
 
-		toolsJSON, err := utils.ExtractValueFromJsonpath(requestBody, p.toolsJSONPath)
+		toolEntries, updatePath, err := extractJSONToolEntries(requestBody, p.toolsJSONPath)
 		if err != nil {
 			return p.buildErrorResponse("Error extracting tools from JSONPath", err)
 		}
 
-		var tools []interface{}
-		var toolsBytes []byte
-		switch v := toolsJSON.(type) {
-		case []byte:
-			toolsBytes = v
-		case string:
-			toolsBytes = []byte(v)
-		default:
-			var err error
-			toolsBytes, err = json.Marshal(v)
-			if err != nil {
-				return p.buildErrorResponse("Invalid tools format in request", err)
-			}
-		}
-		if err := json.Unmarshal(toolsBytes, &tools); err != nil {
-			return p.buildErrorResponse("Invalid tools format in request", err)
-		}
-
-		if len(tools) == 0 {
+		if len(toolEntries) == 0 {
 			slog.Debug("SemanticToolFiltering: No tools to filter")
 			return policy.UpstreamRequestModifications{}
 		}
@@ -413,20 +445,14 @@ func (p *SemanticToolFilteringPolicy) handleMixedRequest(reqCtx *policy.RequestC
 		var embeddingRequests []toolEmbeddingRequest
 		toolMapByHash := make(map[string]map[string]interface{})
 
-		for _, toolRaw := range tools {
-			toolMap, ok := toolRaw.(map[string]interface{})
-			if !ok {
-				slog.Warn("SemanticToolFiltering: Invalid tool format, skipping")
-				continue
-			}
-
-			toolDesc := extractToolDescription(toolMap)
+		for _, entry := range toolEntries {
+			toolName, toolDescription := extractToolNameAndDescription(entry.inspect)
+			toolDesc := buildToolEmbeddingText(toolName, toolDescription)
 			if toolDesc == "" {
-				slog.Warn("SemanticToolFiltering: No description found for tool, skipping")
+				slog.Warn("SemanticToolFiltering: No description found for tool, skipping", "toolName", toolName)
 				continue
 			}
 
-			toolName, _ := toolMap["name"].(string)
 			descHash := p.getCacheKey(toolDesc)
 
 			embeddingRequests = append(embeddingRequests, toolEmbeddingRequest{
@@ -434,7 +460,7 @@ func (p *SemanticToolFilteringPolicy) handleMixedRequest(reqCtx *policy.RequestC
 				Description: toolDesc,
 				HashKey:     descHash,
 			})
-			toolMapByHash[descHash] = toolMap
+			toolMapByHash[descHash] = entry.original
 		}
 
 		embeddingResults := p.processToolEmbeddingsWithCache(embeddingCache, apiId, embeddingRequests)
@@ -465,7 +491,7 @@ func (p *SemanticToolFilteringPolicy) handleMixedRequest(reqCtx *policy.RequestC
 
 		filteredTools := p.filterTools(toolsWithScores)
 
-		if err := updateToolsInRequestBody(&requestBody, p.toolsJSONPath, filteredTools); err != nil {
+		if err := updateToolsInRequestBody(&requestBody, updatePath, filteredTools); err != nil {
 			return p.buildErrorResponse("Error updating request body with filtered tools", err)
 		}
 

--- a/policies/semantic-tool-filtering/policy-definition.yaml
+++ b/policies/semantic-tool-filtering/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: semantic-tool-filtering
-version: v1.0.0
+version: v1.0.1
 description: |
   Dynamically filters the tools provided within an API request based on their semantic relevance to the
   user query. This policy extracts both the query and the tool definitions from the incoming payload,

--- a/policies/semantic-tool-filtering/policy-definition.yaml
+++ b/policies/semantic-tool-filtering/policy-definition.yaml
@@ -49,10 +49,11 @@ parameters:
       type: string
       x-wso2-policy-advanced-param: true
       description: |
-        JSONPath expression to extract the tools array from the request body (used when toolsIsJson is true).
-        Example: "$.tools"
+        JSONPath expression to extract the tools definition from the request body (used when toolsIsJson is true).
+        This can point to the tools array itself (for example, "$.tools") or to the iterated
+        object inside each array item using a single wildcard (for example, "$.tools[*].function").
       default: "$.tools"
-      pattern: '^(?:\$\.)?[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$'
+      pattern: '^\$\.([A-Za-z_][A-Za-z0-9_]*(\[(\d+|\*)\])?\.)*[A-Za-z_][A-Za-z0-9_]*(\[(\d+|\*)\])?$'
     userQueryIsJson:
       type: boolean
       x-wso2-policy-advanced-param: true

--- a/policies/semantic-tool-filtering/semantictoolfiltering.go
+++ b/policies/semantic-tool-filtering/semantictoolfiltering.go
@@ -237,7 +237,6 @@ func GetPolicy(
 	return p, nil
 }
 
-
 // Mode returns the processing mode for the semantic tool filtering policy.
 func (p *SemanticToolFilteringPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
@@ -466,10 +465,14 @@ func extractBool(value interface{}) (bool, error) {
 	}
 }
 
-// simpleJSONPathPattern validates that a JSONPath is a simple dotted path with optional array indices
-// Supports patterns like: $.tools, $.data.items, $.results[0].tools, $.a.b[1].c[2].d
-// Does NOT support: complex JSONPath expressions like $..[*], $..book[?(@.price<10)], etc.
-var simpleJSONPathPattern = regexp.MustCompile(`^\$\.([a-zA-Z_][a-zA-Z0-9_]*(\[\d+\])?\.)*[a-zA-Z_][a-zA-Z0-9_]*(\[\d+\])?$`)
+// jsonPathSegmentPattern validates a single JSONPath segment with an optional
+// numeric array index or a single wildcard iterator marker.
+var jsonPathSegmentPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*(\[(\d+|\*)\])?$`)
+
+type toolsPathSpec struct {
+	arrayPath             string
+	iteratedObjectSubpath string
+}
 
 // validateSimpleJSONPath validates that the given JSONPath is a simple dotted path
 // that can be handled by updateToolsInRequestBody
@@ -483,12 +486,105 @@ func validateSimpleJSONPath(path string) error {
 		return fmt.Errorf("path must start with '$.' prefix, got: %s", path)
 	}
 
-	// Validate against the simple pattern
-	if !simpleJSONPathPattern.MatchString(path) {
-		return fmt.Errorf("path contains unsupported JSONPath syntax; only simple dotted paths with optional array indices are supported (e.g., '$.tools', '$.data.items', '$.results[0].tools'); got: %s", path)
+	segments := strings.Split(strings.TrimPrefix(path, "$."), ".")
+	wildcardCount := 0
+
+	for _, segment := range segments {
+		if segment == "" {
+			return fmt.Errorf("path contains an empty segment: %s", path)
+		}
+		if !jsonPathSegmentPattern.MatchString(segment) {
+			return fmt.Errorf("path contains unsupported JSONPath syntax; only simple dotted paths with optional array indices or a single iterator wildcard are supported (e.g., '$.tools', '$.results[0].tools', '$.tools[*].function'); got: %s", path)
+		}
+		if strings.Contains(segment, "[*]") {
+			wildcardCount++
+		}
+	}
+
+	if wildcardCount > 1 {
+		return fmt.Errorf("path can contain at most one iterator wildcard [*]: %s", path)
 	}
 
 	return nil
+}
+
+func parseToolsJSONPath(path string) (toolsPathSpec, error) {
+	if err := validateSimpleJSONPath(path); err != nil {
+		return toolsPathSpec{}, err
+	}
+
+	spec := toolsPathSpec{arrayPath: path}
+	wildcardIdx := strings.Index(path, "[*]")
+	if wildcardIdx == -1 {
+		return spec, nil
+	}
+
+	spec.arrayPath = path[:wildcardIdx]
+	suffix := path[wildcardIdx+3:]
+	if suffix == "" {
+		return spec, nil
+	}
+	if !strings.HasPrefix(suffix, ".") {
+		return toolsPathSpec{}, fmt.Errorf("invalid tools path after iterator wildcard: %s", path)
+	}
+
+	spec.iteratedObjectSubpath = strings.TrimPrefix(suffix, ".")
+	return spec, nil
+}
+
+func extractValueFromRelativePath(root interface{}, relativePath string) (interface{}, error) {
+	if relativePath == "" {
+		return root, nil
+	}
+
+	segments := strings.Split(relativePath, ".")
+	current := root
+
+	for _, segment := range segments {
+		if segment == "" {
+			return nil, fmt.Errorf("relative path contains an empty segment: %s", relativePath)
+		}
+		if strings.Contains(segment, "[*]") {
+			return nil, fmt.Errorf("relative path cannot contain iterator wildcard [*]: %s", relativePath)
+		}
+		if !jsonPathSegmentPattern.MatchString(segment) {
+			return nil, fmt.Errorf("relative path contains unsupported syntax: %s", relativePath)
+		}
+
+		field := segment
+		index := -1
+		if openIdx := strings.Index(segment, "["); openIdx != -1 && strings.HasSuffix(segment, "]") {
+			field = segment[:openIdx]
+			indexValue, err := strconv.Atoi(segment[openIdx+1 : len(segment)-1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid array index in relative path: %s", segment)
+			}
+			index = indexValue
+		}
+
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, nil
+		}
+
+		next, ok := currentMap[field]
+		if !ok {
+			return nil, nil
+		}
+
+		if index == -1 {
+			current = next
+			continue
+		}
+
+		array, ok := next.([]interface{})
+		if !ok || index < 0 || index >= len(array) {
+			return nil, nil
+		}
+		current = array[index]
+	}
+
+	return current, nil
 }
 
 // createEmbeddingProvider creates a new embedding provider based on the config
@@ -644,36 +740,51 @@ func cleanupWhitespace(content string) string {
 	return content
 }
 
-// extractToolDescription extracts description text from a tool definition
-func extractToolDescription(tool map[string]interface{}) string {
-	// Try common fields for tool description
-	fields := []string{"description", "desc", "summary", "info"}
-
-	for _, field := range fields {
-		if desc, ok := tool[field].(string); ok && desc != "" {
-			return desc
-		}
-	}
-
-	// If no description field, try to use name + function description
+func extractToolNameAndDescription(tool map[string]interface{}) (string, string) {
 	name, _ := tool["name"].(string)
 
-	// Check for function/parameters structure (OpenAI format)
-	if function, ok := tool["function"].(map[string]interface{}); ok {
-		if desc, ok := function["description"].(string); ok && desc != "" {
-			if name != "" {
-				return fmt.Sprintf("%s: %s", name, desc)
-			}
-			return desc
+	fields := []string{"description", "desc", "summary", "info"}
+	description := ""
+	for _, field := range fields {
+		if desc, ok := tool[field].(string); ok && desc != "" {
+			description = desc
+			break
 		}
 	}
 
-	// Fallback to just name if available
-	if name != "" {
-		return name
+	// Support OpenAI-style wrappers such as {"type":"function","function":{...}}
+	if function, ok := tool["function"].(map[string]interface{}); ok {
+		if name == "" {
+			if nestedName, ok := function["name"].(string); ok && nestedName != "" {
+				name = nestedName
+			}
+		}
+		if description == "" {
+			for _, field := range fields {
+				if desc, ok := function[field].(string); ok && desc != "" {
+					description = desc
+					break
+				}
+			}
+		}
 	}
 
-	return ""
+	return name, description
+}
+
+func buildToolEmbeddingText(name, description string) string {
+	if name != "" && description != "" {
+		return fmt.Sprintf("%s: %s", name, description)
+	}
+	if description != "" {
+		return description
+	}
+	return name
+}
+
+// extractToolDescription extracts the text used to represent a tool for embedding generation.
+func extractToolDescription(tool map[string]interface{}) string {
+	return buildToolEmbeddingText(extractToolNameAndDescription(tool))
 }
 
 // cosineSimilarity calculates cosine similarity between two embeddings
@@ -734,8 +845,13 @@ func (p *SemanticToolFilteringPolicy) filterTools(toolsWithScores []ToolWithScor
 
 // updateToolsInRequestBody updates the tools array in the request body
 func updateToolsInRequestBody(requestBody *map[string]interface{}, toolsPath string, tools []map[string]interface{}) error {
+	spec, err := parseToolsJSONPath(toolsPath)
+	if err != nil {
+		return err
+	}
+
 	// Remove leading "$." if present
-	path := strings.TrimPrefix(toolsPath, "$.")
+	path := strings.TrimPrefix(spec.arrayPath, "$.")
 	parts := strings.Split(path, ".")
 
 	if len(parts) == 0 {


### PR DESCRIPTION
## Summary

Fix `semantic-tool-filtering` so `toolsJSONPath` can target either:

- the tools array directly, such as `$.tools`
- an iterated nested tool object, such as `$.tools[*].function`

This allows the policy to work with OpenAI/Mistral-style tool payloads where tool metadata lives under `function.name` and `function.description`.

## What Changed

- added support for a single iterator wildcard in `toolsJSONPath`
- normalized iterator paths like `$.tools[*].function` back to the parent array path for request-body updates
- added relative-path extraction for nested iterated tool objects
- updated tool metadata extraction to read:
  - top-level `name` / `description`
  - nested `function.name` / `function.description`
- preserved the original request payload shape after filtering
  - wrapper objects such as `{ "type": "function", "function": { ... } }` remain unchanged
  - direct tool objects under `$.tools` also remain unchanged
- updated policy definition and docs to describe the new `toolsJSONPath` behavior

## Example

This now works correctly for payloads like:

```yaml
queryJSONPath: "$.messages[0].content"
toolsJSONPath: "$.tools[*].function"
```

with requests shaped like:

```json
{
  "messages": [
    {
      "role": "user",
      "content": "Give current weather of Sri Lanka"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get current weather"
      }
    }
  ]
}
```

## Mistral LlmProvider Example

```yaml
apiVersion: gateway.api-platform.wso2.com/v1alpha1
kind: LlmProvider
metadata:
  name: mistral-agent
spec:
  displayName: Mistral agent
  version: v1.0
  template: mistralai
  upstream:
    url: "https://api.mistral.ai/v1"
    auth:
      type: api-key
      header: Authorization
      value: "Bearer <api key>"
  accessControl:
    mode: deny_all
    exceptions:
      - path: /chat/completions
        methods: [POST]
  policies:
    - name: semantic-tool-filtering
      version: v1
      paths:
        - path: /chat/completions
          methods: [POST]
          params:
            selectionMode: "By Rank"
            limit: 2
            queryJSONPath: "$.messages[0].content"
            toolsJSONPath: "$.tools[*].function"
            userQueryIsJson: true
            toolsIsJson: true
```

### Example Request Body

```json
{
  "model": "mistral-large-latest",
  "messages": [
    {
      "role": "user",
      "content": "Give current weather of Sri Lanka"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get current weather"
      }
    },
    {
      "type": "function",
      "function": {
        "name": "send_email",
        "description": "Send email notification"
      }
    },
    {
      "type": "function",
      "function": {
        "name": "calculate_tax",
        "description": "Calculate sales tax"
      }
    }
  ]
}
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked key JSON-related parameters as required and added a new scenario clarifying OpenAI/Mistral-style function wrapper configuration.

* **New Features**
  * Support for targeting nested tool structures (e.g., $.tools[*].function) and improved tool extraction and embedding text construction.

* **Policy Updates**
  * Policy version bumped to v1.0.1 with stricter JSONPath validation and clearer parameter descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->