### PR TITLE
Add monetization support in subscription validation policy

### DIFF
--- a/policies/subscription-validation/go.mod
+++ b/policies/subscription-validation/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/subscription-validation
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.12

--- a/policies/subscription-validation/go.sum
+++ b/policies/subscription-validation/go.sum
@@ -1,2 +1,2 @@
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.12 h1:todO77VOlxw8bWniFK/GyEbuM1R5ELnULgR+37Xdrak=
+github.com/wso2/api-platform/sdk/core v0.2.12/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v1.0.1
+version: v1.0.2
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -225,21 +225,21 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 		if len(headerValues) > 0 {
 			token := strings.TrimSpace(headerValues[0])
 			if token != "" {
-				action, entry := p.validateByToken(apiID, token)
-				if action == nil {
-					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
+				block, subscription := p.validateByToken(apiID, token)
+				if block == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, subscription)
 					return policy.UpstreamRequestHeaderModifications{
 						HeadersToRemove: []string{normalizeHeaderName(p.cfg.SubscriptionKeyHeader)},
 					}
 				}
-				return action.(policy.ImmediateResponse)
+				return block.(policy.ImmediateResponse)
 			}
 		}
 		if p.cfg.SubscriptionKeyCookie != "" {
 			if token := getCookieValue(reqCtx.Headers, p.cfg.SubscriptionKeyCookie); token != "" {
-				action, entry := p.validateByToken(apiID, token)
-				if action == nil {
-					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
+				block, subscription := p.validateByToken(apiID, token)
+				if block == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, subscription)
 					cookieValues := reqCtx.Headers.Get("Cookie")
 					updated, removed := stripCookie(cookieValues, p.cfg.SubscriptionKeyCookie)
 					if removed {
@@ -254,7 +254,7 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 					}
 					return policy.UpstreamRequestHeaderModifications{}
 				}
-				return action.(policy.ImmediateResponse)
+				return block.(policy.ImmediateResponse)
 			}
 		}
 	}
@@ -264,12 +264,12 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 		if rawAppID, ok := metadata[applicationIDMetadataKey]; ok {
 			appID := strings.TrimSpace(fmt.Sprint(rawAppID))
 			if appID != "" {
-				action, entry := p.validateByApplication(apiID, appID)
-				if action == nil {
-					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
+				block, subscription := p.validateByApplication(apiID, appID)
+				if block == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, subscription)
 					return policy.UpstreamRequestHeaderModifications{}
 				}
-				return action.(policy.ImmediateResponse)
+				return block.(policy.ImmediateResponse)
 			}
 		}
 	}

--- a/policies/subscription-validation/subscriptionvalidation.go
+++ b/policies/subscription-validation/subscriptionvalidation.go
@@ -15,11 +15,15 @@ import (
 )
 
 const (
-	defaultSubscriptionKeyHeader = "Subscription-Key"
-	defaultSubscriptionKeyCookie = ""
-	applicationIDMetadataKey     = "x-wso2-application-id"
-	forbiddenStatusCode          = 403
-	forbiddenMessage             = "Subscription required for this API"
+	defaultSubscriptionKeyHeader     = "Subscription-Key"
+	defaultSubscriptionKeyCookie     = ""
+	applicationIDMetadataKey         = "x-wso2-application-id"
+	forbiddenStatusCode              = 403
+	forbiddenMessage                 = "Subscription required for this API"
+	billingCustomerIDMetadataKey     = "x-wso2-billing-customer-id"
+	billingSubscriptionIDMetadataKey = "x-wso2-billing-subscription-id"
+	subscriptionStatusMetadataKey    = "x-wso2-subscription-status"
+	subscriptionPlanNameMetadataKey  = "x-wso2-subscription-plan-name"
 
 	// Eviction TTL: entries not seen in this duration are removed to prevent unbounded growth.
 	rateLimitEvictionTTL     = 2 * time.Hour
@@ -95,7 +99,6 @@ func GetPolicy(
 	}
 	return p, nil
 }
