### PR TITLE
feat(policy): add set-status-code policy v0.1.0

### DIFF
--- a/docs/set-status-code/v0.1/docs/set-status-code.md
+++ b/docs/set-status-code/v0.1/docs/set-status-code.md
@@ -1,0 +1,71 @@
+---
+title: "Overview"
+---
+# Set Status Code
+
+## Overview
+
+The Set Status Code policy overwrites the HTTP status code of the upstream response
+before it is forwarded to the downstream client. This is useful for normalising status
+codes across backends or masking upstream error codes from clients.
+
+## Features
+
+- Overwrite the upstream response status code with any valid HTTP status code (100–599)
+- Simple single-parameter configuration (`statusCode`)
+- Validates that the provided status code is within the allowed range
+
+## Configuration
+
+This policy expects a single parameter `statusCode` (integer) that specifies the HTTP
+status code to set on the response.
+
+### User Parameters (API Definition)
+
+| Parameter    | Type    | Required | Description |
+|--------------|---------|----------|-------------|
+| `statusCode` | integer | Yes      | The HTTP status code to set on the upstream response. Must be between 100 and 599. |
+
+### Sample policy params
+
+```yaml
+- name: set-status-code
+  version: v0.1
+  params:
+    statusCode: 200
+```
+
+## Example API snippet
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: example-api
+spec:
+  displayName: Example API
+  version: v1
+  context: /example/$version
+  upstream:
+    main:
+      url: http://example-backend:8080
+  policies:
+    - name: set-status-code
+      version: v0.1
+      params:
+        statusCode: 200
+```
+
+## How it works
+
+- At response body processing, the policy validates the `statusCode` parameter.
+- If valid, it returns a `DownstreamResponseModifications` action with `StatusCode`
+  set to the configured value. The kernel applies this before forwarding the response
+  to the client. The response body and headers are passed through unchanged.
+- If configuration is invalid (missing, wrong type, or out of range), the policy
+  returns an immediate 500 configuration error response.
+
+## Notes
+
+- Only the status code is modified; the response body and headers are forwarded as-is.
+- The status code must be a valid HTTP status code integer between 100 and 599.

--- a/docs/set-status-code/v0.1/metadata.json
+++ b/docs/set-status-code/v0.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "set-status-code",
+  "displayName": "Set Status Code",
+  "version": "0.1",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation"
+  ],
+  "description": "Overwrites the upstream response status code before forwarding to the client. Useful for normalising status codes or masking upstream error codes."
+}

--- a/policies/analytics-header-filter/go.mod
+++ b/policies/analytics-header-filter/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/analytics-header-filter
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     request:
       type: object

--- a/policies/azure-content-safety-content-moderation/go.mod
+++ b/policies/azure-content-safety-content-moderation/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/azure-content-safety-content
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -6,6 +6,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     request:
       type: object

--- a/policies/basic-auth/go.mod
+++ b/policies/basic-auth/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/basic-auth
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/basic-auth/policy-definition.yaml
+++ b/policies/basic-auth/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     username:
       type: string

--- a/policies/content-length-guardrail/go.mod
+++ b/policies/content-length-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/content-length-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/content-length-guardrail/policy-definition.yaml
+++ b/policies/content-length-guardrail/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     request:
       type: object

--- a/policies/cors/go.mod
+++ b/policies/cors/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/cors
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/cors/policy-definition.yaml
+++ b/policies/cors/policy-definition.yaml
@@ -7,6 +7,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     allowedOrigins:
       type: array

--- a/policies/dynamic-endpoint/go.mod
+++ b/policies/dynamic-endpoint/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/dynamic-endpoint
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/host-rewrite/policy-definition.yaml
+++ b/policies/host-rewrite/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     host:
       type: string

--- a/policies/json-schema-guardrail/policy-definition.yaml
+++ b/policies/json-schema-guardrail/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     request:
       type: object

--- a/policies/json-xml-mediator/go.mod
+++ b/policies/json-xml-mediator/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/json-xml-mediator
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/llm-cost/go.mod
+++ b/policies/llm-cost/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/llm-cost
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/log-message/go.mod
+++ b/policies/log-message/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/log-message
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/mcp-acl-list/go.mod
+++ b/policies/mcp-acl-list/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-acl-list
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -2,7 +2,7 @@ module github.com/wso2/gateway-controllers/policies/mcp-auth
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9
 
 require github.com/wso2/gateway-controllers/policies/jwt-auth v1.0.1
 

--- a/policies/mcp-authz/go.mod
+++ b/policies/mcp-authz/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-authz
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/mcp-rewrite/go.mod
+++ b/policies/mcp-rewrite/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/mcp-rewrite
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/model-round-robin/go.mod
+++ b/policies/model-round-robin/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/model-round-robin
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -6,6 +6,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     models:
       type: array

--- a/policies/model-weighted-round-robin/go.mod
+++ b/policies/model-weighted-round-robin/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/model-weighted-round-robin
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     models:
       type: array

--- a/policies/pii-masking-regex/go.mod
+++ b/policies/pii-masking-regex/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/pii-masking-regex
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -6,6 +6,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     email:
       type: boolean

--- a/policies/prompt-decorator/go.mod
+++ b/policies/prompt-decorator/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/prompt-decorator
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     promptDecoratorConfig:
       type: object

--- a/policies/prompt-template/go.mod
+++ b/policies/prompt-template/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/prompt-template
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/prompt-template/policy-definition.yaml
+++ b/policies/prompt-template/policy-definition.yaml
@@ -6,6 +6,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     templates:
       type: array

--- a/policies/regex-guardrail/go.mod
+++ b/policies/regex-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/regex-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/regex-guardrail/policy-definition.yaml
+++ b/policies/regex-guardrail/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     request:
       type: object

--- a/policies/remove-headers/go.mod
+++ b/policies/remove-headers/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/remove-headers
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/request-rewrite/go.mod
+++ b/policies/request-rewrite/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/request-rewrite
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/respond/go.mod
+++ b/policies/respond/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/respond
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/semantic-cache/policy-definition.yaml
+++ b/policies/semantic-cache/policy-definition.yaml
@@ -7,6 +7,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     similarityThreshold:
       type: number

--- a/policies/semantic-prompt-guard/policy-definition.yaml
+++ b/policies/semantic-prompt-guard/policy-definition.yaml
@@ -7,6 +7,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     jsonPath:
       type: string

--- a/policies/semantic-tool-filtering/policy-definition.yaml
+++ b/policies/semantic-tool-filtering/policy-definition.yaml
@@ -10,6 +10,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     selectionMode:
       type: string

--- a/policies/sentence-count-guardrail/go.mod
+++ b/policies/sentence-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/sentence-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/set-headers/go.mod
+++ b/policies/set-headers/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/set-headers
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/set-status-code/go.mod
+++ b/policies/set-status-code/go.mod
@@ -1,0 +1,5 @@
+module github.com/wso2/gateway-controllers/policies/set-status-code
+
+go 1.26.1
+
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/set-status-code/go.sum
+++ b/policies/set-status-code/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.9 h1:3lvAsMlLhy8nNgPL24/UFS/f4sq5e+XpryA4L1PO7dU=
+github.com/wso2/api-platform/sdk/core v0.2.9/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/set-status-code/policy-definition.yaml
+++ b/policies/set-status-code/policy-definition.yaml
@@ -1,0 +1,20 @@
+name: set-status-code
+version: v0.1.0
+description: |
+  Overwrite the upstream response status code before forwarding to the client.
+
+parameters:
+  type: object
+  properties:
+    statusCode:
+      type: integer
+      x-wso2-policy-advanced-param: false
+      description: The HTTP status code to set on the upstream response.
+      minimum: 100
+      maximum: 599
+  required:
+    - statusCode
+systemParameters:
+  type: object
+  additionalProperties: false
+  properties: {}

--- a/policies/set-status-code/policy-definition.yaml
+++ b/policies/set-status-code/policy-definition.yaml
@@ -5,6 +5,7 @@ description: |
 
 parameters:
   type: object
+  additionalProperties: false
   properties:
     statusCode:
       type: integer

--- a/policies/set-status-code/setstatuscode.go
+++ b/policies/set-status-code/setstatuscode.go
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package setstatuscode
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+var ins = &SetStatusCodePolicy{}
+
+// SetStatusCodePolicy overwrites the upstream response status code before forwarding to the client.
+type SetStatusCodePolicy struct{}
+
+// GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	return ins, nil
+}
+
+func (p *SetStatusCodePolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+}
+
+// policyConfig holds the configuration for the set-status-code policy.
+type policyConfig struct {
+	StatusCode int
+}
+
+// parseConfig extracts and validates the statusCode parameter from the policy configuration.
+func parseConfig(params map[string]interface{}) (*policyConfig, error) {
+	if len(params) == 0 {
+		return nil, fmt.Errorf("statusCode parameter is required")
+	}
+
+	raw, ok := params["statusCode"]
+	if !ok {
+		return nil, fmt.Errorf("statusCode parameter is required")
+	}
+
+	var statusCode int
+	switch v := raw.(type) {
+	case int:
+		statusCode = v
+	case float64:
+		statusCode = int(v)
+	default:
+		return nil, fmt.Errorf("statusCode parameter must be an integer")
+	}
+
+	if statusCode < 100 || statusCode > 599 {
+		return nil, fmt.Errorf("statusCode must be between 100 and 599, got %d", statusCode)
+	}
+
+	return &policyConfig{StatusCode: statusCode}, nil
+}
+
+// OnResponseBody overwrites the upstream response status code before forwarding to the client.
+func (p *SetStatusCodePolicy) OnResponseBody(ctx context.Context, respCtx *policy.ResponseContext, params map[string]interface{}) policy.ResponseAction {
+	cfg, err := parseConfig(params)
+	if err != nil {
+		slog.Error("[Set Status Code]: Configuration error", "error", err)
+		return policy.ImmediateResponse{
+			StatusCode: 500,
+			Headers:    map[string]string{"content-type": "application/json"},
+			Body:       fmt.Appendf(nil, `{"error":"Configuration Error","message":"%s"}`, err.Error()),
+		}
+	}
+
+	slog.Info("[Set Status Code]: Overwriting response status code", "from", respCtx.ResponseStatus, "to", cfg.StatusCode)
+
+	return policy.DownstreamResponseModifications{
+		StatusCode: &cfg.StatusCode,
+	}
+}

--- a/policies/set-status-code/setstatuscode.go
+++ b/policies/set-status-code/setstatuscode.go
@@ -68,7 +68,11 @@ func parseConfig(params map[string]interface{}) (*policyConfig, error) {
 	case int:
 		statusCode = v
 	case float64:
-		statusCode = int(v)
+		parsed := int(v)
+		if float64(parsed) != v {
+			return nil, fmt.Errorf("statusCode parameter must be an integer, got fractional value %v", v)
+		}
+		statusCode = parsed
 	default:
 		return nil, fmt.Errorf("statusCode parameter must be an integer")
 	}

--- a/policies/set-status-code/setstatuscode_test.go
+++ b/policies/set-status-code/setstatuscode_test.go
@@ -1,0 +1,221 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package setstatuscode
+
+import (
+	"context"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+func newResponseContext(statusCode int) *policy.ResponseContext {
+	return &policy.ResponseContext{
+		ResponseStatus: statusCode,
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_Valid(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{
+		"statusCode": 201,
+	}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	mods, ok := result.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("Expected DownstreamResponseModifications, got %T", result)
+	}
+
+	if mods.StatusCode == nil {
+		t.Fatal("Expected StatusCode to be set, got nil")
+	}
+
+	if *mods.StatusCode != 201 {
+		t.Errorf("Expected StatusCode 201, got %d", *mods.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_Float64Param(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	// JSON unmarshalling yields float64 for numbers
+	params := map[string]interface{}{
+		"statusCode": float64(404),
+	}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	mods, ok := result.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("Expected DownstreamResponseModifications, got %T", result)
+	}
+
+	if mods.StatusCode == nil || *mods.StatusCode != 404 {
+		t.Errorf("Expected StatusCode 404, got %v", mods.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_BoundaryMin(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{"statusCode": 100}
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	mods, ok := result.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("Expected DownstreamResponseModifications, got %T", result)
+	}
+	if mods.StatusCode == nil || *mods.StatusCode != 100 {
+		t.Errorf("Expected StatusCode 100, got %v", mods.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_BoundaryMax(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{"statusCode": 599}
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	mods, ok := result.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("Expected DownstreamResponseModifications, got %T", result)
+	}
+	if mods.StatusCode == nil || *mods.StatusCode != 599 {
+		t.Errorf("Expected StatusCode 599, got %v", mods.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_MissingParam(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), map[string]interface{}{})
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_NilParams(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), nil)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_InvalidType(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{"statusCode": "200"}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_BelowRange(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{"statusCode": 99}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_AboveRange(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	params := map[string]interface{}{"statusCode": 600}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	immResp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+	if immResp.StatusCode != 500 {
+		t.Errorf("Expected status code 500, got %d", immResp.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_Mode(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+	mode := p.Mode()
+
+	if mode.RequestHeaderMode != policy.HeaderModeSkip {
+		t.Errorf("Expected RequestHeaderMode to be HeaderModeSkip, got %v", mode.RequestHeaderMode)
+	}
+	if mode.RequestBodyMode != policy.BodyModeSkip {
+		t.Errorf("Expected RequestBodyMode to be BodyModeSkip, got %v", mode.RequestBodyMode)
+	}
+	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+		t.Errorf("Expected ResponseHeaderMode to be HeaderModeSkip, got %v", mode.ResponseHeaderMode)
+	}
+	if mode.ResponseBodyMode != policy.BodyModeBuffer {
+		t.Errorf("Expected ResponseBodyMode to be BodyModeBuffer, got %v", mode.ResponseBodyMode)
+	}
+}
+
+func TestSetStatusCodePolicy_GetPolicy(t *testing.T) {
+	metadata := policy.PolicyMetadata{
+		RouteName:  "test-route",
+		APIId:      "test-api-id",
+		APIName:    "test-api",
+		APIVersion: "v1.0.0",
+		AttachedTo: policy.LevelRoute,
+	}
+
+	params := map[string]interface{}{"statusCode": 202}
+
+	pol, err := GetPolicy(metadata, params)
+	if err != nil {
+		t.Fatalf("Expected no error from GetPolicy, got %v", err)
+	}
+	if pol == nil {
+		t.Fatal("Expected policy instance, got nil")
+	}
+	if _, ok := pol.(*SetStatusCodePolicy); !ok {
+		t.Fatalf("Expected *SetStatusCodePolicy, got %T", pol)
+	}
+}

--- a/policies/set-status-code/setstatuscode_test.go
+++ b/policies/set-status-code/setstatuscode_test.go
@@ -56,7 +56,7 @@ func TestSetStatusCodePolicy_OnResponseBody_Valid(t *testing.T) {
 func TestSetStatusCodePolicy_OnResponseBody_Float64Param(t *testing.T) {
 	p := &SetStatusCodePolicy{}
 
-	// JSON unmarshalling yields float64 for numbers
+	// JSON unmarshalling yields float64 for numbers; whole-number floats are accepted
 	params := map[string]interface{}{
 		"statusCode": float64(404),
 	}
@@ -70,6 +70,26 @@ func TestSetStatusCodePolicy_OnResponseBody_Float64Param(t *testing.T) {
 
 	if mods.StatusCode == nil || *mods.StatusCode != 404 {
 		t.Errorf("Expected StatusCode 404, got %v", mods.StatusCode)
+	}
+}
+
+func TestSetStatusCodePolicy_OnResponseBody_Float64FractionalParam(t *testing.T) {
+	p := &SetStatusCodePolicy{}
+
+	// Fractional float64 should be rejected
+	params := map[string]interface{}{
+		"statusCode": float64(200.9),
+	}
+
+	result := p.OnResponseBody(context.Background(), newResponseContext(200), params)
+
+	immediate, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", result)
+	}
+
+	if immediate.StatusCode != 500 {
+		t.Errorf("Expected status 500 for fractional float64, got %d", immediate.StatusCode)
 	}
 }
 

--- a/policies/subscription-validation/go.mod
+++ b/policies/subscription-validation/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/subscription-validation
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/url-guardrail/go.mod
+++ b/policies/url-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/url-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9

--- a/policies/word-count-guardrail/go.mod
+++ b/policies/word-count-guardrail/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/word-count-guardrail
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.9


### PR DESCRIPTION
## Purpose

Add a new `set-status-code` gateway policy that overwrites the upstream response status code before forwarding to the downstream client. This is useful for normalising status codes across backends or masking upstream error codes from clients.

## Approach

- Implements `ResponsePolicy.OnResponseBody` using `DownstreamResponseModifications.StatusCode` from `sdk/core` v1alpha2
- Accepts a single `statusCode` integer parameter (100–599); handles both `int` and `float64` types to support JSON-unmarshalled params
- Returns a 500 config error response on missing, invalid type, or out-of-range parameter
- Adds `policy-definition.yaml` with parameter schema (min: 100, max: 599)
- Adds unit tests covering valid codes, boundary values, float64 input, nil/missing params, invalid types, and out-of-range values
- Adds docs under `docs/set-status-code/v0.1/` with metadata and usage guide

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Set Status Code policy available to overwrite upstream response HTTP status for API gateways (configurable 100–599).

* **Documentation**
  * Added comprehensive docs and examples for the Set Status Code policy, including configuration and runtime behavior.

* **Chores**
  * Tightened policy parameter schemas to reject unspecified fields and updated underlying module dependencies across multiple policies for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->