### PR TITLE
fix: metaKey trailing colon when instanceID is empty in advanced-ratelimit                                                     

### DIFF
--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -434,6 +434,9 @@ func GetPolicy(
 // metaKey returns an instance-specific metadata key to avoid collisions when
 // multiple advanced-ratelimit instances are present in the same request chain.
 func (p *RateLimitPolicy) metaKey(base string) string {
+	if p.instanceID == "" {
+		return base
+	}
 	return base + ":" + p.instanceID
 }
 


### PR DESCRIPTION
When metaKey() was introduced to namespace metadata keys per policy instance, it always appended ":" + instanceID even when instanceID was empty. 

- Tests construct RateLimitPolicy directly as struct literals (to inject fake limiters), so instanceID is never set, causing keys like "ratelimit:result:" to be written while tests read from "ratelimit:result" — breaking all metadata lookups in TestOnRequestBehavior and TestOnResponseBehavior.
- Fixed by returning the base key unchanged when instanceID is empty.