-
 
 // mergeConfig merges raw parameters from the policy configuration into a base config.
 func mergeConfig(base PolicyConfig, params map[string]interface{}) PolicyConfig {
@@ -222,19 +225,21 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 		if len(headerValues) > 0 {
 			token := strings.TrimSpace(headerValues[0])
 			if token != "" {
-				result := p.validateByToken(apiID, token)
-				if result == nil {
+				action, entry := p.validateByToken(apiID, token)
+				if action == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
 					return policy.UpstreamRequestHeaderModifications{
 						HeadersToRemove: []string{normalizeHeaderName(p.cfg.SubscriptionKeyHeader)},
 					}
 				}
-				return result.(policy.ImmediateResponse)
+				return action.(policy.ImmediateResponse)
 			}
 		}
 		if p.cfg.SubscriptionKeyCookie != "" {
 			if token := getCookieValue(reqCtx.Headers, p.cfg.SubscriptionKeyCookie); token != "" {
-				result := p.validateByToken(apiID, token)
-				if result == nil {
+				action, entry := p.validateByToken(apiID, token)
+				if action == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
 					cookieValues := reqCtx.Headers.Get("Cookie")
 					updated, removed := stripCookie(cookieValues, p.cfg.SubscriptionKeyCookie)
 					if removed {
@@ -249,7 +254,7 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 					}
 					return policy.UpstreamRequestHeaderModifications{}
 				}
-				return result.(policy.ImmediateResponse)
+				return action.(policy.ImmediateResponse)
 			}
 		}
 	}
@@ -259,11 +264,12 @@ func (p *SubscriptionValidationPolicy) OnRequestHeaders(ctx context.Context, req
 		if rawAppID, ok := metadata[applicationIDMetadataKey]; ok {
 			appID := strings.TrimSpace(fmt.Sprint(rawAppID))
 			if appID != "" {
-				result := p.validateByApplication(apiID, appID)
-				if result == nil {
+				action, entry := p.validateByApplication(apiID, appID)
+				if action == nil {
+					writeSubscriptionMetadata(reqCtx.SharedContext, entry)
 					return policy.UpstreamRequestHeaderModifications{}
 				}
-				return result.(policy.ImmediateResponse)
+				return action.(policy.ImmediateResponse)
 			}
 		}
 	}
@@ -296,24 +302,24 @@ func (p *SubscriptionValidationPolicy) forbiddenResponse(detail string) policy.R
 	}
 }
 
