### PR TITLE
Add WebBroker category to existing policies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,10 +31,10 @@ All available policies, sorted alphabetically.
 | Policy | Categories | Description |
 |--------|------------|-------------|
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
-| [API Key Auth](./api-key-auth/v1.0/docs/apikey-authentication.md) | Security, AI | Implements API Key Authentication to protect APIs with pre-shared API keys. |
+| [API Key Auth](./api-key-auth/v1.0/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
-| [Basic Auth](./basic-auth/v1.0/docs/basic-auth.md) | Security, AI | Implements HTTP Basic Authentication to protect APIs with username and password credentials. |
+| [Basic Auth](./basic-auth/v1.0/docs/basic-auth.md) | Security, AI, WebSub, WebBroker | Implements HTTP Basic Authentication to protect APIs with username and password credentials. |
 | [Content Length Guardrail](./content-length-guardrail/v1.0/docs/content-length.md) | Guardrails, AI | Validates the byte length of request or response body content. |
 | [CORS](./cors/v1.0/docs/cors.md) | Security, AI, MCP | Cross-Origin Resource Sharing (CORS) policy that handles preflight requests and adds appropriate CORS headers to responses. |
 | [Dynamic Endpoint](./dynamic-endpoint/v1.0/docs/dynamic-endpoint.md) | Transformation | Routes requests to a named upstream definition at request time. |
@@ -43,10 +43,10 @@ All available policies, sorted alphabetically.
 | [Interceptor Service](./interceptor-service/v1.0/docs/interceptor-service.md) | Transformation | Invokes a user-defined HTTP interceptor service in the request and/or response phase. |
 | [JSON Schema Guardrail](./json-schema-guardrail/v1.0/docs/json-schema.md) | Guardrails, AI | Validates request or response body content against a JSON Schema. |
 | [JSON/XML Mediator](./json-xml-mediator/v1.0/docs/json-xml-mediator.md) | Transformation | Mediates request and response payloads between downstream and upstream JSON/XML formats. |
-| [JWT Auth](./jwt-auth/v1.0/docs/jwt-authentication.md) | Security, AI | Validates JWT access tokens using one or more JWKS providers (key managers). |
+| [JWT Auth](./jwt-auth/v1.0/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens using one or more JWKS providers (key managers). |
 | [LLM Cost](./llm-cost/v1.0/docs/llm-cost.md) | AI | Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. |
 | [LLM Cost Based Ratelimit](./llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md) | AI | A specialized rate limiting policy that enforces monetary budget limits on LLM API usage. |
-| [Log Message](./log-message/v1.0/docs/log-message.md) | Logging, Analytics & Monitoring, MCP | This policy provides the capability to log the payload and headers of a request/response. |
+| [Log Message](./log-message/v1.0/docs/log-message.md) | Logging, Analytics & Monitoring, MCP, WebSub, WebBroker | This policy provides the capability to log the payload and headers of a request/response. |
 | [MCP Access Control](./mcp-acl-list/v1.0/docs/mcp-acl-list.md) | MCP, AI | MCP ACL List policy controls access to tools, resources, and prompts using mode and exceptions. |
 | [MCP Authentication](./mcp-auth/v1.0/docs/mcp-authentication.md) | MCP, AI, Security | This policy is used to secure traffic to Model Context Protocol server as defined in the specification (https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). |
 | [MCP Authorization](./mcp-authz/v1.0/docs/mcp-authorization.md) | MCP, AI, Security | MCP Authorization policy validates access to MCP resources (tools, resources, prompts) and methods based on JWT claims or OAuth scopes provided by the mcp-auth policy. |
@@ -61,14 +61,14 @@ All available policies, sorted alphabetically.
 | [Rate Limit - Advanced](./advanced-ratelimit/v1.0/docs/advanced-ratelimit.md) | Security, AI | Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas, weighted rate limiting, flexible key extraction, and both in-memory and Redis backends. |
 | [Rate Limit - Basic](./basic-ratelimit/v1.0/docs/basic-ratelimit.md) | Security, AI | Simple request rate limiting policy that limits the number of requests per time window. |
 | [Regex Guardrail](./regex-guardrail/v1.0/docs/regex.md) | Guardrails, AI | Validates request or response body content against a regular expression pattern. |
-| [Remove Headers](./remove-headers/v1.0/docs/remove-headers.md) | Transformation, MCP | This policy provides the capability to remove headers from either the request or the response. |
+| [Remove Headers](./remove-headers/v1.0/docs/remove-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to remove headers from either the request or the response. |
 | [Request Rewrite](./request-rewrite/v1.0/docs/request-rewrite.md) | Transformation | Rewrites incoming requests by updating path, query parameters, and/or HTTP method before forwarding to upstream services. |
 | [Respond](./respond/v1.0/docs/respond.md) | AI | Returns an immediate response to the client without forwarding the request to the upstream backend. |
 | [Semantic Cache](./semantic-cache/v1.0/docs/semantic-caching.md) | AI | Implements semantic caching for LLM responses using vector similarity search. |
 | [Semantic Prompt Guard](./semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md) | Guardrails, AI | Blocks or allows prompts based on semantic similarity to configured allow/deny phrase embeddings. |
 | [Semantic Tool Filtering](./semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md) | Guardrails, AI | Dynamically filters the tools provided within an API request based on their semantic relevance to the user query. |
 | [Sentence Count Guardrail](./sentence-count-guardrail/v1.0/docs/sentence-count.md) | Guardrails, AI | Validates the sentence count of request or response body content. |
-| [Set Headers](./set-headers/v1.0/docs/set-headers.md) | Transformation, MCP | This policy provides the capability to set arbitrary headers to either the request or the response. |
+| [Set Headers](./set-headers/v1.0/docs/set-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to set arbitrary headers to either the request or the response. |
 | [Subscription Validation](./subscription-validation/v1.0/docs/subscription-validation.md) | Security | Validates that incoming requests are associated with an active subscription for the target API. |
 | [Token Based Ratelimit](./token-based-ratelimit/v1.0/docs/token-based-ratelimit.md) | AI | A specialized rate limiting policy for LLM APIs that enforces usage quotas based on token counts. |
 | [URL Guardrail](./url-guardrail/v1.0/docs/url.md) | Guardrails, AI | Validates URLs found in request or response body content. |

--- a/docs/api-key-auth/v0.1/metadata.json
+++ b/docs/api-key-auth/v0.1/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.2/metadata.json
+++ b/docs/api-key-auth/v0.2/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.3/metadata.json
+++ b/docs/api-key-auth/v0.3/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "The API Key Authentication policy secures APIs by requiring clients to include a valid API key with each request. The API key can be provided either as an HTTP header or as a query parameter, based on the API configuration."
 }

--- a/docs/api-key-auth/v0.8/metadata.json
+++ b/docs/api-key-auth/v0.8/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v0.9/metadata.json
+++ b/docs/api-key-auth/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v1.0/metadata.json
+++ b/docs/api-key-auth/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/basic-auth/v0.1/metadata.json
+++ b/docs/basic-auth/v0.1/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.2/metadata.json
+++ b/docs/basic-auth/v0.2/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.8/metadata.json
+++ b/docs/basic-auth/v0.8/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v0.9/metadata.json
+++ b/docs/basic-auth/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/basic-auth/v1.0/metadata.json
+++ b/docs/basic-auth/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Implements HTTP Basic Authentication to protect APIs with username and password credentials.\nValidates the Authorization header against configured credentials and sets authentication\nmetadata in the request context for downstream policies to use."
 }

--- a/docs/jwt-auth/v0.1/metadata.json
+++ b/docs/jwt-auth/v0.1/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.2/metadata.json
+++ b/docs/jwt-auth/v0.2/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.3/metadata.json
+++ b/docs/jwt-auth/v0.3/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens included in API requests. The gateway verifies the token's signature, expiry, issuer, audience, scopes, and required claims."
 }

--- a/docs/jwt-auth/v0.8/metadata.json
+++ b/docs/jwt-auth/v0.8/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v0.9/metadata.json
+++ b/docs/jwt-auth/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/jwt-auth/v1.0/metadata.json
+++ b/docs/jwt-auth/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Security",
     "AI",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Validates JWT access tokens using one or more JWKS providers (key managers).\nSystem-level configuration holds key manager endpoints and fetch behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
 }

