### PR TITLE
Add Prompt Compressor Policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ All available policies, sorted alphabetically.
 | [Model Round Robin](./model-round-robin/v1.0/docs/model-round-robin.md) | AI | Implements round-robin load balancing for AI models. |
 | [Model Weighted Round Robin](./model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
 | [PII Masking Regex](./pii-masking-regex/v1.0/docs/pii-masking-regex.md) | Guardrails, AI | Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns. |
+| [Prompt Compressor](./prompt-compressor/v0.1/docs/prompt-compressor.md) | AI | Compresses selected prompt text in JSON request bodies before upstream LLM calls. |
 | [Prompt Decorator](./prompt-decorator/v1.0/docs/prompt-decorator.md) | AI | Dynamically modifies the prompt by applying custom decorations using a configured strategy. |
 | [Prompt Template](./prompt-template/v1.0/docs/prompt-template.md) | AI | Dynamically modifies the prompt by applying custom templates using a configured strategy. |
 | [Rate Limit - Advanced](./advanced-ratelimit/v1.0/docs/advanced-ratelimit.md) | Security, AI | Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas, weighted rate limiting, flexible key extraction, and both in-memory and Redis backends. |

--- a/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
+++ b/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
@@ -258,3 +258,15 @@ Upstream request after the policy runs:
 Only the tagged region is compressed. The opening and closing compression tags are removed before the request is sent upstream.
 
 When compression is applied, the policy publishes summary metrics, including status flags, segment counts, and input/output token estimates as dynamic metadata.
+
+## Notes
+
+- **Semantic Preservation**: Aggressive compression may reduce semantic meaning. This can be mitigated through conservative defaults and configurability, such as specifying higher retention ratios or targeting specific regions.
+- **Compression Efficiency**: There is a considerable gap between the expected level of prompt size reduction and the actual reduction achieved by the policy, often resulting in a prompt that is longer than expected.
+- **Protected Content**: To maintain structural and factual integrity, the underlying compression engine automatically detects and protects specific types of semantic content. The following elements are not compressed:
+  - Code blocks
+  - JSON blocks and objects
+  - File paths and URLs
+  - Technical identifiers (e.g., `CamelCase`, `snake_case`, `UPPER_SNAKE_CASE`)
+  - Hashes and large numerical values
+  - Content enclosed in brackets, braces, or parentheses

--- a/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
+++ b/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
@@ -13,7 +13,7 @@ Use this policy when prompts include long instructions, retrieved context, conve
 
 - Compresses selected prompt text in the request body before the upstream LLM call
 - Targets a single JSON string field with configurable `jsonPath`
-- Supports ordered compression rules based on estimated token count
+- Supports ordered compression rules based on estimated input token count
 - Supports `ratio` mode for retained-size compression and `token` mode for target-token compression
 - Supports selective compression via `<APIP-COMPRESS>`...`</APIP-COMPRESS>` tags to compress only marked prompt regions
 - Removes selective compression tags before forwarding the request upstream

--- a/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
+++ b/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
@@ -1,0 +1,260 @@
+---
+title: "Overview"
+---
+# Prompt Compressor
+
+## Overview
+
+The Prompt Compressor policy reduces prompt size before the gateway forwards a JSON request body to an upstream LLM service. It extracts a single string field using `jsonPath`, estimates the selected text's token count, chooses the first matching compression rule, and writes the compressed text back to the same JSON location.
+
+Use this policy when prompts include long instructions, retrieved context, conversation history, or other text that can be compacted before the model call. The policy is designed to be non-blocking: if the request body cannot be parsed or the configured target cannot be updated safely, the request continues upstream unchanged.
+
+## Features
+
+- Compresses selected prompt text in the request body before the upstream LLM call
+- Targets a single JSON string field with configurable `jsonPath`
+- Supports ordered compression rules based on estimated token count
+- Supports `ratio` mode for retained-size compression and `token` mode for target-token compression
+- Supports selective compression via `<APIP-COMPRESS>`...`</APIP-COMPRESS>` tags to compress only marked prompt regions
+- Removes selective compression tags before forwarding the request upstream
+- Leaves the request unchanged when compression is not applicable or cannot be completed safely
+- Publishes compression summary data as dynamic metadata for downstream gateway processing
+
+## Configuration
+
+The Prompt Compressor policy uses API definition parameters and does not require system-level configuration. It runs in buffered request-body mode and only modifies JSON request bodies where the configured `jsonPath` resolves to a string value.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jsonPath` | string | No | `$.messages[0].content` | JSONPath expression that resolves to the prompt string to compress. The selected value must be a string. |
+| `rules` | array of `CompressionRule` objects | Yes | - | Compression rules evaluated in ascending `upperTokenLimit` order. The first matching rule is applied. |
+
+#### CompressionRule Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `upperTokenLimit` | integer | Yes | - | Inclusive upper bound for the estimated token count. Use `-1` as the fallback rule for all remaining prompts. |
+| `type` | string | Yes | - | Compression mode. Supported values are `ratio` and `token`. |
+| `value` | number | Yes | - | Rule value. For `ratio`, this is the retained-size ratio. For `token`, this is the target retained token estimate. |
+
+#### Rule Evaluation
+
+Rules are normalized and sorted before evaluation. Explicit token limits are evaluated from smallest to largest, and the `upperTokenLimit: -1` fallback is evaluated after all explicit limits.
+
+The policy estimates tokens as approximately one token per four characters in the selected text. In `ratio` mode, `value` is used as the target retained-size ratio. In `token` mode, `value` is converted to a retained-size ratio by dividing the target token estimate by the selected text's estimated token count. If the resolved ratio is greater than or equal to `1.0`, compression is skipped and the request is forwarded unchanged.
+
+Invalid rules are ignored. A rule is invalid when `upperTokenLimit` is lower than `-1`, `type` is not `ratio` or `token`, or `value` is not greater than zero.
+
+#### JSONPath Targeting
+
+The configured `jsonPath` must resolve to a string value in the JSON request body. The policy supports simple dot-separated object traversal and array indexes, including negative array indexes. If the path is missing, points to a non-string value, or cannot be updated after compression, the request body is not modified.
+
+#### Selective Compression Tags
+
+If the selected prompt string does not contain compression tags, the whole selected string is considered for compression. If the selected prompt string contains `<APIP-COMPRESS>` and `</APIP-COMPRESS>`, the policy compresses only the tagged regions. Text outside tagged regions is preserved, and the tags are removed before the request is forwarded upstream.
+
+Use selective compression when only part of the prompt is safe to compact, such as retrieved context, transcripts, or reference material, while instructions and user questions should remain verbatim.
+
+#### build.yaml Integration
+
+Inside the `api-platform` repository, add the policy package under `policies:` in `/gateway/build.yaml`:
+
+```yaml
+- name: prompt-compressor
+  pipPackage: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
+```
+
+## Reference Scenarios
+
+### Example 1: Compress Long Chat Prompts by Ratio
+
+Attach the policy to an OpenAI-compatible chat completions route and apply stronger compression as prompts get larger:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: compressed-chat-provider
+spec:
+  displayName: Compressed Chat Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-compressor
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            jsonPath: "$.messages[0].content"
+            rules:
+              - upperTokenLimit: 800
+                type: ratio
+                value: 0.90
+              - upperTokenLimit: 2000
+                type: ratio
+                value: 0.65
+              - upperTokenLimit: -1
+                type: ratio
+                value: 0.45
+```
+
+Test the policy with a long prompt:
+
+```bash
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Summarize the following technical document in clear bullet points. The document is long enough that it should be compressed before being sent upstream. <large document text here>"
+      }
+    ]
+  }'
+```
+
+The upstream request keeps the same JSON shape, but `messages[0].content` is replaced with a compressed version when a matching rule produces a smaller prompt:
+
+```json
+{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "<compressed version of the original prompt>"
+    }
+  ]
+}
+```
+
+### Example 2: Target the Latest User Message with a Token Budget
+
+Use `token` mode when the desired result is easier to express as a retained token target instead of a ratio:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: budgeted-chat-provider
+spec:
+  displayName: Budgeted Chat Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-compressor
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            jsonPath: "$.messages[-1].content"
+            rules:
+              - upperTokenLimit: 1200
+                type: token
+                value: 800
+              - upperTokenLimit: -1
+                type: token
+                value: 1200
+```
+
+For a selected prompt estimated at `1000` tokens, the first rule resolves to a retained-size ratio of `0.8`. For a selected prompt estimated above `1200` tokens, the fallback rule targets approximately `1200` retained tokens.
+
+### Example 3: Compress Only Retrieved Context
+
+Use selective compression tags when prompt instructions must remain exact, but retrieved context can be compacted:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: rag-chat-provider
+spec:
+  displayName: RAG Chat Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: prompt-compressor
+      version: v0
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            jsonPath: "$.messages[0].content"
+            rules:
+              - upperTokenLimit: -1
+                type: ratio
+                value: 0.50
+```
+
+Client request:
+
+```json
+{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Answer the question using the provided context only.\n\nQuestion: What changed in the deployment plan?\n\n<APIP-COMPRESS>Retrieved context: deployment notes, incident summaries, rollout timelines, and long historical discussion text...</APIP-COMPRESS>\n\nReturn a concise answer."
+    }
+  ]
+}
+```
+
+Upstream request after the policy runs:
+
+```json
+{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Answer the question using the provided context only.\n\nQuestion: What changed in the deployment plan?\n\n<compressed retrieved context>\n\nReturn a concise answer."
+    }
+  ]
+}
+```
+
+Only the tagged region is compressed. The opening and closing compression tags are removed before the request is sent upstream.
+
+When compression is applied, the policy publishes summary metrics, including status flags, segment counts, and input/output token estimates as dynamic metadata.

--- a/docs/prompt-compressor/v0.1/metadata.json
+++ b/docs/prompt-compressor/v0.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "prompt-compressor",
+  "displayName": "Prompt Compressor",
+  "version": "0.1",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Compresses selected prompt text in JSON request bodies before upstream LLM calls.\nSupports JSONPath targeting, ordered rule-based compression thresholds, and selective compression tags for compressing only specific prompt regions."
+}