-// validateByToken checks the token against the store, then enforces rate limits.
-// The store uses hashed tokens; we hash the incoming token before lookup.
-func (p *SubscriptionValidationPolicy) validateByToken(apiID, token string) policy.RequestAction {
+// validateByToken looks up the subscription entry for the given token and enforces
+// plan-based rate limits. Returns (nil, entry) on success, (action, nil) on failure.
+func (p *SubscriptionValidationPolicy) validateByToken(apiID, token string) (policy.RequestAction, *policyenginev1.SubscriptionEntry) {
 	hashedToken := policyenginev1.HashSubscriptionToken(token)
 	active, entry := p.store.IsActiveByToken(apiID, hashedToken)
 	if !active {
 		slog.Info("subscriptionValidation: no active subscription found (token)",
 			"apiId", apiID)
-		return p.forbiddenResponse("")
+		return p.forbiddenResponse(""), nil
 	}
 
 	if entry != nil && entry.ThrottleLimitCount > 0 && entry.ThrottleLimitUnit != "" {
 		if blocked := p.checkRateLimit(apiID, token, entry); blocked != nil {
-			return blocked
+			return blocked, nil
 		}
 	}
 
-	return nil
+	return nil, entry
 }
 
 // checkRateLimit enforces the plan's throttle limit for the given token.
@@ -356,24 +362,48 @@ func (p *SubscriptionValidationPolicy) checkRateLimit(apiID, token string, entry
 	return nil
 }
 
-// validateByApplication checks the application ID against the store, then enforces rate limits.
-// This is the legacy path; it now recovers quota/throttle metadata from the store.
-func (p *SubscriptionValidationPolicy) validateByApplication(apiID, appID string) policy.RequestAction {
+// validateByApplication looks up the subscription entry for the given application ID and
+// enforces plan-based rate limits. Returns (nil, entry) on success, (action, nil) on failure.
+func (p *SubscriptionValidationPolicy) validateByApplication(apiID, appID string) (policy.RequestAction, *policyenginev1.SubscriptionEntry) {
 	active, entry := p.store.IsActiveByApplication(apiID, appID)
 	if !active {
 		slog.Info("subscriptionValidation: no active subscription found (appId fallback)",
 			"apiId", apiID,
 			"applicationId", appID)
-		return p.forbiddenResponse("")
+		return p.forbiddenResponse(""), nil
 	}
 
 	if entry != nil && entry.ThrottleLimitCount > 0 && entry.ThrottleLimitUnit != "" {
 		if blocked := p.checkRateLimit(apiID, appID, entry); blocked != nil {
-			return blocked
+			return blocked, nil
 		}
 	}
 
-	return nil
+	return nil, entry
+}
+
+// writeSubscriptionMetadata copies billing and plan fields from entry into
+// sc.Metadata so downstream policies can access them without an additional store
+// lookup. It is a no-op when sc or entry is nil.
+func writeSubscriptionMetadata(sc *policy.SharedContext, entry *policyenginev1.SubscriptionEntry) {
+	if sc == nil || entry == nil {
+		return
+	}
+	if sc.Metadata == nil {
+		sc.Metadata = make(map[string]interface{})
+	}
+	if entry.BillingCustomerID != nil {
+		sc.Metadata[billingCustomerIDMetadataKey] = *entry.BillingCustomerID
+	}
+	if entry.BillingSubscriptionID != nil {
+		sc.Metadata[billingSubscriptionIDMetadataKey] = *entry.BillingSubscriptionID
+	}
+	if entry.Status != "" {
+		sc.Metadata[subscriptionStatusMetadataKey] = entry.Status
+	}
+	if entry.PlanName != "" {
+		sc.Metadata[subscriptionPlanNameMetadataKey] = entry.PlanName
+	}
 }
 
 // getCookieValue parses the Cookie header and returns the value for the given cookie name.

--- a/policies/subscription-validation/subscriptionvalidation_test.go
+++ b/policies/subscription-validation/subscriptionvalidation_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
-	"testing"
 	"strings"
+	"testing"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 	policyenginev1 "github.com/wso2/api-platform/sdk/core/policyengine"
@@ -309,7 +309,7 @@ func TestOnRequestHeaders_HeaderTakesPrecedenceOverCookie(t *testing.T) {
 		},
 		Headers: policy.NewHeaders(map[string][]string{
 			defaultSubscriptionKeyHeader: {"tok-1"},
-			"Cookie":                    {"sub-key=wrong-token"},
+			"Cookie":                     {"sub-key=wrong-token"},
 		}),
 	}
 	// Header value should be used; tok-1 is valid
@@ -519,4 +519,130 @@ func TestOnRequestHeaders_NilStore(t *testing.T) {
 	p := newPolicy(defaultCfg(), nil)
 	ctx := headerCtxWithToken("api-1", "tok-1", "")
 	assertImmediate(t, p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{})), 403, "forbidden")