--- a/docs/log-message/v0.1/metadata.json
+++ b/docs/log-message/v0.1/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Logging",
     "Analytics & Monitoring",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows."
 }

--- a/docs/log-message/v0.2/metadata.json
+++ b/docs/log-message/v0.2/metadata.json
@@ -7,7 +7,8 @@
     "Logging",
     "Analytics & Monitoring",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows."
 }

--- a/docs/log-message/v0.9/metadata.json
+++ b/docs/log-message/v0.9/metadata.json
@@ -7,7 +7,8 @@
     "Logging",
     "Analytics & Monitoring",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows.\nSupports streaming (SSE) payloads by logging each chunk independently as it arrives."
 }

--- a/docs/log-message/v1.0/metadata.json
+++ b/docs/log-message/v1.0/metadata.json
@@ -7,7 +7,8 @@
     "Logging",
     "Analytics & Monitoring",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to log the payload and headers of a request/response.\nIt supports separate configuration for request and response flows.\nSupports streaming (SSE) payloads by logging each chunk independently as it arrives."
 }

--- a/docs/remove-headers/v0.1/metadata.json
+++ b/docs/remove-headers/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.2/metadata.json
+++ b/docs/remove-headers/v0.2/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.3/metadata.json
+++ b/docs/remove-headers/v0.3/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Removes configured headers from requests and/or responses. Header matching is case-insensitive, and removing a non-existent header is ignored."
 }