--- a/policies/prompt-compressor/README.md
+++ b/policies/prompt-compressor/README.md
@@ -1,22 +1,3 @@
 # Prompt Compressor Policy
 
-`prompt-compressor` compresses prompt text before the upstream LLM call.
-
-## Use In `build.yaml`
-
-Add the policy package under `policies:`:
-
-```yaml
-version: v1
-policies:
-  - name: prompt-compressor
-    pipPackage: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
-```
-
-Use the policy in API configuration with the major-only version:
-
-```yaml
-policies:
-  - name: prompt-compressor
-    version: v0
-```
+`prompt-compressor` is a Python policy package that compresses prompt text before the upstream LLM call.

--- a/policies/prompt-compressor/README.md
+++ b/policies/prompt-compressor/README.md
@@ -1,0 +1,40 @@
+# Prompt Compressor Policy
+
+`prompt-compressor` is a Python executor policy for the WSO2 AI Gateway that
+compresses prompt text before the upstream LLM call.
+
+## Install From GitHub
+
+From this monorepo, the package can be installed directly with:
+
+```bash
+pip install "git+https://github.com/<org>/<repo>.git@<tag-or-commit>#subdirectory=gateway/sample-policies/prompt-compressor"
+```
+
+Example:
+
+```bash
+pip install "git+https://github.com/wso2/api-platform.git@v0.1.0#subdirectory=gateway/sample-policies/prompt-compressor"
+```
+
+## Use In `build.yaml`
+
+The gateway builder can consume the same Git reference through `pipPackage`:
+
+```yaml
+version: v1
+policies:
+  - name: prompt-compressor
+    pipPackage: "git+https://github.com/<org>/<repo>.git@<tag-or-commit>#subdirectory=gateway/sample-policies/prompt-compressor"
+```
+
+Keep the API configuration policy version as the major-only version:
+
+```yaml
+policies:
+  - name: prompt-compressor
+    version: v0
+```
+
+The package metadata version is `0.1.0`, while the gateway policy definition
+version remains `v0.1.0`.

--- a/policies/prompt-compressor/README.md
+++ b/policies/prompt-compressor/README.md
@@ -1,40 +1,22 @@
 # Prompt Compressor Policy
 