+}
+
+// --- billing metadata in SharedContext.Metadata -----------------------------
+
+func billingStr(s string) *string { return &s }
+
+func TestOnRequestHeaders_WritesBillingMetadataOnTokenSuccess(t *testing.T) {
+	custID := "cust-123"
+	subID := "sub-456"
+	store := newStore([]policyenginev1.SubscriptionData{
+		{
+			APIId:                 "api-1",
+			SubscriptionToken:     policyenginev1.HashSubscriptionToken("tok-1"),
+			Status:                "ACTIVE",
+			PlanName:              "Pro",
+			BillingCustomerId:     billingStr(custID),
+			BillingSubscriptionId: billingStr(subID),
+		},
+	})
+	p := newPolicy(defaultCfg(), store)
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	action := p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{}))
+	assertSuccess(t, action)
+
+	md := ctx.SharedContext.Metadata
+	if got, ok := md[billingCustomerIDMetadataKey].(string); !ok || got != custID {
+		t.Fatalf("expected %s=%q in metadata, got %v", billingCustomerIDMetadataKey, custID, md[billingCustomerIDMetadataKey])
+	}
+	if got, ok := md[billingSubscriptionIDMetadataKey].(string); !ok || got != subID {
+		t.Fatalf("expected %s=%q in metadata, got %v", billingSubscriptionIDMetadataKey, subID, md[billingSubscriptionIDMetadataKey])
+	}
+	if got, ok := md[subscriptionStatusMetadataKey].(string); !ok || got != "ACTIVE" {
+		t.Fatalf("expected %s=%q in metadata, got %v", subscriptionStatusMetadataKey, "ACTIVE", md[subscriptionStatusMetadataKey])
+	}
+	if got, ok := md[subscriptionPlanNameMetadataKey].(string); !ok || got != "Pro" {
+		t.Fatalf("expected %s=%q in metadata, got %v", subscriptionPlanNameMetadataKey, "Pro", md[subscriptionPlanNameMetadataKey])
+	}
+}
+
+func TestOnRequestHeaders_WritesBillingMetadataOnCookieSuccess(t *testing.T) {
+	custID := "cust-cookie"
+	store := newStore([]policyenginev1.SubscriptionData{
+		{
+			APIId:             "api-1",
+			SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"),
+			Status:            "ACTIVE",
+			PlanName:          "Basic",
+			BillingCustomerId: billingStr(custID),
+		},
+	})
+	cfg := defaultCfg()
+	cfg.SubscriptionKeyCookie = "sub-key"
+	p := newPolicy(cfg, store)
+	ctx := headerCtxWithCookie("api-1", "tok-1", "sub-key")
+	action := p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{}))
+	assertSuccess(t, action)
+
+	md := ctx.SharedContext.Metadata
+	if got, ok := md[billingCustomerIDMetadataKey].(string); !ok || got != custID {
+		t.Fatalf("expected %s=%q in metadata, got %v", billingCustomerIDMetadataKey, custID, md[billingCustomerIDMetadataKey])
+	}
+	if got, ok := md[subscriptionPlanNameMetadataKey].(string); !ok || got != "Basic" {
+		t.Fatalf("expected %s=%q in metadata, got %v", subscriptionPlanNameMetadataKey, "Basic", md[subscriptionPlanNameMetadataKey])
+	}
+}
+
+func TestOnRequestHeaders_WritesBillingMetadataOnAppIDSuccess(t *testing.T) {
+	subID := "sub-app"
+	store := newStore([]policyenginev1.SubscriptionData{
+		{
+			APIId:                 "api-1",
+			ApplicationId:         "app-1",
+			Status:                "ACTIVE",
+			BillingSubscriptionId: billingStr(subID),
+		},
+	})
+	p := newPolicy(defaultCfg(), store)
+	ctx := headerCtxWithAppID("api-1", "app-1")
+	action := p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{}))
+	assertSuccess(t, action)
+
+	md := ctx.SharedContext.Metadata
+	if got, ok := md[billingSubscriptionIDMetadataKey].(string); !ok || got != subID {
+		t.Fatalf("expected %s=%q in metadata, got %v", billingSubscriptionIDMetadataKey, subID, md[billingSubscriptionIDMetadataKey])
+	}
+}
+
+func TestOnRequestHeaders_NoBillingMetadataOnFailure(t *testing.T) {
+	store := newStore([]policyenginev1.SubscriptionData{
+		{APIId: "api-1", SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"), Status: "ACTIVE"},
+	})
+	p := newPolicy(defaultCfg(), store)
+	ctx := headerCtxWithToken("api-1", "wrong-token", "")
+	action := p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{}))
+	assertImmediate(t, action, 403, "forbidden")
+
+	md := ctx.SharedContext.Metadata
+	if _, ok := md[billingCustomerIDMetadataKey]; ok {
+		t.Fatalf("expected no billing metadata on failure, got %v", md[billingCustomerIDMetadataKey])
+	}
+}
+
+func TestOnRequestHeaders_PartialBillingMetadata(t *testing.T) {
+	// Only PlanName is set; nil billing IDs must not appear in metadata.
+	store := newStore([]policyenginev1.SubscriptionData{
+		{
+			APIId:             "api-1",
+			SubscriptionToken: policyenginev1.HashSubscriptionToken("tok-1"),
+			Status:            "ACTIVE",
+			PlanName:          "Free",
+		},
+	})
+	p := newPolicy(defaultCfg(), store)
+	ctx := headerCtxWithToken("api-1", "tok-1", "")
+	p.OnRequestHeaders(context.Background(), ctx, make(map[string]interface{}))
+
+	md := ctx.SharedContext.Metadata
+	if got, ok := md[subscriptionPlanNameMetadataKey].(string); !ok || got != "Free" {
+		t.Fatalf("expected plan name in metadata, got %v", md[subscriptionPlanNameMetadataKey])
+	}
+	if _, ok := md[billingCustomerIDMetadataKey]; ok {
+		t.Fatalf("expected billingCustomerID absent when nil, got %v", md[billingCustomerIDMetadataKey])
+	}
+	if _, ok := md[billingSubscriptionIDMetadataKey]; ok {
+		t.Fatalf("expected billingSubscriptionID absent when nil, got %v", md[billingSubscriptionIDMetadataKey])
+	}
 }


