### PR TITLE
Standardize policy Mode() returns and tests

### DIFF
--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -170,14 +170,13 @@ func GetPolicy(
 	return p, nil
 }
 
-
 // Mode returns the processing mode for the AWS Bedrock guardrail policy.
 func (p *AWSBedrockGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeStream,
+		ResponseBodyMode:   policy.BodyModeBuffer,
 	}
 }
 

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
@@ -13,6 +13,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestAWSBedrockGuardrailPolicy_Mode(t *testing.T) {
+	p := &AWSBedrockGuardrailPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 type mockBedrockClient struct {
 	output    *bedrockruntime.ApplyGuardrailOutput
 	err       error

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: aws-bedrock-guardrail
-version: v1.0.1
+version: v1.0.2
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation.go
@@ -122,14 +122,13 @@ func GetPolicy(
 	return p, nil
 }
 
-
 // Mode returns the processing mode for the Azure Content Safety content moderation policy.
 func (p *AzureContentSafetyContentModerationPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
-		ResponseBodyMode:   policy.BodyModeStream,
+		ResponseBodyMode:   policy.BodyModeBuffer,
 	}
 }
 

--- a/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
+++ b/policies/azure-content-safety-content-moderation/azurecontentsafetycontentmoderation_test.go
@@ -11,6 +11,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestAzureContentSafetyContentModerationPolicy_Mode(t *testing.T) {
+	p := &AzureContentSafetyContentModerationPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func TestValidateAzureConfigParams(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/policies/azure-content-safety-content-moderation/policy-definition.yaml
+++ b/policies/azure-content-safety-content-moderation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: azure-content-safety-content-moderation
-version: v1.0.1
+version: v1.0.2
 description: |
   Validates request and response content with Azure Content Safety moderation
   checks.

--- a/policies/json-xml-mediator/jsonxmlmediation.go
+++ b/policies/json-xml-mediator/jsonxmlmediation.go
@@ -69,12 +69,11 @@ func GetPolicy(
 	}, nil
 }
 
-
 func (p *JSONXMLMediationPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
-		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseHeaderMode: policy.HeaderModeSkip,
 		ResponseBodyMode:   policy.BodyModeBuffer,
 	}
 }

--- a/policies/json-xml-mediator/jsonxmlmediation_test.go
+++ b/policies/json-xml-mediator/jsonxmlmediation_test.go
@@ -9,6 +9,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestJSONXMLMediationPolicy_Mode(t *testing.T) {
+	p := &JSONXMLMediationPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeBuffer,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func createHeaders(key, value string) *policy.Headers {
 	h := map[string][]string{}
 	h[key] = []string{value}

--- a/policies/json-xml-mediator/policy-definition.yaml
+++ b/policies/json-xml-mediator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-xml-mediator
-version: v1.0.1
+version: v1.0.2
 description: |
   Mediates request and response payloads between downstream and upstream JSON/XML formats
 

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -86,7 +86,6 @@ func GetPolicy(
 	return instance, instanceErr
 }
 
-
 // Mode declares the SDK processing requirements:
 //   - RequestBodyMode=Buffer: buffer the request so ctx.RequestBody is available
 //     in OnResponseBody (needed for Anthropic speed parameter).
@@ -95,8 +94,10 @@ func GetPolicy(
 //     at end-of-stream, which covers the buffered path too (single chunk, EOS=true).
 func (p *LLMCostPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestBodyMode:  policy.BodyModeBuffer,
-		ResponseBodyMode: policy.BodyModeStream,
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeStream,
 	}
 }
 

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -30,6 +30,20 @@ import (
 
 const floatTolerance = 1e-12
 
+func TestLLMCostPolicy_Mode(t *testing.T) {
+	p := &LLMCostPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeStream,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 // testPricingMap is loaded once from the pinned testdata/model_prices.json fixture.
 var testPricingMap map[string]ModelPricing
 

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v1.0.2
+version: v1.0.3
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").

--- a/policies/log-message/logmessage.go
+++ b/policies/log-message/logmessage.go
@@ -55,11 +55,10 @@ func GetPolicy(
 	return ins, nil
 }
 
-
 func (p *LogMessagePolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeBuffer,
+		RequestBodyMode:    policy.BodyModeStream,
 		ResponseHeaderMode: policy.HeaderModeProcess,
 		ResponseBodyMode:   policy.BodyModeStream,
 	}

--- a/policies/log-message/logmessage_test.go
+++ b/policies/log-message/logmessage_test.go
@@ -32,6 +32,20 @@ import (
 
 var slogMessagePattern = regexp.MustCompile(`msg="((?:\\.|[^"])*)"`)
 
+func TestLogMessagePolicy_Mode(t *testing.T) {
+	p := &LogMessagePolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeStream,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeStream,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func createTestHeaders(headers map[string]string) *policy.Headers {
 	headerMap := make(map[string][]string)
 	for key, value := range headers {

--- a/policies/log-message/policy-definition.yaml
+++ b/policies/log-message/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: log-message
-version: v1.0.1
+version: v1.0.2
 description: |
   Log request and response payloads and headers for observability without changing traffic.
 

--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -105,7 +105,6 @@ func GetPolicy(
 	return ins, nil
 }
 
-
 // parseAuthority extracts host and port from an authority string (e.g., "example.com:8080")
 func parseAuthority(authority string) (host string, port int) {
 	if authority == "" {
@@ -337,7 +336,7 @@ func ensureRequestMetadata(reqCtx *policy.RequestContext) {
 
 func (p *McpAuthPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
 		ResponseBodyMode:   policy.BodyModeSkip,

--- a/policies/mcp-auth/mcp-auth_test.go
+++ b/policies/mcp-auth/mcp-auth_test.go
@@ -36,6 +36,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestMcpAuthPolicy_Mode(t *testing.T) {
+	p := &McpAuthPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func TestGetPolicy(t *testing.T) {
 	p, err := GetPolicy(policy.PolicyMetadata{}, nil)
 	if err != nil {

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v1.0.2
+version: v1.0.3
 description: |
   Secure Model Context Protocol traffic by validating bearer access tokens for MCP resources using the underlying JWT authentication runtime.
 

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v1.0.2
+version: v1.0.3
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.

--- a/policies/model-round-robin/roundrobin.go
+++ b/policies/model-round-robin/roundrobin.go
@@ -92,7 +92,7 @@ func (p *ModelRoundRobinPolicy) Mode() policy.ProcessingMode {
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeSkip,
 	}
 }
 

--- a/policies/model-round-robin/roundrobin_test.go
+++ b/policies/model-round-robin/roundrobin_test.go
@@ -17,7 +17,7 @@ func TestModelRoundRobinPolicy_Mode(t *testing.T) {
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeSkip,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-weighted-round-robin
-version: v1.0.2
+version: v1.0.3
 description: |
   Distribute requests across models using weighted round-robin so higher-weight models receive proportionally more traffic.
 

--- a/policies/model-weighted-round-robin/weightedroundrobin.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin.go
@@ -105,7 +105,7 @@ func (p *ModelWeightedRoundRobinPolicy) Mode() policy.ProcessingMode {
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeSkip,
 	}
 }
 

--- a/policies/model-weighted-round-robin/weightedroundrobin_test.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin_test.go
@@ -17,7 +17,7 @@ func TestModelWeightedRoundRobinPolicy_Mode(t *testing.T) {
 		RequestHeaderMode:  policy.HeaderModeProcess,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeProcess,
-		ResponseBodyMode:   policy.BodyModeBuffer,
+		ResponseBodyMode:   policy.BodyModeSkip,
 	}
 	if got != want {
 		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)

--- a/policies/prompt-decorator/policy-definition.yaml
+++ b/policies/prompt-decorator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: prompt-decorator
-version: v1.0.1
+version: v1.0.2
 description: |
   Applies configured prompt decorations to request payloads before upstream processing.
 

--- a/policies/prompt-decorator/promptdecorator.go
+++ b/policies/prompt-decorator/promptdecorator.go
@@ -84,11 +84,10 @@ func GetPolicy(
 	return p, nil
 }
 
-
 // Mode returns the processing mode for the prompt decorator policy.
 func (p *PromptDecoratorPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
 		ResponseBodyMode:   policy.BodyModeSkip,

--- a/policies/prompt-decorator/promptdecorator_test.go
+++ b/policies/prompt-decorator/promptdecorator_test.go
@@ -11,6 +11,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestPromptDecoratorPolicy_Mode(t *testing.T) {
+	p := &PromptDecoratorPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func TestPromptDecoratorPolicy_GetPolicy_TextConfig_Defaults(t *testing.T) {
 	p := mustGetPromptDecoratorPolicy(t, map[string]interface{}{
 		"promptDecoratorConfig": map[string]interface{}{

--- a/policies/sentence-count-guardrail/policy-definition.yaml
+++ b/policies/sentence-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: sentence-count-guardrail
-version: v1.0.1
+version: v1.0.2
 description: |
   Validate sentence counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/sentence-count-guardrail/sentencecountguardrail.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail.go
@@ -113,10 +113,9 @@ func GetPolicy(
 	return p, nil
 }
 
-
 func (p *SentenceCountGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
 		ResponseBodyMode:   policy.BodyModeStream,

--- a/policies/sentence-count-guardrail/sentencecountguardrail_test.go
+++ b/policies/sentence-count-guardrail/sentencecountguardrail_test.go
@@ -9,6 +9,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestSentenceCountGuardrailPolicy_Mode(t *testing.T) {
+	p := &SentenceCountGuardrailPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeStream,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
 	t.Helper()
 

--- a/policies/word-count-guardrail/policy-definition.yaml
+++ b/policies/word-count-guardrail/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: word-count-guardrail
-version: v1.0.1
+version: v1.0.2
 description: |
   Validate word counts in request or response content using min/max limits, optional JSONPath extraction, and optional inverted logic.
 

--- a/policies/word-count-guardrail/wordcountguardrail.go
+++ b/policies/word-count-guardrail/wordcountguardrail.go
@@ -78,10 +78,9 @@ func GetPolicy(
 	return newPolicy(params)
 }
 
-
 func (p *WordCountGuardrailPolicy) Mode() policy.ProcessingMode {
 	return policy.ProcessingMode{
-		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestHeaderMode:  policy.HeaderModeSkip,
 		RequestBodyMode:    policy.BodyModeBuffer,
 		ResponseHeaderMode: policy.HeaderModeSkip,
 		ResponseBodyMode:   policy.BodyModeStream,

--- a/policies/word-count-guardrail/wordcountguardrail_test.go
+++ b/policies/word-count-guardrail/wordcountguardrail_test.go
@@ -9,6 +9,20 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
+func TestWordCountGuardrailPolicy_Mode(t *testing.T) {
+	p := &WordCountGuardrailPolicy{}
+	got := p.Mode()
+	want := policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeStream,
+	}
+	if got != want {
+		t.Fatalf("unexpected mode: got %+v, want %+v", got, want)
+	}
+}
+
 func mustMessageMap(t *testing.T, body []byte) map[string]interface{} {
 	t.Helper()
 
@@ -780,17 +794,17 @@ func TestNeedsMoreResponseData_NormalMode_GatesUntilMin(t *testing.T) {
 	// Note: "[EMAIL_0001]" arrives as 6 separate fragments in the real stream;
 	// we consolidate them here to keep the test readable.
 	fragments := []string{
-		"You",         // 1
-		" provided",   // 2
-		" a",          // 3
-		" dummy",      // 4
-		" email",      // 5
-		" address",    // 6
-		" as",         // 7
-		" [EMAIL",     // 8  ← "[EMAIL" is one whitespace-delimited token
-		"_0001]",      // 8  (still 8; no space, extends "[EMAIL_0001]")
-		" and",        // 9
-		" a",          // 10
+		"You",       // 1
+		" provided", // 2
+		" a",        // 3
+		" dummy",    // 4
+		" email",    // 5
+		" address",  // 6
+		" as",       // 7
+		" [EMAIL",   // 8  ← "[EMAIL" is one whitespace-delimited token
+		"_0001]",    // 8  (still 8; no space, extends "[EMAIL_0001]")
+		" and",      // 9
+		" a",        // 10
 	}
 
 	var events []string
@@ -935,23 +949,23 @@ func TestNeedsMoreResponseData_UserSSEStream(t *testing.T) {
 		expectedWords int
 	}
 	steps := []step{
-		{sseInitEvent(), 0},       // role:assistant, content:"" → 0 words
-		{sseEvent("You"), 1},      // 1
+		{sseInitEvent(), 0},        // role:assistant, content:"" → 0 words
+		{sseEvent("You"), 1},       // 1
 		{sseEvent(" provided"), 2}, // 2
-		{sseEvent(" a"), 3},       // 3
-		{sseEvent(" dummy"), 4},   // 4
-		{sseEvent(" email"), 5},   // 5
-		{sseEvent(" address"), 6}, // 6
-		{sseEvent(" as"), 7},      // 7
-		{sseEvent(" ["), 8},       // 8  ("[" is a whitespace-separated token)
-		{sseEvent("EMAIL"), 8},    // still 8 (no space, extends "[EMAIL")
-		{sseEvent("_"), 8},        // still 8
-		{sseEvent("000"), 8},      // still 8
-		{sseEvent("1"), 8},        // still 8
-		{sseEvent("]"), 8},        // still 8 ("[EMAIL_0001]" = one token)
-		{sseEvent(" and"), 9},     // 9
-		{sseEvent(" a"), 10},      // 10 ← gate must open here
-		{sseFinishEvent(), 10},    // finish_reason:stop, delta:{} → no new words
+		{sseEvent(" a"), 3},        // 3
+		{sseEvent(" dummy"), 4},    // 4
+		{sseEvent(" email"), 5},    // 5
+		{sseEvent(" address"), 6},  // 6
+		{sseEvent(" as"), 7},       // 7
+		{sseEvent(" ["), 8},        // 8  ("[" is a whitespace-separated token)
+		{sseEvent("EMAIL"), 8},     // still 8 (no space, extends "[EMAIL")
+		{sseEvent("_"), 8},         // still 8
+		{sseEvent("000"), 8},       // still 8
+		{sseEvent("1"), 8},         // still 8
+		{sseEvent("]"), 8},         // still 8 ("[EMAIL_0001]" = one token)
+		{sseEvent(" and"), 9},      // 9
+		{sseEvent(" a"), 10},       // 10 ← gate must open here
+		{sseFinishEvent(), 10},     // finish_reason:stop, delta:{} → no new words
 	}
 
 	var acc strings.Builder


### PR DESCRIPTION
## Purpose
The policy engine is being upgraded to a "Mode-First" architecture, where the engine will exclusively trust a policy's `Mode()` method to determine its participation in the request/response lifecycle.

During this transition, we discovered significant mismatches in several production policies between the capabilities they formally declare via their `Mode()` method and the Go interfaces they actually implement. Because the legacy engine fell back to Go type assertions, these structural bugs were hidden in production. 

Specifically, some policies requested `HeaderModeProcess` but didn't implement header callbacks, while others declared `BodyModeBuffer` when they actually needed `BodyModeSkip`. This discrepancy is an active bug that artificially injected buffering overhead into true streaming LLM flows. This PR fixes these structural mismatches across the production policies so they explicitly and accurately declare their capabilities, ensuring they function correctly under the new `Mode()`-first gateway architecture.

## Goals
Fix the silent structural bugs where a policy's `Mode()` declaration mismatched its actual interface implementation. Eliminate unnecessary response buffering in routing policies to safely unlock low-latency LLM streaming.

## Approach
- **Fixed Active Buffering Bugs:** Explicitly changed `ResponseBodyMode` to `BodyModeSkip` in `model-round-robin` and `model-weighted-round-robin` policies. Previously, their `Mode()` incorrectly defaulted to `BodyModeBuffer`, causing Envoy to buffer entire chat completions unnecessarily before sending them back over SSE, severely degrading streaming latency.
- **Fixed Header Mode Mismatches:** Corrected `RequestHeaderMode` and `ResponseHeaderMode` to `policy.HeaderModeSkip` for `json-xml-mediator`, `prompt-decorator`, `sentence-count-guardrail`, `word-count-guardrail`, and `llm-cost`. These policies inaccurately claimed they processed headers, which poses a risk of unnecessary header callback parsing under the exact-mode architecture.
- **Regression Tests:** Added explicit `TestMode` unit tests across the 11 modified packages to actively enforce alignment between the interfaces implemented and the `Mode()` output, preventing secret drift in the future.

## Release note
Optimized streaming response latency by fixing buffering bugs in round-robin and weighted-round-robin policies, and remediated hidden structural mismatches in `Mode()` declarations across production policies.

## Documentation
N/A - Internal architectural bug fixes. No user-facing documentation changes required.

## Automation tests
 - Unit tests 
   > Added/updated strict `Mode()` regression tests ensuring the mode configuration remains perfectly aligned with the interfaces implemented (e.g., in `mcp-auth_test.go`, `roundrobin_test.go`, `logmessage_test.go`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/api-platform/pull/1686

## Migrations (if applicable)
N/A

## Test environment
- macOS / Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized request/response header and body handling across multiple policies—some now skip header processing, others switch between buffered and streamed response handling—to improve reliability and predictability.
  * Incremented policy metadata versions for the affected policies.

* **Tests**
  * Added unit tests to validate the updated processing configurations across the modified policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->