### PR TITLE
docs: update gomodule version to v1 for multiple policy documents

### DIFF
--- a/docs/advanced-ratelimit/v1.0/docs/advanced-ratelimit.md
+++ b/docs/advanced-ratelimit/v1.0/docs/advanced-ratelimit.md
@@ -247,7 +247,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: advanced-ratelimit
-  gomodule: github.com/wso2/gateway-controllers/policies/advanced-ratelimit@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/advanced-ratelimit@v1
 ```
 
 ## Reference Scenarios

--- a/docs/analytics-header-filter/v1.0/docs/analytics-header-filter.md
+++ b/docs/analytics-header-filter/v1.0/docs/analytics-header-filter.md
@@ -74,7 +74,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: analytics-header-filter
-  gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/analytics-header-filter@v1
 ```
 
 ## Reference Scenarios

--- a/docs/api-key-auth/v1.0/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.0/docs/apikey-authentication.md
@@ -48,7 +48,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: api-key-auth
-  gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
 ```
 
 ## Reference Scenarios

--- a/docs/aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md
@@ -104,7 +104,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: aws-bedrock-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md
+++ b/docs/azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md
@@ -94,7 +94,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: azure-content-safety-content-moderation
-  gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/azure-content-safety-content-moderation@v1
 ```
 
 ## Reference Scenarios

--- a/docs/basic-auth/v1.0/docs/basic-auth.md
+++ b/docs/basic-auth/v1.0/docs/basic-auth.md
@@ -39,7 +39,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: basic-auth
-  gomodule: github.com/wso2/gateway-controllers/policies/basic-auth@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/basic-auth@v1
 ```
 
 ## Reference Scenarios

--- a/docs/basic-ratelimit/v1.0/docs/basic-ratelimit.md
+++ b/docs/basic-ratelimit/v1.0/docs/basic-ratelimit.md
@@ -80,7 +80,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: basic-ratelimit
-  gomodule: github.com/wso2/gateway-controllers/policies/basic-ratelimit@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/basic-ratelimit@v1
 ```
 
 ## Reference Scenarios

--- a/docs/content-length-guardrail/v1.0/docs/content-length.md
+++ b/docs/content-length-guardrail/v1.0/docs/content-length.md
@@ -74,7 +74,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: content-length-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/content-length-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/content-length-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/cors/v1.0/docs/cors.md
+++ b/docs/cors/v1.0/docs/cors.md
@@ -45,7 +45,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: cors
-  gomodule: github.com/wso2/gateway-controllers/policies/cors@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/cors@v1
 ```
 
 ## Reference Scenarios

--- a/docs/dynamic-endpoint/v1.0/docs/dynamic-endpoint.md
+++ b/docs/dynamic-endpoint/v1.0/docs/dynamic-endpoint.md
@@ -32,7 +32,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: dynamic-endpoint
-  gomodule: github.com/wso2/gateway-controllers/policies/dynamic-endpoint@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/dynamic-endpoint@v1
 ```
 
 ## Reference Scenarios

--- a/docs/json-schema-guardrail/v1.0/docs/json-schema.md
+++ b/docs/json-schema-guardrail/v1.0/docs/json-schema.md
@@ -66,7 +66,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: json-schema-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/json-schema-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/json-schema-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/json-xml-mediator/v1.0/docs/json-xml-mediator.md
+++ b/docs/json-xml-mediator/v1.0/docs/json-xml-mediator.md
@@ -40,7 +40,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: json-xml-mediator
-  gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/json-xml-mediator@v1
 ```
 
 ## Reference Scenarios

--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -110,7 +110,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: jwt-auth
-  gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v1
 ```
 
 ## Reference Scenarios

--- a/docs/llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md
+++ b/docs/llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md
@@ -120,9 +120,9 @@ Inside the `gateway/build.yaml`, ensure both policy modules are added under `pol
 
 ```yaml
 - name: llm-cost
-  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v1
 - name: llm-cost-based-ratelimit
-  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit@v1
 ```
 
 ## Reference Scenarios

--- a/docs/llm-cost/v1.0/docs/llm-cost.md
+++ b/docs/llm-cost/v1.0/docs/llm-cost.md
@@ -47,7 +47,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: llm-cost
-  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v1
 ```
 
 ## Reference Scenarios

--- a/docs/log-message/v1.0/docs/log-message.md
+++ b/docs/log-message/v1.0/docs/log-message.md
@@ -50,7 +50,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: log-message
-  gomodule: github.com/wso2/gateway-controllers/policies/log-message@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/log-message@v1
 ```
 
 ## Reference Scenarios

--- a/docs/mcp-acl-list/v1.0/docs/mcp-acl-list.md
+++ b/docs/mcp-acl-list/v1.0/docs/mcp-acl-list.md
@@ -75,7 +75,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: mcp-acl-list
-  gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-acl-list@v1
 ```
 
 ## Reference Scenarios

--- a/docs/mcp-auth/v1.0/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v1.0/docs/mcp-authentication.md
@@ -126,7 +126,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: mcp-auth
-  gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-auth@v1
 ```
 
 ## Reference Scenarios

--- a/docs/mcp-authz/v1.0/docs/mcp-authorization.md
+++ b/docs/mcp-authz/v1.0/docs/mcp-authorization.md
@@ -54,7 +54,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: mcp-authz
-  gomodule: github.com/wso2/gateway-controllers/policies/mcp-authz@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-authz@v1
 ```
 
 ## Reference Scenarios