### PR DESCRIPTION
## Purpose

This pull request enhances the `subscription-validation` policy by ensuring that billing and subscription plan metadata are written into the request context upon successful subscription validation. This allows downstream policies to access billing information without additional lookups. The changes also include comprehensive tests to verify that the metadata is correctly propagated only on successful validation.

## Approach

**Enhancements to Metadata Propagation:**

* Added new metadata keys (`x-wso2-billing-customer-id`, `x-wso2-billing-subscription-id`, `x-wso2-subscription-status`, `x-wso2-subscription-plan-name`) for billing and subscription details.
* Introduced the `writeSubscriptionMetadata` function, which copies relevant billing and plan fields from the validated subscription entry into `SharedContext.Metadata` for downstream access.
* Refactored validation methods (`validateByToken`, `validateByApplication`) to return both the action and the subscription entry, enabling metadata writing on success. [[1]](diffhunk://#diff-cf5d3c0b19ae5d0618fd7456f420a1e0315e50e3988bdaa76d84bbca124407a8L299-R322) [[2]](diffhunk://#diff-cf5d3c0b19ae5d0618fd7456f420a1e0315e50e3988bdaa76d84bbca124407a8L359-R406)
* Updated the request header handling logic to call `writeSubscriptionMetadata` only when validation succeeds, ensuring metadata is not set on failure. [[1]](diffhunk://#diff-cf5d3c0b19ae5d0618fd7456f420a1e0315e50e3988bdaa76d84bbca124407a8L225-R242) [[2]](diffhunk://#diff-cf5d3c0b19ae5d0618fd7456f420a1e0315e50e3988bdaa76d84bbca124407a8L262-R272) [[3]](diffhunk://#diff-cf5d3c0b19ae5d0618fd7456f420a1e0315e50e3988bdaa76d84bbca124407a8L252-R257)

**Testing Improvements:**

* Added a suite of tests that verify billing and plan metadata are correctly written to `SharedContext.Metadata` on successful validation (via token, cookie, or application ID), and confirm no metadata is written on failure or when fields are missing.