### PR TITLE
Feat/consumer based rl

### DIFF
--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v1.0.2
+version: v1.0.3
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -71,6 +71,7 @@ type KeyComponent struct {
 	Type       string // "header", "metadata", "ip", "apiname", "apiversion", "routename", "cel"
 	Key        string // header name or metadata key (required for header/metadata)
 	Expression string // CEL expression (required for cel type)
+	Fallback   string // value to use when the key is missing (optional; defaults to a "_missing_*_" placeholder)
 }
 
 // LimitConfig holds parsed rate limit configuration
@@ -857,6 +858,15 @@ func parseKeyExtraction(raw interface{}) ([]KeyComponent, error) {
 			}
 		}
 
+		// Parse optional fallback value
+		if fallbackRaw, ok := compMap["fallback"]; ok {
+			if fallbackStr, ok := fallbackRaw.(string); ok {
+				comp.Fallback = fallbackStr
+			} else {
+				return nil, fmt.Errorf("keyExtraction[%d].fallback must be a string", i)
+			}
+		}
+
 		// Validate: CEL type requires expression
 		if compType == "cel" && comp.Expression == "" {
 			return nil, fmt.Errorf("keyExtraction[%d]: type 'cel' requires 'expression' field", i)
@@ -1382,6 +1392,9 @@ func (p *RateLimitPolicy) extractKeyComponentFromHeaderCtx(reqCtx *policy.Reques
 			if strVal, ok := val.(string); ok && strVal != "" {
 				return strVal
 			}
+		}
+		if comp.Fallback != "" {
+			return comp.Fallback
 		}
 		placeholder := fmt.Sprintf("_missing_metadata_%s_", comp.Key)
 		slog.Warn("Metadata key not found for rate limit key, using placeholder", "key", comp.Key, "type", comp.Type, "placeholder", placeholder)
@@ -2094,6 +2107,9 @@ func (p *RateLimitPolicy) extractKeyComponent(reqCtx *policy.RequestContext, com
 			if strVal, ok := val.(string); ok && strVal != "" {
 				return strVal
 			}
+		}
+		if comp.Fallback != "" {
+			return comp.Fallback
 		}
 		placeholder := fmt.Sprintf("_missing_metadata_%s_", comp.Key)
 		slog.Warn("Metadata key not found for rate limit key, using placeholder", "key", comp.Key, "type", comp.Type, "placeholder", placeholder)

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -101,6 +101,7 @@ type RateLimitPolicy struct {
 	apiVersion     string         // From metadata, API version
 	attachedTo     policy.Level   // From metadata, whether policy is attached at API or route level
 	baseCacheKey   string         // Base cache key for tracking limiters in memory backend
+	instanceID     string         // Unique per-instance suffix for SharedContext.Metadata keys
 	statusCode     int
 	responseBody   string
 	responseFormat string
@@ -389,6 +390,24 @@ func GetPolicy(
 		"algorithm", algorithm,
 		"quotaCount", len(quotas))
 
+	// Compute a short deterministic instance ID from the quota names and key extraction
+	// types. This namespaces all SharedContext.Metadata keys so that multiple
+	// advanced-ratelimit instances in the same request chain do not overwrite each other.
+	var idBuf strings.Builder
+	for i, q := range quotas {
+		idBuf.WriteString(q.Name)
+		idBuf.WriteString(":")
+		for _, ke := range q.KeyExtraction {
+			idBuf.WriteString(ke.Type)
+			idBuf.WriteString(ke.Key)
+		}
+		if i < len(quotas)-1 {
+			idBuf.WriteString("|")
+		}
+	}
+	idHash := sha256.Sum256([]byte(idBuf.String()))
+	instanceID := hex.EncodeToString(idHash[:])[:8]
+
 	// Return configured policy instance
 	return &RateLimitPolicy{
 		quotas:         quotas,
@@ -398,6 +417,7 @@ func GetPolicy(
 		apiVersion:     apiVersion,
 		attachedTo:     metadata.AttachedTo,
 		baseCacheKey:   baseCacheKey,
+		instanceID:     instanceID,
 		statusCode:     statusCode,
 		responseBody:   responseBody,
 		responseFormat: responseFormat,
@@ -410,6 +430,11 @@ func GetPolicy(
 	}, nil
 }
 
+// metaKey returns an instance-specific metadata key to avoid collisions when
+// multiple advanced-ratelimit instances are present in the same request chain.
+func (p *RateLimitPolicy) metaKey(base string) string {
+	return base + ":" + p.instanceID
+}
 
 func (p *RateLimitPolicy) Mode() policy.ProcessingMode {
 	requestBodyMode := policy.BodyModeSkip
@@ -958,7 +983,6 @@ func (p *RateLimitPolicy) requiresRequestBody() bool {
 	return false
 }
 
-
 // requiresAnyResponseBodyMode returns true if any quota has a response-phase cost
 // source that is not response_header. This is the single gating check used by
 // Mode() to request BodyModeStream and by OnResponseBody to guard the buffered
@@ -1301,9 +1325,9 @@ func (p *RateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.R
 		}
 	}
 
-	reqCtx.Metadata[rateLimitResultKey] = quotaResults
-	reqCtx.Metadata[rateLimitKeysKey] = quotaKeys
-	reqCtx.Metadata[rateLimitHeaderHandledKey] = handledQuotas
+	reqCtx.Metadata[p.metaKey(rateLimitResultKey)] = quotaResults
+	reqCtx.Metadata[p.metaKey(rateLimitKeysKey)] = quotaKeys
+	reqCtx.Metadata[p.metaKey(rateLimitHeaderHandledKey)] = handledQuotas
 
 	return policy.UpstreamRequestHeaderModifications{}
 }
@@ -1413,7 +1437,7 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 		// Retrieve results stored by OnRequestHeaders so header-only quota results
 		// (consumed in OnRequestHeaders) can be carried forward.
 		storedResultsMap := make(map[string]quotaResult)
-		if prev, ok := reqCtx.Metadata[rateLimitResultKey].([]quotaResult); ok {
+		if prev, ok := reqCtx.Metadata[p.metaKey(rateLimitResultKey)].([]quotaResult); ok {
 			for _, r := range prev {
 				storedResultsMap[r.QuotaName] = r
 			}
@@ -1424,7 +1448,7 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 		// header phase unconditionally, so if OnRequestBody also runs (because another
 		// quota needs the body), they must not be charged again.
 		handledInHeaderPhase := make(map[string]bool)
-		if prev, ok := reqCtx.Metadata[rateLimitHeaderHandledKey].(map[string]bool); ok {
+		if prev, ok := reqCtx.Metadata[p.metaKey(rateLimitHeaderHandledKey)].(map[string]bool); ok {
 			handledInHeaderPhase = prev
 		}
 
@@ -1620,8 +1644,8 @@ func (p *RateLimitPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Requ
 		}
 
 		// Store results and keys in metadata for response phase
-		reqCtx.Metadata[rateLimitResultKey] = quotaResults
-		reqCtx.Metadata[rateLimitKeysKey] = quotaKeys
+		reqCtx.Metadata[p.metaKey(rateLimitResultKey)] = quotaResults
+		reqCtx.Metadata[p.metaKey(rateLimitKeysKey)] = quotaKeys
 
 		return policy.UpstreamRequestModifications{}
 	} else {
@@ -1639,7 +1663,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 		"quotaCount", len(p.quotas))
 
 	// Retrieve stored keys for cost extraction
-	quotaKeysRaw, hasKeys := respCtx.Metadata[rateLimitKeysKey]
+	quotaKeysRaw, hasKeys := respCtx.Metadata[p.metaKey(rateLimitKeysKey)]
 	quotaKeys := make(map[string]string)
 	if hasKeys {
 		if keys, ok := quotaKeysRaw.(map[string]string); ok {
@@ -1654,7 +1678,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 	isStreaming := isStreamingResponse(respCtx.ResponseHeaders)
 
 	// Retrieve stored results from request phase
-	resultsRaw, hasResults := respCtx.Metadata[rateLimitResultKey]
+	resultsRaw, hasResults := respCtx.Metadata[p.metaKey(rateLimitResultKey)]
 	var storedResults []quotaResult
 	if hasResults {
 		if results, ok := resultsRaw.([]quotaResult); ok {
@@ -1683,7 +1707,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 		// Skip quotas that require the response body — those are handled exclusively
 		// in OnResponseBody to avoid double consumption.
 		if q.CostExtractionEnabled && q.CostExtractor != nil &&
-			 q.CostExtractor.HasResponsePhaseSources() && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
+			q.CostExtractor.HasResponsePhaseSources() && q.CostExtractor.HasResponseHeaderOnlyCostSources() {
 			slog.Debug("Processing response-header-phase cost extraction",
 				"quota", quotaName)
 
@@ -1818,7 +1842,7 @@ func (p *RateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy
 
 	// Store updated results so OnResponseBody can carry forward response_header
 	// quota results and avoid re-consuming them.
-	respCtx.Metadata[rateLimitResultKey] = allQuotaResults
+	respCtx.Metadata[p.metaKey(rateLimitResultKey)] = allQuotaResults
 
 	// For buffered responses with body-phase sources, defer header emission to
 	// OnResponseBody which has the full body and can report accurate post-consumption
@@ -1866,7 +1890,7 @@ func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Re
 			"quotaCount", len(p.quotas))
 
 		// Retrieve stored keys for cost extraction
-		quotaKeysRaw, hasKeys := respCtx.Metadata[rateLimitKeysKey]
+		quotaKeysRaw, hasKeys := respCtx.Metadata[p.metaKey(rateLimitKeysKey)]
 		quotaKeys := make(map[string]string)
 		if hasKeys {
 			if keys, ok := quotaKeysRaw.(map[string]string); ok {
@@ -1875,7 +1899,7 @@ func (p *RateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Re
 		}
 
 		// Retrieve stored results from request phase
-		resultsRaw, hasResults := respCtx.Metadata[rateLimitResultKey]
+		resultsRaw, hasResults := respCtx.Metadata[p.metaKey(rateLimitResultKey)]
 		var storedResults []quotaResult
 		if hasResults {
 			if results, ok := resultsRaw.([]quotaResult); ok {
@@ -2145,14 +2169,14 @@ func (p *RateLimitPolicy) extractIPAddress(headers *policy.Headers) string {
 // creating and storing it if this is the first chunk of the request.
 // Each quota gets its own streamQuotaState entry keyed by quota name.
 func (p *RateLimitPolicy) getOrInitStreamState(metadata map[string]interface{}) map[string]*streamQuotaState {
-	if existing, ok := metadata[rateLimitStreamStateKey].(map[string]*streamQuotaState); ok {
+	if existing, ok := metadata[p.metaKey(rateLimitStreamStateKey)].(map[string]*streamQuotaState); ok {
 		return existing
 	}
 	state := make(map[string]*streamQuotaState, len(p.quotas))
 	for i := range p.quotas {
 		state[quotaNameFor(&p.quotas[i], i)] = &streamQuotaState{}
 	}
-	metadata[rateLimitStreamStateKey] = state
+	metadata[p.metaKey(rateLimitStreamStateKey)] = state
 	return state
 }
 
@@ -2195,7 +2219,7 @@ func (p *RateLimitPolicy) OnResponseBodyChunk(
 		state[quotaName] = qs
 	}
 	// Persist updated state so the next chunk call sees the accumulated bytes for each quota.
-	respCtx.Metadata[rateLimitStreamStateKey] = state
+	respCtx.Metadata[p.metaKey(rateLimitStreamStateKey)] = state
 
 	// EOS: all chunks have arrived. Finalize JSON extraction (SSE values are
 	// already up-to-date from per-chunk parsing) and consume tokens.
@@ -2234,7 +2258,7 @@ func (p *RateLimitPolicy) finalizeAndConsumeStreamingCosts(
 ) {
 	// quotaKeys were written to metadata during the request phase (OnRequestHeaders /
 	// OnRequestBody) and carry the rate-limit key for each quota into the response phase.
-	quotaKeys, _ := respCtx.Metadata[rateLimitKeysKey].(map[string]string)
+	quotaKeys, _ := respCtx.Metadata[p.metaKey(rateLimitKeysKey)].(map[string]string)
 
 	for i := range p.quotas {
 		q := &p.quotas[i]

--- a/policies/advanced-ratelimit/ratelimit_integration_test.go
+++ b/policies/advanced-ratelimit/ratelimit_integration_test.go
@@ -749,93 +749,93 @@ func TestCostExtractorMethods(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                  string
-		sources               []CostSource
-		wantReqHeaderOnly     bool
-		wantRespHeaderOnly    bool
-		wantReqBodyPhase      bool
-		wantRequiresRespBody  bool
+		name                 string
+		sources              []CostSource
+		wantReqHeaderOnly    bool
+		wantRespHeaderOnly   bool
+		wantReqBodyPhase     bool
+		wantRequiresRespBody bool
 	}{
 		{
-			name:               "request_header only",
-			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}},
-			wantReqHeaderOnly:  true,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   false,
+			name:                 "request_header only",
+			sources:              []CostSource{{Type: CostSourceRequestHeader, Key: "x"}},
+			wantReqHeaderOnly:    true,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "response_header only",
-			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: true,
-			wantReqBodyPhase:   false,
+			name:                 "response_header only",
+			sources:              []CostSource{{Type: CostSourceResponseHeader, Key: "x"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   true,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "request_metadata only",
-			sources:            []CostSource{{Type: CostSourceRequestMetadata, Key: "x"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   true,
+			name:                 "request_metadata only",
+			sources:              []CostSource{{Type: CostSourceRequestMetadata, Key: "x"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     true,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "response_metadata only",
-			sources:            []CostSource{{Type: CostSourceResponseMetadata, Key: "x"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   false,
+			name:                 "response_metadata only",
+			sources:              []CostSource{{Type: CostSourceResponseMetadata, Key: "x"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "request_body only",
-			sources:            []CostSource{{Type: CostSourceRequestBody, JSONPath: "$.x"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   true,
+			name:                 "request_body only",
+			sources:              []CostSource{{Type: CostSourceRequestBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     true,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "response_body only",
-			sources:            []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.x"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   false,
+			name:                 "response_body only",
+			sources:              []CostSource{{Type: CostSourceResponseBody, JSONPath: "$.x"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: true,
 		},
 		{
-			name:               "request_header + request_metadata disqualifies request header only",
-			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceRequestMetadata, Key: "y"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   true,
+			name:                 "request_header + request_metadata disqualifies request header only",
+			sources:              []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceRequestMetadata, Key: "y"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     true,
 			wantRequiresRespBody: false,
 		},
 		{
-			name:               "response_header + response_body disqualifies response header only",
-			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseBody, JSONPath: "$.y"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   false,
+			name:                 "response_header + response_body disqualifies response header only",
+			sources:              []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseBody, JSONPath: "$.y"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: true,
 		},
 		{
-			name:               "response_header + response_metadata disqualifies response header only",
-			sources:            []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseMetadata, Key: "y"}},
-			wantReqHeaderOnly:  false,
-			wantRespHeaderOnly: false,
-			wantReqBodyPhase:   false,
+			name:                 "response_header + response_metadata disqualifies response header only",
+			sources:              []CostSource{{Type: CostSourceResponseHeader, Key: "x"}, {Type: CostSourceResponseMetadata, Key: "y"}},
+			wantReqHeaderOnly:    false,
+			wantRespHeaderOnly:   false,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: false,
 		},
 		{
 			// Response-phase sources are ignored when evaluating request-header-only,
 			// and request-phase sources are ignored when evaluating response-header-only.
-			name:               "request_header + response_header both qualify for their respective header-only paths",
-			sources:            []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceResponseHeader, Key: "y"}},
-			wantReqHeaderOnly:  true,
-			wantRespHeaderOnly: true,
-			wantReqBodyPhase:   false,
+			name:                 "request_header + response_header both qualify for their respective header-only paths",
+			sources:              []CostSource{{Type: CostSourceRequestHeader, Key: "x"}, {Type: CostSourceResponseHeader, Key: "y"}},
+			wantReqHeaderOnly:    true,
+			wantRespHeaderOnly:   true,
+			wantReqBodyPhase:     false,
 			wantRequiresRespBody: false,
 		},
 	}
@@ -919,6 +919,41 @@ func TestKeyExtractionBehavior(t *testing.T) {
 		q2 := &QuotaRuntime{KeyExtraction: []KeyComponent{{Type: "metadata", Key: "intPlan"}}}
 		if got := p.extractQuotaKey(ctx, q2); got != "_missing_metadata_intPlan_" {
 			t.Fatalf("unexpected placeholder: %q", got)
+		}
+	})
+
+	t.Run("missing metadata uses Fallback when set", func(t *testing.T) {
+		q := &QuotaRuntime{KeyExtraction: []KeyComponent{{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"}}}
+		if got := p.extractQuotaKey(ctx, q); got != "default" {
+			t.Fatalf("expected fallback %q, got %q", "default", got)
+		}
+	})
+
+	t.Run("empty string metadata uses Fallback when set", func(t *testing.T) {
+		ctxEmptyApp := newRequestCtx(nil, map[string]interface{}{"x-wso2-application-id": ""})
+		q := &QuotaRuntime{KeyExtraction: []KeyComponent{{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"}}}
+		if got := p.extractQuotaKey(ctxEmptyApp, q); got != "default" {
+			t.Fatalf("expected fallback %q for empty string value, got %q", "default", got)
+		}
+	})
+
+	t.Run("present metadata value ignores Fallback", func(t *testing.T) {
+		ctxWithApp := newRequestCtx(nil, map[string]interface{}{"x-wso2-application-id": "app-123"})
+		q := &QuotaRuntime{KeyExtraction: []KeyComponent{{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"}}}
+		if got := p.extractQuotaKey(ctxWithApp, q); got != "app-123" {
+			t.Fatalf("expected actual value %q, got %q", "app-123", got)
+		}
+	})
+
+	t.Run("multi-component consumer key with fallback", func(t *testing.T) {
+		ctxNoApp := newRequestCtx(nil, nil)
+		q := &QuotaRuntime{KeyExtraction: []KeyComponent{
+			{Type: "routename"},
+			{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"},
+		}}
+		p2 := &RateLimitPolicy{routeName: "my-route"}
+		if got := p2.extractQuotaKey(ctxNoApp, q); got != "my-route:default" {
+			t.Fatalf("expected %q, got %q", "my-route:default", got)
 		}
 	})
 
@@ -1031,6 +1066,132 @@ func TestKeyExtractionHeaderPhase(t *testing.T) {
 			t.Fatalf("expected empty string, got %q", got)
 		}
 	})
+
+	t.Run("missing metadata uses Fallback in header phase", func(t *testing.T) {
+		noAppCtx := newRequestHeaderCtx(nil, nil) // no x-wso2-application-id in metadata
+		got := p.extractKeyComponentFromHeaderCtx(noAppCtx, KeyComponent{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"})
+		if got != "default" {
+			t.Fatalf("expected fallback %q, got %q", "default", got)
+		}
+	})
+
+	t.Run("empty string metadata uses Fallback in header phase", func(t *testing.T) {
+		emptyAppCtx := newRequestHeaderCtx(nil, map[string]interface{}{"x-wso2-application-id": ""})
+		got := p.extractKeyComponentFromHeaderCtx(emptyAppCtx, KeyComponent{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"})
+		if got != "default" {
+			t.Fatalf("expected fallback %q for empty string, got %q", "default", got)
+		}
+	})
+
+	t.Run("present metadata uses actual value over Fallback in header phase", func(t *testing.T) {
+		withAppCtx := newRequestHeaderCtx(nil, map[string]interface{}{"x-wso2-application-id": "app-456"})
+		got := p.extractKeyComponentFromHeaderCtx(withAppCtx, KeyComponent{Type: "metadata", Key: "x-wso2-application-id", Fallback: "default"})
+		if got != "app-456" {
+			t.Fatalf("expected actual value %q, got %q", "app-456", got)
+		}
+	})
+}
+
+func TestParseKeyExtraction_FallbackField(t *testing.T) {
+	t.Run("fallback string is parsed", func(t *testing.T) {
+		raw := []interface{}{
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": "default"},
+		}
+		comps, err := parseKeyExtraction(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(comps) != 1 {
+			t.Fatalf("expected 1 component, got %d", len(comps))
+		}
+		if comps[0].Fallback != "default" {
+			t.Fatalf("expected Fallback %q, got %q", "default", comps[0].Fallback)
+		}
+	})
+
+	t.Run("no fallback field leaves Fallback empty", func(t *testing.T) {
+		raw := []interface{}{
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id"},
+		}
+		comps, err := parseKeyExtraction(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if comps[0].Fallback != "" {
+			t.Fatalf("expected empty Fallback, got %q", comps[0].Fallback)
+		}
+	})
+
+	t.Run("non-string fallback returns error", func(t *testing.T) {
+		raw := []interface{}{
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": 42},
+		}
+		_, err := parseKeyExtraction(raw)
+		if err == nil || !strings.Contains(err.Error(), "fallback must be a string") {
+			t.Fatalf("expected fallback type error, got %v", err)
+		}
+	})
+}
+
+// TestConsumerFallbackKey_UsesDefaultWhenAppIDMissing verifies that when a consumer-based
+// rate limit is configured with fallback "default" and a request arrives without an application
+// ID in metadata, the key used is "routename:default" — not the backend key "routename".
+// This means:
+//  1. Unauthenticated requests share a single "default" counter (not the backend counter).
+//  2. Once the "default" counter is exhausted, authenticated requests with a real app ID
+//     are still allowed (their counter is independent).
+func TestConsumerFallbackKey_UsesDefaultWhenAppIDMissing(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	consumerParams := map[string]interface{}{
+		"backend":   "memory",
+		"algorithm": "fixed-window",
+		"quotas": []interface{}{
+			map[string]interface{}{
+				"name": "consumer-request-limit",
+				"limits": []interface{}{
+					map[string]interface{}{"limit": float64(2), "duration": "1h"},
+				},
+				"keyExtraction": []interface{}{
+					map[string]interface{}{"type": "routename"},
+					map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": "default"},
+				},
+			},
+		},
+	}
+
+	pol, err := GetPolicy(policy.PolicyMetadata{RouteName: "route-main"}, consumerParams)
+	if err != nil {
+		t.Fatalf("GetPolicy failed: %v", err)
+	}
+	p := pol.(*RateLimitPolicy)
+
+	// Request 1 — no app ID — key: "route-main:default" — should be allowed (1/2)
+	req1 := newRequestHeaderCtx(nil, nil)
+	action1 := p.OnRequestHeaders(context.Background(), req1, consumerParams)
+	if _, ok := action1.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("request 1 (no app ID): expected allowed, got %T", action1)
+	}
+
+	// Request 2 — no app ID — key: "route-main:default" — should be allowed (2/2)
+	req2 := newRequestHeaderCtx(nil, nil)
+	action2 := p.OnRequestHeaders(context.Background(), req2, consumerParams)
+	if _, ok := action2.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("request 2 (no app ID): expected allowed, got %T", action2)
+	}
+
+	// Request 3 — no app ID — key: "route-main:default" — counter exhausted, should be blocked
+	req3 := newRequestHeaderCtx(nil, nil)
+	action3 := p.OnRequestHeaders(context.Background(), req3, consumerParams)
+	assertImmediateResponse(t, action3, 429)
+
+	// Request with a real app ID — key: "route-main:app-123" — separate counter, should be allowed
+	reqWithApp := newRequestHeaderCtx(nil, map[string]interface{}{"x-wso2-application-id": "app-123"})
+	actionWithApp := p.OnRequestHeaders(context.Background(), reqWithApp, consumerParams)
+	if _, ok := actionWithApp.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("request with app ID: expected allowed (separate counter), got %T", actionWithApp)
+	}
 }
 
 func TestOnRequestBehavior(t *testing.T) {
@@ -2779,7 +2940,7 @@ func TestOnResponseBodyChunk_EmptyFirstChunkDeferrsSSEDetection(t *testing.T) {
 	respCtx := newResponseStreamCtx(nil, nil, meta, 200)
 
 	sendChunks(t, p, respCtx, [][]byte{
-		{},  // empty keep-alive — must not trigger JSON mode
+		{}, // empty keep-alive — must not trigger JSON mode
 		[]byte("data: {\"usage\":{\"total_tokens\":33}}\n"),
 		[]byte("data: [DONE]\n"),
 	})
@@ -3084,10 +3245,10 @@ func TestOnResponseBodyChunk_OpenAISSE_BufferedAndIndividualChunks(t *testing.T)
 	}, "\n")
 
 	sendChunks(t, p, respCtx, [][]byte{
-		[]byte(buffered),                                       // chunk 0: 4 events buffered together
-		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\" jumps\"}}]}\n"), // chunk 1: individual
+		[]byte(buffered), // chunk 0: 4 events buffered together
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\" jumps\"}}]}\n"),                          // chunk 1: individual
 		[]byte("data: {\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":5,\"total_tokens\":13}}\n"), // chunk 2: usage
-		[]byte("data: [DONE]\n"),                              // chunk 3: EOS
+		[]byte("data: [DONE]\n"), // chunk 3: EOS
 	})
 
 	if lim.consumeNCalls != 1 {

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -51,7 +51,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-
 func (p *APIKeyPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeProcess,
@@ -230,6 +229,10 @@ func (p *APIKeyPolicy) authenticate(
 			"ApplicationID":   resolvedKey.ApplicationID,
 		},
 	}
+	if shared.Metadata == nil {
+		shared.Metadata = make(map[string]interface{})
+	}
+	shared.Metadata[applicationIDMetadataKey] = resolvedKey.ApplicationID
 	return nil
 }
 

--- a/policies/api-key-auth/apikey_test.go
+++ b/policies/api-key-auth/apikey_test.go
@@ -291,6 +291,52 @@ func assertUnauthorizedJSON(t *testing.T, action policy.RequestHeaderAction) {
 	}
 }
 
+// TestAPIKeyPolicy_OnRequestHeaders_WritesApplicationIDToSharedContextMetadata verifies
+// that after a successful authentication, the application ID is written to
+// SharedContext.Metadata so that downstream rate limiting policies can read it.
+func TestAPIKeyPolicy_OnRequestHeaders_WritesApplicationIDToSharedContextMetadata(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("x-api-key"): {"header-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	got, ok := ctx.SharedContext.Metadata[applicationIDMetadataKey]
+	if !ok {
+		t.Fatalf("expected %q to be present in SharedContext.Metadata", applicationIDMetadataKey)
+	}
+	if got != "test-app-id" {
+		t.Errorf("expected SharedContext.Metadata[%q]=%q, got %v", applicationIDMetadataKey, "test-app-id", got)
+	}
+}
+
+// TestAPIKeyPolicy_OnRequestHeaders_DoesNotWriteMetadataOnFailure verifies that
+// SharedContext.Metadata is not populated with the application ID when auth fails.
+func TestAPIKeyPolicy_OnRequestHeaders_DoesNotWriteMetadataOnFailure(t *testing.T) {
+	resetAPIKeyStore(t)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("x-api-key"): {"wrong-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
+		"key": "x-api-key",
+		"in":  "header",
+	})
+
+	if _, ok := ctx.SharedContext.Metadata[applicationIDMetadataKey]; ok {
+		t.Errorf("expected %q to be absent from SharedContext.Metadata on auth failure", applicationIDMetadataKey)
+	}
+}
+
 func TestAPIKeyPolicy_AuthContext_PreviousPreserved_OnSuccess(t *testing.T) {
 	resetAPIKeyStore(t)
 	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
@@ -358,16 +404,16 @@ func resetAPIKeyStore(t *testing.T) {
 func seedExternalAPIKey(t *testing.T, apiID, plainKey, operations string) {
 	t.Helper()
 	key := &apikeycommon.APIKey{
-		ID:          "id-" + sanitizeTestName(t.Name()),
-		Name:        "name-" + sanitizeTestName(t.Name()),
-		DisplayName: "test-key",
+		ID:              "id-" + sanitizeTestName(t.Name()),
+		Name:            "name-" + sanitizeTestName(t.Name()),
+		DisplayName:     "test-key",
 		ApplicationID:   "test-app-id",
 		ApplicationName: "test-app-name",
-		APIKey:      apikeycommon.ComputeAPIKeyHash(plainKey),
-		APIId:       apiID,
-		Operations:  operations,
-		Status:      apikeycommon.Active,
-		Source:      "external",
+		APIKey:          apikeycommon.ComputeAPIKeyHash(plainKey),
+		APIId:           apiID,
+		Operations:      operations,
+		Status:          apikeycommon.Active,
+		Source:          "external",
 	}
 	if err := apikeycommon.GetAPIkeyStoreInstance().StoreAPIKey(apiID, key); err != nil {
 		t.Fatalf("failed to store API key: %v", err)

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v1.0.1
+version: v1.0.2
 description: |
   Secures APIs by validating API keys in incoming requests. API keys can be
   provided through a configured HTTP header or query parameter.

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -70,7 +70,6 @@ func GetPolicy(
 	}, nil
 }
 
-
 // Mode returns the processing mode for this policy.
 // ResponseBodyMode is Stream so that OnResponseBodyChunk is called for each chunk,
 // delegating to the advanced-ratelimit instance which reads x-llm-cost from
@@ -584,13 +583,24 @@ func transformToRatelimitParams(params map[string]interface{}) map[string]interf
 		},
 	}
 
+	consumerBased, _ := params["consumerBased"].(bool)
+	var keyExtraction []interface{}
+	if consumerBased {
+		keyExtraction = []interface{}{
+			map[string]interface{}{"type": "routename"},
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id"},
+		}
+	} else {
+		keyExtraction = []interface{}{
+			map[string]interface{}{"type": "routename"},
+		}
+	}
+
 	// Build the quota
 	quota := map[string]interface{}{
-		"name":   "llm_cost_quota",
-		"limits": limits,
-		"keyExtraction": []interface{}{
-			map[string]interface{}{"type": "routename"},
-		},
+		"name":          "llm_cost_quota",
+		"limits":        limits,
+		"keyExtraction": keyExtraction,
 	}
 
 	quota["costExtraction"] = map[string]interface{}{

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -588,7 +588,7 @@ func transformToRatelimitParams(params map[string]interface{}) map[string]interf
 	if consumerBased {
 		keyExtraction = []interface{}{
 			map[string]interface{}{"type": "routename"},
-			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id"},
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": "default"},
 		}
 	} else {
 		keyExtraction = []interface{}{

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -35,9 +35,11 @@ import (
 )
 
 const (
-	MetadataKeyProviderName    = "provider_name"
-	MetadataKeyDelegate        = "llm_cost_delegate"
-	MetadataKeyCostScaleFactor = "llm_cost_scale_factor"
+	MetadataKeyProviderName            = "provider_name"
+	MetadataKeyDelegate                = "llm_cost_delegate"
+	metadataKeyDelegateConsumer        = "llm_cost_delegate_consumer"
+	MetadataKeyCostScaleFactor         = "llm_cost_scale_factor"
+	metadataKeyCostScaleFactorConsumer = "llm_cost_scale_factor_consumer"
 
 	// DefaultCostScaleFactor is the default scaling factor for dollar amounts.
 	// Converts dollars to nano-dollars to preserve precision in int64 counters.
@@ -45,6 +47,25 @@ const (
 	// Can be overridden via systemParameters.costScaleFactor
 	DefaultCostScaleFactor = 1_000_000_000
 )
+
+// delegateMetadataKey returns the metadata key for the delegate reference.
+// Backend and consumer instances use separate keys to prevent one overwriting the other
+// when both are in the same request chain.
+func delegateMetadataKey(params map[string]interface{}) string {
+	if consumerBased, _ := params["consumerBased"].(bool); consumerBased {
+		return metadataKeyDelegateConsumer
+	}
+	return MetadataKeyDelegate
+}
+
+// costScaleFactorMetadataKey returns the metadata key for the cost scale factor.
+// Backend and consumer instances use separate keys for the same reason as delegateMetadataKey.
+func costScaleFactorMetadataKey(params map[string]interface{}) string {
+	if consumerBased, _ := params["consumerBased"].(bool); consumerBased {
+		return metadataKeyCostScaleFactorConsumer
+	}
+	return MetadataKeyCostScaleFactor
+}
 
 // delegateEntry holds a delegate and its cache key for atomic storage
 type delegateEntry struct {
@@ -124,11 +145,11 @@ func (p *LLMCostRateLimitPolicy) OnRequestHeaders(ctx context.Context, reqCtx *p
 	if reqCtx.SharedContext.Metadata == nil {
 		reqCtx.SharedContext.Metadata = make(map[string]interface{})
 	}
-	reqCtx.SharedContext.Metadata[MetadataKeyDelegate] = delegate
+	reqCtx.SharedContext.Metadata[delegateMetadataKey(params)] = delegate
 
 	// Store the cost scale factor for use in OnResponseHeaders
 	costScaleFactor := extractCostScaleFactor(params)
-	reqCtx.SharedContext.Metadata[MetadataKeyCostScaleFactor] = costScaleFactor
+	reqCtx.SharedContext.Metadata[costScaleFactorMetadataKey(params)] = costScaleFactor
 
 	slog.Debug("OnRequestHeaders: delegating to advanced-ratelimit",
 		"route", p.metadata.RouteName,
@@ -161,12 +182,12 @@ func (p *LLMCostRateLimitPolicy) OnResponseHeaders(ctx context.Context, respCtx 
 	// Retrieve the cost scale factor: prefer the value pinned during OnRequestHeaders,
 	// fall back to extracting it from params.
 	costScaleFactor := extractCostScaleFactor(params)
-	if scaleFactor, ok := respCtx.Metadata[MetadataKeyCostScaleFactor].(int); ok && scaleFactor > 0 {
+	if scaleFactor, ok := respCtx.Metadata[costScaleFactorMetadataKey(params)].(int); ok && scaleFactor > 0 {
 		costScaleFactor = scaleFactor
 	}
 
 	// First, try to use the delegate pinned during OnRequestHeaders (ensures consistency)
-	if delegate, ok := respCtx.Metadata[MetadataKeyDelegate].(policy.Policy); ok {
+	if delegate, ok := respCtx.Metadata[delegateMetadataKey(params)].(policy.Policy); ok {
 		slog.Debug("OnResponseHeaders: using pinned delegate from request phase",
 			"route", p.metadata.RouteName)
 		if rl, ok := delegate.(responseHeaderPolicer); ok {
@@ -219,7 +240,7 @@ func (p *LLMCostRateLimitPolicy) OnResponseBodyChunk(
 	}
 
 	// First, try the delegate pinned during OnRequestHeaders.
-	if delegate, ok := respCtx.Metadata[MetadataKeyDelegate].(policy.Policy); ok {
+	if delegate, ok := respCtx.Metadata[delegateMetadataKey(params)].(policy.Policy); ok {
 		if rl, ok := delegate.(responseChunkPolicer); ok {
 			return rl.OnResponseBodyChunk(ctx, respCtx, chunk, params)
 		}
@@ -270,12 +291,12 @@ func (p *LLMCostRateLimitPolicy) OnResponseBody(ctx context.Context, respCtx *po
 	}
 
 	costScaleFactor := extractCostScaleFactor(params)
-	if scaleFactor, ok := respCtx.SharedContext.Metadata[MetadataKeyCostScaleFactor].(int); ok && scaleFactor > 0 {
+	if scaleFactor, ok := respCtx.SharedContext.Metadata[costScaleFactorMetadataKey(params)].(int); ok && scaleFactor > 0 {
 		costScaleFactor = scaleFactor
 	}
 
 	// First, try to use the delegate pinned during OnRequestHeaders
-	if delegate, ok := respCtx.SharedContext.Metadata[MetadataKeyDelegate].(policy.Policy); ok {
+	if delegate, ok := respCtx.SharedContext.Metadata[delegateMetadataKey(params)].(policy.Policy); ok {
 		slog.Debug("OnResponseBody: using pinned delegate from request phase",
 			"route", p.metadata.RouteName)
 		if rl, ok := delegate.(responseBodyPolicer); ok {

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
@@ -533,3 +533,83 @@ func TestLLMCostRateLimitPolicy_OnResponseBodyChunk_FallsBackToDelegatesMap(t *t
 		t.Errorf("expected delegate OnResponseBodyChunk called 1 time via fallback, got %d", stub.chunkCalls)
 	}
 }
+
+// TestTransformToRatelimitParams_ConsumerBased_False verifies that when consumerBased is
+// false (or absent), keyExtraction only contains the routename key.
+func TestTransformToRatelimitParams_ConsumerBased_False(t *testing.T) {
+	params := map[string]interface{}{
+		"budgetLimits": []interface{}{
+			map[string]interface{}{
+				"amount":   float64(10),
+				"duration": "1h",
+			},
+		},
+		"consumerBased": false,
+	}
+
+	result := transformToRatelimitParams(params)
+
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok {
+		t.Fatal("Expected keyExtraction to be []interface{}")
+	}
+
+	if len(keyExtraction) != 1 {
+		t.Fatalf("Expected 1 key extraction entry for backend limit, got %d", len(keyExtraction))
+	}
+
+	entry := keyExtraction[0].(map[string]interface{})
+	if entry["type"] != "routename" {
+		t.Errorf("Expected type 'routename', got %v", entry["type"])
+	}
+}
+
+// TestTransformToRatelimitParams_ConsumerBased_True verifies that when consumerBased is
+// true, keyExtraction contains both routename and the application ID metadata key.
+func TestTransformToRatelimitParams_ConsumerBased_True(t *testing.T) {
+	params := map[string]interface{}{
+		"budgetLimits": []interface{}{
+			map[string]interface{}{
+				"amount":   float64(10),
+				"duration": "1h",
+			},
+		},
+		"consumerBased": true,
+	}
+
+	result := transformToRatelimitParams(params)
+
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok {
+		t.Fatal("Expected keyExtraction to be []interface{}")
+	}
+
+	if len(keyExtraction) != 2 {
+		t.Fatalf("Expected 2 key extraction entries for consumer limit, got %d", len(keyExtraction))
+	}
+
+	first := keyExtraction[0].(map[string]interface{})
+	if first["type"] != "routename" {
+		t.Errorf("Expected first entry type 'routename', got %v", first["type"])
+	}
+
+	second := keyExtraction[1].(map[string]interface{})
+	if second["type"] != "metadata" {
+		t.Errorf("Expected second entry type 'metadata', got %v", second["type"])
+	}
+	if second["key"] != "x-wso2-application-id" {
+		t.Errorf("Expected second entry key 'x-wso2-application-id', got %v", second["key"])
+	}
+}

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit_test.go
@@ -612,4 +612,7 @@ func TestTransformToRatelimitParams_ConsumerBased_True(t *testing.T) {
 	if second["key"] != "x-wso2-application-id" {
 		t.Errorf("Expected second entry key 'x-wso2-application-id', got %v", second["key"])
 	}
+	if second["fallback"] != "default" {
+		t.Errorf("Expected second entry fallback 'default', got %v", second["fallback"])
+	}
 }

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v1.0.2
+version: v1.0.3
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost
@@ -41,6 +41,16 @@ parameters:
               Time window for the budget limit (Go duration string format).
               Examples: "1h" (1 hour), "24h" (1 day), "168h" (1 week), "720h" (30 days)
             pattern: "^(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+
+    consumerBased:
+      type: boolean
+      x-wso2-policy-advanced-param: false
+      description: |
+        When true, rate limits are applied per consumer (GenAI application) identified
+        by the x-wso2-application-id metadata key set by the api-key-auth policy.
+        Each application gets its own independent cost counter.
+        When false (default), a single shared limit applies across all consumers.
+      default: false
 
 systemParameters:
   type: object

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v1.0.2
+version: v1.0.3
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the
@@ -75,6 +75,15 @@ parameters:
             description: Specifies the duration window for the limit as a Go
               duration string, for example "1s", "1m", "1h", or "24h".
             pattern: "^[-+]?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+    consumerBased:
+      type: boolean
+      x-wso2-policy-advanced-param: false
+      description: |
+        When true, rate limits are applied per consumer (GenAI application) identified
+        by the x-wso2-application-id metadata key set by the api-key-auth policy.
+        Each application gets its own independent token counter.
+        When false (default), a single shared limit applies across all consumers.
+      default: false
   oneOf:
     - required: ["promptTokenLimits"]
       not:

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -275,7 +275,7 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 	if consumerBased {
 		keyExtraction = []interface{}{
 			map[string]interface{}{"type": "routename"},
-			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id"},
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": "default"},
 		}
 	} else {
 		keyExtraction = []interface{}{

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -58,7 +58,6 @@ func GetPolicy(
 	}, nil
 }
 
-
 func (p *TokenBasedRateLimitPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeProcess,
@@ -271,6 +270,19 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 
 	var quotas []interface{}
 
+	consumerBased, _ := params["consumerBased"].(bool)
+	var keyExtraction []interface{}
+	if consumerBased {
+		keyExtraction = []interface{}{
+			map[string]interface{}{"type": "routename"},
+			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id"},
+		}
+	} else {
+		keyExtraction = []interface{}{
+			map[string]interface{}{"type": "routename"},
+		}
+	}
+
 	addQuota := func(name string, limitsKey string, templateKey string) {
 		limits := params[limitsKey]
 		if limits == nil {
@@ -289,11 +301,9 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 		}
 
 		quota := map[string]interface{}{
-			"name":   name,
-			"limits": convertedLimits,
-			"keyExtraction": []interface{}{
-				map[string]interface{}{"type": "routename"},
-			},
+			"name":          name,
+			"limits":        convertedLimits,
+			"keyExtraction": keyExtraction,
 		}
 
 		if template != nil {

--- a/policies/token-based-ratelimit/token_based_ratelimit_test.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit_test.go
@@ -476,3 +476,83 @@ func TestTokenBasedRateLimitPolicy_OnResponseBodyChunk_DelegateCalled(t *testing
 		t.Errorf("expected delegate OnResponseBodyChunk called 2 times, got %d", stub.chunkCalls)
 	}
 }
+
+// TestTransformToRatelimitParams_ConsumerBased_False verifies that when consumerBased is
+// false (or absent), keyExtraction only contains the routename key.
+func TestTransformToRatelimitParams_ConsumerBased_False(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{
+				"count":    float64(1000),
+				"duration": "1h",
+			},
+		},
+		"consumerBased": false,
+	}
+
+	result := transformToRatelimitParams(params, nil)
+
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok {
+		t.Fatal("Expected keyExtraction to be []interface{}")
+	}
+
+	if len(keyExtraction) != 1 {
+		t.Fatalf("Expected 1 key extraction entry for backend limit, got %d", len(keyExtraction))
+	}
+
+	entry := keyExtraction[0].(map[string]interface{})
+	if entry["type"] != "routename" {
+		t.Errorf("Expected type 'routename', got %v", entry["type"])
+	}
+}
+
+// TestTransformToRatelimitParams_ConsumerBased_True verifies that when consumerBased is
+// true, keyExtraction contains both routename and the application ID metadata key.
+func TestTransformToRatelimitParams_ConsumerBased_True(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{
+				"count":    float64(1000),
+				"duration": "1h",
+			},
+		},
+		"consumerBased": true,
+	}
+
+	result := transformToRatelimitParams(params, nil)
+
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok {
+		t.Fatal("Expected keyExtraction to be []interface{}")
+	}
+
+	if len(keyExtraction) != 2 {
+		t.Fatalf("Expected 2 key extraction entries for consumer limit, got %d", len(keyExtraction))
+	}
+
+	first := keyExtraction[0].(map[string]interface{})
+	if first["type"] != "routename" {
+		t.Errorf("Expected first entry type 'routename', got %v", first["type"])
+	}
+
+	second := keyExtraction[1].(map[string]interface{})
+	if second["type"] != "metadata" {
+		t.Errorf("Expected second entry type 'metadata', got %v", second["type"])
+	}
+	if second["key"] != "x-wso2-application-id" {
+		t.Errorf("Expected second entry key 'x-wso2-application-id', got %v", second["key"])
+	}
+}

--- a/policies/token-based-ratelimit/token_based_ratelimit_test.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit_test.go
@@ -555,4 +555,7 @@ func TestTransformToRatelimitParams_ConsumerBased_True(t *testing.T) {
 	if second["key"] != "x-wso2-application-id" {
 		t.Errorf("Expected second entry key 'x-wso2-application-id', got %v", second["key"])
 	}
+	if second["fallback"] != "default" {
+		t.Errorf("Expected second entry fallback 'default', got %v", second["fallback"])
+	}
 }


### PR DESCRIPTION
## Purpose

Adds consumer-based rate limiting support to gateway-controllers policies. Currently, token and cost rate limits are shared across all GenAI applications — if App A exhausts the token budget, App B gets blocked too. This change allows each application to have its own independent counter against the same limit.

## Goals

- Allow per-application rate limiting for token usage, cost, and request count
- Each GenAI application (identified by `x-wso2-application-id`) gets its own independent counter
- The limit value is the same for all apps, but counters are tracked separately per app
- Support running backend-level and consumer-level limits simultaneously in the same request chain

## Approach

### `api-key-auth`
After a successful API key authentication, write the application ID into `SharedContext.Metadata` (in addition to `AuthContext.Properties` and `AnalyticsMetadata` where it was already written). This makes it accessible to downstream rate limiting policies via key extraction.

### `token-based-ratelimit`
- Added a `consumerBased` boolean parameter to `policy-definition.yaml`
- When `consumerBased: true`, key extraction switches from `routename` alone to `routename + x-wso2-application-id`, giving each application its own counter

### `llm-cost-based-ratelimit`
- Added a `consumerBased` boolean parameter to `policy-definition.yaml`
- Same key extraction switch as `token-based-ratelimit`
- Fixed a metadata key collision: when backend and consumer instances are both in the request chain, the consumer instance was overwriting the backend's delegate reference stored under `llm_cost_delegate`. The backend's response phase then read the consumer's delegate and drained the consumer counter twice while never touching the backend counter. Fixed by using separate keys: `llm_cost_delegate` for backend and `llm_cost_delegate_consumer` for consumer.

### `advanced-ratelimit`
Fixed a metadata key collision that occurs when two instances with different key extraction configs run in the same request chain (e.g. a backend request-count limit and a consumer request-count limit):

- `advanced-ratelimit` passes state between its request and response phases via hardcoded metadata keys (`ratelimit:keys`, `ratelimit:result`, etc.)
- The second instance blindly overwrites the first's entry. When both instances share the same key extraction config this is harmless (same value). But when a backend instance writes `routename` and a consumer instance writes `routename:app-id`, the backend's response phase reads the consumer's key and deducts from the wrong counter — backend budget is never exhausted
- Fixed by adding an `instanceID` field to `RateLimitPolicy` — a short SHA-256 hash of the quota names and key extraction config. All metadata reads/writes go through `p.metaKey(base)` which appends the instance ID, namespacing each instance's metadata slots. Limiter objects and the limiter cache are unaffected.

## Release note

Added consumer-based rate limiting support to `token-based-ratelimit`, `llm-cost-based-ratelimit`, and `advanced-ratelimit` policies. A new `consumerBased` parameter allows limits to be tracked independently per GenAI application rather than shared across all applications. Also fixed metadata key collisions in `advanced-ratelimit` and `llm-cost-based-ratelimit` that caused incorrect counter updates when backend and consumer instances ran in the same request chain.

## Documentation

N/A