### PR TITLE
feat(jwt-auth)!: add forwardToken param JWT Auth and remove query param in API Key auth

### DIFF
--- a/docs/api-key-auth/v1.0/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.0/docs/apikey-authentication.md
@@ -5,12 +5,12 @@ title: "Overview"
 
 ## Overview
 
-The API Key Authentication policy validates API keys to secure APIs by verifying pre-generated keys before allowing access to protected resources. This policy is essential for API security, supporting both header-based and query parameter-based key validation.
+The API Key Authentication policy validates API keys to secure APIs by verifying pre-generated keys before allowing access to protected resources. This policy is essential for API security, supporting header-based key validation.
 
 ## Features
 
-- Validates API keys from request headers or query parameters
-- Configurable key extraction from headers (case-insensitive) or query parameters (exact match)
+- Validates API keys from request headers
+- Configurable key extraction from headers (case-insensitive)
 - Pre-generated key validation against gateway-managed key lists
 - Request context enrichment with authentication metadata
 - Issuer-based key validation via system configuration
@@ -26,8 +26,8 @@ These parameters are configured per-API/route by the API developer:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `key` | string | Yes | `API-Key` | The name of the header or query parameter that contains the API key. For headers: case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). For query parameters: exact name matching is used (e.g., "api_key", "token"). Length: 1-128 characters. |
-| `in` | string | Yes | `header` | Specifies where to look for the API key. Must be either "header" or "query". |
+| `key` | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters. |
+| `in` | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported. |
 
 ### System Parameters (config.toml)
 
@@ -115,38 +115,7 @@ spec:
       path: /alerts/active
 ```
 
-### Example 3: Query Parameter Authentication
-
-Extract API key from query parameter
-
-```yaml
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
-kind: RestApi
-metadata:
-  name: weather-api-v1.0
-spec:
-  displayName: Weather-API
-  version: v1.0
-  context: /weather/$version
-  upstream:
-    main:
-      url: http://sample-backend:5000/api/v2
-  policies:
-    - name: api-key-auth
-      version: v1
-      params:
-        key: api_key
-        in: query
-  operations:
-    - method: GET
-      path: /{country_code}/{city}
-    - method: GET
-      path: /alerts/active
-    - method: POST
-      path: /alerts/active
-```
-
-### Example 4: Custom Header Name
+### Example 3: Custom Header Name
 
 Use a custom header for API key authentication
 
@@ -177,7 +146,7 @@ spec:
       path: /alerts/active
 ```
 
-### Example 5: Route-Specific Authentication
+### Example 4: Route-Specific Authentication
 
 Apply different API key configurations to different routes
 
@@ -224,7 +193,7 @@ spec:
 
 - On each request, the gateway policy reads `key` and `in` from the policy configuration and validates that required parameters are present.
 
-- Based on `in`, it extracts the API key either from a request header (case-insensitive header lookup) or from a query parameter in the request URL.
+- Based on `in`, it extracts the API key from a request header (case-insensitive header lookup).
 
 - If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
 

--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -18,6 +18,7 @@ The JWT Authentication policy validates JWT access tokens using one or more JWKS
 - Authorization header scheme enforcement and clock skew tolerance
 - Customizable error responses
 - Optional `userIdClaim` mapping for analytics
+- Optional forwarding of the original `Authorization` header (JWT) to the upstream
 
 ## Configuration
 