--- a/docs/mcp-rewrite/v1.0/docs/mcp-rewrite.md
+++ b/docs/mcp-rewrite/v1.0/docs/mcp-rewrite.md
@@ -74,7 +74,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: mcp-rewrite
-  gomodule: github.com/wso2/gateway-controllers/policies/mcp-rewrite@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/mcp-rewrite@v1
 ```
 
 ## Reference Scenarios

--- a/docs/model-round-robin/v1.0/docs/model-round-robin.md
+++ b/docs/model-round-robin/v1.0/docs/model-round-robin.md
@@ -55,7 +55,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: model-round-robin
-  gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v1
 ```
 
 ## Reference Scenarios

--- a/docs/model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md
+++ b/docs/model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md
@@ -55,7 +55,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: model-weighted-round-robin
-  gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v1
 ```
 
 ## Reference Scenarios

--- a/docs/pii-masking-regex/v1.0/docs/pii-masking-regex.md
+++ b/docs/pii-masking-regex/v1.0/docs/pii-masking-regex.md
@@ -58,7 +58,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: pii-masking-regex
-  gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/pii-masking-regex@v1
 ```
 
 ## Reference Scenarios

--- a/docs/prompt-decorator/v1.0/docs/prompt-decorator.md
+++ b/docs/prompt-decorator/v1.0/docs/prompt-decorator.md
@@ -55,7 +55,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: prompt-decorator
-  gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-decorator@v1
 ```
 
 ## Reference Scenarios

--- a/docs/prompt-template/v1.0/docs/prompt-template.md
+++ b/docs/prompt-template/v1.0/docs/prompt-template.md
@@ -90,7 +90,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: prompt-template
-  gomodule: github.com/wso2/gateway-controllers/policies/prompt-template@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/prompt-template@v1
 ```
 
 ## Reference Scenarios

--- a/docs/regex-guardrail/v1.0/docs/regex.md
+++ b/docs/regex-guardrail/v1.0/docs/regex.md
@@ -77,7 +77,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: regex-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/regex-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/regex-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/remove-headers/v1.0/docs/remove-headers.md
+++ b/docs/remove-headers/v1.0/docs/remove-headers.md
@@ -47,7 +47,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: remove-headers
-  gomodule: github.com/wso2/gateway-controllers/policies/remove-headers@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/remove-headers@v1
 ```
 
 ## Reference Scenarios:

--- a/docs/request-rewrite/v1.0/docs/request-rewrite.md
+++ b/docs/request-rewrite/v1.0/docs/request-rewrite.md
@@ -109,7 +109,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: request-rewrite
-  gomodule: github.com/wso2/gateway-controllers/policies/request-rewrite@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/request-rewrite@v1
 ```
 
 ## Reference Scenarios

--- a/docs/respond/v1.0/docs/respond.md
+++ b/docs/respond/v1.0/docs/respond.md
@@ -49,7 +49,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: respond
-  gomodule: github.com/wso2/gateway-controllers/policies/respond@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/respond@v1
 ```
 
 ## Reference Scenarios:

--- a/docs/semantic-cache/v1.0/docs/semantic-caching.md
+++ b/docs/semantic-cache/v1.0/docs/semantic-caching.md
@@ -100,7 +100,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: semantic-cache
-  gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v1
 ```
 
 ## Reference Scenarios

--- a/docs/semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md
+++ b/docs/semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md
@@ -81,7 +81,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: semantic-prompt-guard
-  gomodule: github.com/wso2/gateway-controllers/policies/semantic-prompt-guard@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-prompt-guard@v1
 ```
 
 ## Reference Scenarios

--- a/docs/semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md
+++ b/docs/semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md
@@ -60,7 +60,7 @@ Add the following entry to the `policies` section in `/gateway/build.yaml`:
 
 ```yaml
 - name: semantic-tool-filtering
-  gomodule: github.com/wso2/gateway-controllers/policies/semantic-tool-filtering@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-tool-filtering@v1
 ```
 
 ## Reference Scenarios

--- a/docs/sentence-count-guardrail/v1.0/docs/sentence-count.md
+++ b/docs/sentence-count-guardrail/v1.0/docs/sentence-count.md
@@ -74,7 +74,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: sentence-count-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/sentence-count-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/sentence-count-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/set-headers/v1.0/docs/set-headers.md
+++ b/docs/set-headers/v1.0/docs/set-headers.md
@@ -50,7 +50,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: set-headers
-  gomodule: github.com/wso2/gateway-controllers/policies/set-headers@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/set-headers@v1
 ```
 
 ## Reference Scenarios:

--- a/docs/subscription-validation/v1.0/docs/subscription-validation.md
+++ b/docs/subscription-validation/v1.0/docs/subscription-validation.md
@@ -70,7 +70,7 @@ Inside `gateway/build.yaml`, ensure the policy module is added under `policies`:
 
 ```yaml
 - name: subscription-validation
-  gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/subscription-validation@v1
 ```
 
 ## Reference Scenarios

--- a/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
+++ b/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
@@ -126,7 +126,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: token-based-ratelimit
-  gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/token-based-ratelimit@v1
 ```
 
 ## Reference Scenarios

--- a/docs/url-guardrail/v1.0/docs/url.md
+++ b/docs/url-guardrail/v1.0/docs/url.md
@@ -72,7 +72,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: url-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/url-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/url-guardrail@v1
 ```
 
 ## Reference Scenarios

--- a/docs/word-count-guardrail/v1.0/docs/word-count.md
+++ b/docs/word-count-guardrail/v1.0/docs/word-count.md
@@ -74,7 +74,7 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 
 ```yaml
 - name: word-count-guardrail
-  gomodule: github.com/wso2/gateway-controllers/policies/word-count-guardrail@v0
+  gomodule: github.com/wso2/gateway-controllers/policies/word-count-guardrail@v1
 ```
 
 ## Reference Scenarios


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy module configuration examples across 44 documentation files to reference v1 versions instead of v0, ensuring current guidance for users implementing gateway policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->