### PR TITLE
feat(jwt-auth): add forwardedTokenHeader param for upstream token forwarding

### DIFF
--- a/.github/workflows/gateway-integration-test.yml
+++ b/.github/workflows/gateway-integration-test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1503,6 +1503,9 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 
 	for claimName, headerName := range claimMappings {
 		if claimValue, ok := claims[claimName]; ok {
+			if forwardToken && http.CanonicalHeaderKey(headerName) == canonicalOut {
+				continue
+			}
 			modifications.HeadersToSet[headerName] = claimValueToString(claimValue)
 		}
 	}

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1310,6 +1310,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	userIdClaim := getStringParam(params, "userIdClaim", "sub")
 	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
 	forwardToken := getBoolParam(params, "forwardToken", true)
+	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
 
 	slog.Debug("JWT Auth Policy: User configuration loaded",
 		"issuers", userIssuers,
@@ -1456,12 +1457,12 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 
 	slog.Debug("JWT Auth Policy: All validations passed, authentication successful")
 
-	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, forwardToken)
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
 }
 
 // handleAuthSuccessHeaders handles successful JWT authentication in the header phase.
 func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, claims jwt.MapClaims, claimMappings map[string]string,
-	userIdClaim string, headerName string, forwardToken bool) policy.RequestHeaderAction {
+	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 
@@ -1489,8 +1490,15 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 	modifications := policy.UpstreamRequestHeaderModifications{
 		HeadersToSet: make(map[string]string),
 	}
+
+	canonicalIn := http.CanonicalHeaderKey(headerName)
+	canonicalOut := http.CanonicalHeaderKey(forwardedTokenHeader)
+
 	if !forwardToken {
-		modifications.HeadersToRemove = []string{http.CanonicalHeaderKey(headerName)}
+		modifications.HeadersToRemove = []string{canonicalIn}
+	} else if canonicalOut != canonicalIn {
+		modifications.HeadersToSet[canonicalOut] = authHeaderValue
+		modifications.HeadersToRemove = []string{canonicalIn}
 	}
 
 	for claimName, headerName := range claimMappings {

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -127,11 +127,20 @@ func TestJWTAuthPolicy_ValidToken(t *testing.T) {
 		t.Errorf("Expected X-User-Name header to be 'John Doe', got %s", modifications.HeadersToSet["X-User-Name"])
 	}
 
-	// forwardToken defaults to true, so the Authorization header must NOT be stripped.
+	// forwardToken defaults to true and forwardedTokenHeader defaults to x-forwarded-authorization,
+	// so the token is renamed: Authorization is removed and x-forwarded-authorization is set.
+	foundRemoved := false
 	for _, h := range modifications.HeadersToRemove {
 		if strings.EqualFold(h, "Authorization") {
-			t.Errorf("Expected Authorization header to be forwarded by default, but it was in HeadersToRemove")
+			foundRemoved = true
+			break
 		}
+	}
+	if !foundRemoved {
+		t.Errorf("Expected Authorization header to be removed (renamed to x-forwarded-authorization), HeadersToRemove=%v", modifications.HeadersToRemove)
+	}
+	if modifications.HeadersToSet["X-Forwarded-Authorization"] == "" {
+		t.Errorf("Expected x-forwarded-authorization header to be set with token value, HeadersToSet=%v", modifications.HeadersToSet)
 	}
 }
 

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.0.3
+version: v1.0.4
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.
@@ -81,6 +81,18 @@ parameters:
         forwarded to the upstream service after successful validation. If
         false, the header is stripped before the request is proxied.
       default: true
+
+    forwardedTokenHeader:
+      type: string
+      x-wso2-policy-advanced-param: true
+      minLength: 1
+      pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+      description: >-
+        The header name used to forward the JWT to the upstream service when
+        `forwardToken` is true. If this differs from `headerName`, the original
+        header is removed and the token is forwarded under this name instead.
+        Has no effect when `forwardToken` is false.
+      default: x-forwarded-authorization
 
 systemParameters:          
   type: object


### PR DESCRIPTION
## Purpose

Add a new user parameter `forwardedTokenHeader` (default: `x-forwarded-authorization`) that controls the header name used when forwarding the JWT to upstream services.

- When `forwardToken: true` and `forwardedTokenHeader` differs from `headerName`, the original auth header is removed and the token is set on the new header instead.
- When both headers are the same, the original header passes through unchanged (no-op).
- When `forwardToken: false`, the header is always stripped regardless of `forwardedTokenHeader`.

Bumps policy version to v1.0.4.

BREAKING CHANGE: the default behaviour of `forwardToken: true` changes — the JWT is now forwarded as `x-forwarded-authorization` instead of being kept in the original `Authorization` header. Set `forwardedTokenHeader: Authorization` to restore the previous behaviour.
