### PR TITLE
add WebSub cattegory to existing policies

### DIFF
--- a/docs/api-key-auth/v0.1/metadata.json
+++ b/docs/api-key-auth/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.2/metadata.json
+++ b/docs/api-key-auth/v0.2/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.3/metadata.json
+++ b/docs/api-key-auth/v0.3/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "The API Key Authentication policy secures APIs by requiring clients to include a valid API key with each request. The API key can be provided either as an HTTP header or as a query parameter, based on the API configuration."
 }

--- a/docs/api-key-auth/v0.8/metadata.json
+++ b/docs/api-key-auth/v0.8/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.9/metadata.json
+++ b/docs/api-key-auth/v0.9/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v1.0/metadata.json
+++ b/docs/api-key-auth/v1.0/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/basic-auth/v0.1/metadata.json
+++ b/docs/basic-auth/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.2/metadata.json
+++ b/docs/basic-auth/v0.2/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.8/metadata.json
+++ b/docs/basic-auth/v0.8/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.9/metadata.json
+++ b/docs/basic-auth/v0.9/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v1.0/metadata.json
+++ b/docs/basic-auth/v1.0/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/jwt-auth/v0.1/metadata.json
+++ b/docs/jwt-auth/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.2/metadata.json
+++ b/docs/jwt-auth/v0.2/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.3/metadata.json
+++ b/docs/jwt-auth/v0.3/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens included in API requests. The gateway verifies the token's signature, expiry, issuer, audience, scopes, and required claims."
 }

--- a/docs/jwt-auth/v0.8/metadata.json
+++ b/docs/jwt-auth/v0.8/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.9/metadata.json
+++ b/docs/jwt-auth/v0.9/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v1.0/metadata.json
+++ b/docs/jwt-auth/v1.0/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Security",
-    "AI"
+    "AI",
+    "WebSub"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/log-message/v0.1/metadata.json
+++ b/docs/log-message/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Logging",
-    "Analytics & Monitoring"
+    "Analytics & Monitoring",
+    "WebSub"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows."
 }

--- a/docs/log-message/v0.2/metadata.json
+++ b/docs/log-message/v0.2/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Logging",
     "Analytics & Monitoring",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows."
 }

--- a/docs/log-message/v0.9/metadata.json
+++ b/docs/log-message/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Logging",
     "Analytics & Monitoring",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows.\nSupports streaming (SSE) payloads by logging each chunk independently as it arrives."
 }

--- a/docs/log-message/v1.0/metadata.json
+++ b/docs/log-message/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Logging",
     "Analytics & Monitoring",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows.\nSupports streaming (SSE) payloads by logging each chunk independently as it arrives."
 }

--- a/docs/remove-headers/v0.1/metadata.json
+++ b/docs/remove-headers/v0.1/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.1",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.2/metadata.json
+++ b/docs/remove-headers/v0.2/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.2",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.3/metadata.json
+++ b/docs/remove-headers/v0.3/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.3",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "Removes configured headers from requests and/or responses. Header matching is case-insensitive, and removing a non-existent header is ignored."
 }

--- a/docs/remove-headers/v0.8/metadata.json
+++ b/docs/remove-headers/v0.8/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.9/metadata.json
+++ b/docs/remove-headers/v0.9/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v1.0/metadata.json
+++ b/docs/remove-headers/v1.0/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/set-headers/v0.1/metadata.json
+++ b/docs/set-headers/v0.1/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.1",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.2/metadata.json
+++ b/docs/set-headers/v0.2/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.2",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.3/metadata.json
+++ b/docs/set-headers/v0.3/metadata.json
@@ -4,7 +4,8 @@
   "version": "0.3",
   "provider": "WSO2",
   "categories": [
-    "Transformation"
+    "Transformation",
+    "WebSub"
   ],
   "description": "Sets configured headers on requests and/or responses. If the same header is set multiple times, the latest configured value overwrites earlier values."
 }

--- a/docs/set-headers/v0.8/metadata.json
+++ b/docs/set-headers/v0.8/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.9/metadata.json
+++ b/docs/set-headers/v0.9/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v1.0/metadata.json
+++ b/docs/set-headers/v1.0/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "MCP"
+    "MCP",
+    "WebSub"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }


### PR DESCRIPTION
add WebSub cattegory to existing policies
This pull request updates the metadata for several authentication and logging policies by adding the "WebSub" category to their `categories` fields across multiple versions. This change ensures that these policies are discoverable under the "WebSub" category in documentation or catalog views.

**Category updates for authentication policies:**

* Added "WebSub" to the `categories` array in all versions of the following authentication policies' metadata:
  - API Key Authentication (`docs/api-key-auth/v0.1`, `v0.2`, `v0.3`, `v0.8`, `v0.9`, `v1.0`) [[1]](diffhunk://#diff-7b22615685d4b705b4cd2b5b3fd4f10e1be820a7d977b93f880889b56aff90e9L8-R9) [[2]](diffhunk://#diff-b71f3d4df5c78bd0820d3526fe42a18920fd4af2ecdda3f3221459a8f72dbb84L8-R9) [[3]](diffhunk://#diff-4b258ebce19b733ea406900b66b146eb5de460d74d4f4cd0dc6421671b3349d6L8-R9) [[4]](diffhunk://#diff-e76031f8a5e95792169cc1c62e248f8b1884b8e6159ce613a6f5cdd6c35b4280L8-R9) [[5]](diffhunk://#diff-58e411f3ea72f24c00799702bba869d5b4fb1d19e39c9a498179e57ee34b98faL8-R9) [[6]](diffhunk://#diff-907e1c5bc33a8786113b3adfe1f0448d8a72c0bbeecac6ab555d537f60266042L8-R9)
  - Basic Authentication (`docs/basic-auth/v0.1`, `v0.2`, `v0.8`, `v0.9`, `v1.0`) [[1]](diffhunk://#diff-eccbcc45feaea066ea4101232c5286bab58da2d3e1786e56735102fc203e65a9L8-R9) [[2]](diffhunk://#diff-124f3b002f57f361fe4fe9aefef72061af739f0d7ae71de820ddbd144642f6a1L8-R9) [[3]](diffhunk://#diff-aafb0bcde5086f634689ea414e5e71c16e539b8721220d454dcf5d4c292f3caeL8-R9) [[4]](diffhunk://#diff-21f27406bb0252f48f5115735b342696fadf988e3ae65608bc1bdc1e8db3a856L8-R9) [[5]](diffhunk://#diff-bf039c5913605125b93efb36d97a6f7a1bb1750acdf0ecf10e346694c082f55eL8-R9)
  - JWT Authentication (`docs/jwt-auth/v0.1`, `v0.2`, `v0.3`, `v0.8`, `v0.9`, `v1.0`) [[1]](diffhunk://#diff-2b503b17a321e0bb9894af910cbff7a7fcb7497e403ed9a28dc7894d62182139L8-R9) [[2]](diffhunk://#diff-8a776a9710ecde5c2ade354034d05c1769cf905345840374b8cfe8a73a292eddL8-R9) [[3]](diffhunk://#diff-f85f59ecdd8314d74db6bd2639b2dd2e4de88ff7b0dd8a2f12a4732297cf562eL8-R9) [[4]](diffhunk://#diff-6544abfe21fc8990fe807bcd6711ac93480fd6aca9e9c9f80e68833d471c61ccL8-R9) [[5]](diffhunk://#diff-5d685e3af80ea84d0d34fbcff0f2e968c7a9be929cda9b5ca6082f16e0de877cL8-R9) [[6]](diffhunk://#diff-7d5e267230535a729b338f557745c325ec3f7c4e18aa74edb01cab68ca742158L8-R9)

**Category updates for logging policy:**

* Added "WebSub" to the `categories` array in all versions of the Log Message policy's metadata (`docs/log-message/v0.1`, `v0.2`, `v0.9`) [[1]](diffhunk://#diff-cc2f28d5fbbd0b04f687190bb5c1cd8bb00a5834361539e8a3deed231981984bL8-R9) [[2]](diffhunk://#diff-1205d612df520285813f2e7b412d7d91720b3ca1a0954b813ce72c75c220a0abL9-R10) [[3]](diffhunk://#diff-d74c5919fe2fb0f2e5cbdfbe60a08d4164367284619be9bb708ecc3becd08a35L9-R10)