@@ -102,6 +103,7 @@ skipTlsVerify = false
 | `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
 | `headerName` | string | No | Header name to extract the token from (e.g., `"Authorization"`). Overrides `system.headerName`. Must be a valid HTTP header field name (non-empty, no spaces or control characters). |
 | `userIdClaim` | string | No | Claim name to extract user ID for analytics. Defaults to `sub`. |
+| `forwardToken` | boolean | No | If `true` (default), the original `Authorization` header (containing the JWT) is forwarded to the upstream after successful validation. Set to `false` to strip the header before proxying. |
 
 
 **Note:**
@@ -254,4 +256,32 @@ spec:
               email: X-User-Email
               role: X-User-Role
             userIdClaim: username
+```
+
+### Example 6: Strip JWT Before Forwarding to Upstream
+
+By default, the original `Authorization` header is forwarded to the upstream after successful validation. Set `forwardToken: false` to strip it before proxying.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-strip-token-api
+spec:
+  displayName: JWT Auth Strip Token API
+  version: v1.0
+  context: /jwt-auth-strip/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: false
 ```

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,8 +1,8 @@
 name: api-key-auth
 version: v1.0.2
 description: |
-  Secures APIs by validating API keys in incoming requests. API keys can be
-  provided through a configured HTTP header or query parameter.
+  Secures APIs by validating API keys in incoming requests. API keys are
+  provided through a configured HTTP header.
 
 parameters:
   type: object
@@ -12,8 +12,8 @@ parameters:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
-        Specifies the header or query parameter name that carries the API key.
-        Header lookup is case-insensitive; query parameter lookup uses exact matching.
+        Specifies the header name that carries the API key.
+        Header lookup is case-insensitive.
       default: API-Key
       validation:
         minLength: 1
@@ -23,12 +23,11 @@ parameters:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
-        Specifies where to read the API key. Supported values are "header" and
-        "query".
+        Specifies where to read the API key. Currently only "header" is
+        supported.
       default: header
       enum:
         - "header"
-        - "query"
 
   required:
     - key

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1309,6 +1309,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	userClaimMappings := getStringMapParam(params, "claimMappings", map[string]string{})
 	userIdClaim := getStringParam(params, "userIdClaim", "sub")
 	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
+	forwardToken := getBoolParam(params, "forwardToken", true)
 
 	slog.Debug("JWT Auth Policy: User configuration loaded",
 		"issuers", userIssuers,
@@ -1455,12 +1456,12 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 
 	slog.Debug("JWT Auth Policy: All validations passed, authentication successful")
 
-	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName)
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, forwardToken)
 }
 
 // handleAuthSuccessHeaders handles successful JWT authentication in the header phase.
 func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, claims jwt.MapClaims, claimMappings map[string]string,
-	userIdClaim string, headerName string) policy.RequestHeaderAction {
+	userIdClaim string, headerName string, forwardToken bool) policy.RequestHeaderAction {
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 
@@ -1487,8 +1488,9 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 
 	modifications := policy.UpstreamRequestHeaderModifications{
 		HeadersToSet: make(map[string]string),
-		// Drop the original auth header to prevent it from being sent upstream
-		HeadersToRemove: []string{http.CanonicalHeaderKey(headerName)},
+	}
+	if !forwardToken {
+		modifications.HeadersToRemove = []string{http.CanonicalHeaderKey(headerName)}
 	}
 
 	for claimName, headerName := range claimMappings {

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -126,6 +126,76 @@ func TestJWTAuthPolicy_ValidToken(t *testing.T) {
 	if modifications.HeadersToSet["X-User-Name"] != "John Doe" {
 		t.Errorf("Expected X-User-Name header to be 'John Doe', got %s", modifications.HeadersToSet["X-User-Name"])
 	}
+
+	// forwardToken defaults to true, so the Authorization header must NOT be stripped.
+	for _, h := range modifications.HeadersToRemove {
+		if strings.EqualFold(h, "Authorization") {
+			t.Errorf("Expected Authorization header to be forwarded by default, but it was in HeadersToRemove")
+		}
+	}
+}
+
+// TestJWTAuthPolicy_ForwardTokenFalse verifies the Authorization header is stripped
+// from the upstream request when forwardToken=false.
+func TestJWTAuthPolicy_ForwardTokenFalse(t *testing.T) {
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://issuer.example.com",
+		"aud": "api-audience",
+	})
+
+	ctx := createMockRequestHeaderContext(map[string][]string{
+		"authorization": {fmt.Sprintf("Bearer %s", token)},
+	})
+
+	params := map[string]interface{}{
+		"headerName":          "Authorization",
+		"authHeaderScheme":    "Bearer",
+		"onFailureStatusCode": 401,
+		"errorMessageFormat":  "json",
+		"leeway":              "30s",
+		"allowedAlgorithms":   []interface{}{"RS256", "ES256"},
+		"forwardToken":        false,
+		"keyManagers": []interface{}{
+			map[string]interface{}{
+				"name":   "test-issuer",
+				"issuer": "https://issuer.example.com",
+				"jwks": map[string]interface{}{
+					"remote": map[string]interface{}{
+						"uri": jwksServer.URL + "/jwks.json",
+					},
+				},
+			},
+		},
+		"audiences": []interface{}{"api-audience"},
+	}
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("Failed to create policy: %v", err)
+	}
+
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+
+	modifications, ok := action.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+
+	found := false
+	for _, h := range modifications.HeadersToRemove {
+		if strings.EqualFold(h, "Authorization") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected Authorization header to be stripped when forwardToken=false, HeadersToRemove=%v", modifications.HeadersToRemove)
+	}
 }
 
 // TestJWTAuthPolicy_MissingToken tests authentication failure when Authorization header is missing

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.0.2
+version: v1.0.3
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.
@@ -72,6 +72,15 @@ parameters:
       pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
       description: Header name to extract token from (for example "Authorization") that overrides `system.headerName`.
       default: Authorization
+
+    forwardToken:
+      type: boolean
+      x-wso2-policy-advanced-param: true
+      description: >-
+        If true, the original Authorization header (containing the JWT) is
+        forwarded to the upstream service after successful validation. If
+        false, the header is stripped before the request is proxied.
+      default: true
 
 systemParameters:          
   type: object


### PR DESCRIPTION
## Purpose
Adds a new advanced user parameter `forwardToken` (default true) to the jwt-auth policy. When true, the original Authorization header is forwarded to the upstream after successful validation; when false, it is stripped (the previous unconditional behavior).

BREAKING CHANGE: jwt-auth previously stripped the Authorization header from upstream requests unconditionally. With the new default of true, the JWT is now forwarded to the upstream by default. Set `forwardToken: false` on existing routes to preserve prior behavior.

Fix https://github.com/wso2/api-platform/issues/1797
Related: https://github.com/wso2/api-platform/issues/1279