-`prompt-compressor` is a Python executor policy for the WSO2 AI Gateway that
-compresses prompt text before the upstream LLM call.
-
-## Install From GitHub
-
-From this monorepo, the package can be installed directly with:
-
-```bash
-pip install "git+https://github.com/<org>/<repo>.git@<tag-or-commit>#subdirectory=gateway/sample-policies/prompt-compressor"
-```
-
-Example:
-
-```bash
-pip install "git+https://github.com/wso2/api-platform.git@v0.1.0#subdirectory=gateway/sample-policies/prompt-compressor"
-```
+`prompt-compressor` compresses prompt text before the upstream LLM call.
 
 ## Use In `build.yaml`
 
-The gateway builder can consume the same Git reference through `pipPackage`:
+Add the policy package under `policies:`:
 
 ```yaml
 version: v1
 policies:
   - name: prompt-compressor
-    pipPackage: "git+https://github.com/<org>/<repo>.git@<tag-or-commit>#subdirectory=gateway/sample-policies/prompt-compressor"
+    pipPackage: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
 ```
 
-Keep the API configuration policy version as the major-only version:
+Use the policy in API configuration with the major-only version:
 
 ```yaml
 policies:
   - name: prompt-compressor
     version: v0
 ```
-
-The package metadata version is `0.1.0`, while the gateway policy definition
-version remains `v0.1.0`.

--- a/policies/prompt-compressor/__init__.py
+++ b/policies/prompt-compressor/__init__.py
@@ -1,0 +1,3 @@
+"""Prompt compressor policy package."""
+
+__version__ = "0.1.0"

--- a/policies/prompt-compressor/policy-definition.yaml
+++ b/policies/prompt-compressor/policy-definition.yaml
@@ -1,0 +1,63 @@
+name: prompt-compressor
+version: v0.1.0
+displayName: Prompt Compressor
+description: |
+  Compresses prompt text just before the upstream LLM call to reduce token usage.
+  The policy targets a single string field selected by jsonPath and applies the
+  first matching rule based on an estimated token count. When selective
+  compression tags are present, only tagged regions are considered for
+  compression and the tags are removed before the request is forwarded.
+
+parameters:
+  type: object
+  additionalProperties: false
+  properties:
+    jsonPath:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        JSONPath expression that resolves to the prompt string to compress.
+        This policy currently supports string targets only.
+      default: "$.messages[0].content"
+    rules:
+      type: array
+      x-wso2-policy-advanced-param: false
+      description: |
+        Compression rules evaluated in ascending upperTokenLimit order.
+        The first matching rule is used. Use upperTokenLimit -1 as the catch-all
+        fallback rule.
+      minItems: 1
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          upperTokenLimit:
+            type: integer
+            description: |
+              Inclusive upper bound for the estimated token count. Use -1 as the
+              fallback rule for all remaining cases.
+          type:
+            type: string
+            description: |
+              Compression mode. "ratio" uses value directly as the retained-size
+              ratio. "token" converts value into a retained-size ratio based on
+              the estimated token count of the selected prompt segment.
+            enum:
+              - ratio
+              - token
+          value:
+            type: number
+            description: |
+              Rule value. For "ratio", use a retained-size ratio such as 0.8.
+              For "token", use the target retained token estimate.
+        required:
+          - upperTokenLimit
+          - type
+          - value
+  required:
+    - rules
+
+systemParameters:
+  type: object
+  additionalProperties: false
+  properties: {}

--- a/policies/prompt-compressor/policy.py
+++ b/policies/prompt-compressor/policy.py
@@ -61,14 +61,14 @@ class PromptCompressorPolicy(RequestPolicy):
     def mode(self) -> ProcessingMode:
         return ProcessingMode(request_body_mode=BodyProcessingMode.BUFFER)
 
-    def on_request_body(self, execution_ctx, ctx, params):
-        if ctx.body is None or not ctx.body.present or ctx.body.content is None:
+    def on_request_body(self, execution_ctx, req_ctx, params):
+        if req_ctx.body is None or not req_ctx.body.present or req_ctx.body.content is None:
             return None
 
         if not self._params.rules:
             return None
 
-        body_bytes = ctx.body.content or b""
+        body_bytes = req_ctx.body.content or b""
         if not body_bytes:
             return None
 

