### PR TITLE
Require fallback rule for prompt-compressor

### DIFF
--- a/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
+++ b/docs/prompt-compressor/v0.1/docs/prompt-compressor.md
@@ -29,7 +29,7 @@ The Prompt Compressor policy uses API definition parameters and does not require
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `jsonPath` | string | No | `$.messages[0].content` | JSONPath expression that resolves to the prompt string to compress. The selected value must be a string. |
-| `rules` | array of `CompressionRule` objects | Yes | - | Compression rules evaluated in ascending `upperTokenLimit` order. The first matching rule is applied. |
+| `rules` | array of `CompressionRule` objects | Yes | - | Compression rules evaluated in ascending `upperTokenLimit` order. The `rules` array must contain at least one fallback rule with `upperTokenLimit: -1`. The first matching rule is applied. |
 
 #### CompressionRule Configuration
 
@@ -41,7 +41,7 @@ The Prompt Compressor policy uses API definition parameters and does not require
 
 #### Rule Evaluation
 
-Rules are normalized and sorted before evaluation. Explicit token limits are evaluated from smallest to largest, and the `upperTokenLimit: -1` fallback is evaluated after all explicit limits.
+Rules are normalized and sorted before evaluation. Explicit token limits are evaluated from smallest to largest, and the `upperTokenLimit: -1` fallback is evaluated after all explicit limits. The rules array must contain at least one fallback rule.
 
 The policy estimates tokens as approximately one token per four characters in the selected text. In `ratio` mode, `value` is used as the target retained-size ratio. In `token` mode, `value` is converted to a retained-size ratio by dividing the target token estimate by the selected text's estimated token count. If the resolved ratio is greater than or equal to `1.0`, compression is skipped and the request is forwarded unchanged.
 

--- a/policies/prompt-compressor/policy-definition.yaml
+++ b/policies/prompt-compressor/policy-definition.yaml
@@ -27,6 +27,11 @@ parameters:
         The first matching rule is used. Use upperTokenLimit -1 as the catch-all
         fallback rule.
       minItems: 1
+      contains:
+        properties:
+          upperTokenLimit:
+            const: -1
+      minContains: 1
       items:
         type: object
         additionalProperties: false


### PR DESCRIPTION
## Purpose
Document and enforce that the `rules` array must include at least one fallback rule with `upperTokenLimit: -1`. The docs were updated to clarify the fallback requirement and rule evaluation order, and the policy schema (policy-definition.yaml) now uses `contains`/`const`/`minContains` to validate presence of a catch-all rule.