### PR TITLE
feat(host-rewrite): add policy to rewrite Host header before upstream

### DIFF
--- a/docs/host-rewrite/v1.0/docs/host-rewrite.md
+++ b/docs/host-rewrite/v1.0/docs/host-rewrite.md
@@ -1,0 +1,91 @@
+---
+title: "Overview"
+---
+# Host Rewrite
+
+## Overview
+
+The Host Rewrite policy sets (rewrites) the Host/:authority header on requests before
+they are forwarded to the upstream. This is useful when the upstream expects a
+specific Host header that differs from the incoming request's Host.
+
+Important: for the kernel to forward the request using the rewritten Host, the
+upstream definition must set hostRewrite: manual on the named upstream.
+
+Example upstream configuration:
+
+```yaml
+upstream:
+  main:
+    url: "http://example.com"
+    hostRewrite: manual
+```
+
+## Features
+
+- Rewrite the Host/:authority header sent to the upstream
+- Simple single-parameter configuration (host)
+- Validates that a non-empty host string is provided
+
+## Configuration
+
+This policy expects a single parameter `host` (string) that contains the Host
+value to send to the upstream. The parameter is configured in the API/operation
+policies list in the API definition YAML.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `host` | string | Yes | The Host header value to set on the upstream request. Allowed characters: letters, digits, `-` and `.`. Length: 1-255. |
+
+### Sample policy params
+
+```yaml
+- name: host-rewrite
+  version: v1
+  params:
+    host: example-updated.com
+```
+
+## Example API snippet
+
+Apply the policy to the API (or an operation). The upstream must use `hostRewrite: manual`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: example-api
+spec:
+  displayName: Example API
+  version: v1
+  context: /example/$version
+  upstream:
+    main:
+      url: http://example-backend:8080
+      hostRewrite: manual
+  policies:
+    - name: host-rewrite
+      version: v1
+      params:
+        host: example-updated.com
+```
+
+## How it works
+
+- At request header processing, the policy validates the `host` parameter.
+- If valid, it returns an UpstreamRequestHeaderModifications action with the
+  Host field set to the configured value. The kernel applies this before
+  forwarding the request to the upstream.
+- If configuration is invalid (missing/empty/incorrect type), the policy
+  returns an immediate 500 configuration error response.
+
+## Notes
+
+- The policy only rewrites the Host sent to upstream; it does not change the
+  request URL or routing unless the upstream uses the Host for virtual hosting.
+- Ensure `host` is a hostname optionally including ports if required by your
+  upstream (e.g. `backend.example.com:8080`).
+- The upstream `hostRewrite: manual` setting is required for the rewritten Host
+  to be used when forwarding to the upstream.

--- a/docs/host-rewrite/v1.0/metadata.json
+++ b/docs/host-rewrite/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "host-rewrite",
+  "displayName": "Host Rewrite",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation",
+    "Routing"
+  ],
+  "description": "Sets the Host/:authority header sent to the upstream. Useful when the upstream requires a specific Host value different from the incoming request. Requires upstream.hostRewrite set to 'manual'."
+}

--- a/policies/host-rewrite/go.mod
+++ b/policies/host-rewrite/go.mod
@@ -1,0 +1,5 @@
+module github.com/wso2/gateway-controllers/policies/host-rewrite
+
+go 1.26.1
+
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/host-rewrite/go.sum
+++ b/policies/host-rewrite/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.9 h1:3lvAsMlLhy8nNgPL24/UFS/f4sq5e+XpryA4L1PO7dU=
+github.com/wso2/api-platform/sdk/core v0.2.9/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/host-rewrite/hostrewrite.go
+++ b/policies/host-rewrite/hostrewrite.go
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package hostrewrite
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+var ins = &HostRewritePolicy{}
+
+// HostRewritePolicy implements host header rewriting for upstream requests
+type HostRewritePolicy struct{}
+
+// GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	return ins, nil
+}
+
+func (p *HostRewritePolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// policyConfig holds the configuration for the host-rewrite policy
+type policyConfig struct {
+	Host string `json:"host"`
+}
+
+// parseConfig extracts and validates the host parameter from the policy configuration
+func parseConfig(params map[string]interface{}) (*policyConfig, error) {
+	if len(params) == 0 {
+		return nil, fmt.Errorf("host parameter is required")
+	}
+
+	hostRaw, ok := params["host"]
+	if !ok {
+		return nil, fmt.Errorf("host parameter is required")
+	}
+
+	host, ok := hostRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("host parameter must be a string")
+	}
+
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil, fmt.Errorf("host parameter cannot be empty")
+	}
+
+	return &policyConfig{
+		Host: host,
+	}, nil
+}
+
+// OnRequestHeaders rewrites the Host header (authority) before forwarding the request to upstream
+func (p *HostRewritePolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
+	cfg, err := parseConfig(params)
+	if err != nil {
+		slog.Error("[Host Rewrite]: Configuration error", "error", err)
+		return policy.ImmediateResponse{
+			StatusCode: 500,
+			Headers:    map[string]string{"content-type": "application/json"},
+			Body:       []byte(fmt.Sprintf(`{"error":"Configuration Error","message":"%s"}`, err.Error())),
+		}
+	}
+
+	slog.Info("[Host Rewrite]: Rewriting host header", "from", reqCtx.Headers.Get(":authority"), "to", cfg.Host)
+
+	return policy.UpstreamRequestHeaderModifications{
+		Host: &cfg.Host,
+	}
+}

--- a/policies/host-rewrite/hostrewrite_test.go
+++ b/policies/host-rewrite/hostrewrite_test.go
@@ -1,0 +1,350 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package hostrewrite
+
+import (
+	"context"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+func TestHostRewritePolicy_OnRequestHeaders_ValidHost(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "new-backend.example.com",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original-host.example.com"},
+			"content-type": {"application/json"},
+		}),
+		Path:   "/api/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	// Verify the result is UpstreamRequestHeaderModifications
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	// Verify Host field is set correctly
+	if mods.Host == nil {
+		t.Fatal("Expected Host to be set, got nil")
+	}
+
+	if *mods.Host != "new-backend.example.com" {
+		t.Errorf("Expected Host to be 'new-backend.example.com', got '%s'", *mods.Host)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_HostWithDash(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "api-backend-v2.example.com",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/",
+		Method: "POST",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if mods.Host == nil || *mods.Host != "api-backend-v2.example.com" {
+		t.Errorf("Expected Host to be 'api-backend-v2.example.com', got %v", mods.Host)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_HostWithPort(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "backend.example.com",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"frontend.example.com:8080"},
+		}),
+		Path:   "/api/users",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if mods.Host == nil || *mods.Host != "backend.example.com" {
+		t.Errorf("Expected Host to be 'backend.example.com', got %v", mods.Host)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_MissingHostParam(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	// Should return ImmediateResponse with error
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+
+	if immResp.Headers["content-type"] != "application/json" {
+		t.Errorf("Expected content-type application/json, got %s", immResp.Headers["content-type"])
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_EmptyHostParam(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_WhitespaceHostParam(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "   ",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_InvalidHostParamType(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": 12345, // Invalid type
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_NilParams(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"original.example.com"},
+		}),
+		Path:   "/test",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, nil)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestHostRewritePolicy_Mode(t *testing.T) {
+	p := &HostRewritePolicy{}
+	mode := p.Mode()
+
+	if mode.RequestHeaderMode != policy.HeaderModeProcess {
+		t.Errorf("Expected RequestHeaderMode to be HeaderModeProcess, got %v", mode.RequestHeaderMode)
+	}
+
+	if mode.RequestBodyMode != policy.BodyModeSkip {
+		t.Errorf("Expected RequestBodyMode to be BodyModeSkip, got %v", mode.RequestBodyMode)
+	}
+
+	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+		t.Errorf("Expected ResponseHeaderMode to be HeaderModeSkip, got %v", mode.ResponseHeaderMode)
+	}
+
+	if mode.ResponseBodyMode != policy.BodyModeSkip {
+		t.Errorf("Expected ResponseBodyMode to be BodyModeSkip, got %v", mode.ResponseBodyMode)
+	}
+}
+
+func TestHostRewritePolicy_GetPolicy(t *testing.T) {
+	metadata := policy.PolicyMetadata{
+		RouteName:  "test-route",
+		APIId:      "test-api-id",
+		APIName:    "test-api",
+		APIVersion: "v1.0.0",
+		AttachedTo: policy.LevelRoute,
+	}
+
+	params := map[string]interface{}{
+		"host": "backend.example.com",
+	}
+
+	pol, err := GetPolicy(metadata, params)
+	if err != nil {
+		t.Fatalf("Expected no error from GetPolicy, got %v", err)
+	}
+
+	if pol == nil {
+		t.Fatal("Expected policy instance, got nil")
+	}
+
+	_, ok := pol.(*HostRewritePolicy)
+	if !ok {
+		t.Fatalf("Expected *HostRewritePolicy, got %T", pol)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_HostWithSubdomains(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "api.v2.staging.backend.example.com",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"www.frontend.example.com"},
+		}),
+		Path:   "/api/resource",
+		Method: "PUT",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if mods.Host == nil || *mods.Host != "api.v2.staging.backend.example.com" {
+		t.Errorf("Expected Host to be 'api.v2.staging.backend.example.com', got %v", mods.Host)
+	}
+}
+
+func TestHostRewritePolicy_OnRequestHeaders_HostTrimmedWhitespace(t *testing.T) {
+	p := &HostRewritePolicy{}
+
+	params := map[string]interface{}{
+		"host": "  backend.example.com  ",
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		Headers: policy.NewHeaders(map[string][]string{
+			":authority": {"frontend.example.com"},
+		}),
+		Path:   "/",
+		Method: "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if mods.Host == nil || *mods.Host != "backend.example.com" {
+		t.Errorf("Expected Host to be 'backend.example.com' (trimmed), got %v", mods.Host)
+	}
+}

--- a/policies/host-rewrite/policy-definition.yaml
+++ b/policies/host-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: host-rewrite
-version: v0.1.0
+version: v1.0.0
 description: |
   Rewrite the Host header of incoming requests before forwarding to the upstream.
 

--- a/policies/host-rewrite/policy-definition.yaml
+++ b/policies/host-rewrite/policy-definition.yaml
@@ -1,0 +1,21 @@
+name: host-rewrite
+version: v0.1.0
+description: |
+  Rewrite the Host header of incoming requests before forwarding to the upstream.
+
+parameters:
+  type: object
+  properties:
+    host:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: The new Host header value to set for the request.
+      minLength: 1
+      maxLength: 255
+      pattern: "^[a-zA-Z0-9.-]+$"
+  required:
+    - host
+systemParameters:
+  type: object
+  additionalProperties: false
+  properties: {}


### PR DESCRIPTION
## Purpose
Related issue: https://github.com/wso2/api-platform/issues/1598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Host Rewrite policy to customize Host/authority headers in upstream requests with parameter validation and error handling for invalid configurations.

* **Documentation**
  * Added comprehensive documentation, metadata, and policy definitions for the Host Rewrite policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->