--- a/policies/prompt-compressor/policy.py
+++ b/policies/prompt-compressor/policy.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from compression_prompt import Compressor, CompressorConfig
+from compression_prompt.compressor import CompressionError, InputTooShortError, NegativeGainError
+from wso2_gateway_policy_sdk import (
+    BodyProcessingMode,
+    ProcessingMode,
+    RequestPolicy,
+    UpstreamRequestModifications,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_JSON_PATH = "$.messages[0].content"
+OPEN_TAG = "<APIP-COMPRESS>"
+CLOSE_TAG = "</APIP-COMPRESS>"
+DYNAMIC_METADATA_NAMESPACE = "prompt_compressor"
+_ARRAY_INDEX_RE = re.compile(r"^([A-Za-z0-9_]+)\[(-?\d+)\]$")
+
+
+class JSONPathError(ValueError):
+    """Raised when the configured JSONPath cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class CompressionRule:
+    upper_token_limit: int
+    rule_type: str
+    value: float
+
+
+@dataclass(frozen=True)
+class PolicyParams:
+    json_path: str
+    rules: tuple[CompressionRule, ...]
+
+
+@dataclass(frozen=True)
+class TransformationSummary:
+    selective_mode: bool
+    tagged_segments: int
+    compressed_segments: int
+    input_tokens_estimated: int
+    output_tokens_estimated: int
+
+
+class PromptCompressorPolicy(RequestPolicy):
+    """Compress prompt text in buffered request payloads."""
+
+    def __init__(self, policy_params: PolicyParams):
+        self._params = policy_params
+        self._compressor_cache: dict[float, Compressor] = {}
+
+    def mode(self) -> ProcessingMode:
+        return ProcessingMode(request_body_mode=BodyProcessingMode.BUFFER)
+
+    def on_request_body(self, execution_ctx, ctx, params):
+        if ctx.body is None or not ctx.body.present or ctx.body.content is None:
+            return None
+
+        if not self._params.rules:
+            return None
+
+        body_bytes = ctx.body.content or b""
+        if not body_bytes:
+            return None
+
+        try:
+            payload = json.loads(body_bytes)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            LOGGER.warning("PromptCompressor: request body is not valid JSON: %s", exc)
+            return None
+
+        try:
+            original_text = extract_string_value_from_jsonpath(payload, self._params.json_path)
+        except JSONPathError as exc:
+            LOGGER.warning(
+                "PromptCompressor: failed to extract prompt from jsonPath %s: %s",
+                self._params.json_path,
+                exc,
+            )
+            return None
+
+        updated_text, summary = self._transform_text(original_text)
+        if updated_text == original_text:
+            return None
+
+        try:
+            set_value_at_jsonpath(payload, self._params.json_path, updated_text)
+        except JSONPathError as exc:
+            LOGGER.warning(
+                "PromptCompressor: failed to update jsonPath %s: %s",
+                self._params.json_path,
+                exc,
+            )
+            return None
+
+        try:
+            updated_body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode(
+                "utf-8"
+            )
+        except (TypeError, ValueError) as exc:
+            LOGGER.warning("PromptCompressor: failed to marshal updated JSON payload: %s", exc)
+            return None
+
+        dynamic_metadata = {
+            DYNAMIC_METADATA_NAMESPACE: {
+                "compression_applied": summary.compressed_segments > 0,
+                "selective_mode": summary.selective_mode,
+                "tagged_segments": summary.tagged_segments,
+                "compressed_segments": summary.compressed_segments,
+                "input_tokens_estimated": summary.input_tokens_estimated,
+                "output_tokens_estimated": summary.output_tokens_estimated,
+            }
+        }
+        return UpstreamRequestModifications(body=updated_body, dynamic_metadata=dynamic_metadata)
+
+    def _transform_text(self, text: str) -> tuple[str, TransformationSummary]:
+        if OPEN_TAG not in text and CLOSE_TAG not in text:
+            compressed_text, compressed = self._compress_segment(text)
+            summary = TransformationSummary(
+                selective_mode=False,
+                tagged_segments=0,
+                compressed_segments=1 if compressed else 0,
+                input_tokens_estimated=estimate_tokens(text),
+                output_tokens_estimated=estimate_tokens(compressed_text),
+            )
+            return compressed_text, summary
+
+        transformed_text, tagged_segments, compressed_segments = self._apply_selective_compression(text)
+        summary = TransformationSummary(
+            selective_mode=True,
+            tagged_segments=tagged_segments,
+            compressed_segments=compressed_segments,
+            input_tokens_estimated=estimate_tokens(text),
+            output_tokens_estimated=estimate_tokens(transformed_text),
+        )
+        return transformed_text, summary
+
+    def _apply_selective_compression(self, text: str) -> tuple[str, int, int]:
+        output: list[str] = []
+        inside_region: list[str] = []
+        plain_start = 0
+        depth = 0
+        index = 0
+        tagged_segments = 0
+        compressed_segments = 0
+
+        while index < len(text):
+            if text.startswith(OPEN_TAG, index):
+                if depth == 0:
+                    output.append(text[plain_start:index])
+                    inside_region = []
+                    tagged_segments += 1
+                depth += 1
+                index += len(OPEN_TAG)
+                continue
+
+            if text.startswith(CLOSE_TAG, index):
+                if depth > 0:
+                    depth -= 1
+                    index += len(CLOSE_TAG)
+                    if depth == 0:
+                        original_region = "".join(inside_region)
+                        updated_region, compressed = self._compress_segment(original_region)
+                        output.append(updated_region)
+                        if compressed:
+                            compressed_segments += 1
+                        plain_start = index
+                        inside_region = []
+                    continue
+
+                output.append(text[plain_start:index])
+                index += len(CLOSE_TAG)
+                plain_start = index
+                continue
+
+            if depth > 0:
+                inside_region.append(text[index])
+            index += 1
+
+        if depth > 0:
+            output.append("".join(inside_region))
+            plain_start = len(text)
+
+        if plain_start < len(text):
+            output.append(text[plain_start:])
+
+        return "".join(output), tagged_segments, compressed_segments
+
+    def _compress_segment(self, text: str) -> tuple[str, bool]:
+        estimated_tokens = estimate_tokens(text)
+        if estimated_tokens <= 0:
+            return text, False
+
+        rule = select_rule(self._params.rules, estimated_tokens)
+        if rule is None:
+            return text, False
+
+        compression_ratio = resolve_ratio(rule, estimated_tokens)
+        if compression_ratio is None or compression_ratio >= 1.0:
+            return text, False
+
+        compressor = self._get_compressor(compression_ratio)
+        try:
+            result = compressor.compress(text)
+        except (InputTooShortError, NegativeGainError) as exc:
+            LOGGER.debug("PromptCompressor: skipped compression for segment: %s", exc)
+            return text, False
+        except CompressionError as exc:
+            LOGGER.warning("PromptCompressor: compression failed for segment: %s", exc)
+            return text, False
+        except Exception as exc:  # pragma: no cover - defensive guard for library/runtime issues
+            LOGGER.warning("PromptCompressor: unexpected compression failure: %s", exc)
+            return text, False
+
+        compressed_text = result.compressed or text
+        return compressed_text, compressed_text != text
+
+    def _get_compressor(self, compression_ratio: float) -> Compressor:
+        cache_key = round(compression_ratio, 6)
+        compressor = self._compressor_cache.get(cache_key)
+        if compressor is None:
+            compressor = Compressor(
+                CompressorConfig(
+                    target_ratio=cache_key,
+                    min_input_tokens=1,
+                    min_input_bytes=1,
+                )
+            )
+            self._compressor_cache[cache_key] = compressor
+        return compressor
+
+
+def get_policy(metadata, params):
+    normalized = normalize_params(params)
+    return PromptCompressorPolicy(normalized)
+
+
+def normalize_params(params: dict[str, Any] | None) -> PolicyParams:
+    params = params or {}
+
+    json_path = params.get("jsonPath", DEFAULT_JSON_PATH)
+    if not isinstance(json_path, str) or not json_path.strip():
+        LOGGER.warning(
+            "PromptCompressor: invalid jsonPath %r, falling back to %s",
+            json_path,
+            DEFAULT_JSON_PATH,
+        )
+        json_path = DEFAULT_JSON_PATH
+    else:
+        json_path = json_path.strip()
+
+    raw_rules = params.get("rules", [])
+    if not isinstance(raw_rules, list):
+        LOGGER.warning("PromptCompressor: rules must be a list, got %s", type(raw_rules).__name__)
+        raw_rules = []
+
+    normalized_rules: list[CompressionRule] = []
+    for index, raw_rule in enumerate(raw_rules):
+        rule = normalize_rule(raw_rule)
+        if rule is None:
+            LOGGER.warning("PromptCompressor: dropping invalid rule at index %d: %r", index, raw_rule)
+            continue
+        normalized_rules.append(rule)
+
+    normalized_rules.sort(key=lambda rule: (rule.upper_token_limit == -1, rule.upper_token_limit))
+
+    return PolicyParams(
+        json_path=json_path,
+        rules=tuple(normalized_rules),
+    )
+
+
+def normalize_rule(raw_rule: Any) -> CompressionRule | None:
+    if not isinstance(raw_rule, dict):
+        return None
+
+    upper_token_limit = coerce_int(raw_rule.get("upperTokenLimit"))
+    rule_type = raw_rule.get("type")
+    value = coerce_float(raw_rule.get("value"))
+
+    if upper_token_limit is None or rule_type not in {"ratio", "token"} or value is None:
+        return None
+
+    if upper_token_limit < -1:
+        return None
+
+    if rule_type == "token" and value <= 0:
+        return None
+
+    if rule_type == "ratio" and value <= 0:
+        return None
+
+    return CompressionRule(
+        upper_token_limit=upper_token_limit,
+        rule_type=rule_type,
+        value=value,
+    )
+
+
+def coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return None
+    if isinstance(value, str):
+        try:
+            float_value = float(value)
+        except ValueError:
+            return None
+        if float_value.is_integer():
+            return int(float_value)
+    return None
+
+
+def coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text) // 4
+
+
+def select_rule(rules: tuple[CompressionRule, ...], estimated_tokens: int) -> CompressionRule | None:
+    for rule in rules:
+        if rule.upper_token_limit == -1 or estimated_tokens <= rule.upper_token_limit:
+            return rule
+    return None
+
+
+def resolve_ratio(rule: CompressionRule, estimated_tokens: int) -> float | None:
+    if estimated_tokens <= 0:
+        return None
+
+    if rule.rule_type == "ratio":
+        return min(rule.value, 1.0)
+
+    target_tokens = int(rule.value)
+    if target_tokens <= 0 or target_tokens >= estimated_tokens:
+        return None
+    return target_tokens / estimated_tokens
+
+
+def extract_string_value_from_jsonpath(data: Any, json_path: str) -> str:
+    value = extract_value_from_jsonpath(data, json_path)
+    if not isinstance(value, str):
+        raise JSONPathError("value at JSONPath is not a string")
+    return value
+
+
+def extract_value_from_jsonpath(data: Any, json_path: str) -> Any:
+    current = data
+    for component in split_json_path(json_path):
+        current = get_path_component(current, component)
+    return current
+
+
+def set_value_at_jsonpath(data: Any, json_path: str, value: str) -> None:
+    components = split_json_path(json_path)
+    if not components:
+        raise JSONPathError("empty JSONPath")
+
+    current = data
+    for component in components[:-1]:
+        current = get_path_component(current, component)
+
+    final_component = components[-1]
+    match = _ARRAY_INDEX_RE.match(final_component)
+    if match:
+        array_name, index = parse_array_component(final_component)
+        if not isinstance(current, dict):
+            raise JSONPathError(f"invalid structure for key: {array_name}")
+        if array_name not in current:
+            raise JSONPathError(f"key not found: {array_name}")
+        array_value = current.get(array_name)
+        if not isinstance(array_value, list):
+            raise JSONPathError(f"not an array: {array_name}")
+        try:
+            array_value[index] = value
+        except IndexError as exc:
+            raise JSONPathError(f"array index out of range: {index}") from exc
+        return
+
+    if not isinstance(current, dict):
+        raise JSONPathError(f"invalid structure for key: {final_component}")
+    if final_component not in current:
+        raise JSONPathError(f"key not found: {final_component}")
+    current[final_component] = value
+
+
+def split_json_path(json_path: str) -> list[str]:
+    if not isinstance(json_path, str):
+        raise JSONPathError("jsonPath must be a string")
+    parts = json_path.split(".")
+    if parts and parts[0] == "$":
+        parts = parts[1:]
+    if not parts or any(not part for part in parts):
+        raise JSONPathError("empty JSONPath")
+    return parts
+
+
+def get_path_component(current: Any, component: str) -> Any:
+    match = _ARRAY_INDEX_RE.match(component)
+    if match:
+        array_name, index = parse_array_component(component)
+        if not isinstance(current, dict):
+            raise JSONPathError(f"invalid structure for key: {array_name}")
+        if array_name not in current:
+            raise JSONPathError(f"key not found: {array_name}")
+        array_value = current.get(array_name)
+        if not isinstance(array_value, list):
+            raise JSONPathError(f"not an array: {array_name}")
+        try:
+            return array_value[index]
+        except IndexError as exc:
+            raise JSONPathError(f"array index out of range: {index}") from exc
+
+    if not isinstance(current, dict):
+        raise JSONPathError(f"invalid structure for key: {component}")
+    if component not in current:
+        raise JSONPathError(f"key not found: {component}")
+    return current[component]
+
+
+def parse_array_component(component: str) -> tuple[str, int]:
+    match = _ARRAY_INDEX_RE.match(component)
+    if not match:
+        raise JSONPathError(f"invalid array component: {component}")
+
+    name = match.group(1)
+    raw_index = int(match.group(2))
+    return name, raw_index

--- a/policies/prompt-compressor/policy.py
+++ b/policies/prompt-compressor/policy.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from compression_prompt import Compressor, CompressorConfig
 from compression_prompt.compressor import CompressionError, InputTooShortError, NegativeGainError
-from wso2_gateway_policy_sdk import (
+from apip_sdk_core import (
     BodyProcessingMode,
     ProcessingMode,
     RequestPolicy,

--- a/policies/prompt-compressor/pyproject.toml
+++ b/policies/prompt-compressor/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "prompt-compressor"
+name = "prompt-compressor-v0"
 version = "0.1.0"
 description = "WSO2 AI Gateway prompt compression policy for the Python executor"
 readme = "README.md"
@@ -26,11 +26,11 @@ classifiers = [
 ]
 
 [tool.setuptools]
-packages = ["prompt_compressor"]
+packages = ["prompt_compressor_v0"]
 include-package-data = true
 
 [tool.setuptools.package-dir]
-prompt_compressor = "."
+prompt_compressor_v0 = "."
 
 [tool.setuptools.package-data]
-prompt_compressor = ["policy-definition.yaml"]
+prompt_compressor_v0 = ["policy-definition.yaml"]

--- a/policies/prompt-compressor/pyproject.toml
+++ b/policies/prompt-compressor/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prompt-compressor"
+version = "0.1.0"
+description = "WSO2 AI Gateway prompt compression policy for the Python executor"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "WSO2" }
+]
+dependencies = [
+  "compression-prompt==0.1.0",
+]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+
+[tool.setuptools]
+packages = ["prompt_compressor"]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+prompt_compressor = "."
+
+[tool.setuptools.package-data]
+prompt_compressor = ["policy-definition.yaml"]

--- a/policies/prompt-compressor/pyproject.toml
+++ b/policies/prompt-compressor/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "WSO2" }
 ]
 dependencies = [
-  "compression-prompt==0.1.0",
+  "compression-prompt==0.1.2",
 ]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/policies/prompt-compressor/requirements.txt
+++ b/policies/prompt-compressor/requirements.txt
@@ -1,1 +1,1 @@
-compression-prompt==0.1.0
+compression-prompt==0.1.2

--- a/policies/prompt-compressor/requirements.txt
+++ b/policies/prompt-compressor/requirements.txt
@@ -1,0 +1,1 @@
+compression-prompt==0.1.0

--- a/policies/prompt-compressor/test_policy.py
+++ b/policies/prompt-compressor/test_policy.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+import unittest
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class HeaderProcessingMode(Enum):
+    SKIP = "SKIP"
+    PROCESS = "PROCESS"
+
+
+class BodyProcessingMode(Enum):
+    SKIP = "SKIP"
+    BUFFER = "BUFFER"
+    STREAM = "STREAM"
+
+
+@dataclass
+class ProcessingMode:
+    request_header_mode: HeaderProcessingMode = HeaderProcessingMode.SKIP
+    request_body_mode: BodyProcessingMode = BodyProcessingMode.SKIP
+    response_header_mode: HeaderProcessingMode = HeaderProcessingMode.SKIP
+    response_body_mode: BodyProcessingMode = BodyProcessingMode.SKIP
+
+
+class RequestPolicy:
+    pass
+
+
+@dataclass
+class UpstreamRequestModifications:
+    body: bytes | None = None
+    dynamic_metadata: dict[str, dict[str, object]] = field(default_factory=dict)
+
+
+@dataclass
+class CompressorConfig:
+    target_ratio: float
+    min_input_tokens: int = 1
+    min_input_bytes: int = 1
+
+
+class CompressionError(Exception):
+    pass
+
+
+class InputTooShortError(CompressionError):
+    pass
+
+
+class NegativeGainError(CompressionError):
+    pass
+
+
+class FakeCompressor:
+    instances: list["FakeCompressor"] = []
+
+    def __init__(self, config: CompressorConfig):
+        self.config = config
+        self.calls: list[str] = []
+        FakeCompressor.instances.append(self)
+
+    def compress(self, text: str):
+        self.calls.append(text)
+        if text.startswith("raise-input-too-short"):
+            raise InputTooShortError("input is too short")
+        if text.startswith("raise-negative-gain"):
+            raise NegativeGainError("compression would not help")
+        if text.startswith("raise-compression-error"):
+            raise CompressionError("compression failed")
+
+        retained = max(1, int(len(text) * self.config.target_ratio))
+        return SimpleNamespace(compressed=text[:retained])
+
+
+def install_dependency_stubs() -> None:
+    sdk_module = types.ModuleType("apip_sdk_core")
+    sdk_module.BodyProcessingMode = BodyProcessingMode
+    sdk_module.ProcessingMode = ProcessingMode
+    sdk_module.RequestPolicy = RequestPolicy
+    sdk_module.UpstreamRequestModifications = UpstreamRequestModifications
+    sys.modules["apip_sdk_core"] = sdk_module
+
+    compression_module = types.ModuleType("compression_prompt")
+    compression_module.Compressor = FakeCompressor
+    compression_module.CompressorConfig = CompressorConfig
+    sys.modules["compression_prompt"] = compression_module
+
+    compressor_submodule = types.ModuleType("compression_prompt.compressor")
+    compressor_submodule.CompressionError = CompressionError
+    compressor_submodule.InputTooShortError = InputTooShortError
+    compressor_submodule.NegativeGainError = NegativeGainError
+    sys.modules["compression_prompt.compressor"] = compressor_submodule
+
+
+def load_policy_module():
+    install_dependency_stubs()
+    policy_dir = Path(__file__).resolve().parent
+    if str(policy_dir) not in sys.path:
+        sys.path.insert(0, str(policy_dir))
+    sys.modules.pop("policy", None)
+    return importlib.import_module("policy")
+
+
+policy = load_policy_module()
+
+
+def request_context(payload: object | bytes | str, present: bool = True):
+    if isinstance(payload, bytes):
+        body = payload
+    elif isinstance(payload, str):
+        body = payload.encode("utf-8")
+    else:
+        body = json.dumps(payload).encode("utf-8")
+    return SimpleNamespace(body=SimpleNamespace(content=body, present=present))
+
+
+class PromptCompressorPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeCompressor.instances.clear()
+        self._logger_disabled = policy.LOGGER.disabled
+        policy.LOGGER.disabled = True
+
+    def tearDown(self) -> None:
+        policy.LOGGER.disabled = self._logger_disabled
+
+    def test_mode_buffers_request_body_only(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        mode = instance.mode()
+
+        self.assertEqual(HeaderProcessingMode.SKIP, mode.request_header_mode)
+        self.assertEqual(BodyProcessingMode.BUFFER, mode.request_body_mode)
+        self.assertEqual(HeaderProcessingMode.SKIP, mode.response_header_mode)
+        self.assertEqual(BodyProcessingMode.SKIP, mode.response_body_mode)
+
+    def test_normalize_params_applies_defaults_coerces_values_and_sorts_rules(self) -> None:
+        params = policy.normalize_params(
+            {
+                "jsonPath": " $.messages[-1].content ",
+                "rules": [
+                    {"upperTokenLimit": -1, "type": "ratio", "value": "0.4"},
+                    {"upperTokenLimit": "30.0", "type": "token", "value": "12"},
+                    {"upperTokenLimit": 10, "type": "ratio", "value": 0.75},
+                    {"upperTokenLimit": 3.5, "type": "ratio", "value": 0.8},
+                    {"upperTokenLimit": -2, "type": "ratio", "value": 0.8},
+                    {"upperTokenLimit": 20, "type": "unknown", "value": 0.8},
+                    {"upperTokenLimit": 40, "type": "ratio", "value": False},
+                    "not-a-rule",
+                ],
+            }
+        )
+
+        self.assertEqual("$.messages[-1].content", params.json_path)
+        self.assertEqual(
+            [
+                policy.CompressionRule(10, "ratio", 0.75),
+                policy.CompressionRule(30, "token", 12.0),
+                policy.CompressionRule(-1, "ratio", 0.4),
+            ],
+            list(params.rules),
+        )
+
+    def test_normalize_params_falls_back_for_invalid_jsonpath_and_rules(self) -> None:
+        params = policy.normalize_params({"jsonPath": "  ", "rules": "bad"})
+
+        self.assertEqual(policy.DEFAULT_JSON_PATH, params.json_path)
+        self.assertEqual((), params.rules)
+
+    def test_rule_selection_and_ratio_resolution(self) -> None:
+        rules = (
+            policy.CompressionRule(10, "ratio", 0.75),
+            policy.CompressionRule(30, "token", 12.0),
+            policy.CompressionRule(-1, "ratio", 0.4),
+        )
+
+        self.assertEqual(rules[0], policy.select_rule(rules, 10))
+        self.assertEqual(rules[1], policy.select_rule(rules, 20))
+        self.assertEqual(rules[2], policy.select_rule(rules, 31))
+        self.assertEqual(0.6, policy.resolve_ratio(rules[1], 20))
+        self.assertEqual(1.0, policy.resolve_ratio(policy.CompressionRule(-1, "ratio", 1.5), 20))
+        self.assertIsNone(policy.resolve_ratio(policy.CompressionRule(-1, "token", 20), 20))
+
+    def test_jsonpath_extracts_and_updates_nested_array_values(self) -> None:
+        payload = {
+            "messages": [
+                {"content": "first"},
+                {"content": "second"},
+            ]
+        }
+
+        self.assertEqual(
+            "second",
+            policy.extract_string_value_from_jsonpath(payload, "$.messages[-1].content"),
+        )
+
+        policy.set_value_at_jsonpath(payload, "$.messages[-1].content", "updated")
+
+        self.assertEqual("updated", payload["messages"][1]["content"])
+
+    def test_jsonpath_rejects_missing_or_non_string_targets(self) -> None:
+        payload = {"messages": [{"content": {"text": "not a string"}}]}
+
+        with self.assertRaises(policy.JSONPathError):
+            policy.extract_string_value_from_jsonpath(payload, "$.messages[0].content")
+
+        with self.assertRaises(policy.JSONPathError):
+            policy.extract_string_value_from_jsonpath(payload, "$.messages[1].content")
+
+        with self.assertRaises(policy.JSONPathError):
+            policy.set_value_at_jsonpath(payload, "$.messages[0].missing", "updated")
+
+    def test_compresses_default_chat_prompt_and_sets_metadata(self) -> None:
+        original_text = "abcdefgh" * 10
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        action = instance.on_request_body(
+            execution_ctx=None,
+            ctx=request_context({"messages": [{"role": "user", "content": original_text}]}),
+            params={},
+        )
+
+        self.assertIsInstance(action, UpstreamRequestModifications)
+        updated_payload = json.loads(action.body)
+        self.assertEqual(original_text[:40], updated_payload["messages"][0]["content"])
+
+        metadata = action.dynamic_metadata[policy.DYNAMIC_METADATA_NAMESPACE]
+        self.assertTrue(metadata["compression_applied"])
+        self.assertFalse(metadata["selective_mode"])
+        self.assertEqual(0, metadata["tagged_segments"])
+        self.assertEqual(1, metadata["compressed_segments"])
+        self.assertEqual(20, metadata["input_tokens_estimated"])
+        self.assertEqual(10, metadata["output_tokens_estimated"])
+
+        self.assertEqual(1, len(FakeCompressor.instances))
+        self.assertEqual(0.5, FakeCompressor.instances[0].config.target_ratio)
+        self.assertEqual([original_text], FakeCompressor.instances[0].calls)
+
+    def test_compresses_configured_jsonpath_with_token_rule(self) -> None:
+        original_text = "0123456789" * 8
+        instance = policy.get_policy(
+            metadata={},
+            params={
+                "jsonPath": "$.prompt.text",
+                "rules": [{"upperTokenLimit": -1, "type": "token", "value": 5}],
+            },
+        )
+
+        action = instance.on_request_body(
+            execution_ctx=None,
+            ctx=request_context({"prompt": {"text": original_text}}),
+            params={},
+        )
+
+        updated_payload = json.loads(action.body)
+        self.assertEqual(original_text[:20], updated_payload["prompt"]["text"])
+        self.assertEqual(0.25, FakeCompressor.instances[0].config.target_ratio)
+
+    def test_selective_tags_compress_only_tagged_regions_and_are_removed(self) -> None:
+        tagged_region = "z" * 40
+        original_text = f"keep this {policy.OPEN_TAG}{tagged_region}{policy.CLOSE_TAG} tail"
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        action = instance.on_request_body(
+            execution_ctx=None,
+            ctx=request_context({"messages": [{"content": original_text}]}),
+            params={},
+        )
+
+        updated_payload = json.loads(action.body)
+        self.assertEqual("keep this " + ("z" * 20) + " tail", updated_payload["messages"][0]["content"])
+
+        metadata = action.dynamic_metadata[policy.DYNAMIC_METADATA_NAMESPACE]
+        self.assertTrue(metadata["compression_applied"])
+        self.assertTrue(metadata["selective_mode"])
+        self.assertEqual(1, metadata["tagged_segments"])
+        self.assertEqual(1, metadata["compressed_segments"])
+        self.assertEqual([tagged_region], FakeCompressor.instances[0].calls)
+
+    def test_nested_selective_tags_are_treated_as_one_region(self) -> None:
+        original_text = (
+            "start "
+            f"{policy.OPEN_TAG}abc{policy.OPEN_TAG}def{policy.CLOSE_TAG}ghi{policy.CLOSE_TAG}"
+            " end"
+        )
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        transformed, summary = instance._transform_text(original_text)
+
+        self.assertEqual("start abcd end", transformed)
+        self.assertTrue(summary.selective_mode)
+        self.assertEqual(1, summary.tagged_segments)
+        self.assertEqual(1, summary.compressed_segments)
+        self.assertEqual(["abcdefghi"], FakeCompressor.instances[0].calls)
+
+    def test_returns_none_when_request_body_is_absent_invalid_or_not_json(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        self.assertIsNone(
+            instance.on_request_body(None, SimpleNamespace(body=None), {})
+        )
+        self.assertIsNone(
+            instance.on_request_body(None, request_context({"messages": [{"content": "abc"}]}, present=False), {})
+        )
+        self.assertIsNone(
+            instance.on_request_body(None, request_context(b"{not json"), {})
+        )
+
+    def test_returns_none_when_jsonpath_is_missing_or_not_a_string(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        self.assertIsNone(
+            instance.on_request_body(None, request_context({"messages": []}), {})
+        )
+        self.assertIsNone(
+            instance.on_request_body(
+                None,
+                request_context({"messages": [{"content": {"nested": "value"}}]}),
+                {},
+            )
+        )
+
+    def test_returns_none_when_no_rule_reduces_the_prompt(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 1.0}]},
+        )
+
+        action = instance.on_request_body(
+            execution_ctx=None,
+            ctx=request_context({"messages": [{"content": "abcdefgh" * 10}]}),
+            params={},
+        )
+
+        self.assertIsNone(action)
+        self.assertEqual([], FakeCompressor.instances)
+
+    def test_returns_none_when_compressor_reports_non_fatal_failure(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        action = instance.on_request_body(
+            execution_ctx=None,
+            ctx=request_context({"messages": [{"content": "raise-input-too-short" + ("x" * 40)}]}),
+            params={},
+        )
+
+        self.assertIsNone(action)
+
+    def test_compressor_instances_are_cached_by_rounded_ratio(self) -> None:
+        instance = policy.get_policy(
+            metadata={},
+            params={"rules": [{"upperTokenLimit": -1, "type": "ratio", "value": 0.5}]},
+        )
+
+        first = instance._get_compressor(0.3333331)
+        second = instance._get_compressor(0.3333334)
+        third = instance._get_compressor(0.333334)
+
+        self.assertIs(first, second)
+        self.assertIsNot(first, third)
+        self.assertEqual(2, len(FakeCompressor.instances))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/policies/prompt-compressor/test_policy.py
+++ b/policies/prompt-compressor/test_policy.py
@@ -229,7 +229,7 @@ class PromptCompressorPolicyTest(unittest.TestCase):
 
         action = instance.on_request_body(
             execution_ctx=None,
-            ctx=request_context({"messages": [{"role": "user", "content": original_text}]}),
+            req_ctx=request_context({"messages": [{"role": "user", "content": original_text}]}),
             params={},
         )
 
@@ -261,7 +261,7 @@ class PromptCompressorPolicyTest(unittest.TestCase):
 
         action = instance.on_request_body(
             execution_ctx=None,
-            ctx=request_context({"prompt": {"text": original_text}}),
+            req_ctx=request_context({"prompt": {"text": original_text}}),
             params={},
         )
 
@@ -279,7 +279,7 @@ class PromptCompressorPolicyTest(unittest.TestCase):
 
         action = instance.on_request_body(
             execution_ctx=None,
-            ctx=request_context({"messages": [{"content": original_text}]}),
+            req_ctx=request_context({"messages": [{"content": original_text}]}),
             params={},
         )
 
@@ -353,7 +353,7 @@ class PromptCompressorPolicyTest(unittest.TestCase):
 
         action = instance.on_request_body(
             execution_ctx=None,
-            ctx=request_context({"messages": [{"content": "abcdefgh" * 10}]}),
+            req_ctx=request_context({"messages": [{"content": "abcdefgh" * 10}]}),
             params={},
         )
 
@@ -368,7 +368,9 @@ class PromptCompressorPolicyTest(unittest.TestCase):
 
         action = instance.on_request_body(
             execution_ctx=None,
-            ctx=request_context({"messages": [{"content": "raise-input-too-short" + ("x" * 40)}]}),
+            req_ctx=request_context(
+                {"messages": [{"content": "raise-input-too-short" + ("x" * 40)}]}
+            ),
             params={},
         )
 


### PR DESCRIPTION
Refers to - https://github.com/wso2/api-platform/issues/1714

## Purpose
Add the `prompt-compressor` policy to reduce prompt size before upstream LLM calls and document how to include and configure it.

## Goals
- Compress selected prompt text in JSON request bodies.
- Support JSONPath-based prompt targeting.
- Support rule-based compression using ratio or target-token modes.
- Support selective compression using `<APIP-COMPRESS>` tags.
- Add policy hub documentation for `docs/prompt-compressor/v0.1`.

## Approach
- Added the `prompt-compressor` policy package under `policies/prompt-compressor`.
- Added `policy-definition.yaml`, package metadata, requirements, and README.
- Added policy documentation and metadata under `docs/prompt-compressor/v0.1`.
- Documented the `build.yaml` entry:

```yaml
- name: prompt-compressor
  pipPackage: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
```

## Documentation
Added documentation:
- `docs/prompt-compressor/v0.1/docs/prompt-compressor.md`
- `docs/prompt-compressor/v0.1/metadata.json`

## Automation tests
- Documentation/catalog validation completed.
- Package/runtime tests: N/A for this PR.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A
- Confirmed no keys, passwords, tokens, usernames, or other secrets are committed: yes

## Samples
Included sample policy configurations in the Prompt Compressor documentation.

## Related PRs
N/A

## Test environment
Local development environment.