--- a/docs/remove-headers/v0.8/metadata.json
+++ b/docs/remove-headers/v0.8/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v0.9/metadata.json
+++ b/docs/remove-headers/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/remove-headers/v1.0/metadata.json
+++ b/docs/remove-headers/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to remove headers from either the request or the response.\nHeader removal is performed by header name matching (case-insensitive). If a header does not exist, the removal operation is ignored without error."
 }

--- a/docs/set-headers/v0.1/metadata.json
+++ b/docs/set-headers/v0.1/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.2/metadata.json
+++ b/docs/set-headers/v0.2/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.3/metadata.json
+++ b/docs/set-headers/v0.3/metadata.json
@@ -5,7 +5,8 @@
   "provider": "WSO2",
   "categories": [
     "Transformation",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "Sets configured headers on requests and/or responses. If the same header is set multiple times, the latest configured value overwrites earlier values."
 }

--- a/docs/set-headers/v0.8/metadata.json
+++ b/docs/set-headers/v0.8/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v0.9/metadata.json
+++ b/docs/set-headers/v0.9/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }

--- a/docs/set-headers/v1.0/metadata.json
+++ b/docs/set-headers/v1.0/metadata.json
@@ -6,7 +6,8 @@
   "categories": [
     "Transformation",
     "MCP",
-    "WebSub"
+    "WebSub",
+    "WebBroker"
   ],
   "description": "This policy provides the capability to set arbitrary headers to either the request or the response.\nSetting the same header multiple times will overwrite the existing header value."
 }


### PR DESCRIPTION
Add WebBroker category to existing policies.
This pull request updates the metadata for several authentication and logging policies by adding the "WebBroker" category to their categories fields across multiple versions. This change ensures that these policies are discoverable under the "WebBroker" category in documentation or catalog views.

- api-key-auth (v0.1, v0.2, v0.3, v0.8, v0.9, v1.0)
- basic-auth (v0.1, v0.2, v0.8, v0.9, v1.0)
- jwt-auth (v0.1, v0.2, v0.3, v0.8, v0.9, v1.0)
- log-message (v0.1, v0.2, v0.9, v1.0)
- remove-headers (v0.1, v0.2, v0.3, v0.8, v0.9, v1.0)
- set-headers (v0.1, v0.2, v0.3, v0.8, v0.9, v1.0)

Resolves: https://github.com/wso2/api-platform/issues/2022