### PR TITLE
[APIP] Add Backend JWT Policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ All available policies, sorted alphabetically.
 | [API Key Auth](./api-key-auth/v1.0/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
+| [Backend JWT](./backend-jwt/v1.0/docs/backend-jwt.md) | Security | Generates a signed JWT containing authenticated user information and injects it into the upstream request header. |
 | [Basic Auth](./basic-auth/v1.0/docs/basic-auth.md) | Security, AI, WebSub, WebBroker | Implements HTTP Basic Authentication to protect APIs with username and password credentials. |
 | [Content Length Guardrail](./content-length-guardrail/v1.0/docs/content-length.md) | Guardrails, AI | Validates the byte length of request or response body content. |
 | [CORS](./cors/v1.0/docs/cors.md) | Security, AI, MCP | Cross-Origin Resource Sharing (CORS) policy that handles preflight requests and adds appropriate CORS headers to responses. |

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -28,8 +28,7 @@ If no authentication context is present:
 | `auth_type` | `AuthContext.AuthType` (e.g. `jwt`, `basic`, `apikey`) |
 | `original_iss` | `AuthContext.Issuer` — the original token issuer (JWT auth only) |
 | `aud` | `AuthContext.Audience` (JWT auth only) |
-| `credential_id` | `AuthContext.CredentialID` (API key application ID, OAuth client_id) |
-| _mapped_ | Selected `AuthContext.Properties` keys via `claimMappings` |
+| `credential_id` | `AuthContext.CredentialID` (OAuth client_id, API key credential) |
 | _custom_ | Static values from `customClaims` |
 
 ## Configuration
@@ -50,7 +49,6 @@ If no authentication context is present:
 |---|---|---|---|
 | `header` | string | `x-jwt-assertion` | Upstream request header to set the generated JWT on |
 | `requireAuthentication` | boolean | `false` | Reject unauthenticated requests with 401 when true |
-| `claimMappings` | object | `{}` | Map `AuthContext.Properties` keys to JWT claim names |
 | `customClaims` | object | `{}` | Static claim name→value pairs added to every generated token |
 
 ## Dynamic Context Claims
@@ -70,16 +68,16 @@ If no authentication context is present:
 | `$ctx:api.context` | API base context path |
 | `$ctx:auth.subject` | Authenticated subject (same value as the `sub` claim) |
 | `$ctx:auth.type` | Auth type (`jwt`, `basic`, `apikey`) |
-| `$ctx:auth.credential_id` | Credential / application ID |
+| `$ctx:auth.credential_id` | Credential ID (OAuth client_id or API key) |
 | `$ctx:auth.property.<key>` | Custom property from `AuthContext.Properties` |
 
 Context variables that cannot be resolved (missing header, nil auth context, unknown variable name) are **silently skipped** — the claim is omitted from the token rather than causing an error or rejecting the request.
 
-Use this to put an auth context value under a different claim name. For example, to expose the application ID as `applicationId` rather than `credential_id`:
+Use this to put an auth context value under a different claim name. For example, to expose the credential ID as `clientId` rather than `credential_id`:
 
 ```yaml
 customClaims:
-  applicationId: $ctx:auth.credential_id
+  clientId: $ctx:auth.credential_id
 ```
 
 ## Example
@@ -99,12 +97,10 @@ policies:
     parameters:
       header: x-jwt-assertion
       requireAuthentication: true
-      claimMappings:
-        app_id: application_id
-        org:    organization
       customClaims:
         env: production                              # static
-        applicationId: $ctx:auth.credential_id      # dynamic — application/client ID
+        clientId: $ctx:auth.credential_id            # dynamic — credential ID
+        clientName: $ctx:auth.property.client_name  # dynamic — from auth context property
         tenantId: $ctx:request.header.x-tenant-id   # dynamic — from request header
 ```
 
@@ -114,4 +110,4 @@ The upstream service then validates the `x-jwt-assertion` header using the publi
 
 - [`jwt-auth`](../../jwt-auth/v1.0/docs/jwt-authentication.md) — validates incoming JWTs from clients
 - [`basic-auth`](../../basic-auth/) — authenticates clients with username/password; pairs well with Backend JWT to forward user identity
-- [`api-key-auth`](../../api-key-auth/) — authenticates clients with API keys; pairs well with Backend JWT to forward application identity
+- [`api-key-auth`](../../api-key-auth/) — authenticates clients with API keys; pairs well with Backend JWT to forward client identity

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -51,6 +51,35 @@ If no authentication context is present:
 | `claimMappings` | object | `{}` | Map `AuthContext.Properties` keys to JWT claim names |
 | `customClaims` | object | `{}` | Static claim name→value pairs added to every generated token |
 
+## Dynamic Context Claims
+
+`customClaims` values that start with `$ctx:` are resolved from the request context at runtime instead of being treated as static strings.
+
+| Variable | Resolves to |
+|---|---|
+| `$ctx:request.path` | Request path (e.g. `/petstore/v1/pets/42`) |
+| `$ctx:request.method` | HTTP method (`GET`, `POST`, …) |
+| `$ctx:request.authority` | Host authority |
+| `$ctx:request.scheme` | `http` or `https` |
+| `$ctx:request.header.<name>` | First value of request header `<name>` (case-insensitive) |
+| `$ctx:api.id` | API UUID |
+| `$ctx:api.name` | API name |
+| `$ctx:api.version` | API version |
+| `$ctx:api.context` | API base context path |
+| `$ctx:auth.subject` | Authenticated subject (same value as the `sub` claim) |
+| `$ctx:auth.type` | Auth type (`jwt`, `basic`, `apikey`) |
+| `$ctx:auth.credential_id` | Credential / application ID |
+| `$ctx:auth.property.<key>` | Custom property from `AuthContext.Properties` |
+
+Context variables that cannot be resolved (missing header, nil auth context, unknown variable name) are **silently skipped** — the claim is omitted from the token rather than causing an error or rejecting the request.
+
+Use this to put an auth context value under a different claim name. For example, to expose the application ID as `applicationId` rather than `credential_id`:
+
+```yaml
+customClaims:
+  applicationId: $ctx:auth.credential_id
+```
+
 ## Example
 
 ```yaml
@@ -72,7 +101,9 @@ policies:
         app_id: application_id
         org:    organization
       customClaims:
-        env: production
+        env: production                              # static
+        applicationId: $ctx:auth.credential_id      # dynamic — application/client ID
+        tenantId: $ctx:request.header.x-tenant-id   # dynamic — from request header
 ```
 
 The upstream service then validates the `x-jwt-assertion` header using the public key matching the gateway's private key.

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -49,7 +49,25 @@ If no authentication context is present:
 |---|---|---|---|
 | `header` | string | `x-jwt-assertion` | Upstream request header to set the generated JWT on |
 | `requireAuthentication` | boolean | `false` | Reject unauthenticated requests with 401 when true |
-| `customClaims` | object | `{}` | Static claim name→value pairs added to every generated token |
+| `claimMappings` | object | `{}` | Maps upstream JWT claim names to backend JWT claim names (see below) |
+| `customClaims` | object | `{}` | Static or dynamic claim name→value pairs added to every generated token (see below) |
+
+## Claim Mappings
+
+`claimMappings` provides a structured way to forward upstream JWT claims into the backend JWT under a different name. The key is the backend JWT claim name to set; the value is the property key from the authenticated context (populated by `jwt-auth` from the upstream JWT's custom claims).
+
+| `claimMappings` key | Source | Notes |
+|---|---|---|
+| any non-reserved name | `AuthContext.Properties[value]` | String values only |
+
+Claims mapped to reserved names (`iss`, `sub`, `aud`, `exp`, `iat`) are skipped with a warning. Missing source properties are silently skipped. `customClaims` entries take precedence over `claimMappings` — if the same destination claim appears in both, `customClaims` wins.
+
+```yaml
+claimMappings:
+  email: email           # forward AuthContext.Properties["email"] as "email"
+  clientRole: role       # forward AuthContext.Properties["role"] as "clientRole"
+  orgId: organization    # forward AuthContext.Properties["organization"] as "orgId"
+```
 
 ## Dynamic Context Claims
 
@@ -97,6 +115,9 @@ policies:
     parameters:
       header: x-jwt-assertion
       requireAuthentication: true
+      claimMappings:
+        email: email                                 # AuthContext.Properties["email"] → "email"
+        clientRole: role                             # AuthContext.Properties["role"] → "clientRole"
       customClaims:
         env: production                              # static
         clientId: $ctx:auth.credential_id            # dynamic — credential ID

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -43,7 +43,8 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `signingKey.path` | string | — | Path to a PEM private key file (mutually exclusive with `inline`) |
 | `algorithm` | string | `SHA256withRSA` | Signing algorithm: `SHA256withRSA` (RSA) or `ES256` (ECDSA) or `NONE` (unsigned) |
 | `issuer` | string | `""` | Value of the `iss` claim in generated tokens |
-| `tokenExpiry` | string | `15m` | Token validity as a Go duration string (e.g. `"15m"`, `"1h"`) |
+| `tokenExpiry` | string | `15m` | Default token validity as a Go duration string (e.g. `"15m"`, `"1h"`). Can be overridden per-API via the user parameter of the same name. |
+| `tokenCaching` | boolean | `true` | When `false`, disables token caching — every request signs a new token. Useful for debugging or when dynamic claims must reflect per-request state without a cache window. |
 
 ### User Parameters
 
@@ -52,6 +53,7 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `header` | string | `x-jwt-assertion` | Upstream request header to set the generated JWT on |
 | `claimMappings` | object | `{}` | Maps upstream JWT claim names to backend JWT claim names (see below) |
 | `customClaims` | object | `{}` | Static or dynamic claim name→value pairs added to every generated token (see below) |
+| `tokenExpiry` | string | _(system default)_ | Override the system `tokenExpiry` for this API (e.g. `"5m"`, `"1h"`). When set, takes precedence over the system-level value. |
 
 ## Claim Mappings
 
@@ -115,6 +117,7 @@ policies:
   - name: backend-jwt
     parameters:
       header: x-jwt-assertion
+      tokenExpiry: 5m                               # override system default for this API
       claimMappings:
         email: email                                 # AuthContext.Properties["email"] → "email"
         clientRole: role                             # AuthContext.Properties["role"] → "clientRole"

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -13,9 +13,9 @@ Backend services can verify the generated JWT using the gateway's corresponding 
 
 When the incoming credential is a JWT (authenticated by `jwt-auth`), all non-standard claims from the original token are automatically forwarded to the backend JWT under their original names. Standard claims (`iss`, `aud`, `sub`, etc.) are handled via their dedicated typed fields (see table below). Scopes are forwarded as a space-delimited `scope` claim. `claimMappings` and `customClaims` can add aliases or override any auto-forwarded claim.
 
-Generated tokens are cached in memory for half their configured `tokenExpiry` (minimum 30 seconds). The cache key is derived from the authenticated client identity, API operation path, and all resolved claim values. Requests from the same client hitting the same operation within the cache window receive the previously signed token, avoiding repeated cryptographic operations. Dynamic custom claims that differ between requests (e.g. `$ctx:request.header.*`) produce separate cache entries, preserving correctness.
+Generated tokens are cached in memory for half their configured `tokenExpiry` (minimum 30 seconds). The cache key is derived from the authenticated client identity and the operation path and method. Only `customClaims` values resolved from `$ctx:` references are included in the key, because static claims and `claimMappings` values are constant per-operation or already captured in the identity hash. Requests from the same client hitting the same operation within the cache window receive the previously signed token, avoiding repeated cryptographic operations. Dynamic custom claims that differ between requests (e.g. `$ctx:request.header.*`) produce separate cache entries, preserving correctness.
 
-If no authentication context is present (no auth policy in the chain), a backend JWT is still generated using the available system claims (`iss`, `iat`, `exp`). Auth-derived claims (`sub`, `auth_type`, `original_iss`, `aud`, `credential_id`) are omitted. Static `customClaims` and request-context variables (`$ctx:request.*`, `$ctx:api.*`) still resolve normally. To enforce that authentication must have occurred before this policy runs, add an auth policy earlier in the chain.
+If no authentication context is present (no auth policy in the chain), a backend JWT is still generated using the available system claims (`iss`, `iat`, `exp`). Auth-derived claims (`sub`, `auth_type`, `aud`, `credential_id`) are omitted. Static `customClaims` and request-context variables (`$ctx:request.*`, `$ctx:api.*`) still resolve normally. To enforce that authentication must have occurred before this policy runs, add an auth policy earlier in the chain.
 
 ## Claims in the Generated Token
 
@@ -26,7 +26,6 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `iat` | Current time |
 | `exp` | Current time + `system.tokenExpiry` |
 | `auth_type` | `AuthContext.AuthType` (e.g. `jwt`, `basic`, `apikey`) |
-| `original_iss` | `AuthContext.Issuer` — the original token issuer (JWT auth only) |
 | `aud` | `AuthContext.Audience` (JWT auth only) |
 | `credential_id` | `AuthContext.CredentialID` (OAuth client_id, API key credential) |
 | `scope` | `AuthContext.Scopes` as space-delimited string (JWT auth only) |
@@ -39,9 +38,9 @@ If no authentication context is present (no auth policy in the chain), a backend
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `signingKey.inline` | string | — | PEM-encoded RSA or ECDSA private key (mutually exclusive with `path`) |
-| `signingKey.path` | string | — | Path to a PEM private key file (mutually exclusive with `inline`) |
-| `algorithm` | string | `SHA256withRSA` | Signing algorithm: `SHA256withRSA` (RSA) or `ES256` (ECDSA) or `NONE` (unsigned) |
+| `signingKey.inline` | string | — | PEM-encoded RSA or ECDSA private key (mutually exclusive with `path`). Not required when `algorithm` is `NONE`. |
+| `signingKey.path` | string | — | Path to a PEM private key file (mutually exclusive with `inline`). Not required when `algorithm` is `NONE`. |
+| `algorithm` | string | `SHA256withRSA` | Signing algorithm: `SHA256withRSA` (RSA) or `ES256` (ECDSA) or `NONE` (unsigned, no key required) |
 | `issuer` | string | `""` | Value of the `iss` claim in generated tokens |
 | `tokenExpiry` | string | `15m` | Default token validity as a Go duration string (e.g. `"15m"`, `"1h"`). Can be overridden per-API via the user parameter of the same name. |
 | `tokenCaching` | boolean | `true` | When `false`, disables token caching — every request signs a new token. Useful for debugging or when dynamic claims must reflect per-request state without a cache window. |
@@ -54,6 +53,8 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `claimMappings` | object | `{}` | Maps upstream JWT claim names to backend JWT claim names (see below) |
 | `customClaims` | object | `{}` | Static or dynamic claim name→value pairs added to every generated token (see below) |
 | `tokenExpiry` | string | _(system default)_ | Override the system `tokenExpiry` for this API (e.g. `"5m"`, `"1h"`). When set, takes precedence over the system-level value. |
+| `dialect` | string | `""` | Namespace prefix applied to auto-forwarded original-JWT claims. When set, each claim forwarded from the incoming JWT's properties is emitted as `<dialect><claimName>` (e.g. `"http://wso2.org/claims/"` turns `email` into `http://wso2.org/claims/email`). Does not affect standard claims (`sub`, `scope`, etc.) or explicitly configured `claimMappings`/`customClaims`. |
+| `excludedClaims` | string[] | `[]` | List of original-JWT claim names to exclude from auto-forwarding. Matched by original name before any `dialect` prefix is applied. Does not affect standard claims or explicitly configured `claimMappings`/`customClaims`. |
 
 ## Claim Mappings
 

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -53,7 +53,7 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `claimMappings` | object | `{}` | Maps upstream JWT claim names to backend JWT claim names (see below) |
 | `customClaims` | object | `{}` | Static or dynamic claim name→value pairs added to every generated token (see below) |
 | `tokenExpiry` | string | _(system default)_ | Override the system `tokenExpiry` for this API (e.g. `"5m"`, `"1h"`). When set, takes precedence over the system-level value. |
-| `dialect` | string | `""` | Namespace prefix applied to auto-forwarded original-JWT claims. When set, each claim forwarded from the incoming JWT's properties is emitted as `<dialect><claimName>` (e.g. `"http://wso2.org/claims/"` turns `email` into `http://wso2.org/claims/email`). Does not affect standard claims (`sub`, `scope`, etc.) or explicitly configured `claimMappings`/`customClaims`. |
+| `dialect` | string | `""` | Namespace prefix applied to all user-configured and auto-forwarded claims. When set, auto-forwarded original-JWT claims, `claimMappings` destinations, and `customClaims` keys are all emitted as `<dialect><claimName>` (e.g. `"http://wso2.org/claims/"` turns `email` into `http://wso2.org/claims/email`). Does not affect standard claims set by the policy itself (`sub`, `iss`, `aud`, `scope`, etc.). |
 | `excludedClaims` | string[] | `[]` | List of original-JWT claim names to exclude from auto-forwarding. Matched by original name before any `dialect` prefix is applied. Does not affect standard claims or explicitly configured `claimMappings`/`customClaims`. |
 
 ## Claim Mappings

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -1,0 +1,84 @@
+# Backend JWT
+
+Generates a signed JWT containing authenticated user information and injects it into the upstream request header. Run this policy **after** an authentication policy (e.g. `jwt-auth`, `basic-auth`, `api-key-auth`) to forward a gateway-signed assertion to backend services.
+
+Backend services can verify the generated JWT using the gateway's corresponding public key — they do not need access to the original client credential (API key, OAuth token, etc.).
+
+## How It Works
+
+1. After an auth policy authenticates the request, the gateway's `AuthContext` is populated with the subject, auth type, issuer, audience, and any custom properties.
+2. The Backend JWT policy reads this context, builds a JWT with the configured claims, and signs it with the configured RSA or ECDSA private key.
+3. The signed JWT is set as the value of the configured upstream header (default: `x-jwt-assertion`).
+4. The upstream service verifies the JWT using the matching public key.
+
+If no authentication context is present:
+- With `requireAuthentication: false` (default) — the request is forwarded without a backend JWT.
+- With `requireAuthentication: true` — the request is rejected with `401 Unauthorized`.
+
+## Claims in the Generated Token
+
+| Claim | Source |
+|---|---|
+| `sub` | `AuthContext.Subject` (JWT sub, basic-auth username, API key owner) |
+| `iss` | `system.issuer` parameter |
+| `iat` | Current time |
+| `exp` | Current time + `system.tokenExpiry` |
+| `auth_type` | `AuthContext.AuthType` (e.g. `jwt`, `basic`, `apikey`) |
+| `original_iss` | `AuthContext.Issuer` — the original token issuer (JWT auth only) |
+| `aud` | `AuthContext.Audience` (JWT auth only) |
+| `credential_id` | `AuthContext.CredentialID` (API key application ID, OAuth client_id) |
+| _mapped_ | Selected `AuthContext.Properties` keys via `claimMappings` |
+| _custom_ | Static values from `customClaims` |
+
+## Configuration
+
+### System Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `signingKey.inline` | string | — | PEM-encoded RSA or ECDSA private key (mutually exclusive with `path`) |
+| `signingKey.path` | string | — | Path to a PEM private key file (mutually exclusive with `inline`) |
+| `algorithm` | string | `RS256` | Signing algorithm: `RS256`, `RS384`, `RS512` (RSA) or `ES256`, `ES384`, `ES512` (ECDSA) |
+| `issuer` | string | `""` | Value of the `iss` claim in generated tokens |
+| `tokenExpiry` | string | `15m` | Token validity as a Go duration string (e.g. `"15m"`, `"1h"`) |
+
+### User Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `header` | string | `x-jwt-assertion` | Upstream request header to set the generated JWT on |
+| `requireAuthentication` | boolean | `false` | Reject unauthenticated requests with 401 when true |
+| `claimMappings` | object | `{}` | Map `AuthContext.Properties` keys to JWT claim names |
+| `customClaims` | object | `{}` | Static claim name→value pairs added to every generated token |
+
+## Example
+
+```yaml
+# System-level (gateway config)
+system:
+  signingKey:
+    path: /etc/certs/backend-jwt.key
+  algorithm: RS256
+  issuer: https://gateway.example.com
+  tokenExpiry: 15m
+
+# Per-route policy attachment
+policies:
+  - name: backend-jwt
+    parameters:
+      header: x-jwt-assertion
+      requireAuthentication: true
+      claimMappings:
+        app_id: application_id
+        org:    organization
+      customClaims:
+        env: production
+```
+
+The upstream service then validates the `x-jwt-assertion` header using the public key matching the gateway's private key.
+
+## Related Policies
+
+- [`jwt-auth`](../../jwt-auth/v1.0/docs/jwt-authentication.md) — validates incoming JWTs from clients
+- [`basic-auth`](../../basic-auth/) — authenticates clients with username/password; pairs well with Backend JWT to forward user identity
+- [`api-key-auth`](../../api-key-auth/) — authenticates clients with API keys; pairs well with Backend JWT to forward application identity

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -13,9 +13,7 @@ Backend services can verify the generated JWT using the gateway's corresponding 
 
 Generated tokens are cached in memory for half their configured `tokenExpiry` (minimum 30 seconds). The cache key is derived from the authenticated client identity, API operation path, and all resolved claim values. Requests from the same client hitting the same operation within the cache window receive the previously signed token, avoiding repeated cryptographic operations. Dynamic custom claims that differ between requests (e.g. `$ctx:request.header.*`) produce separate cache entries, preserving correctness.
 
-If no authentication context is present:
-- With `requireAuthentication: false` (default) — the request is forwarded without a backend JWT.
-- With `requireAuthentication: true` — the request is rejected with `401 Unauthorized`.
+If no authentication context is present (no auth policy in the chain), a backend JWT is still generated using the available system claims (`iss`, `iat`, `exp`). Auth-derived claims (`sub`, `auth_type`, `original_iss`, `aud`, `credential_id`) are omitted. Static `customClaims` and request-context variables (`$ctx:request.*`, `$ctx:api.*`) still resolve normally. To enforce that authentication must have occurred before this policy runs, add an auth policy earlier in the chain.
 
 ## Claims in the Generated Token
 
@@ -48,7 +46,6 @@ If no authentication context is present:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `header` | string | `x-jwt-assertion` | Upstream request header to set the generated JWT on |
-| `requireAuthentication` | boolean | `false` | Reject unauthenticated requests with 401 when true |
 | `claimMappings` | object | `{}` | Maps upstream JWT claim names to backend JWT claim names (see below) |
 | `customClaims` | object | `{}` | Static or dynamic claim name→value pairs added to every generated token (see below) |
 

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -6,10 +6,12 @@ Backend services can verify the generated JWT using the gateway's corresponding 
 
 ## How It Works
 
-1. After an auth policy authenticates the request, the gateway's `AuthContext` is populated with the subject, auth type, issuer, audience, and any custom properties.
+1. After an auth policy authenticates the request, the gateway's `AuthContext` is populated with the subject, auth type, issuer, audience, scopes, and any custom properties from the incoming credential.
 2. The Backend JWT policy reads this context, builds a JWT with the configured claims, and signs it with the configured RSA or ECDSA private key.
 3. The signed JWT is set as the value of the configured upstream header (default: `x-jwt-assertion`).
 4. The upstream service verifies the JWT using the matching public key.
+
+When the incoming credential is a JWT (authenticated by `jwt-auth`), all non-standard claims from the original token are automatically forwarded to the backend JWT under their original names. Standard claims (`iss`, `aud`, `sub`, etc.) are handled via their dedicated typed fields (see table below). Scopes are forwarded as a space-delimited `scope` claim. `claimMappings` and `customClaims` can add aliases or override any auto-forwarded claim.
 
 Generated tokens are cached in memory for half their configured `tokenExpiry` (minimum 30 seconds). The cache key is derived from the authenticated client identity, API operation path, and all resolved claim values. Requests from the same client hitting the same operation within the cache window receive the previously signed token, avoiding repeated cryptographic operations. Dynamic custom claims that differ between requests (e.g. `$ctx:request.header.*`) produce separate cache entries, preserving correctness.
 
@@ -27,7 +29,9 @@ If no authentication context is present (no auth policy in the chain), a backend
 | `original_iss` | `AuthContext.Issuer` — the original token issuer (JWT auth only) |
 | `aud` | `AuthContext.Audience` (JWT auth only) |
 | `credential_id` | `AuthContext.CredentialID` (OAuth client_id, API key credential) |
-| _custom_ | Static values from `customClaims` |
+| `scope` | `AuthContext.Scopes` as space-delimited string (JWT auth only) |
+| _all other claims_ | All non-standard claims from the incoming JWT, forwarded under their original names (JWT auth only — see below) |
+| _custom_ | `customClaims` — add new claims or override any of the above |
 
 ## Configuration
 
@@ -111,7 +115,6 @@ policies:
   - name: backend-jwt
     parameters:
       header: x-jwt-assertion
-      requireAuthentication: true
       claimMappings:
         email: email                                 # AuthContext.Properties["email"] → "email"
         clientRole: role                             # AuthContext.Properties["role"] → "clientRole"

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -39,7 +39,7 @@ If no authentication context is present:
 |---|---|---|---|
 | `signingKey.inline` | string | — | PEM-encoded RSA or ECDSA private key (mutually exclusive with `path`) |
 | `signingKey.path` | string | — | Path to a PEM private key file (mutually exclusive with `inline`) |
-| `algorithm` | string | `RS256` | Signing algorithm: `RS256`, `RS384`, `RS512` (RSA) or `ES256`, `ES384`, `ES512` (ECDSA) |
+| `algorithm` | string | `SHA256withRSA` | Signing algorithm: `SHA256withRSA` (RSA) or `ES256` (ECDSA) or `NONE` (unsigned) |
 | `issuer` | string | `""` | Value of the `iss` claim in generated tokens |
 | `tokenExpiry` | string | `15m` | Token validity as a Go duration string (e.g. `"15m"`, `"1h"`) |
 
@@ -87,7 +87,7 @@ customClaims:
 system:
   signingKey:
     path: /etc/certs/backend-jwt.key
-  algorithm: RS256
+  algorithm: SHA256withRSA
   issuer: https://gateway.example.com
   tokenExpiry: 15m
 

--- a/docs/backend-jwt/v1.0/docs/backend-jwt.md
+++ b/docs/backend-jwt/v1.0/docs/backend-jwt.md
@@ -11,6 +11,8 @@ Backend services can verify the generated JWT using the gateway's corresponding 
 3. The signed JWT is set as the value of the configured upstream header (default: `x-jwt-assertion`).
 4. The upstream service verifies the JWT using the matching public key.
 
+Generated tokens are cached in memory for half their configured `tokenExpiry` (minimum 30 seconds). The cache key is derived from the authenticated client identity, API operation path, and all resolved claim values. Requests from the same client hitting the same operation within the cache window receive the previously signed token, avoiding repeated cryptographic operations. Dynamic custom claims that differ between requests (e.g. `$ctx:request.header.*`) produce separate cache entries, preserving correctness.
+
 If no authentication context is present:
 - With `requireAuthentication: false` (default) — the request is forwarded without a backend JWT.
 - With `requireAuthentication: true` — the request is rejected with `401 Unauthorized`.

--- a/docs/backend-jwt/v1.0/metadata.json
+++ b/docs/backend-jwt/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "backend-jwt",
+  "displayName": "Backend JWT",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security"
+  ],
+  "description": "Generates a signed JWT containing authenticated user information and injects it into the upstream request header. Designed to run after an authentication policy so that backend services can verify caller identity without access to the original client credential."
+}

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -50,13 +50,11 @@ type cachedToken struct {
 	expiresAt time.Time
 }
 
-// resolvedClaims holds the extra claims derived from claimMappings and customClaims
-// in a single pass, split by type so cache-key and JWT population can share the work.
+// resolvedClaims holds the extra claims derived from customClaims, split by type
+// so the cache key and JWT population can share the same resolved values.
 type resolvedClaims struct {
-	// stringClaims: claimMappings results + resolved string customClaims (including $ctx:).
-	stringClaims map[string]string
-	// rawClaims: non-string customClaims (numbers, booleans) preserved as-is for JWT.
-	rawClaims map[string]interface{}
+	stringClaims map[string]string      // resolved string customClaims, including $ctx: refs
+	rawClaims    map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
 }
 
 // BackendJWTPolicy generates a signed JWT from the authenticated user context
@@ -180,7 +178,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	headerName := getString(params, "header", defaultHeader)
 
 	// Resolve extra claims once — used for both the cache key and JWT population.
-	extras := resolveExtraClaims(authCtx, reqCtx, params)
+	extras := resolveExtraClaims(reqCtx, params)
 
 	cacheKey := buildTokenCacheKey(
 		authCtx.CredentialID, authCtx.Subject, reqCtx.APIContext, reqCtx.APIVersion,
@@ -281,32 +279,30 @@ func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
 	return parsed, nil
 }
 
-// resolveExtraClaims resolves claimMappings and customClaims in a single pass.
-// stringClaims holds claimMappings results and resolved string customClaims (including $ctx: refs).
+// restrictedClaims are set by the policy itself; custom claims must not override them.
+var restrictedClaims = map[string]bool{
+	"iss": true,
+	"sub": true,
+	"aud": true,
+	"exp": true,
+	"iat": true,
+}
+
+// resolveExtraClaims resolves customClaims from params.
+// stringClaims holds resolved string customClaims (including $ctx: refs).
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
-func resolveExtraClaims(authCtx *policy.AuthContext, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
+func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
 	result := resolvedClaims{
 		stringClaims: make(map[string]string),
 		rawClaims:    make(map[string]interface{}),
 	}
 
-	if mappingsRaw, ok := params["claimMappings"]; ok {
-		if mappings, ok := mappingsRaw.(map[string]interface{}); ok {
-			for propKey, claimNameRaw := range mappings {
-				claimName, ok := claimNameRaw.(string)
-				if !ok {
-					continue
-				}
-				if val, ok := authCtx.Properties[propKey]; ok {
-					result.stringClaims[claimName] = val
-				}
-			}
-		}
-	}
-
 	if customRaw, ok := params["customClaims"]; ok {
 		if custom, ok := customRaw.(map[string]interface{}); ok {
 			for k, v := range custom {
+				if restrictedClaims[k] {
+					slog.Warn("Backend JWT: customClaim overrides a reserved claim", "claim", k)
+				}
 				strVal, ok := v.(string)
 				if !ok {
 					result.rawClaims[k] = v

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -282,50 +282,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		signKey = key
 	}
 
-	now := time.Now()
-	claims := jwt.MapClaims{
-		"iat": now.Unix(),
-		"exp": now.Add(expiry).Unix(),
-	}
-	if issuer != "" {
-		claims["iss"] = issuer
-	}
-	if authCtx != nil && authCtx.Subject != "" {
-		claims["sub"] = authCtx.Subject
-	}
-	if authCtx != nil && authCtx.AuthType != "" {
-		claims["auth_type"] = authCtx.AuthType
-	}
-	if authCtx != nil && len(authCtx.Audience) > 0 {
-		claims["aud"] = authCtx.Audience
-	}
-	if authCtx != nil && authCtx.CredentialID != "" {
-		claims["credential_id"] = authCtx.CredentialID
-	}
-	// For JWT auth: forward all non-standard claims from the incoming token under their
-	// original names. claimMappings and customClaims applied below can add aliases or override.
-	if authCtx != nil && authCtx.AuthType == "jwt" {
-		for k, v := range authCtx.Properties {
-			if restrictedClaims[k] || excluded[k] || extras.mappedSources[k] {
-				continue
-			}
-			claims[dialect+k] = v
-		}
-		if len(authCtx.Scopes) > 0 {
-			scopes := make([]string, 0, len(authCtx.Scopes))
-			for s := range authCtx.Scopes {
-				scopes = append(scopes, s)
-			}
-			sort.Strings(scopes)
-			claims["scope"] = strings.Join(scopes, " ")
-		}
-	}
-	for k, v := range extras.stringClaims {
-		claims[dialect+k] = v
-	}
-	for k, v := range extras.rawClaims {
-		claims[dialect+k] = v
-	}
+	claims := buildClaims(authCtx, issuer, dialect, expiry, excluded, extras, time.Now())
 
 	token := jwt.NewWithClaims(signingMethod, claims)
 	signed, err := token.SignedString(signKey)
@@ -344,6 +301,59 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 			headerName: signed,
 		},
 	}
+}
+
+// buildClaims assembles the JWT claim set: the standard registered claims (iat/exp/iss),
+// identity claims derived from the auth context, the auto-forwarded original-JWT claims (jwt
+// auth only), and the resolved custom and mapped claims. The dialect prefix is applied to
+// user-configured and auto-forwarded claim names; standard claims the policy sets itself are
+// never prefixed. now anchors iat and exp.
+func buildClaims(authCtx *policy.AuthContext, issuer, dialect string, expiry time.Duration, excluded map[string]bool, extras resolvedClaims, now time.Time) jwt.MapClaims {
+	claims := jwt.MapClaims{
+		"iat": now.Unix(),
+		"exp": now.Add(expiry).Unix(),
+	}
+	if issuer != "" {
+		claims["iss"] = issuer
+	}
+
+	if authCtx != nil {
+		if authCtx.Subject != "" {
+			claims["sub"] = authCtx.Subject
+		}
+		if authCtx.AuthType != "" {
+			claims["auth_type"] = authCtx.AuthType
+		}
+		if len(authCtx.Audience) > 0 {
+			claims["aud"] = authCtx.Audience
+		}
+		if authCtx.CredentialID != "" {
+			claims["credential_id"] = authCtx.CredentialID
+		}
+
+		// For JWT auth, forward the incoming token's non-standard claims under their original
+		// names. Reserved, excluded, and already-mapped claims are skipped; the claimMappings
+		// and customClaims applied below can still add aliases or override.
+		if authCtx.AuthType == "jwt" {
+			for k, v := range authCtx.Properties {
+				if restrictedClaims[k] || excluded[k] || extras.mappedSources[k] {
+					continue
+				}
+				claims[dialect+k] = v
+			}
+			if scope := sortedScopeString(authCtx.Scopes); scope != "" {
+				claims["scope"] = scope
+			}
+		}
+	}
+
+	for k, v := range extras.stringClaims {
+		claims[dialect+k] = v
+	}
+	for k, v := range extras.rawClaims {
+		claims[dialect+k] = v
+	}
+	return claims
 }
 
 // loadKey returns a cached private key, parsing and caching it on first use.
@@ -375,7 +385,7 @@ var restrictedClaims = map[string]bool{
 	"jti": true,
 }
 
-// resolveExtraClaims resolves claimMappings and customClaims from params.
+// resolveExtraClaims resolves claimMappings and customClaims from params into a resolvedClaims.
 // claimMappings are processed first; customClaims run after and take precedence.
 // stringClaims holds resolved string values (including $ctx: refs and mapped properties).
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
@@ -385,69 +395,69 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 		rawClaims:     make(map[string]interface{}),
 		mappedSources: make(map[string]bool),
 	}
-
-	authCtx := reqCtx.SharedContext.AuthContext
-
-	// Process claimMappings first so customClaims can override them.
-	if raw, ok := params["claimMappings"]; ok {
-		if cm, ok := raw.(map[string]interface{}); ok {
-			for dest, srcRaw := range cm {
-				src, ok := srcRaw.(string)
-				if !ok || src == "" {
-					continue
-				}
-				if restrictedClaims[dest] {
-					slog.Warn("Backend JWT: claimMapping targets a reserved claim; skipping", "claim", dest)
-					continue
-				}
-				if authCtx == nil {
-					continue
-				}
-				val, ok := authCtx.Properties[src]
-				if !ok {
-					continue
-				}
-				result.stringClaims[dest] = val
-				result.mappedSources[src] = true
-			}
-		}
-	}
-
-	if customRaw, ok := params["customClaims"]; ok {
-		if custom, ok := customRaw.(map[string]interface{}); ok {
-			for k, v := range custom {
-				if restrictedClaims[k] {
-					slog.Warn("Backend JWT: customClaim targets a reserved claim; skipping", "claim", k)
-					continue
-				}
-				strVal, ok := v.(string)
-				if !ok {
-					result.rawClaims[k] = v
-					continue
-				}
-				resolved, ok := resolveClaimValue(strVal, reqCtx)
-				if !ok {
-					slog.Debug("Backend JWT: skipping claim — context variable not resolvable",
-						"claim", k, "ref", strVal)
-					continue
-				}
-				result.stringClaims[k] = resolved
-			}
-		}
-	}
-
+	result.applyClaimMappings(objectParam(params, "claimMappings"), reqCtx.SharedContext.AuthContext)
+	result.applyCustomClaims(objectParam(params, "customClaims"), reqCtx)
 	return result
 }
 
-// keyBufPool reuses byte buffers across cache key constructions to reduce GC pressure.
-var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+// applyClaimMappings copies authenticated-context properties into destination claim names per the
+// claimMappings config. Reserved destinations are skipped with a warning; non-string or empty
+// entries and missing source properties are silently skipped. Each consumed source is recorded in
+// mappedSources so the auto-forward loop in buildClaims won't also emit it under its original name.
+func (r resolvedClaims) applyClaimMappings(mappings map[string]interface{}, authCtx *policy.AuthContext) {
+	for dest, srcRaw := range mappings {
+		src, ok := srcRaw.(string)
+		if !ok || src == "" {
+			continue
+		}
+		if restrictedClaims[dest] {
+			slog.Warn("Backend JWT: claimMapping targets a reserved claim; skipping", "claim", dest)
+			continue
+		}
+		if authCtx == nil {
+			continue
+		}
+		val, ok := authCtx.Properties[src]
+		if !ok {
+			continue
+		}
+		r.stringClaims[dest] = val
+		r.mappedSources[src] = true
+	}
+}
 
-// buildTokenCacheKey returns a cache key for the token cache.
+// applyCustomClaims adds the configured customClaims, which take precedence over claimMappings.
+// Reserved names are skipped with a warning. Non-string values are preserved as-is in rawClaims;
+// string values are resolved through resolveClaimValue ($ctx: refs), skipping any that don't
+// resolve.
+func (r resolvedClaims) applyCustomClaims(custom map[string]interface{}, reqCtx *policy.RequestHeaderContext) {
+	for k, v := range custom {
+		if restrictedClaims[k] {
+			slog.Warn("Backend JWT: customClaim targets a reserved claim; skipping", "claim", k)
+			continue
+		}
+		strVal, ok := v.(string)
+		if !ok {
+			r.rawClaims[k] = v
+			continue
+		}
+		resolved, ok := resolveClaimValue(strVal, reqCtx)
+		if !ok {
+			slog.Debug("Backend JWT: skipping claim — context variable not resolvable",
+				"claim", k, "ref", strVal)
+			continue
+		}
+		r.stringClaims[k] = resolved
+	}
+}
+
+// buildTokenCacheKey returns a cache key for the token cache. Every component is concatenated
+// into a single buffer and SHA256-hashed, so the key is a fixed-length digest of everything
+// regardless of identity shape:
 //
-//   - TokenId, no claims:    raw concatenation — TokenId + path + method.
-//   - TokenId, with claims:  SHA256 of the above + the configured claim set.
-//   - authCtx nil:           SHA256 of path + method + the configured claim set.
-//   - otherwise:             SHA256 of all identity fields + path + method + the configured claim set.
+//   - TokenId present:  namespace + TokenId + path + method (+ claims).
+//   - authCtx nil:      namespace + path + method (+ claims).
+//   - otherwise:        namespace + all identity fields + path + method (+ claims).
 //
 // The key is a complete function of the token: ns folds in the API namespace plus the
 // token-shaping config that is not part of the caller identity (issuer, algorithm, dialect,
@@ -462,88 +472,69 @@ func buildTokenCacheKey(ns keyNamespace, authCtx *policy.AuthContext, path, meth
 		path = path[:i]
 	}
 
-	nsPrefix := ns.prefix()
 	claimPairs := keyClaims(extras)
 
-	if authCtx != nil && authCtx.TokenId != "" {
-		if len(claimPairs) == 0 {
-			// Fast path: no claims configured, no hash needed.
-			key := nsPrefix + authCtx.TokenId + "\x00" + path + "\x00" + method
-			slog.Debug("Backend JWT: cache key (TokenId)", "path", path, "method", method, "cacheKey", key)
-			return key
-		}
-		// Claims present: SHA256 to normalize key length.
-		buf := keyBufPool.Get().(*bytes.Buffer)
-		buf.Reset()
+	var buf bytes.Buffer
+
+	// Namespace: API plus the token-shaping config that is not part of the caller identity.
+	buf.WriteString(ns.prefix())
+
+	var keyType string
+	switch {
+	case authCtx != nil && authCtx.TokenId != "":
+		keyType = "tokenId"
 		buf.WriteString(authCtx.TokenId)
 		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
-		appendClaims(buf, claimPairs)
-		sum := sha256.Sum256(buf.Bytes())
-		keyBufPool.Put(buf)
-		key := nsPrefix + fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (TokenId+claims)", "path", path, "method", method, "claims", claimPairs, "cacheKey", key)
-		return key
-	}
 
-	buf := keyBufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer keyBufPool.Put(buf)
-
-	if authCtx == nil {
+	case authCtx == nil:
+		keyType = "no-auth"
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
-		appendClaims(buf, claimPairs)
-		sum := sha256.Sum256(buf.Bytes())
-		key := nsPrefix + fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (no-auth)", "path", path, "method", method, "claims", claimPairs, "cacheKey", key)
-		return key
+
+	default:
+		// Non-nil authCtx without TokenId: include all available identity fields.
+		keyType = "identity"
+		buf.WriteString(authCtx.AuthType)
+		buf.WriteByte('|')
+		buf.WriteString(authCtx.Issuer)
+		buf.WriteByte('|')
+		buf.WriteString(authCtx.Subject)
+		buf.WriteByte('|')
+		buf.WriteString(authCtx.CredentialID)
+		buf.WriteByte('|')
+		buf.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
+		propKeys := make([]string, 0, len(authCtx.Properties))
+		for k := range authCtx.Properties {
+			propKeys = append(propKeys, k)
+		}
+		sort.Strings(propKeys)
+		for _, k := range propKeys {
+			buf.WriteByte('|')
+			buf.WriteString(k)
+			buf.WriteByte('=')
+			buf.WriteString(authCtx.Properties[k])
+		}
+		if scope := sortedScopeString(authCtx.Scopes); scope != "" {
+			buf.WriteByte('|')
+			buf.WriteString("scope=")
+			buf.WriteString(scope)
+		}
+		buf.WriteByte('|')
+		buf.WriteString(path)
+		buf.WriteByte('|')
+		buf.WriteString(method)
 	}
 
-	// Non-nil authCtx without TokenId: include all available identity fields.
-	buf.WriteString(authCtx.AuthType)
-	buf.WriteByte('|')
-	buf.WriteString(authCtx.Issuer)
-	buf.WriteByte('|')
-	buf.WriteString(authCtx.Subject)
-	buf.WriteByte('|')
-	buf.WriteString(authCtx.CredentialID)
-	buf.WriteByte('|')
-	buf.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
-	propKeys := make([]string, 0, len(authCtx.Properties))
-	for k := range authCtx.Properties {
-		propKeys = append(propKeys, k)
-	}
-	sort.Strings(propKeys)
-	for _, k := range propKeys {
-		buf.WriteByte('|')
-		buf.WriteString(k)
-		buf.WriteByte('=')
-		buf.WriteString(authCtx.Properties[k])
-	}
-	if len(authCtx.Scopes) > 0 {
-		scopeKeys := make([]string, 0, len(authCtx.Scopes))
-		for s := range authCtx.Scopes {
-			scopeKeys = append(scopeKeys, s)
-		}
-		sort.Strings(scopeKeys)
-		buf.WriteByte('|')
-		buf.WriteString("scope=")
-		buf.WriteString(strings.Join(scopeKeys, " "))
-	}
-	buf.WriteByte('|')
-	buf.WriteString(path)
-	buf.WriteByte('|')
-	buf.WriteString(method)
-	appendClaims(buf, claimPairs)
+	appendClaims(&buf, claimPairs)
 
 	sum := sha256.Sum256(buf.Bytes())
-	key := nsPrefix + fmt.Sprintf("%x", sum)
-	slog.Debug("Backend JWT: cache key (identity hash)",
-		"authType", authTypeLabel(authCtx),
+	key := fmt.Sprintf("%x", sum)
+	slog.Debug("Backend JWT: cache key",
+		"keyType", keyType,
 		"path", path,
 		"method", method,
 		"claims", claimPairs,
@@ -584,6 +575,20 @@ func sortedSlice(s []string) []string {
 	copy(out, s)
 	sort.Strings(out)
 	return out
+}
+
+// sortedScopeString renders the scope set as the JWT "scope" claim: scope names sorted for
+// determinism and joined by a single space. Returns "" when there are no scopes.
+func sortedScopeString(scopes map[string]bool) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(scopes))
+	for s := range scopes {
+		names = append(names, s)
+	}
+	sort.Strings(names)
+	return strings.Join(names, " ")
 }
 
 // sortedSetKeys returns the keys of a string set as a sorted slice, for deterministic key building.
@@ -773,6 +778,17 @@ func getInt(params map[string]interface{}, key string, defaultVal int) int {
 		}
 	}
 	return defaultVal
+}
+
+// objectParam returns params[key] as a map[string]interface{}, or nil when the key is absent or
+// not an object. Ranging over the nil result is a no-op, so callers need no separate presence check.
+func objectParam(params map[string]interface{}, key string) map[string]interface{} {
+	if raw, ok := params[key]; ok {
+		if m, ok := raw.(map[string]interface{}); ok {
+			return m
+		}
+	}
+	return nil
 }
 
 // getStringSet reads a string-array param into a lookup set. Non-string

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -154,11 +155,23 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		}
 	}
 
-	// Apply custom static claims (can override derived claims).
+	// Apply custom claims — string values starting with "$ctx:" resolve from request context.
 	if customRaw, ok := params["customClaims"]; ok {
 		if custom, ok := customRaw.(map[string]interface{}); ok {
 			for k, v := range custom {
-				claims[k] = v
+				strVal, ok := v.(string)
+				if !ok {
+					// Non-string values (numbers, booleans) pass through as-is.
+					claims[k] = v
+					continue
+				}
+				resolved, ok := resolveClaimValue(strVal, reqCtx)
+				if !ok {
+					slog.Debug("Backend JWT: skipping claim — context variable not resolvable",
+						"claim", k, "ref", strVal)
+					continue
+				}
+				claims[k] = resolved
 			}
 		}
 	}
@@ -333,6 +346,69 @@ func parseDuration(s string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return d
+}
+
+const ctxPrefix = "$ctx:"
+
+// resolveClaimValue returns the value to use for a custom JWT claim.
+// Values prefixed with "$ctx:" are resolved from the request context at runtime.
+// Returns ("", false) when a context variable cannot be resolved — the caller
+// silently skips the claim rather than treating it as an error.
+func resolveClaimValue(value string, reqCtx *policy.RequestHeaderContext) (string, bool) {
+	if !strings.HasPrefix(value, ctxPrefix) {
+		return value, true
+	}
+	variable := strings.ToLower(strings.TrimPrefix(value, ctxPrefix))
+
+	switch {
+	case variable == "request.path":
+		return reqCtx.Path, true
+	case variable == "request.method":
+		return reqCtx.Method, true
+	case variable == "request.authority":
+		return reqCtx.Authority, true
+	case variable == "request.scheme":
+		return reqCtx.Scheme, true
+	case strings.HasPrefix(variable, "request.header."):
+		name := strings.TrimPrefix(variable, "request.header.")
+		vals := reqCtx.Headers.Get(name)
+		if len(vals) == 0 {
+			return "", false
+		}
+		return vals[0], true
+	case variable == "api.id":
+		return reqCtx.APIId, true
+	case variable == "api.name":
+		return reqCtx.APIName, true
+	case variable == "api.version":
+		return reqCtx.APIVersion, true
+	case variable == "api.context":
+		return reqCtx.APIContext, true
+	case variable == "auth.subject":
+		if reqCtx.SharedContext.AuthContext == nil {
+			return "", false
+		}
+		return reqCtx.SharedContext.AuthContext.Subject, true
+	case variable == "auth.type":
+		if reqCtx.SharedContext.AuthContext == nil {
+			return "", false
+		}
+		return reqCtx.SharedContext.AuthContext.AuthType, true
+	case variable == "auth.credential_id":
+		if reqCtx.SharedContext.AuthContext == nil {
+			return "", false
+		}
+		return reqCtx.SharedContext.AuthContext.CredentialID, true
+	case strings.HasPrefix(variable, "auth.property."):
+		if reqCtx.SharedContext.AuthContext == nil {
+			return "", false
+		}
+		key := strings.TrimPrefix(variable, "auth.property.")
+		val, ok := reqCtx.SharedContext.AuthContext.Properties[key]
+		return val, ok
+	default:
+		return "", false
+	}
 }
 
 func internalError() policy.ImmediateResponse {

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -290,8 +290,9 @@ var restrictedClaims = map[string]bool{
 	"iat": true,
 }
 
-// resolveExtraClaims resolves customClaims from params.
-// stringClaims holds resolved string customClaims (including $ctx: refs).
+// resolveExtraClaims resolves claimMappings and customClaims from params.
+// claimMappings are processed first; customClaims run after and take precedence.
+// stringClaims holds resolved string values (including $ctx: refs and mapped properties).
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
 func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
 	result := resolvedClaims{
@@ -299,11 +300,38 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 		rawClaims:    make(map[string]interface{}),
 	}
 
+	authCtx := reqCtx.SharedContext.AuthContext
+
+	// Process claimMappings first so customClaims can override them.
+	if raw, ok := params["claimMappings"]; ok {
+		if cm, ok := raw.(map[string]interface{}); ok {
+			for dest, srcRaw := range cm {
+				src, ok := srcRaw.(string)
+				if !ok || src == "" {
+					continue
+				}
+				if restrictedClaims[dest] {
+					slog.Warn("Backend JWT: claimMapping targets a reserved claim; skipping", "claim", dest)
+					continue
+				}
+				if authCtx == nil {
+					continue
+				}
+				val, ok := authCtx.Properties[src]
+				if !ok {
+					continue
+				}
+				result.stringClaims[dest] = val
+			}
+		}
+	}
+
 	if customRaw, ok := params["customClaims"]; ok {
 		if custom, ok := customRaw.(map[string]interface{}); ok {
 			for k, v := range custom {
 				if restrictedClaims[k] {
-					slog.Warn("Backend JWT: customClaim overrides a reserved claim", "claim", k)
+					slog.Warn("Backend JWT: customClaim targets a reserved claim; skipping", "claim", k)
+					continue
 				}
 				strVal, ok := v.(string)
 				if !ok {

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -49,8 +49,9 @@ const (
 // resolvedClaims holds the extra claims derived from customClaims, split by type
 // so the cache key and JWT population can share the same resolved values.
 type resolvedClaims struct {
-	stringClaims map[string]string      // resolved string customClaims, including $ctx: refs
-	rawClaims    map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
+	stringClaims  map[string]string      // resolved string customClaims, including $ctx: refs
+	rawClaims     map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
+	mappedSources map[string]bool        // Properties keys consumed by claimMappings; skip in auto-forward
 }
 
 // BackendJWTPolicy generates a signed JWT from the authenticated user context
@@ -144,6 +145,8 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	headerName := getString(params, "header", defaultHeader)
 
 	tokenCaching := getBool(params, "tokenCaching", true)
+	dialect := getString(params, "dialect", "")
+	excluded := getStringSet(params, "excludedClaims")
 
 	// Resolve extra claims once — used for both the cache key and JWT population.
 	extras := resolveExtraClaims(reqCtx, params)
@@ -195,9 +198,6 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	if authCtx != nil && authCtx.AuthType != "" {
 		claims["auth_type"] = authCtx.AuthType
 	}
-	if authCtx != nil && authCtx.Issuer != "" {
-		claims["original_iss"] = authCtx.Issuer
-	}
 	if authCtx != nil && len(authCtx.Audience) > 0 {
 		claims["aud"] = authCtx.Audience
 	}
@@ -208,9 +208,10 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	// original names. claimMappings and customClaims applied below can add aliases or override.
 	if authCtx != nil && authCtx.AuthType == "jwt" {
 		for k, v := range authCtx.Properties {
-			if !restrictedClaims[k] {
-				claims[k] = v
+			if restrictedClaims[k] || excluded[k] || extras.mappedSources[k] {
+				continue
 			}
+			claims[dialect+k] = v
 		}
 		if len(authCtx.Scopes) > 0 {
 			scopes := make([]string, 0, len(authCtx.Scopes))
@@ -282,8 +283,9 @@ var restrictedClaims = map[string]bool{
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
 func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
 	result := resolvedClaims{
-		stringClaims: make(map[string]string),
-		rawClaims:    make(map[string]interface{}),
+		stringClaims:  make(map[string]string),
+		rawClaims:     make(map[string]interface{}),
+		mappedSources: make(map[string]bool),
 	}
 
 	authCtx := reqCtx.SharedContext.AuthContext
@@ -308,6 +310,7 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 					continue
 				}
 				result.stringClaims[dest] = val
+				result.mappedSources[src] = true
 			}
 		}
 	}
@@ -632,6 +635,22 @@ func getBool(params map[string]interface{}, key string, defaultVal bool) bool {
 		}
 	}
 	return defaultVal
+}
+
+// getStringSet reads a string-array param into a lookup set. Non-string
+// elements are skipped. Returns an empty (non-nil) set when absent.
+func getStringSet(params map[string]interface{}, key string) map[string]bool {
+	out := make(map[string]bool)
+	if raw, ok := params[key]; ok {
+		if arr, ok := raw.([]interface{}); ok {
+			for _, e := range arr {
+				if s, ok := e.(string); ok && s != "" {
+					out[s] = true
+				}
+			}
+		}
+	}
+	return out
 }
 
 

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -49,9 +49,10 @@ const (
 // resolvedClaims holds the extra claims derived from customClaims, split by type
 // so the cache key and JWT population can share the same resolved values.
 type resolvedClaims struct {
-	stringClaims  map[string]string      // resolved string customClaims, including $ctx: refs
-	rawClaims     map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
-	mappedSources map[string]bool        // Properties keys consumed by claimMappings; skip in auto-forward
+	stringClaims       map[string]string      // resolved string customClaims, including $ctx: refs
+	rawClaims          map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
+	mappedSources      map[string]bool        // Properties keys consumed by claimMappings; skip in auto-forward
+	dynamicStringClaims map[string]string     // subset of stringClaims resolved from $ctx: refs; used for cache key
 }
 
 // BackendJWTPolicy generates a signed JWT from the authenticated user context
@@ -283,9 +284,10 @@ var restrictedClaims = map[string]bool{
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
 func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
 	result := resolvedClaims{
-		stringClaims:  make(map[string]string),
-		rawClaims:     make(map[string]interface{}),
-		mappedSources: make(map[string]bool),
+		stringClaims:        make(map[string]string),
+		rawClaims:           make(map[string]interface{}),
+		mappedSources:       make(map[string]bool),
+		dynamicStringClaims: make(map[string]string),
 	}
 
 	authCtx := reqCtx.SharedContext.AuthContext
@@ -334,6 +336,9 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 					continue
 				}
 				result.stringClaims[k] = resolved
+				if strings.HasPrefix(strVal, ctxPrefix) {
+					result.dynamicStringClaims[k] = resolved
+				}
 			}
 		}
 	}
@@ -346,21 +351,22 @@ var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
 // buildTokenCacheKey returns a cache key for the token cache.
 //
-//   - TokenId, no extras:  raw concatenation — TokenId + api name + path + method.
-//   - TokenId, with extras: SHA256 of the above + resolved claim values.
-//   - authCtx nil:          FNV-64a of api name + path + method + extras.
-//   - otherwise:            FNV-64a of all identity fields + api name + path + method + extras.
+//   - TokenId, no dynamic extras:  raw concatenation — TokenId + api name + path + method.
+//   - TokenId, with dynamic extras: SHA256 of the above + resolved $ctx: claim values.
+//   - authCtx nil:                  SHA256 of api name + path + method + dynamic extras.
+//   - otherwise:                    SHA256 of all identity fields + api name + path + method + dynamic extras.
 //
-// Extras (resolved customClaims / claimMappings) are included in all paths so that
-// dynamic values such as $ctx:request.header.* produce distinct cache entries per request.
+// Only $ctx:-resolved customClaims are included in the key because they vary per-request.
+// Static customClaims and claimMappings are constant per-API config (already disambiguated by
+// apiName) or per-identity (already captured in the identity hash), so they add no information.
 func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method string, extras resolvedClaims) string {
 	if i := strings.IndexByte(path, '?'); i != -1 {
 		path = path[:i]
 	}
 
 	var extraKeys []string
-	if len(extras.stringClaims) > 0 || len(extras.rawClaims) > 0 {
-		extraKeys = sortedExtraKeys(extras)
+	if len(extras.dynamicStringClaims) > 0 {
+		extraKeys = sortedDynamicKeys(extras)
 	}
 
 	if authCtx != nil && authCtx.TokenId != "" {
@@ -462,14 +468,9 @@ func appendExtras(buf *bytes.Buffer, keys []string, extras resolvedClaims) {
 		buf.WriteByte('|')
 		buf.WriteString(k)
 		buf.WriteByte('=')
-		if v, ok := extras.stringClaims[k]; ok {
-			buf.WriteString(v)
-		} else {
-			fmt.Fprintf(buf, "%v", extras.rawClaims[k])
-		}
+		buf.WriteString(extras.dynamicStringClaims[k])
 	}
 }
-
 
 func sortedSlice(s []string) []string {
 	out := make([]string, len(s))
@@ -478,15 +479,10 @@ func sortedSlice(s []string) []string {
 	return out
 }
 
-func sortedExtraKeys(extras resolvedClaims) []string {
-	keys := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
-	for k := range extras.stringClaims {
+func sortedDynamicKeys(extras resolvedClaims) []string {
+	keys := make([]string, 0, len(extras.dynamicStringClaims))
+	for k := range extras.dynamicStringClaims {
 		keys = append(keys, k)
-	}
-	for k := range extras.rawClaims {
-		if _, exists := extras.stringClaims[k]; !exists {
-			keys = append(keys, k)
-		}
 	}
 	sort.Strings(keys)
 	return keys

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -153,21 +153,7 @@ func (p *BackendJWTPolicy) Validate(params map[string]interface{}) error {
 
 // OnRequestHeaders generates a signed JWT from the auth context and sets it on the upstream request.
 func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
-	requireAuth := getBool(params, "requireAuthentication", false)
 	authCtx := reqCtx.SharedContext.AuthContext
-
-	if authCtx == nil || !authCtx.Authenticated {
-		if requireAuth {
-			slog.Debug("Backend JWT: no authenticated context, rejecting request")
-			return policy.ImmediateResponse{
-				StatusCode: 401,
-				Headers:    map[string]string{"content-type": "application/json"},
-				Body:       []byte(`{"error":"Unauthorized","message":"Authentication is required to generate a backend JWT"}`),
-			}
-		}
-		slog.Debug("Backend JWT: no authenticated context, passing through")
-		return policy.UpstreamRequestHeaderModifications{}
-	}
 
 	alg := getString(params, "algorithm", defaultAlgorithm)
 	entry, ok := algorithms[alg]
@@ -182,12 +168,17 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	// Resolve extra claims once — used for both the cache key and JWT population.
 	extras := resolveExtraClaims(reqCtx, params)
 
-	cacheKey := buildTokenCacheKey(
-		authCtx.CredentialID, authCtx.Subject, reqCtx.APIContext, reqCtx.APIVersion,
-		authCtx.Audience, extras,
-	)
+	var credentialID, subject, tokenId string
+	var audience []string
+	if authCtx != nil {
+		credentialID = authCtx.CredentialID
+		subject = authCtx.Subject
+		tokenId = authCtx.TokenId
+		audience = authCtx.Audience
+	}
+	cacheKey := buildTokenCacheKey(credentialID, subject, reqCtx.APIContext, reqCtx.APIVersion, tokenId, audience, extras)
 	if signed, ok := p.getCachedToken(cacheKey); ok {
-		slog.Debug("Backend JWT: cache hit", "subject", authCtx.Subject)
+		slog.Debug("Backend JWT: cache hit", "subject", subject)
 		return policy.UpstreamRequestHeaderModifications{
 			HeadersToSet: map[string]string{headerName: signed},
 		}
@@ -217,21 +208,25 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"iat":       now.Unix(),
-		"exp":       now.Add(expiry).Unix(),
-		"sub":       authCtx.Subject,
-		"auth_type": authCtx.AuthType,
+		"iat": now.Unix(),
+		"exp": now.Add(expiry).Unix(),
 	}
 	if issuer != "" {
 		claims["iss"] = issuer
 	}
-	if authCtx.Issuer != "" {
+	if authCtx != nil && authCtx.Subject != "" {
+		claims["sub"] = authCtx.Subject
+	}
+	if authCtx != nil && authCtx.AuthType != "" {
+		claims["auth_type"] = authCtx.AuthType
+	}
+	if authCtx != nil && authCtx.Issuer != "" {
 		claims["original_iss"] = authCtx.Issuer
 	}
-	if len(authCtx.Audience) > 0 {
+	if authCtx != nil && len(authCtx.Audience) > 0 {
 		claims["aud"] = authCtx.Audience
 	}
-	if authCtx.CredentialID != "" {
+	if authCtx != nil && authCtx.CredentialID != "" {
 		claims["credential_id"] = authCtx.CredentialID
 	}
 	for k, v := range extras.stringClaims {
@@ -249,7 +244,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	}
 
 	p.putCachedToken(cacheKey, signed, expiry)
-	slog.Debug("Backend JWT: generated token", "header", headerName, "subject", authCtx.Subject)
+	slog.Debug("Backend JWT: generated token", "header", headerName, "subject", subject)
 
 	return policy.UpstreamRequestHeaderModifications{
 		HeadersToSet: map[string]string{
@@ -288,6 +283,8 @@ var restrictedClaims = map[string]bool{
 	"aud": true,
 	"exp": true,
 	"iat": true,
+	"nbf": true,
+	"jti": true,
 }
 
 // resolveExtraClaims resolves claimMappings and customClaims from params.
@@ -354,7 +351,9 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 
 // buildTokenCacheKey returns a hex SHA256 of the fields that determine what the generated JWT contains.
 // audience and extra claims are sorted so the key is deterministic regardless of slice/map ordering.
-func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion string, audience []string, extras resolvedClaims) string {
+// jti is the upstream JWT ID (empty for non-JWT auth); when present it pins the cache entry to the
+// specific upstream token instance so that rotating the upstream JWT invalidates the cached backend JWT.
+func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion, jti string, audience []string, extras resolvedClaims) string {
 	sortedAud := make([]string, len(audience))
 	copy(sortedAud, audience)
 	sort.Strings(sortedAud)
@@ -380,6 +379,8 @@ func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion string, au
 	sb.WriteString(apiVersion)
 	sb.WriteByte('|')
 	sb.WriteString(strings.Join(sortedAud, ","))
+	sb.WriteByte('|')
+	sb.WriteString(jti)
 	for _, k := range allKeys {
 		sb.WriteByte('|')
 		sb.WriteString(k)
@@ -391,7 +392,20 @@ func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion string, au
 		}
 	}
 	sum := sha256.Sum256([]byte(sb.String()))
-	return fmt.Sprintf("%x", sum)
+	key := fmt.Sprintf("%x", sum)
+
+	slog.Debug("Backend JWT: built token cache key",
+		"credentialID", credentialID,
+		"subject", subject,
+		"apiContext", apiContext,
+		"apiVersion", apiVersion,
+		"jti", jti,
+		"audience", sortedAud,
+		"extraClaimKeys", allKeys,
+		"cacheKey", key,
+	)
+
+	return key
 }
 
 // getCachedToken returns a previously signed token if it exists and has not yet expired.
@@ -534,14 +548,6 @@ func getString(params map[string]interface{}, key, defaultVal string) string {
 	return defaultVal
 }
 
-func getBool(params map[string]interface{}, key string, defaultVal bool) bool {
-	if v, ok := params[key]; ok {
-		if b, ok := v.(bool); ok {
-			return b
-		}
-	}
-	return defaultVal
-}
 
 func parseDuration(s string, fallback time.Duration) time.Duration {
 	if s == "" {

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -1,0 +1,344 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package backendjwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+const (
+	defaultHeader      = "x-jwt-assertion"
+	defaultTokenExpiry = 15 * time.Minute
+	defaultAlgorithm   = "RS256"
+)
+
+// BackendJWTPolicy generates a signed JWT from the authenticated user context
+// and injects it into the upstream request header. It is designed to run after
+// an authentication policy (e.g. jwt-auth, basic-auth, api-key-auth).
+type BackendJWTPolicy struct {
+	keyMu    sync.RWMutex
+	keyCache map[[32]byte]crypto.PrivateKey
+}
+
+var ins = &BackendJWTPolicy{
+	keyCache: make(map[[32]byte]crypto.PrivateKey),
+}
+
+// GetPolicy is the v1alpha2 factory entry point.
+func GetPolicy(metadata policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
+	return ins, nil
+}
+
+func (p *BackendJWTPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// Validate checks that the signing key is present and parseable at config load time.
+func (p *BackendJWTPolicy) Validate(params map[string]interface{}) error {
+	pemBytes, err := extractSigningKeyPEM(params)
+	if err != nil {
+		return fmt.Errorf("invalid signingKey: %w", err)
+	}
+	if _, err := parsePrivateKey(pemBytes); err != nil {
+		return fmt.Errorf("invalid signingKey: %w", err)
+	}
+	return nil
+}
+
+// OnRequestHeaders generates a signed JWT from the auth context and sets it on the upstream request.
+func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
+	requireAuth := getBool(params, "requireAuthentication", false)
+	authCtx := reqCtx.SharedContext.AuthContext
+
+	if authCtx == nil || !authCtx.Authenticated {
+		if requireAuth {
+			slog.Debug("Backend JWT: no authenticated context, rejecting request")
+			return policy.ImmediateResponse{
+				StatusCode: 401,
+				Headers:    map[string]string{"content-type": "application/json"},
+				Body:       []byte(`{"error":"Unauthorized","message":"Authentication is required to generate a backend JWT"}`),
+			}
+		}
+		slog.Debug("Backend JWT: no authenticated context, passing through")
+		return policy.UpstreamRequestHeaderModifications{}
+	}
+
+	pemBytes, err := extractSigningKeyPEM(params)
+	if err != nil {
+		slog.Error("Backend JWT: failed to extract signing key", "error", err)
+		return internalError()
+	}
+
+	privateKey, err := p.loadKey(pemBytes)
+	if err != nil {
+		slog.Error("Backend JWT: failed to parse signing key", "error", err)
+		return internalError()
+	}
+
+	algorithm := getString(params, "algorithm", defaultAlgorithm)
+	signingMethod, err := getSigningMethod(algorithm, privateKey)
+	if err != nil {
+		slog.Error("Backend JWT: unsupported algorithm or mismatched key type", "algorithm", algorithm, "error", err)
+		return internalError()
+	}
+
+	issuer := getString(params, "issuer", "")
+	expiry := parseDuration(getString(params, "tokenExpiry", ""), defaultTokenExpiry)
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iat":       now.Unix(),
+		"exp":       now.Add(expiry).Unix(),
+		"sub":       authCtx.Subject,
+		"auth_type": authCtx.AuthType,
+	}
+	if issuer != "" {
+		claims["iss"] = issuer
+	}
+	if authCtx.Issuer != "" {
+		claims["original_iss"] = authCtx.Issuer
+	}
+	if len(authCtx.Audience) > 0 {
+		claims["aud"] = authCtx.Audience
+	}
+	if authCtx.CredentialID != "" {
+		claims["credential_id"] = authCtx.CredentialID
+	}
+
+	// Map selected AuthContext.Properties keys to JWT claims.
+	if mappingsRaw, ok := params["claimMappings"]; ok {
+		if mappings, ok := mappingsRaw.(map[string]interface{}); ok {
+			for propKey, claimNameRaw := range mappings {
+				claimName, ok := claimNameRaw.(string)
+				if !ok {
+					continue
+				}
+				if val, ok := authCtx.Properties[propKey]; ok {
+					claims[claimName] = val
+				}
+			}
+		}
+	}
+
+	// Apply custom static claims (can override derived claims).
+	if customRaw, ok := params["customClaims"]; ok {
+		if custom, ok := customRaw.(map[string]interface{}); ok {
+			for k, v := range custom {
+				claims[k] = v
+			}
+		}
+	}
+
+	token := jwt.NewWithClaims(signingMethod, claims)
+	signed, err := token.SignedString(privateKey)
+	if err != nil {
+		slog.Error("Backend JWT: failed to sign token", "error", err)
+		return internalError()
+	}
+
+	headerName := getString(params, "header", defaultHeader)
+	slog.Debug("Backend JWT: generated token", "header", headerName, "subject", authCtx.Subject)
+
+	return policy.UpstreamRequestHeaderModifications{
+		HeadersToSet: map[string]string{
+			headerName: signed,
+		},
+	}
+}
+
+// loadKey returns a cached private key, parsing and caching it on first use.
+func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
+	fingerprint := sha256.Sum256(pemBytes)
+
+	p.keyMu.RLock()
+	key, ok := p.keyCache[fingerprint]
+	p.keyMu.RUnlock()
+	if ok {
+		return key, nil
+	}
+
+	parsed, err := parsePrivateKey(pemBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	p.keyMu.Lock()
+	p.keyCache[fingerprint] = parsed
+	p.keyMu.Unlock()
+
+	return parsed, nil
+}
+
+// extractSigningKeyPEM reads PEM bytes from params["signingKey"].inline or params["signingKey"].path.
+func extractSigningKeyPEM(params map[string]interface{}) ([]byte, error) {
+	signingKeyRaw, ok := params["signingKey"]
+	if !ok {
+		return nil, fmt.Errorf("signingKey is required")
+	}
+	signingKeyMap, ok := signingKeyRaw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("signingKey must be an object with 'inline' or 'path'")
+	}
+
+	if inlineRaw, ok := signingKeyMap["inline"]; ok {
+		inline, ok := inlineRaw.(string)
+		if !ok || inline == "" {
+			return nil, fmt.Errorf("signingKey.inline must be a non-empty string")
+		}
+		return []byte(inline), nil
+	}
+
+	if pathRaw, ok := signingKeyMap["path"]; ok {
+		path, ok := pathRaw.(string)
+		if !ok || path == "" {
+			return nil, fmt.Errorf("signingKey.path must be a non-empty string")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading key file %q: %w", path, err)
+		}
+		return data, nil
+	}
+
+	return nil, fmt.Errorf("signingKey must specify either 'inline' or 'path'")
+}
+
+// parsePrivateKey decodes and parses a PEM-encoded RSA or ECDSA private key.
+func parsePrivateKey(pemBytes []byte) (crypto.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no valid PEM block found in signing key")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		switch k := key.(type) {
+		case *rsa.PrivateKey:
+			return k, nil
+		case *ecdsa.PrivateKey:
+			return k, nil
+		default:
+			return nil, fmt.Errorf("unsupported PKCS8 key type: %T", key)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q; expected RSA PRIVATE KEY, EC PRIVATE KEY, or PRIVATE KEY", block.Type)
+	}
+}
+
+// getSigningMethod returns the jwt.SigningMethod for the given algorithm string,
+// validating that the private key type matches.
+func getSigningMethod(algorithm string, key crypto.PrivateKey) (jwt.SigningMethod, error) {
+	switch algorithm {
+	case "RS256":
+		if _, ok := key.(*rsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("RS256 requires an RSA private key, got %T", key)
+		}
+		return jwt.SigningMethodRS256, nil
+	case "RS384":
+		if _, ok := key.(*rsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("RS384 requires an RSA private key, got %T", key)
+		}
+		return jwt.SigningMethodRS384, nil
+	case "RS512":
+		if _, ok := key.(*rsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("RS512 requires an RSA private key, got %T", key)
+		}
+		return jwt.SigningMethodRS512, nil
+	case "ES256":
+		if _, ok := key.(*ecdsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("ES256 requires an ECDSA private key, got %T", key)
+		}
+		return jwt.SigningMethodES256, nil
+	case "ES384":
+		if _, ok := key.(*ecdsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("ES384 requires an ECDSA private key, got %T", key)
+		}
+		return jwt.SigningMethodES384, nil
+	case "ES512":
+		if _, ok := key.(*ecdsa.PrivateKey); !ok {
+			return nil, fmt.Errorf("ES512 requires an ECDSA private key, got %T", key)
+		}
+		return jwt.SigningMethodES512, nil
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q; supported: RS256, RS384, RS512, ES256, ES384, ES512", algorithm)
+	}
+}
+
+func getString(params map[string]interface{}, key, defaultVal string) string {
+	if v, ok := params[key]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return defaultVal
+}
+
+func getBool(params map[string]interface{}, key string, defaultVal bool) bool {
+	if v, ok := params[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return defaultVal
+}
+
+func parseDuration(s string, fallback time.Duration) time.Duration {
+	if s == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
+func internalError() policy.ImmediateResponse {
+	return policy.ImmediateResponse{
+		StatusCode: 500,
+		Headers:    map[string]string{"content-type": "application/json"},
+		Body:       []byte(`{"error":"Internal Server Error"}`),
+	}
+}

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -224,10 +224,10 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		}
 	}
 	for k, v := range extras.stringClaims {
-		claims[k] = v
+		claims[dialect+k] = v
 	}
 	for k, v := range extras.rawClaims {
-		claims[k] = v
+		claims[dialect+k] = v
 	}
 
 	token := jwt.NewWithClaims(signingMethod, claims)

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -168,17 +168,9 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	// Resolve extra claims once — used for both the cache key and JWT population.
 	extras := resolveExtraClaims(reqCtx, params)
 
-	var credentialID, subject, tokenId string
-	var audience []string
-	if authCtx != nil {
-		credentialID = authCtx.CredentialID
-		subject = authCtx.Subject
-		tokenId = authCtx.TokenId
-		audience = authCtx.Audience
-	}
-	cacheKey := buildTokenCacheKey(credentialID, subject, reqCtx.APIContext, reqCtx.APIVersion, tokenId, audience, extras)
+	cacheKey := buildTokenCacheKey(authCtx, reqCtx.APIContext, reqCtx.APIVersion, extras)
 	if signed, ok := p.getCachedToken(cacheKey); ok {
-		slog.Debug("Backend JWT: cache hit", "subject", subject)
+		slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
 		return policy.UpstreamRequestHeaderModifications{
 			HeadersToSet: map[string]string{headerName: signed},
 		}
@@ -244,7 +236,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	}
 
 	p.putCachedToken(cacheKey, signed, expiry)
-	slog.Debug("Backend JWT: generated token", "header", headerName, "subject", subject)
+	slog.Debug("Backend JWT: generated token", "header", headerName, "authType", authTypeLabel(authCtx))
 
 	return policy.UpstreamRequestHeaderModifications{
 		HeadersToSet: map[string]string{
@@ -349,38 +341,58 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 	return result
 }
 
-// buildTokenCacheKey returns a hex SHA256 of the fields that determine what the generated JWT contains.
-// audience and extra claims are sorted so the key is deterministic regardless of slice/map ordering.
-// jti is the upstream JWT ID (empty for non-JWT auth); when present it pins the cache entry to the
-// specific upstream token instance so that rotating the upstream JWT invalidates the cached backend JWT.
-func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion, jti string, audience []string, extras resolvedClaims) string {
-	sortedAud := make([]string, len(audience))
-	copy(sortedAud, audience)
-	sort.Strings(sortedAud)
+// buildTokenCacheKey returns a hex SHA256 cache key derived from the identity signals
+// most appropriate for the given auth mechanism, plus the API context and extra claims.
+// Dispatches per AuthType so each mechanism uses only its natural identity fields.
+func buildTokenCacheKey(authCtx *policy.AuthContext, apiContext, apiVersion string, extras resolvedClaims) string {
+	var sb strings.Builder
 
-	allKeys := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
-	for k := range extras.stringClaims {
-		allKeys = append(allKeys, k)
-	}
-	for k := range extras.rawClaims {
-		if _, exists := extras.stringClaims[k]; !exists {
-			allKeys = append(allKeys, k)
+	if authCtx != nil {
+		switch authCtx.AuthType {
+		case "jwt":
+			if authCtx.TokenId != "" {
+				// jti is a strong per-token identifier — sufficient on its own.
+				sb.WriteString(authCtx.TokenId)
+			} else {
+				// No jti: include issuer to prevent cross-issuer subject collisions.
+				sb.WriteString(authCtx.Issuer)
+				sb.WriteByte('|')
+				sb.WriteString(authCtx.Subject)
+				sb.WriteByte('|')
+				sb.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
+			}
+		case "basic":
+			sb.WriteString(authCtx.Subject)
+		case "apikey":
+			// api-key-auth stores the per-application identifier in Properties["ApplicationID"].
+			// Fall back to CredentialID for other API key implementations.
+			if appID := authCtx.Properties["ApplicationID"]; appID != "" {
+				sb.WriteString(appID)
+			} else {
+				sb.WriteString(authCtx.CredentialID)
+			}
+		default:
+			// Unknown auth type: include all available identity fields.
+			sb.WriteString(authCtx.AuthType)
+			sb.WriteByte('|')
+			sb.WriteString(authCtx.CredentialID)
+			sb.WriteByte('|')
+			sb.WriteString(authCtx.Subject)
+			sb.WriteByte('|')
+			sb.WriteString(authCtx.TokenId)
+			sb.WriteByte('|')
+			sb.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
 		}
 	}
-	sort.Strings(allKeys)
+	// authCtx == nil: identity portion is empty — all unauthenticated requests to
+	// the same API with the same extras share one backend JWT, which is correct.
 
-	var sb strings.Builder
-	sb.WriteString(credentialID)
-	sb.WriteByte('|')
-	sb.WriteString(subject)
 	sb.WriteByte('|')
 	sb.WriteString(apiContext)
 	sb.WriteByte('|')
 	sb.WriteString(apiVersion)
-	sb.WriteByte('|')
-	sb.WriteString(strings.Join(sortedAud, ","))
-	sb.WriteByte('|')
-	sb.WriteString(jti)
+
+	allKeys := sortedExtraKeys(extras)
 	for _, k := range allKeys {
 		sb.WriteByte('|')
 		sb.WriteString(k)
@@ -391,21 +403,47 @@ func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion, jti strin
 			sb.WriteString(fmt.Sprintf("%v", extras.rawClaims[k]))
 		}
 	}
+
 	sum := sha256.Sum256([]byte(sb.String()))
 	key := fmt.Sprintf("%x", sum)
 
 	slog.Debug("Backend JWT: built token cache key",
-		"credentialID", credentialID,
-		"subject", subject,
+		"authType", authTypeLabel(authCtx),
 		"apiContext", apiContext,
 		"apiVersion", apiVersion,
-		"jti", jti,
-		"audience", sortedAud,
 		"extraClaimKeys", allKeys,
 		"cacheKey", key,
 	)
 
 	return key
+}
+
+func sortedSlice(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	sort.Strings(out)
+	return out
+}
+
+func sortedExtraKeys(extras resolvedClaims) []string {
+	keys := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
+	for k := range extras.stringClaims {
+		keys = append(keys, k)
+	}
+	for k := range extras.rawClaims {
+		if _, exists := extras.stringClaims[k]; !exists {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func authTypeLabel(authCtx *policy.AuthContext) string {
+	if authCtx == nil {
+		return "none"
+	}
+	return authCtx.AuthType
 }
 
 // getCachedToken returns a previously signed token if it exists and has not yet expired.

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -154,7 +154,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 
 	var cacheKey string
 	if tokenCaching {
-		cacheKey = buildTokenCacheKey(authCtx, reqCtx.APIName, reqCtx.Path, reqCtx.Method, extras)
+		cacheKey = buildTokenCacheKey(authCtx, reqCtx.Path, reqCtx.Method, extras)
 		if signed, ok := p.getCachedToken(cacheKey); ok {
 			slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
 			return policy.UpstreamRequestHeaderModifications{
@@ -351,15 +351,18 @@ var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
 // buildTokenCacheKey returns a cache key for the token cache.
 //
-//   - TokenId, no dynamic extras:  raw concatenation — TokenId + api name + path + method.
+//   - TokenId, no dynamic extras:  raw concatenation — TokenId + path + method.
 //   - TokenId, with dynamic extras: SHA256 of the above + resolved $ctx: claim values.
-//   - authCtx nil:                  SHA256 of api name + path + method + dynamic extras.
-//   - otherwise:                    SHA256 of all identity fields + api name + path + method + dynamic extras.
+//   - authCtx nil:                  SHA256 of path + method + dynamic extras.
+//   - otherwise:                    SHA256 of all identity fields + path + method + dynamic extras.
+//
+// apiName is omitted: the gateway enforces globally unique path prefixes per API, so
+// path+method already uniquely identifies the operation and its configuration.
 //
 // Only $ctx:-resolved customClaims are included in the key because they vary per-request.
-// Static customClaims and claimMappings are constant per-API config (already disambiguated by
-// apiName) or per-identity (already captured in the identity hash), so they add no information.
-func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method string, extras resolvedClaims) string {
+// Static customClaims and claimMappings are constant per-operation config or per-identity
+// (already captured in the identity hash), so they add no information.
+func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras resolvedClaims) string {
 	if i := strings.IndexByte(path, '?'); i != -1 {
 		path = path[:i]
 	}
@@ -372,16 +375,14 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 	if authCtx != nil && authCtx.TokenId != "" {
 		if len(extraKeys) == 0 {
 			// Fast path: no extras, no hash needed.
-			key := authCtx.TokenId + "\x00" + apiName + "\x00" + path + "\x00" + method
-			slog.Debug("Backend JWT: cache key (TokenId)", "apiName", apiName, "path", path, "method", method, "cacheKey", key)
+			key := authCtx.TokenId + "\x00" + path + "\x00" + method
+			slog.Debug("Backend JWT: cache key (TokenId)", "path", path, "method", method, "cacheKey", key)
 			return key
 		}
 		// Extras present: SHA256 to normalize key length.
 		buf := keyBufPool.Get().(*bytes.Buffer)
 		buf.Reset()
 		buf.WriteString(authCtx.TokenId)
-		buf.WriteByte('|')
-		buf.WriteString(apiName)
 		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
@@ -390,7 +391,7 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 		sum := sha256.Sum256(buf.Bytes())
 		keyBufPool.Put(buf)
 		key := fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (TokenId+claims)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		slog.Debug("Backend JWT: cache key (TokenId+claims)", "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
 		return key
 	}
 
@@ -399,15 +400,13 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 	defer keyBufPool.Put(buf)
 
 	if authCtx == nil {
-		buf.WriteString(apiName)
-		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
 		appendExtras(buf, extraKeys, extras)
 		sum := sha256.Sum256(buf.Bytes())
 		key := fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (no-auth)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		slog.Debug("Backend JWT: cache key (no-auth)", "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
 		return key
 	}
 
@@ -443,8 +442,6 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 		buf.WriteString(strings.Join(scopeKeys, " "))
 	}
 	buf.WriteByte('|')
-	buf.WriteString(apiName)
-	buf.WriteByte('|')
 	buf.WriteString(path)
 	buf.WriteByte('|')
 	buf.WriteString(method)
@@ -454,7 +451,6 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 	key := fmt.Sprintf("%x", sum)
 	slog.Debug("Backend JWT: cache key (identity hash)",
 		"authType", authTypeLabel(authCtx),
-		"apiName", apiName,
 		"path", path,
 		"method", method,
 		"extraClaimKeys", extraKeys,

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/patrickmn/go-cache"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
@@ -44,12 +45,6 @@ const (
 	defaultAlgorithm   = "SHA256withRSA"
 	minCacheTTL        = 30 * time.Second
 )
-
-// cachedToken holds a signed JWT string and its cache expiry time.
-type cachedToken struct {
-	signed    string
-	expiresAt time.Time
-}
 
 // resolvedClaims holds the extra claims derived from customClaims, split by type
 // so the cache key and JWT population can share the same resolved values.
@@ -62,12 +57,9 @@ type resolvedClaims struct {
 // and injects it into the upstream request header. It is designed to run after
 // an authentication policy (e.g. jwt-auth, basic-auth, api-key-auth).
 type BackendJWTPolicy struct {
-	keyMu    sync.RWMutex
-	keyCache map[[32]byte]crypto.PrivateKey
-	pemCache map[string][]byte // path → PEM bytes; avoids repeated file reads per cache miss
-
-	tokenMu    sync.RWMutex
-	tokenCache map[string]cachedToken
+	keyCache   *cache.Cache // hex(sha256 fingerprint) → crypto.PrivateKey; config-lifetime
+	pemCache   *cache.Cache // path → PEM bytes; avoids repeated file reads per cache miss
+	tokenCache *cache.Cache // cache key → signed JWT string; per-item TTL
 }
 
 // algorithmEntry describes a supported JWT signing algorithm.
@@ -85,39 +77,13 @@ var algorithms = map[string]algorithmEntry{
 }
 
 var ins = &BackendJWTPolicy{
-	keyCache:   make(map[[32]byte]crypto.PrivateKey),
-	pemCache:   make(map[string][]byte),
-	tokenCache: make(map[string]cachedToken),
-}
-
-var startCleanup sync.Once
-
-func startCacheCleanupOnce() {
-	startCleanup.Do(func() {
-		go func() {
-			ticker := time.NewTicker(5 * time.Minute)
-			defer ticker.Stop()
-			for range ticker.C {
-				ins.evictExpired()
-			}
-		}()
-	})
-}
-
-func (p *BackendJWTPolicy) evictExpired() {
-	now := time.Now()
-	p.tokenMu.Lock()
-	for k, v := range p.tokenCache {
-		if now.After(v.expiresAt) {
-			delete(p.tokenCache, k)
-		}
-	}
-	p.tokenMu.Unlock()
+	keyCache:   cache.New(cache.NoExpiration, 0),             // config-lifetime; no janitor needed
+	pemCache:   cache.New(cache.NoExpiration, 0),             // config-lifetime; no janitor needed
+	tokenCache: cache.New(cache.NoExpiration, 5*time.Minute), // per-item TTL; janitor evicts every 5m
 }
 
 // GetPolicy is the v1alpha2 factory entry point.
 func GetPolicy(metadata policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
-	startCacheCleanupOnce()
 	return ins, nil
 }
 
@@ -283,13 +249,10 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 
 // loadKey returns a cached private key, parsing and caching it on first use.
 func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
-	fingerprint := sha256.Sum256(pemBytes)
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256(pemBytes))
 
-	p.keyMu.RLock()
-	key, ok := p.keyCache[fingerprint]
-	p.keyMu.RUnlock()
-	if ok {
-		return key, nil
+	if key, ok := p.keyCache.Get(fingerprint); ok {
+		return key.(crypto.PrivateKey), nil
 	}
 
 	parsed, err := parsePrivateKey(pemBytes)
@@ -297,9 +260,7 @@ func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
 		return nil, err
 	}
 
-	p.keyMu.Lock()
-	p.keyCache[fingerprint] = parsed
-	p.keyMu.Unlock()
+	p.keyCache.Set(fingerprint, parsed, cache.NoExpiration)
 
 	return parsed, nil
 }
@@ -536,14 +497,13 @@ func authTypeLabel(authCtx *policy.AuthContext) string {
 }
 
 // getCachedToken returns a previously signed token if it exists and has not yet expired.
+// Expiry is enforced by go-cache's Get.
 func (p *BackendJWTPolicy) getCachedToken(key string) (string, bool) {
-	p.tokenMu.RLock()
-	entry, ok := p.tokenCache[key]
-	p.tokenMu.RUnlock()
-	if !ok || time.Now().After(entry.expiresAt) {
+	v, ok := p.tokenCache.Get(key)
+	if !ok {
 		return "", false
 	}
-	return entry.signed, true
+	return v.(string), true
 }
 
 // putCachedToken stores a signed token in the cache with a TTL of half the token expiry,
@@ -554,12 +514,7 @@ func (p *BackendJWTPolicy) putCachedToken(key, signed string, tokenExpiry time.D
 	if ttl < minCacheTTL {
 		ttl = minCacheTTL
 	}
-	p.tokenMu.Lock()
-	p.tokenCache[key] = cachedToken{
-		signed:    signed,
-		expiresAt: time.Now().Add(ttl),
-	}
-	p.tokenMu.Unlock()
+	p.tokenCache.Set(key, signed, ttl)
 }
 
 // extractSigningKeyPEM reads PEM bytes from params["signingKey"].inline or params["signingKey"].path.
@@ -589,11 +544,8 @@ func (p *BackendJWTPolicy) extractSigningKeyPEM(params map[string]interface{}) (
 			return nil, fmt.Errorf("signingKey.path must be a non-empty string")
 		}
 
-		p.keyMu.RLock()
-		cached, ok := p.pemCache[path]
-		p.keyMu.RUnlock()
-		if ok {
-			return cached, nil
+		if cached, ok := p.pemCache.Get(path); ok {
+			return cached.([]byte), nil
 		}
 
 		data, err := os.ReadFile(path)
@@ -601,9 +553,7 @@ func (p *BackendJWTPolicy) extractSigningKeyPEM(params map[string]interface{}) (
 			return nil, fmt.Errorf("reading key file %q: %w", path, err)
 		}
 
-		p.keyMu.Lock()
-		p.pemCache[path] = data
-		p.keyMu.Unlock()
+		p.pemCache.Set(path, data, cache.NoExpiration)
 
 		return data, nil
 	}

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -45,9 +45,9 @@ const (
 	defaultAlgorithm   = "SHA256withRSA"
 	minCacheTTL        = 30 * time.Second
 
-	// defaultCacheMaxSize bounds the total number of cached tokens across all APIs when
-	// cacheMaxSize is unset (0). The SDK cache fixes its size at construction, so a changed
-	// cacheMaxSize is applied by rebuilding the cache (see ensureTokenCache).
+	// defaultCacheMaxSize bounds the total number of cached tokens across all APIs. 
+	// The SDK cache fixes its size at construction, so a changed cacheMaxSize is
+	// applied by rebuilding the cache (see ensureTokenCache).
 	defaultCacheMaxSize = 100_000
 )
 
@@ -87,8 +87,11 @@ type cachedToken struct {
 // newTokenCache builds the shared token cache, globally bounded by maxSize across all APIs.
 // ttl is 0 because expiry is enforced per entry in getCachedToken; once full, the cache's LRU
 // policy evicts the least-recently-used entry across all APIs, enforcing a single global bound.
+// The cache is given the policy's default slog logger so its own debug lines flow through the
+// same logging pipeline; slog gates them by level, so they appear only when debug logging is
+// enabled (pass nil instead to force them off regardless of level).
 func newTokenCache(maxSize int) *cache.InMemoryCache[cachedToken] {
-	return cache.NewInMemoryCache[cachedToken]("backend-jwt-tokens", maxSize, 0, cache.LRUEvictionPolicy)
+	return cache.NewInMemoryCache[cachedToken]("backend-jwt-tokens", maxSize, 0, cache.LRUEvictionPolicy, slog.Default())
 }
 
 // keyNamespace carries the per-deployment configuration that shapes the generated token but is
@@ -136,9 +139,9 @@ var ins = &BackendJWTPolicy{
 // operation, claims, issuer, algorithm, dialect, excludedClaims), so a redeploy that changes any
 // of them simply misses the old entries — no explicit flush needed.
 func GetPolicy(_ policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
-	// cacheMaxSize is a single global bound across all APIs. 0 (or invalid) means "use the
-	// default bound".
-	maxSize := getInt(params, "cacheMaxSize", 0)
+	// cacheMaxSize is a single global bound across all APIs; there is no unbounded mode. A missing
+	// or invalid value falls back to the default bound.
+	maxSize := getInt(params, "cacheMaxSize", defaultCacheMaxSize)
 	if maxSize <= 0 {
 		maxSize = defaultCacheMaxSize
 	}

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -27,7 +27,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"hash/fnv"
 	"log/slog"
 	"os"
 	"sort"
@@ -436,7 +435,8 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 		buf.WriteByte('|')
 		buf.WriteString(method)
 		appendExtras(buf, extraKeys, extras)
-		key := fnvHash(buf)
+		sum := sha256.Sum256(buf.Bytes())
+		key := fmt.Sprintf("%x", sum)
 		slog.Debug("Backend JWT: cache key (no-auth)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
 		return key
 	}
@@ -480,7 +480,8 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 	buf.WriteString(method)
 	appendExtras(buf, extraKeys, extras)
 
-	key := fnvHash(buf)
+	sum := sha256.Sum256(buf.Bytes())
+	key := fmt.Sprintf("%x", sum)
 	slog.Debug("Backend JWT: cache key (identity hash)",
 		"authType", authTypeLabel(authCtx),
 		"apiName", apiName,
@@ -490,12 +491,6 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 		"cacheKey", key,
 	)
 	return key
-}
-
-func fnvHash(buf *bytes.Buffer) string {
-	h := fnv.New64a()
-	h.Write(buf.Bytes())
-	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 func appendExtras(buf *bytes.Buffer, keys []string, extras resolvedClaims) {

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -40,7 +41,23 @@ const (
 	defaultHeader      = "x-jwt-assertion"
 	defaultTokenExpiry = 15 * time.Minute
 	defaultAlgorithm   = "RS256"
+	minCacheTTL        = 30 * time.Second
 )
+
+// cachedToken holds a signed JWT string and its cache expiry time.
+type cachedToken struct {
+	signed    string
+	expiresAt time.Time
+}
+
+// resolvedClaims holds the extra claims derived from claimMappings and customClaims
+// in a single pass, split by type so cache-key and JWT population can share the work.
+type resolvedClaims struct {
+	// stringClaims: claimMappings results + resolved string customClaims (including $ctx:).
+	stringClaims map[string]string
+	// rawClaims: non-string customClaims (numbers, booleans) preserved as-is for JWT.
+	rawClaims map[string]interface{}
+}
 
 // BackendJWTPolicy generates a signed JWT from the authenticated user context
 // and injects it into the upstream request header. It is designed to run after
@@ -48,14 +65,44 @@ const (
 type BackendJWTPolicy struct {
 	keyMu    sync.RWMutex
 	keyCache map[[32]byte]crypto.PrivateKey
+
+	tokenMu    sync.RWMutex
+	tokenCache map[string]cachedToken
 }
 
 var ins = &BackendJWTPolicy{
-	keyCache: make(map[[32]byte]crypto.PrivateKey),
+	keyCache:   make(map[[32]byte]crypto.PrivateKey),
+	tokenCache: make(map[string]cachedToken),
+}
+
+var startCleanup sync.Once
+
+func startCacheCleanupOnce() {
+	startCleanup.Do(func() {
+		go func() {
+			ticker := time.NewTicker(5 * time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				ins.evictExpired()
+			}
+		}()
+	})
+}
+
+func (p *BackendJWTPolicy) evictExpired() {
+	now := time.Now()
+	p.tokenMu.Lock()
+	for k, v := range p.tokenCache {
+		if now.After(v.expiresAt) {
+			delete(p.tokenCache, k)
+		}
+	}
+	p.tokenMu.Unlock()
 }
 
 // GetPolicy is the v1alpha2 factory entry point.
 func GetPolicy(metadata policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
+	startCacheCleanupOnce()
 	return ins, nil
 }
 
@@ -98,6 +145,25 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		return policy.UpstreamRequestHeaderModifications{}
 	}
 
+	algorithm := getString(params, "algorithm", defaultAlgorithm)
+	issuer := getString(params, "issuer", "")
+	expiry := parseDuration(getString(params, "tokenExpiry", ""), defaultTokenExpiry)
+	headerName := getString(params, "header", defaultHeader)
+
+	// Resolve extra claims once — used for both the cache key and JWT population.
+	extras := resolveExtraClaims(authCtx, reqCtx, params)
+
+	cacheKey := buildTokenCacheKey(
+		authCtx.Subject, authCtx.CredentialID, authCtx.AuthType, authCtx.Issuer,
+		reqCtx.OperationPath, issuer, algorithm, extras,
+	)
+	if signed, ok := p.getCachedToken(cacheKey); ok {
+		slog.Debug("Backend JWT: cache hit", "subject", authCtx.Subject)
+		return policy.UpstreamRequestHeaderModifications{
+			HeadersToSet: map[string]string{headerName: signed},
+		}
+	}
+
 	pemBytes, err := extractSigningKeyPEM(params)
 	if err != nil {
 		slog.Error("Backend JWT: failed to extract signing key", "error", err)
@@ -110,15 +176,11 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		return internalError()
 	}
 
-	algorithm := getString(params, "algorithm", defaultAlgorithm)
 	signingMethod, err := getSigningMethod(algorithm, privateKey)
 	if err != nil {
 		slog.Error("Backend JWT: unsupported algorithm or mismatched key type", "algorithm", algorithm, "error", err)
 		return internalError()
 	}
-
-	issuer := getString(params, "issuer", "")
-	expiry := parseDuration(getString(params, "tokenExpiry", ""), defaultTokenExpiry)
 
 	now := time.Now()
 	claims := jwt.MapClaims{
@@ -139,41 +201,11 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	if authCtx.CredentialID != "" {
 		claims["credential_id"] = authCtx.CredentialID
 	}
-
-	// Map selected AuthContext.Properties keys to JWT claims.
-	if mappingsRaw, ok := params["claimMappings"]; ok {
-		if mappings, ok := mappingsRaw.(map[string]interface{}); ok {
-			for propKey, claimNameRaw := range mappings {
-				claimName, ok := claimNameRaw.(string)
-				if !ok {
-					continue
-				}
-				if val, ok := authCtx.Properties[propKey]; ok {
-					claims[claimName] = val
-				}
-			}
-		}
+	for k, v := range extras.stringClaims {
+		claims[k] = v
 	}
-
-	// Apply custom claims — string values starting with "$ctx:" resolve from request context.
-	if customRaw, ok := params["customClaims"]; ok {
-		if custom, ok := customRaw.(map[string]interface{}); ok {
-			for k, v := range custom {
-				strVal, ok := v.(string)
-				if !ok {
-					// Non-string values (numbers, booleans) pass through as-is.
-					claims[k] = v
-					continue
-				}
-				resolved, ok := resolveClaimValue(strVal, reqCtx)
-				if !ok {
-					slog.Debug("Backend JWT: skipping claim — context variable not resolvable",
-						"claim", k, "ref", strVal)
-					continue
-				}
-				claims[k] = resolved
-			}
-		}
+	for k, v := range extras.rawClaims {
+		claims[k] = v
 	}
 
 	token := jwt.NewWithClaims(signingMethod, claims)
@@ -183,7 +215,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		return internalError()
 	}
 
-	headerName := getString(params, "header", defaultHeader)
+	p.putCachedToken(cacheKey, signed, expiry)
 	slog.Debug("Backend JWT: generated token", "header", headerName, "subject", authCtx.Subject)
 
 	return policy.UpstreamRequestHeaderModifications{
@@ -214,6 +246,121 @@ func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
 	p.keyMu.Unlock()
 
 	return parsed, nil
+}
+
+// resolveExtraClaims resolves claimMappings and customClaims in a single pass.
+// stringClaims holds claimMappings results and resolved string customClaims (including $ctx: refs).
+// rawClaims holds non-string customClaims preserved as their original types for JWT population.
+func resolveExtraClaims(authCtx *policy.AuthContext, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
+	result := resolvedClaims{
+		stringClaims: make(map[string]string),
+		rawClaims:    make(map[string]interface{}),
+	}
+
+	if mappingsRaw, ok := params["claimMappings"]; ok {
+		if mappings, ok := mappingsRaw.(map[string]interface{}); ok {
+			for propKey, claimNameRaw := range mappings {
+				claimName, ok := claimNameRaw.(string)
+				if !ok {
+					continue
+				}
+				if val, ok := authCtx.Properties[propKey]; ok {
+					result.stringClaims[claimName] = val
+				}
+			}
+		}
+	}
+
+	if customRaw, ok := params["customClaims"]; ok {
+		if custom, ok := customRaw.(map[string]interface{}); ok {
+			for k, v := range custom {
+				strVal, ok := v.(string)
+				if !ok {
+					result.rawClaims[k] = v
+					continue
+				}
+				resolved, ok := resolveClaimValue(strVal, reqCtx)
+				if !ok {
+					slog.Debug("Backend JWT: skipping claim — context variable not resolvable",
+						"claim", k, "ref", strVal)
+					continue
+				}
+				result.stringClaims[k] = resolved
+			}
+		}
+	}
+
+	return result
+}
+
+// buildTokenCacheKey returns a hex SHA256 of all fields that determine what the generated JWT contains.
+// resolvedClaims are sorted so the key is deterministic regardless of map iteration order.
+func buildTokenCacheKey(subject, credentialID, authType, originalIssuer, operationPath, issuer, algorithm string, extras resolvedClaims) string {
+	// Collect all extra claim keys, merging both maps.
+	allKeys := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
+	for k := range extras.stringClaims {
+		allKeys = append(allKeys, k)
+	}
+	for k := range extras.rawClaims {
+		if _, exists := extras.stringClaims[k]; !exists {
+			allKeys = append(allKeys, k)
+		}
+	}
+	sort.Strings(allKeys)
+
+	var sb strings.Builder
+	sb.WriteString(subject)
+	sb.WriteByte('|')
+	sb.WriteString(credentialID)
+	sb.WriteByte('|')
+	sb.WriteString(authType)
+	sb.WriteByte('|')
+	sb.WriteString(originalIssuer)
+	sb.WriteByte('|')
+	sb.WriteString(operationPath)
+	sb.WriteByte('|')
+	sb.WriteString(issuer)
+	sb.WriteByte('|')
+	sb.WriteString(algorithm)
+	for _, k := range allKeys {
+		sb.WriteByte('|')
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		if v, ok := extras.stringClaims[k]; ok {
+			sb.WriteString(v)
+		} else {
+			sb.WriteString(fmt.Sprintf("%v", extras.rawClaims[k]))
+		}
+	}
+	sum := sha256.Sum256([]byte(sb.String()))
+	return fmt.Sprintf("%x", sum)
+}
+
+// getCachedToken returns a previously signed token if it exists and has not yet expired.
+func (p *BackendJWTPolicy) getCachedToken(key string) (string, bool) {
+	p.tokenMu.RLock()
+	entry, ok := p.tokenCache[key]
+	p.tokenMu.RUnlock()
+	if !ok || time.Now().After(entry.expiresAt) {
+		return "", false
+	}
+	return entry.signed, true
+}
+
+// putCachedToken stores a signed token in the cache with a TTL of half the token expiry,
+// subject to a minimum of minCacheTTL. Using half the expiry avoids serving tokens that
+// are about to expire while still providing a meaningful cache window.
+func (p *BackendJWTPolicy) putCachedToken(key, signed string, tokenExpiry time.Duration) {
+	ttl := tokenExpiry / 2
+	if ttl < minCacheTTL {
+		ttl = minCacheTTL
+	}
+	p.tokenMu.Lock()
+	p.tokenCache[key] = cachedToken{
+		signed:    signed,
+		expiresAt: time.Now().Add(ttl),
+	}
+	p.tokenMu.Unlock()
 }
 
 // extractSigningKeyPEM reads PEM bytes from params["signingKey"].inline or params["signingKey"].path.

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -154,7 +154,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 
 	var cacheKey string
 	if tokenCaching {
-		cacheKey = buildTokenCacheKey(authCtx, reqCtx.Path, reqCtx.Method, extras)
+		cacheKey = buildTokenCacheKey(authCtx, reqCtx.APIName, reqCtx.Path, reqCtx.Method, extras)
 		if signed, ok := p.getCachedToken(cacheKey); ok {
 			slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
 			return policy.UpstreamRequestHeaderModifications{
@@ -351,18 +351,15 @@ var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
 // buildTokenCacheKey returns a cache key for the token cache.
 //
-//   - TokenId, no dynamic extras:  raw concatenation — TokenId + path + method.
+//   - TokenId, no dynamic extras:  raw concatenation — TokenId + apiName + path + method.
 //   - TokenId, with dynamic extras: SHA256 of the above + resolved $ctx: claim values.
-//   - authCtx nil:                  SHA256 of path + method + dynamic extras.
-//   - otherwise:                    SHA256 of all identity fields + path + method + dynamic extras.
-//
-// apiName is omitted: the gateway enforces globally unique path prefixes per API, so
-// path+method already uniquely identifies the operation and its configuration.
+//   - authCtx nil:                  SHA256 of apiName + path + method + dynamic extras.
+//   - otherwise:                    SHA256 of all identity fields + apiName + path + method + dynamic extras.
 //
 // Only $ctx:-resolved customClaims are included in the key because they vary per-request.
 // Static customClaims and claimMappings are constant per-operation config or per-identity
 // (already captured in the identity hash), so they add no information.
-func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras resolvedClaims) string {
+func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method string, extras resolvedClaims) string {
 	if i := strings.IndexByte(path, '?'); i != -1 {
 		path = path[:i]
 	}
@@ -375,14 +372,16 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras
 	if authCtx != nil && authCtx.TokenId != "" {
 		if len(extraKeys) == 0 {
 			// Fast path: no extras, no hash needed.
-			key := authCtx.TokenId + "\x00" + path + "\x00" + method
-			slog.Debug("Backend JWT: cache key (TokenId)", "path", path, "method", method, "cacheKey", key)
+			key := authCtx.TokenId + "\x00" + apiName + "\x00" + path + "\x00" + method
+			slog.Debug("Backend JWT: cache key (TokenId)", "apiName", apiName, "path", path, "method", method, "cacheKey", key)
 			return key
 		}
 		// Extras present: SHA256 to normalize key length.
 		buf := keyBufPool.Get().(*bytes.Buffer)
 		buf.Reset()
 		buf.WriteString(authCtx.TokenId)
+		buf.WriteByte('|')
+		buf.WriteString(apiName)
 		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
@@ -400,13 +399,15 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras
 	defer keyBufPool.Put(buf)
 
 	if authCtx == nil {
+		buf.WriteString(apiName)
+		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
 		appendExtras(buf, extraKeys, extras)
 		sum := sha256.Sum256(buf.Bytes())
 		key := fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (no-auth)", "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		slog.Debug("Backend JWT: cache key (no-auth)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
 		return key
 	}
 
@@ -442,6 +443,8 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras
 		buf.WriteString(strings.Join(scopeKeys, " "))
 	}
 	buf.WriteByte('|')
+	buf.WriteString(apiName)
+	buf.WriteByte('|')
 	buf.WriteString(path)
 	buf.WriteByte('|')
 	buf.WriteString(method)
@@ -451,6 +454,7 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, path, method string, extras
 	key := fmt.Sprintf("%x", sum)
 	slog.Debug("Backend JWT: cache key (identity hash)",
 		"authType", authTypeLabel(authCtx),
+		"apiName", apiName,
 		"path", path,
 		"method", method,
 		"extraClaimKeys", extraKeys,

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -139,6 +139,17 @@ func (p *BackendJWTPolicy) Validate(params map[string]interface{}) error {
 	if !ok {
 		return fmt.Errorf("unsupported algorithm %q; supported: %s", alg, algorithmList())
 	}
+
+	if s := getString(params, "tokenExpiry", ""); s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("invalid tokenExpiry %q: %w", s, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("tokenExpiry must be a positive duration, got %q", s)
+		}
+	}
+
 	if entry.keyType == "none" {
 		return nil
 	}
@@ -700,7 +711,8 @@ func resolveClaimValue(value string, reqCtx *policy.RequestHeaderContext) (strin
 	if !strings.HasPrefix(value, ctxPrefix) {
 		return value, true
 	}
-	variable := strings.ToLower(strings.TrimPrefix(value, ctxPrefix))
+	ref := strings.TrimPrefix(value, ctxPrefix)
+	variable := strings.ToLower(ref)
 
 	switch {
 	case variable == "request.path":
@@ -745,7 +757,8 @@ func resolveClaimValue(value string, reqCtx *policy.RequestHeaderContext) (strin
 		if reqCtx.SharedContext.AuthContext == nil {
 			return "", false
 		}
-		key := strings.TrimPrefix(variable, "auth.property.")
+		// Use the original (non-lowercased) suffix — Properties keys are case-sensitive.
+		key := ref[len("auth.property."):]
 		val, ok := reqCtx.SharedContext.AuthContext.Properties[key]
 		return val, ok
 	default:

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -18,6 +18,7 @@
 package backendjwt
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -26,6 +27,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"os"
 	"sort"
@@ -165,14 +167,19 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	expiry := parseDuration(getString(params, "tokenExpiry", ""), defaultTokenExpiry)
 	headerName := getString(params, "header", defaultHeader)
 
+	tokenCaching := getBool(params, "tokenCaching", true)
+
 	// Resolve extra claims once — used for both the cache key and JWT population.
 	extras := resolveExtraClaims(reqCtx, params)
 
-	cacheKey := buildTokenCacheKey(authCtx, reqCtx.APIContext, reqCtx.APIVersion, extras)
-	if signed, ok := p.getCachedToken(cacheKey); ok {
-		slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
-		return policy.UpstreamRequestHeaderModifications{
-			HeadersToSet: map[string]string{headerName: signed},
+	var cacheKey string
+	if tokenCaching {
+		cacheKey = buildTokenCacheKey(authCtx, reqCtx.APIName, reqCtx.Path, reqCtx.Method, extras)
+		if signed, ok := p.getCachedToken(cacheKey); ok {
+			slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
+			return policy.UpstreamRequestHeaderModifications{
+				HeadersToSet: map[string]string{headerName: signed},
+			}
 		}
 	}
 
@@ -221,6 +228,23 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	if authCtx != nil && authCtx.CredentialID != "" {
 		claims["credential_id"] = authCtx.CredentialID
 	}
+	// For JWT auth: forward all non-standard claims from the incoming token under their
+	// original names. claimMappings and customClaims applied below can add aliases or override.
+	if authCtx != nil && authCtx.AuthType == "jwt" {
+		for k, v := range authCtx.Properties {
+			if !restrictedClaims[k] {
+				claims[k] = v
+			}
+		}
+		if len(authCtx.Scopes) > 0 {
+			scopes := make([]string, 0, len(authCtx.Scopes))
+			for s := range authCtx.Scopes {
+				scopes = append(scopes, s)
+			}
+			sort.Strings(scopes)
+			claims["scope"] = strings.Join(scopes, " ")
+		}
+	}
 	for k, v := range extras.stringClaims {
 		claims[k] = v
 	}
@@ -235,7 +259,9 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		return internalError()
 	}
 
-	p.putCachedToken(cacheKey, signed, expiry)
+	if tokenCaching {
+		p.putCachedToken(cacheKey, signed, expiry)
+	}
 	slog.Debug("Backend JWT: generated token", "header", headerName, "authType", authTypeLabel(authCtx))
 
 	return policy.UpstreamRequestHeaderModifications{
@@ -341,82 +367,139 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 	return result
 }
 
-// buildTokenCacheKey returns a hex SHA256 cache key derived from the identity signals
-// most appropriate for the given auth mechanism, plus the API context and extra claims.
-// Dispatches per AuthType so each mechanism uses only its natural identity fields.
-func buildTokenCacheKey(authCtx *policy.AuthContext, apiContext, apiVersion string, extras resolvedClaims) string {
-	var sb strings.Builder
+// keyBufPool reuses byte buffers across cache key constructions to reduce GC pressure.
+var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
-	if authCtx != nil {
-		switch authCtx.AuthType {
-		case "jwt":
-			if authCtx.TokenId != "" {
-				// jti is a strong per-token identifier — sufficient on its own.
-				sb.WriteString(authCtx.TokenId)
-			} else {
-				// No jti: include issuer to prevent cross-issuer subject collisions.
-				sb.WriteString(authCtx.Issuer)
-				sb.WriteByte('|')
-				sb.WriteString(authCtx.Subject)
-				sb.WriteByte('|')
-				sb.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
-			}
-		case "basic":
-			sb.WriteString(authCtx.Subject)
-		case "apikey":
-			// api-key-auth stores the per-application identifier in Properties["ApplicationID"].
-			// Fall back to CredentialID for other API key implementations.
-			if appID := authCtx.Properties["ApplicationID"]; appID != "" {
-				sb.WriteString(appID)
-			} else {
-				sb.WriteString(authCtx.CredentialID)
-			}
-		default:
-			// Unknown auth type: include all available identity fields.
-			sb.WriteString(authCtx.AuthType)
-			sb.WriteByte('|')
-			sb.WriteString(authCtx.CredentialID)
-			sb.WriteByte('|')
-			sb.WriteString(authCtx.Subject)
-			sb.WriteByte('|')
-			sb.WriteString(authCtx.TokenId)
-			sb.WriteByte('|')
-			sb.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
-		}
-	}
-	// authCtx == nil: identity portion is empty — all unauthenticated requests to
-	// the same API with the same extras share one backend JWT, which is correct.
-
-	sb.WriteByte('|')
-	sb.WriteString(apiContext)
-	sb.WriteByte('|')
-	sb.WriteString(apiVersion)
-
-	allKeys := sortedExtraKeys(extras)
-	for _, k := range allKeys {
-		sb.WriteByte('|')
-		sb.WriteString(k)
-		sb.WriteByte('=')
-		if v, ok := extras.stringClaims[k]; ok {
-			sb.WriteString(v)
-		} else {
-			sb.WriteString(fmt.Sprintf("%v", extras.rawClaims[k]))
-		}
+// buildTokenCacheKey returns a cache key for the token cache.
+//
+//   - TokenId, no extras:  raw concatenation — TokenId + api name + path + method.
+//   - TokenId, with extras: SHA256 of the above + resolved claim values.
+//   - authCtx nil:          FNV-64a of api name + path + method + extras.
+//   - otherwise:            FNV-64a of all identity fields + api name + path + method + extras.
+//
+// Extras (resolved customClaims / claimMappings) are included in all paths so that
+// dynamic values such as $ctx:request.header.* produce distinct cache entries per request.
+func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method string, extras resolvedClaims) string {
+	if i := strings.IndexByte(path, '?'); i != -1 {
+		path = path[:i]
 	}
 
-	sum := sha256.Sum256([]byte(sb.String()))
-	key := fmt.Sprintf("%x", sum)
+	var extraKeys []string
+	if len(extras.stringClaims) > 0 || len(extras.rawClaims) > 0 {
+		extraKeys = sortedExtraKeys(extras)
+	}
 
-	slog.Debug("Backend JWT: built token cache key",
+	if authCtx != nil && authCtx.TokenId != "" {
+		if len(extraKeys) == 0 {
+			// Fast path: no extras, no hash needed.
+			key := authCtx.TokenId + "\x00" + apiName + "\x00" + path + "\x00" + method
+			slog.Debug("Backend JWT: cache key (TokenId)", "apiName", apiName, "path", path, "method", method, "cacheKey", key)
+			return key
+		}
+		// Extras present: SHA256 to normalize key length.
+		buf := keyBufPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		buf.WriteString(authCtx.TokenId)
+		buf.WriteByte('|')
+		buf.WriteString(apiName)
+		buf.WriteByte('|')
+		buf.WriteString(path)
+		buf.WriteByte('|')
+		buf.WriteString(method)
+		appendExtras(buf, extraKeys, extras)
+		sum := sha256.Sum256(buf.Bytes())
+		keyBufPool.Put(buf)
+		key := fmt.Sprintf("%x", sum)
+		slog.Debug("Backend JWT: cache key (TokenId+claims)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		return key
+	}
+
+	buf := keyBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer keyBufPool.Put(buf)
+
+	if authCtx == nil {
+		buf.WriteString(apiName)
+		buf.WriteByte('|')
+		buf.WriteString(path)
+		buf.WriteByte('|')
+		buf.WriteString(method)
+		appendExtras(buf, extraKeys, extras)
+		key := fnvHash(buf)
+		slog.Debug("Backend JWT: cache key (no-auth)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		return key
+	}
+
+	// Non-nil authCtx without TokenId: include all available identity fields.
+	buf.WriteString(authCtx.AuthType)
+	buf.WriteByte('|')
+	buf.WriteString(authCtx.Issuer)
+	buf.WriteByte('|')
+	buf.WriteString(authCtx.Subject)
+	buf.WriteByte('|')
+	buf.WriteString(authCtx.CredentialID)
+	buf.WriteByte('|')
+	buf.WriteString(strings.Join(sortedSlice(authCtx.Audience), ","))
+	propKeys := make([]string, 0, len(authCtx.Properties))
+	for k := range authCtx.Properties {
+		propKeys = append(propKeys, k)
+	}
+	sort.Strings(propKeys)
+	for _, k := range propKeys {
+		buf.WriteByte('|')
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		buf.WriteString(authCtx.Properties[k])
+	}
+	if len(authCtx.Scopes) > 0 {
+		scopeKeys := make([]string, 0, len(authCtx.Scopes))
+		for s := range authCtx.Scopes {
+			scopeKeys = append(scopeKeys, s)
+		}
+		sort.Strings(scopeKeys)
+		buf.WriteByte('|')
+		buf.WriteString("scope=")
+		buf.WriteString(strings.Join(scopeKeys, " "))
+	}
+	buf.WriteByte('|')
+	buf.WriteString(apiName)
+	buf.WriteByte('|')
+	buf.WriteString(path)
+	buf.WriteByte('|')
+	buf.WriteString(method)
+	appendExtras(buf, extraKeys, extras)
+
+	key := fnvHash(buf)
+	slog.Debug("Backend JWT: cache key (identity hash)",
 		"authType", authTypeLabel(authCtx),
-		"apiContext", apiContext,
-		"apiVersion", apiVersion,
-		"extraClaimKeys", allKeys,
+		"apiName", apiName,
+		"path", path,
+		"method", method,
+		"extraClaimKeys", extraKeys,
 		"cacheKey", key,
 	)
-
 	return key
 }
+
+func fnvHash(buf *bytes.Buffer) string {
+	h := fnv.New64a()
+	h.Write(buf.Bytes())
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+func appendExtras(buf *bytes.Buffer, keys []string, extras resolvedClaims) {
+	for _, k := range keys {
+		buf.WriteByte('|')
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		if v, ok := extras.stringClaims[k]; ok {
+			buf.WriteString(v)
+		} else {
+			fmt.Fprintf(buf, "%v", extras.rawClaims[k])
+		}
+	}
+}
+
 
 func sortedSlice(s []string) []string {
 	out := make([]string, len(s))
@@ -581,6 +664,15 @@ func getString(params map[string]interface{}, key, defaultVal string) string {
 	if v, ok := params[key]; ok {
 		if s, ok := v.(string); ok && s != "" {
 			return s
+		}
+	}
+	return defaultVal
+}
+
+func getBool(params map[string]interface{}, key string, defaultVal bool) bool {
+	if v, ok := params[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
 		}
 	}
 	return defaultVal

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -40,7 +40,7 @@ import (
 const (
 	defaultHeader      = "x-jwt-assertion"
 	defaultTokenExpiry = 15 * time.Minute
-	defaultAlgorithm   = "RS256"
+	defaultAlgorithm   = "SHA256withRSA"
 	minCacheTTL        = 30 * time.Second
 )
 
@@ -68,6 +68,20 @@ type BackendJWTPolicy struct {
 
 	tokenMu    sync.RWMutex
 	tokenCache map[string]cachedToken
+}
+
+// algorithmEntry describes a supported JWT signing algorithm.
+// To add a new algorithm: add a single entry to the algorithms map below.
+type algorithmEntry struct {
+	method  jwt.SigningMethod
+	keyType string // "rsa", "ecdsa", or "none"
+}
+
+// algorithms is the single source of truth for supported signing algorithms.
+var algorithms = map[string]algorithmEntry{
+	"SHA256withRSA": {jwt.SigningMethodRS256, "rsa"},
+	"ES256":         {jwt.SigningMethodES256, "ecdsa"},
+	"NONE":          {jwt.SigningMethodNone, "none"},
 }
 
 var ins = &BackendJWTPolicy{
@@ -115,16 +129,26 @@ func (p *BackendJWTPolicy) Mode() policy.ProcessingMode {
 	}
 }
 
-// Validate checks that the signing key is present and parseable at config load time.
+// Validate checks the algorithm is supported and, for key-based algorithms,
+// that the signing key is present and parseable at config load time.
 func (p *BackendJWTPolicy) Validate(params map[string]interface{}) error {
+	alg := getString(params, "algorithm", defaultAlgorithm)
+	entry, ok := algorithms[alg]
+	if !ok {
+		return fmt.Errorf("unsupported algorithm %q; supported: %s", alg, algorithmList())
+	}
+	if entry.keyType == "none" {
+		return nil
+	}
 	pemBytes, err := extractSigningKeyPEM(params)
 	if err != nil {
 		return fmt.Errorf("invalid signingKey: %w", err)
 	}
-	if _, err := parsePrivateKey(pemBytes); err != nil {
+	key, err := parsePrivateKey(pemBytes)
+	if err != nil {
 		return fmt.Errorf("invalid signingKey: %w", err)
 	}
-	return nil
+	return checkKeyType(key, entry.keyType, alg)
 }
 
 // OnRequestHeaders generates a signed JWT from the auth context and sets it on the upstream request.
@@ -145,7 +169,12 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		return policy.UpstreamRequestHeaderModifications{}
 	}
 
-	algorithm := getString(params, "algorithm", defaultAlgorithm)
+	alg := getString(params, "algorithm", defaultAlgorithm)
+	entry, ok := algorithms[alg]
+	if !ok {
+		slog.Error("Backend JWT: unsupported algorithm", "algorithm", alg)
+		return internalError()
+	}
 	issuer := getString(params, "issuer", "")
 	expiry := parseDuration(getString(params, "tokenExpiry", ""), defaultTokenExpiry)
 	headerName := getString(params, "header", defaultHeader)
@@ -154,8 +183,8 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	extras := resolveExtraClaims(authCtx, reqCtx, params)
 
 	cacheKey := buildTokenCacheKey(
-		authCtx.Subject, authCtx.CredentialID, authCtx.AuthType, authCtx.Issuer,
-		reqCtx.OperationPath, issuer, algorithm, extras,
+		authCtx.CredentialID, authCtx.Subject, reqCtx.APIContext, reqCtx.APIVersion,
+		authCtx.Audience, extras,
 	)
 	if signed, ok := p.getCachedToken(cacheKey); ok {
 		slog.Debug("Backend JWT: cache hit", "subject", authCtx.Subject)
@@ -164,22 +193,26 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 		}
 	}
 
-	pemBytes, err := extractSigningKeyPEM(params)
-	if err != nil {
-		slog.Error("Backend JWT: failed to extract signing key", "error", err)
-		return internalError()
-	}
-
-	privateKey, err := p.loadKey(pemBytes)
-	if err != nil {
-		slog.Error("Backend JWT: failed to parse signing key", "error", err)
-		return internalError()
-	}
-
-	signingMethod, err := getSigningMethod(algorithm, privateKey)
-	if err != nil {
-		slog.Error("Backend JWT: unsupported algorithm or mismatched key type", "algorithm", algorithm, "error", err)
-		return internalError()
+	signingMethod := entry.method
+	var signKey interface{}
+	if entry.keyType == "none" {
+		signKey = jwt.UnsafeAllowNoneSignatureType
+	} else {
+		pemBytes, err := extractSigningKeyPEM(params)
+		if err != nil {
+			slog.Error("Backend JWT: failed to extract signing key", "error", err)
+			return internalError()
+		}
+		key, err := p.loadKey(pemBytes)
+		if err != nil {
+			slog.Error("Backend JWT: failed to parse signing key", "error", err)
+			return internalError()
+		}
+		if err := checkKeyType(key, entry.keyType, alg); err != nil {
+			slog.Error("Backend JWT: key type mismatch", "algorithm", alg, "error", err)
+			return internalError()
+		}
+		signKey = key
 	}
 
 	now := time.Now()
@@ -209,7 +242,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	}
 
 	token := jwt.NewWithClaims(signingMethod, claims)
-	signed, err := token.SignedString(privateKey)
+	signed, err := token.SignedString(signKey)
 	if err != nil {
 		slog.Error("Backend JWT: failed to sign token", "error", err)
 		return internalError()
@@ -293,10 +326,13 @@ func resolveExtraClaims(authCtx *policy.AuthContext, reqCtx *policy.RequestHeade
 	return result
 }
 
-// buildTokenCacheKey returns a hex SHA256 of all fields that determine what the generated JWT contains.
-// resolvedClaims are sorted so the key is deterministic regardless of map iteration order.
-func buildTokenCacheKey(subject, credentialID, authType, originalIssuer, operationPath, issuer, algorithm string, extras resolvedClaims) string {
-	// Collect all extra claim keys, merging both maps.
+// buildTokenCacheKey returns a hex SHA256 of the fields that determine what the generated JWT contains.
+// audience and extra claims are sorted so the key is deterministic regardless of slice/map ordering.
+func buildTokenCacheKey(credentialID, subject, apiContext, apiVersion string, audience []string, extras resolvedClaims) string {
+	sortedAud := make([]string, len(audience))
+	copy(sortedAud, audience)
+	sort.Strings(sortedAud)
+
 	allKeys := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
 	for k := range extras.stringClaims {
 		allKeys = append(allKeys, k)
@@ -309,19 +345,15 @@ func buildTokenCacheKey(subject, credentialID, authType, originalIssuer, operati
 	sort.Strings(allKeys)
 
 	var sb strings.Builder
-	sb.WriteString(subject)
-	sb.WriteByte('|')
 	sb.WriteString(credentialID)
 	sb.WriteByte('|')
-	sb.WriteString(authType)
+	sb.WriteString(subject)
 	sb.WriteByte('|')
-	sb.WriteString(originalIssuer)
+	sb.WriteString(apiContext)
 	sb.WriteByte('|')
-	sb.WriteString(operationPath)
+	sb.WriteString(apiVersion)
 	sb.WriteByte('|')
-	sb.WriteString(issuer)
-	sb.WriteByte('|')
-	sb.WriteString(algorithm)
+	sb.WriteString(strings.Join(sortedAud, ","))
 	for _, k := range allKeys {
 		sb.WriteByte('|')
 		sb.WriteString(k)
@@ -427,43 +459,29 @@ func parsePrivateKey(pemBytes []byte) (crypto.PrivateKey, error) {
 	}
 }
 
-// getSigningMethod returns the jwt.SigningMethod for the given algorithm string,
-// validating that the private key type matches.
-func getSigningMethod(algorithm string, key crypto.PrivateKey) (jwt.SigningMethod, error) {
-	switch algorithm {
-	case "RS256":
+// checkKeyType verifies that key matches the type required by the given algorithm.
+func checkKeyType(key crypto.PrivateKey, keyType, algorithm string) error {
+	switch keyType {
+	case "rsa":
 		if _, ok := key.(*rsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("RS256 requires an RSA private key, got %T", key)
+			return fmt.Errorf("%s requires an RSA private key, got %T", algorithm, key)
 		}
-		return jwt.SigningMethodRS256, nil
-	case "RS384":
-		if _, ok := key.(*rsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("RS384 requires an RSA private key, got %T", key)
-		}
-		return jwt.SigningMethodRS384, nil
-	case "RS512":
-		if _, ok := key.(*rsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("RS512 requires an RSA private key, got %T", key)
-		}
-		return jwt.SigningMethodRS512, nil
-	case "ES256":
+	case "ecdsa":
 		if _, ok := key.(*ecdsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("ES256 requires an ECDSA private key, got %T", key)
+			return fmt.Errorf("%s requires an ECDSA private key, got %T", algorithm, key)
 		}
-		return jwt.SigningMethodES256, nil
-	case "ES384":
-		if _, ok := key.(*ecdsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("ES384 requires an ECDSA private key, got %T", key)
-		}
-		return jwt.SigningMethodES384, nil
-	case "ES512":
-		if _, ok := key.(*ecdsa.PrivateKey); !ok {
-			return nil, fmt.Errorf("ES512 requires an ECDSA private key, got %T", key)
-		}
-		return jwt.SigningMethodES512, nil
-	default:
-		return nil, fmt.Errorf("unsupported algorithm %q; supported: RS256, RS384, RS512, ES256, ES384, ES512", algorithm)
 	}
+	return nil
+}
+
+// algorithmList returns a sorted, comma-separated list of supported algorithm names.
+func algorithmList() string {
+	names := make([]string, 0, len(algorithms))
+	for k := range algorithms {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 func getString(params map[string]interface{}, key, defaultVal string) string {

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -35,8 +35,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/patrickmn/go-cache"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	"github.com/wso2/api-platform/sdk/core/utils/cache"
 )
 
 const (
@@ -44,24 +44,71 @@ const (
 	defaultTokenExpiry = 15 * time.Minute
 	defaultAlgorithm   = "SHA256withRSA"
 	minCacheTTL        = 30 * time.Second
+
+	// defaultCacheMaxSize bounds the total number of cached tokens across all APIs when
+	// cacheMaxSize is unset (0). The SDK cache fixes its size at construction, so a changed
+	// cacheMaxSize is applied by rebuilding the cache (see ensureTokenCache).
+	defaultCacheMaxSize = 100_000
 )
 
 // resolvedClaims holds the extra claims derived from customClaims, split by type
 // so the cache key and JWT population can share the same resolved values.
 type resolvedClaims struct {
-	stringClaims       map[string]string      // resolved string customClaims, including $ctx: refs
-	rawClaims          map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
-	mappedSources      map[string]bool        // Properties keys consumed by claimMappings; skip in auto-forward
-	dynamicStringClaims map[string]string     // subset of stringClaims resolved from $ctx: refs; used for cache key
+	stringClaims  map[string]string      // resolved string claims: static + $ctx: customClaims and claimMappings destinations
+	rawClaims     map[string]interface{} // non-string customClaims (numbers, booleans) preserved as-is
+	mappedSources map[string]bool        // Properties keys consumed by claimMappings; skip in auto-forward
 }
 
 // BackendJWTPolicy generates a signed JWT from the authenticated user context
 // and injects it into the upstream request header. It is designed to run after
 // an authentication policy (e.g. jwt-auth, basic-auth, api-key-auth).
 type BackendJWTPolicy struct {
-	keyCache   *cache.Cache // hex(sha256 fingerprint) → crypto.PrivateKey; config-lifetime
-	pemCache   *cache.Cache // path → PEM bytes; avoids repeated file reads per cache miss
-	tokenCache *cache.Cache // cache key → signed JWT string; per-item TTL
+	keyCache sync.Map // hex(sha256 fingerprint) → crypto.PrivateKey; config-lifetime, unbounded
+	pemCache sync.Map // path → []byte PEM bytes; config-lifetime, unbounded
+
+	// cacheMu guards the tokenCache pointer and currentMaxSize. The SDK cache fixes its size at
+	// construction (no live resize), so a changed cacheMaxSize is applied by swapping in a new
+	// cache. Reads take the RLock and copy the pointer so an in-flight request keeps using a
+	// consistent cache even if a concurrent deployment rebuilds it.
+	cacheMu        sync.RWMutex
+	tokenCache     *cache.InMemoryCache[cachedToken] // single shared token cache for all APIs; globally bounded by cacheMaxSize
+	currentMaxSize int
+}
+
+// cachedToken is a signed JWT paired with the instant after which it must no longer be served.
+// The SDK cache exposes only a uniform per-cache TTL, but token lifetimes vary per API, so the
+// expiry travels in the value and is enforced on read (see getCachedToken); the cache itself is
+// created with ttl=0 (never expires entries on its own clock).
+type cachedToken struct {
+	signed    string
+	expiresAt time.Time
+}
+
+// newTokenCache builds the shared token cache, globally bounded by maxSize across all APIs.
+// ttl is 0 because expiry is enforced per entry in getCachedToken; once full, the cache's LRU
+// policy evicts the least-recently-used entry across all APIs, enforcing a single global bound.
+func newTokenCache(maxSize int) *cache.InMemoryCache[cachedToken] {
+	return cache.NewInMemoryCache[cachedToken]("backend-jwt-tokens", maxSize, 0, cache.LRUEvictionPolicy)
+}
+
+// keyNamespace carries the per-deployment configuration that shapes the generated token but is
+// not part of the caller identity. Folding it into the cache key makes the key a complete
+// function of the token: a redeploy that changes any of these fields yields a different key
+// (a cache miss), so a stale token built from the old config is never served — no separate
+// invalidation step is needed. apiName keeps each API's entries isolated even when two APIs see
+// identical identity/path/claims but differ in signing config.
+type keyNamespace struct {
+	apiName   string
+	issuer    string
+	algorithm string
+	dialect   string
+	excluded  []string // sorted excludedClaims
+}
+
+// prefix renders the namespace as a deterministic key prefix. excluded is expected pre-sorted.
+func (ns keyNamespace) prefix() string {
+	return ns.apiName + "\x00" + ns.issuer + "\x00" + ns.algorithm + "\x00" +
+		ns.dialect + "\x00" + strings.Join(ns.excluded, ",") + "\x00"
 }
 
 // algorithmEntry describes a supported JWT signing algorithm.
@@ -79,14 +126,54 @@ var algorithms = map[string]algorithmEntry{
 }
 
 var ins = &BackendJWTPolicy{
-	keyCache:   cache.New(cache.NoExpiration, 0),             // config-lifetime; no janitor needed
-	pemCache:   cache.New(cache.NoExpiration, 0),             // config-lifetime; no janitor needed
-	tokenCache: cache.New(cache.NoExpiration, 5*time.Minute), // per-item TTL; janitor evicts every 5m
+	tokenCache:     newTokenCache(defaultCacheMaxSize),
+	currentMaxSize: defaultCacheMaxSize,
 }
 
-// GetPolicy is the v1alpha2 factory entry point.
-func GetPolicy(metadata policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
+// GetPolicy is the v1alpha2 factory entry point. It is called on each API deployment and applies
+// the global cacheMaxSize from systemParameters to the shared token cache. Redeploy invalidation
+// is handled implicitly by the cache key: it folds in every token-shaping field (identity,
+// operation, claims, issuer, algorithm, dialect, excludedClaims), so a redeploy that changes any
+// of them simply misses the old entries — no explicit flush needed.
+func GetPolicy(_ policy.PolicyMetadata, params map[string]interface{}) (policy.Policy, error) {
+	// cacheMaxSize is a single global bound across all APIs. 0 (or invalid) means "use the
+	// default bound".
+	maxSize := getInt(params, "cacheMaxSize", 0)
+	if maxSize <= 0 {
+		maxSize = defaultCacheMaxSize
+	}
+	ins.ensureTokenCache(maxSize)
 	return ins, nil
+}
+
+// ensureTokenCache (re)builds the shared token cache when the configured global size changes.
+// The SDK cache fixes its size at construction (there is no live resize), so applying a new
+// cacheMaxSize means replacing the cache, which flushes all entries. This happens only on the
+// first deployment or a genuine cacheMaxSize change — steady-state redeploys leave it untouched
+// and only bump the generation.
+func (p *BackendJWTPolicy) ensureTokenCache(maxSize int) {
+	p.cacheMu.RLock()
+	if p.tokenCache != nil && p.currentMaxSize == maxSize {
+		p.cacheMu.RUnlock()
+		return
+	}
+	p.cacheMu.RUnlock()
+
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	if p.tokenCache != nil && p.currentMaxSize == maxSize {
+		return
+	}
+	p.tokenCache = newTokenCache(maxSize)
+	p.currentMaxSize = maxSize
+}
+
+// currentTokenCache returns the live token cache pointer under the read lock, so callers operate
+// on a consistent instance even if a concurrent deployment rebuilds the cache.
+func (p *BackendJWTPolicy) currentTokenCache() *cache.InMemoryCache[cachedToken] {
+	p.cacheMu.RLock()
+	defer p.cacheMu.RUnlock()
+	return p.tokenCache
 }
 
 func (p *BackendJWTPolicy) Mode() policy.ProcessingMode {
@@ -154,8 +241,15 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 
 	var cacheKey string
 	if tokenCaching {
-		cacheKey = buildTokenCacheKey(authCtx, reqCtx.APIName, reqCtx.Path, reqCtx.Method, extras)
-		if signed, ok := p.getCachedToken(cacheKey); ok {
+		ns := keyNamespace{
+			apiName:   reqCtx.APIName,
+			issuer:    issuer,
+			algorithm: alg,
+			dialect:   dialect,
+			excluded:  sortedSetKeys(excluded),
+		}
+		cacheKey = buildTokenCacheKey(ns, authCtx, reqCtx.Path, reqCtx.Method, extras)
+		if signed, ok := p.getCachedToken(ctx, cacheKey); ok {
 			slog.Debug("Backend JWT: cache hit", "authType", authTypeLabel(authCtx))
 			return policy.UpstreamRequestHeaderModifications{
 				HeadersToSet: map[string]string{headerName: signed},
@@ -238,7 +332,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	}
 
 	if tokenCaching {
-		p.putCachedToken(cacheKey, signed, expiry)
+		p.putCachedToken(ctx, cacheKey, signed, expiry)
 	}
 	slog.Debug("Backend JWT: generated token", "header", headerName, "authType", authTypeLabel(authCtx))
 
@@ -253,7 +347,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
 	fingerprint := fmt.Sprintf("%x", sha256.Sum256(pemBytes))
 
-	if key, ok := p.keyCache.Get(fingerprint); ok {
+	if key, ok := p.keyCache.Load(fingerprint); ok {
 		return key.(crypto.PrivateKey), nil
 	}
 
@@ -262,7 +356,7 @@ func (p *BackendJWTPolicy) loadKey(pemBytes []byte) (crypto.PrivateKey, error) {
 		return nil, err
 	}
 
-	p.keyCache.Set(fingerprint, parsed, cache.NoExpiration)
+	p.keyCache.Store(fingerprint, parsed)
 
 	return parsed, nil
 }
@@ -284,10 +378,9 @@ var restrictedClaims = map[string]bool{
 // rawClaims holds non-string customClaims preserved as their original types for JWT population.
 func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]interface{}) resolvedClaims {
 	result := resolvedClaims{
-		stringClaims:        make(map[string]string),
-		rawClaims:           make(map[string]interface{}),
-		mappedSources:       make(map[string]bool),
-		dynamicStringClaims: make(map[string]string),
+		stringClaims:  make(map[string]string),
+		rawClaims:     make(map[string]interface{}),
+		mappedSources: make(map[string]bool),
 	}
 
 	authCtx := reqCtx.SharedContext.AuthContext
@@ -336,9 +429,6 @@ func resolveExtraClaims(reqCtx *policy.RequestHeaderContext, params map[string]i
 					continue
 				}
 				result.stringClaims[k] = resolved
-				if strings.HasPrefix(strVal, ctxPrefix) {
-					result.dynamicStringClaims[k] = resolved
-				}
 			}
 		}
 	}
@@ -351,46 +441,47 @@ var keyBufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
 // buildTokenCacheKey returns a cache key for the token cache.
 //
-//   - TokenId, no dynamic extras:  raw concatenation — TokenId + apiName + path + method.
-//   - TokenId, with dynamic extras: SHA256 of the above + resolved $ctx: claim values.
-//   - authCtx nil:                  SHA256 of apiName + path + method + dynamic extras.
-//   - otherwise:                    SHA256 of all identity fields + apiName + path + method + dynamic extras.
+//   - TokenId, no claims:    raw concatenation — TokenId + path + method.
+//   - TokenId, with claims:  SHA256 of the above + the configured claim set.
+//   - authCtx nil:           SHA256 of path + method + the configured claim set.
+//   - otherwise:             SHA256 of all identity fields + path + method + the configured claim set.
 //
-// Only $ctx:-resolved customClaims are included in the key because they vary per-request.
-// Static customClaims and claimMappings are constant per-operation config or per-identity
-// (already captured in the identity hash), so they add no information.
-func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method string, extras resolvedClaims) string {
+// The key is a complete function of the token: ns folds in the API namespace plus the
+// token-shaping config that is not part of the caller identity (issuer, algorithm, dialect,
+// excludedClaims), and the full configured claim set is included too — static and $ctx:-resolved
+// customClaims, claimMappings destinations, and non-string custom claims. So redeploying an API
+// with any token-affecting change yields a different key (a cache miss) and never serves a token
+// built from the old config; no separate invalidation step is needed. Per-identity values (e.g.
+// mapped Properties) are already captured by the identity fields, but including the resolved
+// claim names/values also captures destination-name changes.
+func buildTokenCacheKey(ns keyNamespace, authCtx *policy.AuthContext, path, method string, extras resolvedClaims) string {
 	if i := strings.IndexByte(path, '?'); i != -1 {
 		path = path[:i]
 	}
 
-	var extraKeys []string
-	if len(extras.dynamicStringClaims) > 0 {
-		extraKeys = sortedDynamicKeys(extras)
-	}
+	nsPrefix := ns.prefix()
+	claimPairs := keyClaims(extras)
 
 	if authCtx != nil && authCtx.TokenId != "" {
-		if len(extraKeys) == 0 {
-			// Fast path: no extras, no hash needed.
-			key := authCtx.TokenId + "\x00" + apiName + "\x00" + path + "\x00" + method
-			slog.Debug("Backend JWT: cache key (TokenId)", "apiName", apiName, "path", path, "method", method, "cacheKey", key)
+		if len(claimPairs) == 0 {
+			// Fast path: no claims configured, no hash needed.
+			key := nsPrefix + authCtx.TokenId + "\x00" + path + "\x00" + method
+			slog.Debug("Backend JWT: cache key (TokenId)", "path", path, "method", method, "cacheKey", key)
 			return key
 		}
-		// Extras present: SHA256 to normalize key length.
+		// Claims present: SHA256 to normalize key length.
 		buf := keyBufPool.Get().(*bytes.Buffer)
 		buf.Reset()
 		buf.WriteString(authCtx.TokenId)
 		buf.WriteByte('|')
-		buf.WriteString(apiName)
-		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
-		appendExtras(buf, extraKeys, extras)
+		appendClaims(buf, claimPairs)
 		sum := sha256.Sum256(buf.Bytes())
 		keyBufPool.Put(buf)
-		key := fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (TokenId+claims)", "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		key := nsPrefix + fmt.Sprintf("%x", sum)
+		slog.Debug("Backend JWT: cache key (TokenId+claims)", "path", path, "method", method, "claims", claimPairs, "cacheKey", key)
 		return key
 	}
 
@@ -399,15 +490,13 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 	defer keyBufPool.Put(buf)
 
 	if authCtx == nil {
-		buf.WriteString(apiName)
-		buf.WriteByte('|')
 		buf.WriteString(path)
 		buf.WriteByte('|')
 		buf.WriteString(method)
-		appendExtras(buf, extraKeys, extras)
+		appendClaims(buf, claimPairs)
 		sum := sha256.Sum256(buf.Bytes())
-		key := fmt.Sprintf("%x", sum)
-		slog.Debug("Backend JWT: cache key (no-auth)", "apiName", apiName, "path", path, "method", method, "extraClaimKeys", extraKeys, "cacheKey", key)
+		key := nsPrefix + fmt.Sprintf("%x", sum)
+		slog.Debug("Backend JWT: cache key (no-auth)", "path", path, "method", method, "claims", claimPairs, "cacheKey", key)
 		return key
 	}
 
@@ -443,32 +532,47 @@ func buildTokenCacheKey(authCtx *policy.AuthContext, apiName, path, method strin
 		buf.WriteString(strings.Join(scopeKeys, " "))
 	}
 	buf.WriteByte('|')
-	buf.WriteString(apiName)
-	buf.WriteByte('|')
 	buf.WriteString(path)
 	buf.WriteByte('|')
 	buf.WriteString(method)
-	appendExtras(buf, extraKeys, extras)
+	appendClaims(buf, claimPairs)
 
 	sum := sha256.Sum256(buf.Bytes())
-	key := fmt.Sprintf("%x", sum)
+	key := nsPrefix + fmt.Sprintf("%x", sum)
 	slog.Debug("Backend JWT: cache key (identity hash)",
 		"authType", authTypeLabel(authCtx),
-		"apiName", apiName,
 		"path", path,
 		"method", method,
-		"extraClaimKeys", extraKeys,
+		"claims", claimPairs,
 		"cacheKey", key,
 	)
 	return key
 }
 
-func appendExtras(buf *bytes.Buffer, keys []string, extras resolvedClaims) {
-	for _, k := range keys {
+// keyClaims returns the configured claim contributions to fold into the cache key, as a sorted
+// slice of "name=value" strings covering the full resolved claim set — static and $ctx: custom
+// claims, claimMappings destinations, and non-string custom claims (formatted via fmt). Returns
+// nil when no claims are configured, enabling the no-hash fast path. Sorting the assembled pairs
+// keeps the key deterministic regardless of map iteration order.
+func keyClaims(extras resolvedClaims) []string {
+	if len(extras.stringClaims) == 0 && len(extras.rawClaims) == 0 {
+		return nil
+	}
+	pairs := make([]string, 0, len(extras.stringClaims)+len(extras.rawClaims))
+	for k, v := range extras.stringClaims {
+		pairs = append(pairs, k+"="+v)
+	}
+	for k, v := range extras.rawClaims {
+		pairs = append(pairs, k+"="+fmt.Sprintf("%v", v))
+	}
+	sort.Strings(pairs)
+	return pairs
+}
+
+func appendClaims(buf *bytes.Buffer, pairs []string) {
+	for _, p := range pairs {
 		buf.WriteByte('|')
-		buf.WriteString(k)
-		buf.WriteByte('=')
-		buf.WriteString(extras.dynamicStringClaims[k])
+		buf.WriteString(p)
 	}
 }
 
@@ -479,13 +583,14 @@ func sortedSlice(s []string) []string {
 	return out
 }
 
-func sortedDynamicKeys(extras resolvedClaims) []string {
-	keys := make([]string, 0, len(extras.dynamicStringClaims))
-	for k := range extras.dynamicStringClaims {
-		keys = append(keys, k)
+// sortedSetKeys returns the keys of a string set as a sorted slice, for deterministic key building.
+func sortedSetKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
 	}
-	sort.Strings(keys)
-	return keys
+	sort.Strings(out)
+	return out
 }
 
 func authTypeLabel(authCtx *policy.AuthContext) string {
@@ -495,25 +600,45 @@ func authTypeLabel(authCtx *policy.AuthContext) string {
 	return authCtx.AuthType
 }
 
-// getCachedToken returns a previously signed token if it exists and has not yet expired.
-// Expiry is enforced by go-cache's Get.
-func (p *BackendJWTPolicy) getCachedToken(key string) (string, bool) {
-	v, ok := p.tokenCache.Get(key)
+// getCachedToken returns a previously signed token if it exists and has not yet expired. key is
+// the complete cache key from buildTokenCacheKey (which already folds in the API namespace and
+// token-shaping config). Because the SDK cache never expires entries on its own (ttl=0), expiry
+// is enforced here against the token's stored expiresAt: an entry past its safety window is
+// deleted and reported as a miss, so an expired token is never served.
+func (p *BackendJWTPolicy) getCachedToken(ctx context.Context, key string) (string, bool) {
+	tc := p.currentTokenCache()
+	if tc == nil {
+		return "", false
+	}
+	cacheKey := cache.CacheKey{Key: key}
+	v, ok := tc.Get(ctx, cacheKey)
 	if !ok {
 		return "", false
 	}
-	return v.(string), true
+	if !time.Now().Before(v.expiresAt) {
+		_ = tc.Delete(ctx, cacheKey)
+		return "", false
+	}
+	return v.signed, true
 }
 
-// putCachedToken stores a signed token in the cache with a TTL of half the token expiry,
-// subject to a minimum of minCacheTTL. Using half the expiry avoids serving tokens that
-// are about to expire while still providing a meaningful cache window.
-func (p *BackendJWTPolicy) putCachedToken(key, signed string, tokenExpiry time.Duration) {
+// putCachedToken stores a signed token with a TTL of half the token expiry. Caching for half
+// the validity means a token served from the cache always retains a safety margin before its
+// exp. The minCacheTTL floor widens that window for short-lived tokens, but is applied only
+// when it still fits strictly inside the token's lifetime — the cache TTL must never reach or
+// exceed tokenExpiry, or the cache could serve a JWT whose exp has already passed.
+// key is the complete cache key from buildTokenCacheKey; when the shared cache is full, its LRU
+// policy evicts the least-recently-used entry across all APIs to make room.
+func (p *BackendJWTPolicy) putCachedToken(ctx context.Context, key, signed string, tokenExpiry time.Duration) {
+	tc := p.currentTokenCache()
+	if tc == nil {
+		return
+	}
 	ttl := tokenExpiry / 2
-	if ttl < minCacheTTL {
+	if ttl < minCacheTTL && minCacheTTL < tokenExpiry {
 		ttl = minCacheTTL
 	}
-	p.tokenCache.Set(key, signed, ttl)
+	_ = tc.Set(ctx, cache.CacheKey{Key: key}, cachedToken{signed: signed, expiresAt: time.Now().Add(ttl)})
 }
 
 // extractSigningKeyPEM reads PEM bytes from params["signingKey"].inline or params["signingKey"].path.
@@ -543,7 +668,7 @@ func (p *BackendJWTPolicy) extractSigningKeyPEM(params map[string]interface{}) (
 			return nil, fmt.Errorf("signingKey.path must be a non-empty string")
 		}
 
-		if cached, ok := p.pemCache.Get(path); ok {
+		if cached, ok := p.pemCache.Load(path); ok {
 			return cached.([]byte), nil
 		}
 
@@ -552,7 +677,7 @@ func (p *BackendJWTPolicy) extractSigningKeyPEM(params map[string]interface{}) (
 			return nil, fmt.Errorf("reading key file %q: %w", path, err)
 		}
 
-		p.pemCache.Set(path, data, cache.NoExpiration)
+		p.pemCache.Store(path, data)
 
 		return data, nil
 	}
@@ -628,6 +753,20 @@ func getBool(params map[string]interface{}, key string, defaultVal bool) bool {
 	if v, ok := params[key]; ok {
 		if b, ok := v.(bool); ok {
 			return b
+		}
+	}
+	return defaultVal
+}
+
+func getInt(params map[string]interface{}, key string, defaultVal int) int {
+	if v, ok := params[key]; ok {
+		switch n := v.(type) {
+		case int:
+			return n
+		case int64:
+			return int(n)
+		case float64: // JSON numbers unmarshal as float64
+			return int(n)
 		}
 	}
 	return defaultVal

--- a/policies/backend-jwt/backendjwt.go
+++ b/policies/backend-jwt/backendjwt.go
@@ -63,6 +63,7 @@ type resolvedClaims struct {
 type BackendJWTPolicy struct {
 	keyMu    sync.RWMutex
 	keyCache map[[32]byte]crypto.PrivateKey
+	pemCache map[string][]byte // path → PEM bytes; avoids repeated file reads per cache miss
 
 	tokenMu    sync.RWMutex
 	tokenCache map[string]cachedToken
@@ -84,6 +85,7 @@ var algorithms = map[string]algorithmEntry{
 
 var ins = &BackendJWTPolicy{
 	keyCache:   make(map[[32]byte]crypto.PrivateKey),
+	pemCache:   make(map[string][]byte),
 	tokenCache: make(map[string]cachedToken),
 }
 
@@ -138,7 +140,7 @@ func (p *BackendJWTPolicy) Validate(params map[string]interface{}) error {
 	if entry.keyType == "none" {
 		return nil
 	}
-	pemBytes, err := extractSigningKeyPEM(params)
+	pemBytes, err := p.extractSigningKeyPEM(params)
 	if err != nil {
 		return fmt.Errorf("invalid signingKey: %w", err)
 	}
@@ -196,7 +198,7 @@ func (p *BackendJWTPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	if entry.keyType == "none" {
 		signKey = jwt.UnsafeAllowNoneSignatureType
 	} else {
-		pemBytes, err := extractSigningKeyPEM(params)
+		pemBytes, err := p.extractSigningKeyPEM(params)
 		if err != nil {
 			slog.Error("Backend JWT: failed to extract signing key", "error", err)
 			return internalError()
@@ -392,7 +394,9 @@ func (p *BackendJWTPolicy) putCachedToken(key, signed string, tokenExpiry time.D
 }
 
 // extractSigningKeyPEM reads PEM bytes from params["signingKey"].inline or params["signingKey"].path.
-func extractSigningKeyPEM(params map[string]interface{}) ([]byte, error) {
+// Path-based keys are cached after the first read so that token cache misses under high load do not
+// repeatedly hit the filesystem. Key rotation requires a gateway restart.
+func (p *BackendJWTPolicy) extractSigningKeyPEM(params map[string]interface{}) ([]byte, error) {
 	signingKeyRaw, ok := params["signingKey"]
 	if !ok {
 		return nil, fmt.Errorf("signingKey is required")
@@ -415,10 +419,23 @@ func extractSigningKeyPEM(params map[string]interface{}) ([]byte, error) {
 		if !ok || path == "" {
 			return nil, fmt.Errorf("signingKey.path must be a non-empty string")
 		}
+
+		p.keyMu.RLock()
+		cached, ok := p.pemCache[path]
+		p.keyMu.RUnlock()
+		if ok {
+			return cached, nil
+		}
+
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading key file %q: %w", path, err)
 		}
+
+		p.keyMu.Lock()
+		p.pemCache[path] = data
+		p.keyMu.Unlock()
+
 		return data, nil
 	}
 

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -219,9 +219,6 @@ func TestGeneratesJWTWithSubject(t *testing.T) {
 	if claims["iss"] != "https://gateway.example.com" {
 		t.Errorf("expected iss=https://gateway.example.com, got %v", claims["iss"])
 	}
-	if claims["original_iss"] != "https://idp.example.com" {
-		t.Errorf("expected original_iss=https://idp.example.com, got %v", claims["original_iss"])
-	}
 }
 
 func TestCustomClaims(t *testing.T) {

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -103,6 +103,14 @@ func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
 	return key, string(pemBytes)
 }
 
+func newTestPolicy() *BackendJWTPolicy {
+	return &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
+		tokenCache: make(map[string]cachedToken),
+	}
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 func TestGetPolicySingleton(t *testing.T) {
@@ -120,7 +128,7 @@ func TestGetPolicySingleton(t *testing.T) {
 }
 
 func TestMode(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	mode := p.Mode()
 	if mode.RequestHeaderMode != policy.HeaderModeProcess {
 		t.Errorf("expected RequestHeaderMode=HeaderModeProcess, got %v", mode.RequestHeaderMode)
@@ -139,7 +147,7 @@ func TestMode(t *testing.T) {
 
 func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(nil)
@@ -180,7 +188,7 @@ func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 
 func TestGeneratesJWTWithSubject(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -218,7 +226,7 @@ func TestGeneratesJWTWithSubject(t *testing.T) {
 
 func TestCustomClaims(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"env":     "production",
@@ -246,7 +254,7 @@ func TestCustomClaims(t *testing.T) {
 
 func TestTokenExpiry(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["tokenExpiry"] = "5m"
 
@@ -279,9 +287,36 @@ func TestTokenExpiry(t *testing.T) {
 	}
 }
 
+func TestTokenExpiry_UserOverridesSystem(t *testing.T) {
+	// Simulate the engine merge: system sets tokenExpiry="15m", user API sets "2m".
+	// User value must win — the flat params map carries the merged result.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["tokenExpiry"] = "2m" // user-level override
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "dave"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	expRaw, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatal("exp claim missing or not a number")
+	}
+	iatRaw, ok := claims["iat"].(float64)
+	if !ok {
+		t.Fatal("iat claim missing or not a number")
+	}
+	diff := time.Unix(int64(expRaw), 0).Sub(time.Unix(int64(iatRaw), 0))
+	if diff < 1*time.Minute || diff > 3*time.Minute {
+		t.Errorf("user tokenExpiry override: expected exp-iat≈2m, got %v", diff)
+	}
+}
+
 func TestSHA256withRSASigning(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rsa-user"})
@@ -306,7 +341,7 @@ func TestSHA256withRSASigning(t *testing.T) {
 
 func TestES256Signing(t *testing.T) {
 	ecKey, keyPEM := generateECKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 		"algorithm":  "ES256",
@@ -333,7 +368,7 @@ func TestES256Signing(t *testing.T) {
 
 func TestMismatchedAlgorithmAndKey(t *testing.T) {
 	_, ecKeyPEM := generateECKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": ecKeyPEM},
 		"algorithm":  "SHA256withRSA", // EC key with RSA algorithm
@@ -353,7 +388,7 @@ func TestMismatchedAlgorithmAndKey(t *testing.T) {
 
 func TestCustomHeader(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["header"] = "x-custom-backend-token"
 
@@ -370,7 +405,7 @@ func TestCustomHeader(t *testing.T) {
 }
 
 func TestInvalidPrivateKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "not-a-valid-pem-key",
@@ -392,7 +427,7 @@ func TestInvalidPrivateKey(t *testing.T) {
 
 
 func TestValidate_MissingKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	err := p.Validate(map[string]interface{}{})
 	if err == nil {
 		t.Error("Validate must return error when signingKey is absent")
@@ -400,7 +435,7 @@ func TestValidate_MissingKey(t *testing.T) {
 }
 
 func TestValidate_InvalidKeyMaterial(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "-----BEGIN RSA PRIVATE KEY-----\nbaddata\n-----END RSA PRIVATE KEY-----",
@@ -413,7 +448,7 @@ func TestValidate_InvalidKeyMaterial(t *testing.T) {
 
 func TestValidate_ValidKey(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 	})
@@ -434,7 +469,7 @@ func TestKeyFilePath(t *testing.T) {
 	}
 	f.Close()
 
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"path": f.Name()},
 		"algorithm":  "SHA256withRSA",
@@ -462,7 +497,7 @@ func TestPEMFileCachedAfterFirstRead(t *testing.T) {
 	}
 	f.Close()
 
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"path": f.Name()},
 		"algorithm":  "SHA256withRSA",
@@ -490,7 +525,7 @@ func TestPEMFileCachedAfterFirstRead(t *testing.T) {
 
 func TestKeyCaching(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "judy"}
@@ -515,7 +550,7 @@ func TestKeyCaching(t *testing.T) {
 
 func TestAudienceAndCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -542,36 +577,8 @@ func TestAudienceAndCredentialID(t *testing.T) {
 
 // ─── Algorithm Tests ──────────────────────────────────────────────────────────
 
-func TestAlgorithm_SHA256withRSA(t *testing.T) {
-	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
-	params := map[string]interface{}{
-		"signingKey":  map[string]interface{}{"inline": keyPEM},
-		"algorithm":   "SHA256withRSA",
-		"issuer":      "https://gateway.example.com",
-		"tokenExpiry": "15m",
-	}
-
-	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice"})
-	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
-	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
-	if !ok {
-		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
-	}
-
-	tokenStr := mods.HeadersToSet[defaultHeader]
-	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
-	if err != nil {
-		t.Fatalf("parse unverified: %v", err)
-	}
-	if token.Method != jwt.SigningMethodRS256 {
-		t.Errorf("SHA256withRSA must produce RS256 token, got %v", token.Method.Alg())
-	}
-	decodeJWT(t, tokenStr, &rsaKey.PublicKey)
-}
-
 func TestAlgorithm_NONE(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"algorithm":   "NONE",
 		"tokenExpiry": "15m",
@@ -598,7 +605,7 @@ func TestAlgorithm_NONE(t *testing.T) {
 }
 
 func TestAlgorithm_NONE_ValidateSkipsKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	err := p.Validate(map[string]interface{}{
 		"algorithm": "NONE",
 		// no signingKey — must not error
@@ -610,7 +617,7 @@ func TestAlgorithm_NONE_ValidateSkipsKey(t *testing.T) {
 
 func TestAlgorithm_UnknownReturns500(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 		"algorithm":  "SuperAlgorithmXYZ",
@@ -631,11 +638,7 @@ func TestAlgorithm_UnknownReturns500(t *testing.T) {
 
 func TestTokenCache_HitReturnsSameToken(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", CredentialID: "client-1"}
 
@@ -660,11 +663,7 @@ func TestTokenCache_HitReturnsSameToken(t *testing.T) {
 
 func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	r1 := p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
@@ -683,11 +682,7 @@ func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
 
 func TestTokenCache_MissOnDifferentPath(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "carol"}
 
@@ -719,7 +714,7 @@ func TestTokenCache_MissOnDifferentPath(t *testing.T) {
 func TestTokenCache_QueryParamsIgnored(t *testing.T) {
 	// Requests to the same path with different query strings must share one cache entry.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
 
@@ -745,11 +740,7 @@ func TestTokenCache_QueryParamsIgnored(t *testing.T) {
 
 func TestTokenCache_MissOnDifferentCustomClaim(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "dave"}
 
 	params := map[string]interface{}{
@@ -783,11 +774,7 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 	// We test this at the helper level (not via OnRequestHeaders) because RSA PKCS1v15
 	// is deterministic — re-signing the same claims in the same second produces the
 	// same token string, making "different string" an unreliable expiry signal.
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 
 	p.putCachedToken("key-a", "sentinel-live", time.Hour)
 	p.putCachedToken("key-b", "sentinel-expired", time.Hour)
@@ -811,11 +798,7 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 }
 
 func TestTokenCache_EvictExpired(t *testing.T) {
-	p := &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
-	}
+	p := newTestPolicy()
 	now := time.Now()
 
 	p.tokenMu.Lock()
@@ -843,7 +826,7 @@ func TestTokenCache_EvictExpired(t *testing.T) {
 func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
 	// Different jti on same subject/issuer must produce separate cache entries.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
@@ -866,7 +849,7 @@ func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
 func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
 	// Same jti must hit the cache regardless of other fields.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{
 		Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz",
@@ -886,7 +869,7 @@ func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
 func TestTokenCacheKey_JWT_SameJTI_DifferentHeaderMisses(t *testing.T) {
 	// Same jti but different resolved dynamic claim ($ctx:request.header.*) must not share a cache entry.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"}
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
@@ -913,7 +896,7 @@ func TestTokenCacheKey_JWT_SameJTI_DifferentHeaderMisses(t *testing.T) {
 func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
 	// Without jti, tokens from different issuers with the same subject must not collide.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
@@ -934,7 +917,7 @@ func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
 func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
 	// Different API key ApplicationIDs must produce separate cache entries.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
@@ -957,7 +940,7 @@ func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
 func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
 	// Identical auth context must share one cache entry.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{
 		Authenticated: true, AuthType: "apikey",
@@ -978,7 +961,7 @@ func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
 func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
 	// Multiple unauthenticated requests to the same API must share one cache entry.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
@@ -995,7 +978,7 @@ func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
 func TestTokenCaching_Disabled_NoCacheEntries(t *testing.T) {
 	// With tokenCaching=false, repeated identical requests must not populate the cache.
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["tokenCaching"] = false
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
@@ -1015,7 +998,7 @@ func TestTokenCaching_Disabled_NoCacheEntries(t *testing.T) {
 
 func TestContextClaims_StaticPassthrough(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"env": "production"}
 
@@ -1031,7 +1014,7 @@ func TestContextClaims_StaticPassthrough(t *testing.T) {
 
 func TestContextClaims_RequestPath(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"req_path": "$ctx:request.path"}
 
@@ -1057,7 +1040,7 @@ func TestContextClaims_RequestPath(t *testing.T) {
 
 func TestContextClaims_RequestHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -1083,7 +1066,7 @@ func TestContextClaims_RequestHeader(t *testing.T) {
 
 func TestContextClaims_APIName(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"api": "$ctx:api.name"}
 
@@ -1110,7 +1093,7 @@ func TestContextClaims_APIName(t *testing.T) {
 
 func TestContextClaims_AuthCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"clientId": "$ctx:auth.credential_id"}
 
@@ -1132,7 +1115,7 @@ func TestContextClaims_AuthCredentialID(t *testing.T) {
 
 func TestContextClaims_AuthProperty(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"clientName": "$ctx:auth.property.client_name"}
 
@@ -1154,7 +1137,7 @@ func TestContextClaims_AuthProperty(t *testing.T) {
 
 func TestContextClaims_MissingHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -1172,7 +1155,7 @@ func TestContextClaims_MissingHeader(t *testing.T) {
 
 func TestContextClaims_UnknownVariable(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"x": "$ctx:unknown.variable.name"}
 
@@ -1217,7 +1200,7 @@ func TestContextClaims_NilAuthContext(t *testing.T) {
 
 func TestCustomClaims_RestrictedClaimsSkippedWithWarn(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"iss": "https://custom-issuer.example.com",
@@ -1250,7 +1233,7 @@ func TestCustomClaims_RestrictedClaimsSkippedWithWarn(t *testing.T) {
 
 func TestClaimMappings_Basic(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["claimMappings"] = map[string]interface{}{
 		"clientEmail": "email",
@@ -1278,7 +1261,7 @@ func TestClaimMappings_Basic(t *testing.T) {
 
 func TestClaimMappings_MissingPropertySkipped(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["claimMappings"] = map[string]interface{}{
 		"orgId": "organization", // "organization" not in Properties
@@ -1302,7 +1285,7 @@ func TestClaimMappings_MissingPropertySkipped(t *testing.T) {
 
 func TestClaimMappings_RestrictedDestinationSkipped(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["claimMappings"] = map[string]interface{}{
 		"sub": "injected_subject", // "sub" is restricted
@@ -1330,7 +1313,7 @@ func TestJWTClaimsPassthrough_PropertiesForwarded(t *testing.T) {
 	// All non-standard JWT claims in Properties must appear in the backend JWT
 	// under their original names when auth type is jwt.
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -1358,7 +1341,7 @@ func TestJWTClaimsPassthrough_PropertiesForwarded(t *testing.T) {
 func TestJWTClaimsPassthrough_ScopesForwarded(t *testing.T) {
 	// Scopes must be forwarded as a space-delimited "scope" claim.
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -1389,7 +1372,7 @@ func TestJWTClaimsPassthrough_ScopesForwarded(t *testing.T) {
 func TestJWTClaimsPassthrough_CustomClaimsOverrideProperty(t *testing.T) {
 	// customClaims must override auto-forwarded Properties for the same key.
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"role": "superadmin"}
 
@@ -1412,7 +1395,7 @@ func TestJWTClaimsPassthrough_CustomClaimsOverrideProperty(t *testing.T) {
 func TestJWTClaimsPassthrough_NotForwardedForNonJWTAuth(t *testing.T) {
 	// Properties must NOT be auto-forwarded for non-JWT auth types (e.g. basic).
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -1435,7 +1418,7 @@ func TestTokenCacheKey_JWT_DifferentProperties_NoJTI(t *testing.T) {
 	// Without jti, tokens with same identity but different custom claims must produce
 	// separate cache entries (because the backend JWT content differs).
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 
 	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
@@ -1457,7 +1440,7 @@ func TestTokenCacheKey_JWT_DifferentProperties_NoJTI(t *testing.T) {
 
 func TestClaimMappings_CustomClaimsOverride(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	p := newTestPolicy()
 	params := baseParams(keyPEM)
 	params["claimMappings"] = map[string]interface{}{
 		"role": "role", // maps Properties["role"] → "role"

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -551,3 +551,207 @@ func TestAudienceAndCredentialID(t *testing.T) {
 	}
 	_ = audRaw // audience is present; exact type depends on JWT library serialisation
 }
+
+// ─── Context Claims Tests ─────────────────────────────────────────────────────
+
+func TestContextClaims_StaticPassthrough(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"env": "production"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "leo"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["env"] != "production" {
+		t.Errorf("expected env=production, got %v", claims["env"])
+	}
+}
+
+func TestContextClaims_RequestPath(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"req_path": "$ctx:request.path"}
+
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:   "r1",
+			Metadata:    make(map[string]interface{}),
+			AuthContext: &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "mia"},
+		},
+		Headers: policy.NewHeaders(map[string][]string{}),
+		Path:    "/petstore/v1/pets/42",
+		Method:  "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["req_path"] != "/petstore/v1/pets/42" {
+		t.Errorf("expected req_path=/petstore/v1/pets/42, got %v", claims["req_path"])
+	}
+}
+
+func TestContextClaims_RequestHeader(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
+
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:   "r2",
+			Metadata:    make(map[string]interface{}),
+			AuthContext: &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "noah"},
+		},
+		Headers: policy.NewHeaders(map[string][]string{"x-tenant-id": {"acme-corp"}}),
+		Path:    "/api/v1/data",
+		Method:  "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["tenant"] != "acme-corp" {
+		t.Errorf("expected tenant=acme-corp, got %v", claims["tenant"])
+	}
+}
+
+func TestContextClaims_APIName(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"api": "$ctx:api.name"}
+
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:   "r3",
+			Metadata:    make(map[string]interface{}),
+			APIName:     "PetStoreAPI",
+			AuthContext: &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "olivia"},
+		},
+		Headers: policy.NewHeaders(map[string][]string{}),
+		Path:    "/api/v1",
+		Method:  "GET",
+	}
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["api"] != "PetStoreAPI" {
+		t.Errorf("expected api=PetStoreAPI, got %v", claims["api"])
+	}
+}
+
+func TestContextClaims_AuthCredentialID(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"applicationId": "$ctx:auth.credential_id"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "apikey",
+		Subject:       "peter",
+		CredentialID:  "app-xyz-999",
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["applicationId"] != "app-xyz-999" {
+		t.Errorf("expected applicationId=app-xyz-999, got %v", claims["applicationId"])
+	}
+}
+
+func TestContextClaims_AuthProperty(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"appName": "$ctx:auth.property.application_name"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "quinn",
+		Properties:    map[string]string{"application_name": "MyMobileApp"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["appName"] != "MyMobileApp" {
+		t.Errorf("expected appName=MyMobileApp, got %v", claims["appName"])
+	}
+}
+
+func TestContextClaims_MissingHeader(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "ryan"})
+	// x-tenant-id header is not set
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if _, present := claims["tenant"]; present {
+		t.Error("claim for missing header must be silently skipped")
+	}
+}
+
+func TestContextClaims_UnknownVariable(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"x": "$ctx:unknown.variable.name"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "sam"})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if _, present := claims["x"]; present {
+		t.Error("claim for unknown $ctx variable must be silently skipped")
+	}
+}
+
+func TestContextClaims_NilAuthContext(t *testing.T) {
+	// resolveClaimValue must return ("", false) for auth.* when AuthContext is nil —
+	// verify this directly since the full pipeline requires an authenticated context.
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "r9",
+			Metadata:  make(map[string]interface{}),
+			// AuthContext is deliberately nil
+		},
+		Headers: policy.NewHeaders(map[string][]string{}),
+		Path:    "/test",
+		Method:  "GET",
+	}
+
+	authVars := []string{
+		"$ctx:auth.credential_id",
+		"$ctx:auth.subject",
+		"$ctx:auth.type",
+		"$ctx:auth.property.foo",
+	}
+	for _, v := range authVars {
+		resolved, ok := resolveClaimValue(v, reqCtx)
+		if ok || resolved != "" {
+			t.Errorf("resolveClaimValue(%q) with nil AuthContext: expected (\"\", false), got (%q, %v)", v, resolved, ok)
+		}
+	}
+}

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -1485,3 +1485,214 @@ func TestClaimMappings_CustomClaimsOverride(t *testing.T) {
 		t.Errorf("customClaims must override claimMappings for same key, got %v", claims["role"])
 	}
 }
+
+// ─── Dialect Tests ────────────────────────────────────────────────────────────
+
+func TestDialect_PrefixesForwardedClaims(t *testing.T) {
+	// Dialect must prefix auto-forwarded original-JWT claims; the bare key must be absent.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["dialect"] = "http://wso2.org/claims/"
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	// Prefixed keys must be present.
+	if claims["http://wso2.org/claims/email"] != "alice@example.com" {
+		t.Errorf("expected prefixed claim http://wso2.org/claims/email=alice@example.com, got %v", claims["http://wso2.org/claims/email"])
+	}
+	if claims["http://wso2.org/claims/role"] != "admin" {
+		t.Errorf("expected prefixed claim http://wso2.org/claims/role=admin, got %v", claims["http://wso2.org/claims/role"])
+	}
+	// Bare keys must not be present.
+	if _, present := claims["email"]; present {
+		t.Errorf("bare key 'email' must not appear when dialect is set; only the prefixed form should")
+	}
+	if _, present := claims["role"]; present {
+		t.Errorf("bare key 'role' must not appear when dialect is set; only the prefixed form should")
+	}
+}
+
+func TestDialect_DoesNotAffectStandardOrConfiguredClaims(t *testing.T) {
+	// dialect must not affect sub, scope, or explicitly configured claimMappings/customClaims.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["dialect"] = "http://wso2.org/claims/"
+	params["customClaims"] = map[string]interface{}{"org": "acme"}
+	params["claimMappings"] = map[string]interface{}{"clientEmail": "email"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Scopes:        map[string]bool{"read": true},
+		Properties:    map[string]string{"email": "alice@example.com"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	// Standard claims must use their standard names (no prefix).
+	if claims["sub"] != "alice" {
+		t.Errorf("sub must not be prefixed, got %v", claims["sub"])
+	}
+	if claims["scope"] != "read" {
+		t.Errorf("scope must not be prefixed, got %v", claims["scope"])
+	}
+	// customClaims must use their configured name (no prefix).
+	if claims["org"] != "acme" {
+		t.Errorf("customClaim 'org' must not be prefixed by dialect, got %v", claims["org"])
+	}
+	// claimMappings must use their configured destination name (no prefix).
+	if claims["clientEmail"] != "alice@example.com" {
+		t.Errorf("claimMapping destination 'clientEmail' must not be prefixed by dialect, got %v", claims["clientEmail"])
+	}
+}
+
+// ─── ExcludedClaims Tests ─────────────────────────────────────────────────────
+
+func TestExcludedClaims_DropsListedClaims(t *testing.T) {
+	// Listed claims must not appear; non-listed claims must still be forwarded.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["excludedClaims"] = []interface{}{"role"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin", "org": "acme"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if _, present := claims["role"]; present {
+		t.Errorf("excluded claim 'role' must not be forwarded to the backend JWT")
+	}
+	// Non-excluded claims must still be forwarded.
+	if claims["email"] != "alice@example.com" {
+		t.Errorf("non-excluded claim 'email' must still be forwarded, got %v", claims["email"])
+	}
+	if claims["org"] != "acme" {
+		t.Errorf("non-excluded claim 'org' must still be forwarded, got %v", claims["org"])
+	}
+}
+
+// ─── Combined Dialect + ExcludedClaims Tests ─────────────────────────────────
+
+func TestDialectAndExcludedClaims_Combined(t *testing.T) {
+	// Excluded claim must be absent even with dialect set; remaining claims must be prefixed.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["dialect"] = "http://wso2.org/claims/"
+	params["excludedClaims"] = []interface{}{"role"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	// Excluded claim must be absent in both prefixed and bare form.
+	if _, present := claims["role"]; present {
+		t.Errorf("excluded claim 'role' (bare) must not appear")
+	}
+	if _, present := claims["http://wso2.org/claims/role"]; present {
+		t.Errorf("excluded claim 'role' (prefixed) must not appear")
+	}
+	// Non-excluded claim must appear under the prefixed key.
+	if claims["http://wso2.org/claims/email"] != "alice@example.com" {
+		t.Errorf("non-excluded claim must appear prefixed, got %v", claims["http://wso2.org/claims/email"])
+	}
+	// Bare non-excluded key must not appear.
+	if _, present := claims["email"]; present {
+		t.Errorf("bare 'email' must not appear when dialect is set")
+	}
+}
+
+// ─── Empty Defaults Regression Guard ─────────────────────────────────────────
+
+func TestDialectAndExcludedClaims_EmptyDefaults_PreserveCurrentBehavior(t *testing.T) {
+	// With no dialect and no excludedClaims, forwarding behavior must be identical
+	// to the pre-feature baseline: bare original claim names forwarded unchanged.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	// Explicitly set empty values (matching the param defaults).
+	params["dialect"] = ""
+	params["excludedClaims"] = []interface{}{}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["email"] != "alice@example.com" {
+		t.Errorf("empty dialect: 'email' must be forwarded as-is, got %v", claims["email"])
+	}
+	if claims["role"] != "admin" {
+		t.Errorf("empty dialect: 'role' must be forwarded as-is, got %v", claims["role"])
+	}
+	if claims["sub"] != "alice" {
+		t.Errorf("sub must be present, got %v", claims["sub"])
+	}
+}
+
+func TestClaimMapping_SourceNotDuplicated(t *testing.T) {
+	// A claim that is remapped via claimMappings must appear ONLY under its destination
+	// name — the original source key must not also appear in the backend JWT.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"user_email": "email", // source "email" → dest "user_email"
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["user_email"] != "alice@example.com" {
+		t.Errorf("claimMapping destination 'user_email' must be present, got %v", claims["user_email"])
+	}
+	if _, ok := claims["email"]; ok {
+		t.Errorf("claimMapping source 'email' must not appear in the backend JWT (got %v)", claims["email"])
+	}
+	// Non-remapped claims still forwarded normally.
+	if claims["role"] != "admin" {
+		t.Errorf("non-mapped claim 'role' must still be forwarded, got %v", claims["role"])
+	}
+}

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -1027,14 +1027,14 @@ func TestContextClaims_NilAuthContext(t *testing.T) {
 	}
 }
 
-func TestCustomClaims_RestrictedClaimsOverrideWithWarn(t *testing.T) {
+func TestCustomClaims_RestrictedClaimsSkippedWithWarn(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"iss": "https://custom-issuer.example.com",
 		"sub": "overridden-subject",
-		"env": "production", // non-restricted, must also be present
+		"env": "production", // non-restricted, must still be present
 	}
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -1047,13 +1047,118 @@ func TestCustomClaims_RestrictedClaimsOverrideWithWarn(t *testing.T) {
 	mods := result.(policy.UpstreamRequestHeaderModifications)
 	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
 
-	if claims["iss"] != "https://custom-issuer.example.com" {
-		t.Errorf("iss must be overridden by customClaims, got %v", claims["iss"])
+	// Restricted claims must NOT be overridden — standard values win.
+	if claims["iss"] == "https://custom-issuer.example.com" {
+		t.Errorf("iss must not be overridden by customClaims; restricted claim should be skipped")
 	}
-	if claims["sub"] != "overridden-subject" {
-		t.Errorf("sub must be overridden by customClaims, got %v", claims["sub"])
+	if claims["sub"] != "alice" {
+		t.Errorf("sub must equal AuthContext.Subject (alice), got %v", claims["sub"])
 	}
+	// Non-restricted claims must still be set.
 	if claims["env"] != "production" {
 		t.Errorf("non-restricted claim env must still be set, got %v", claims["env"])
+	}
+}
+
+func TestClaimMappings_Basic(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"clientEmail": "email",
+		"clientRole":  "role",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["clientEmail"] != "alice@example.com" {
+		t.Errorf("clientEmail must be mapped from Properties[email], got %v", claims["clientEmail"])
+	}
+	if claims["clientRole"] != "admin" {
+		t.Errorf("clientRole must be mapped from Properties[role], got %v", claims["clientRole"])
+	}
+}
+
+func TestClaimMappings_MissingPropertySkipped(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"orgId": "organization", // "organization" not in Properties
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if _, present := claims["orgId"]; present {
+		t.Errorf("orgId should be absent when source property is missing, got %v", claims["orgId"])
+	}
+}
+
+func TestClaimMappings_RestrictedDestinationSkipped(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"sub": "injected_subject", // "sub" is restricted
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"injected_subject": "mallory"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["sub"] != "alice" {
+		t.Errorf("sub must equal AuthContext.Subject (alice) when claimMapping target is restricted, got %v", claims["sub"])
+	}
+}
+
+func TestClaimMappings_CustomClaimsOverride(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"role": "role", // maps Properties["role"] → "role"
+	}
+	params["customClaims"] = map[string]interface{}{
+		"role": "superadmin", // customClaims must win over claimMappings
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"role": "viewer"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["role"] != "superadmin" {
+		t.Errorf("customClaims must override claimMappings for same key, got %v", claims["role"])
 	}
 }

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -254,40 +254,6 @@ func TestCustomClaims(t *testing.T) {
 	}
 }
 
-func TestClaimMappings(t *testing.T) {
-	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
-	params := baseParams(keyPEM)
-	params["claimMappings"] = map[string]interface{}{
-		"app_id":  "application_id",
-		"dept":    "department",
-		"missing": "should_not_appear",
-	}
-
-	reqCtx := newRequestContext(&policy.AuthContext{
-		Authenticated: true,
-		AuthType:      "apikey",
-		Subject:       "carol",
-		Properties: map[string]string{
-			"app_id": "app-xyz-123",
-			"dept":   "engineering",
-		},
-	})
-
-	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
-	mods := result.(policy.UpstreamRequestHeaderModifications)
-	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
-
-	if claims["application_id"] != "app-xyz-123" {
-		t.Errorf("expected application_id=app-xyz-123, got %v", claims["application_id"])
-	}
-	if claims["department"] != "engineering" {
-		t.Errorf("expected department=engineering, got %v", claims["department"])
-	}
-	if _, present := claims["should_not_appear"]; present {
-		t.Error("claim for missing property key must not appear in token")
-	}
-}
 
 func TestTokenExpiry(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
@@ -925,21 +891,21 @@ func TestContextClaims_AuthCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
-	params["customClaims"] = map[string]interface{}{"applicationId": "$ctx:auth.credential_id"}
+	params["customClaims"] = map[string]interface{}{"clientId": "$ctx:auth.credential_id"}
 
 	reqCtx := newRequestContext(&policy.AuthContext{
 		Authenticated: true,
 		AuthType:      "apikey",
 		Subject:       "peter",
-		CredentialID:  "app-xyz-999",
+		CredentialID:  "cred-xyz-999",
 	})
 
 	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
 	mods := result.(policy.UpstreamRequestHeaderModifications)
 	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
 
-	if claims["applicationId"] != "app-xyz-999" {
-		t.Errorf("expected applicationId=app-xyz-999, got %v", claims["applicationId"])
+	if claims["clientId"] != "cred-xyz-999" {
+		t.Errorf("expected clientId=cred-xyz-999, got %v", claims["clientId"])
 	}
 }
 
@@ -947,21 +913,21 @@ func TestContextClaims_AuthProperty(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
-	params["customClaims"] = map[string]interface{}{"appName": "$ctx:auth.property.application_name"}
+	params["customClaims"] = map[string]interface{}{"clientName": "$ctx:auth.property.client_name"}
 
 	reqCtx := newRequestContext(&policy.AuthContext{
 		Authenticated: true,
 		AuthType:      "jwt",
 		Subject:       "quinn",
-		Properties:    map[string]string{"application_name": "MyMobileApp"},
+		Properties:    map[string]string{"client_name": "MyService"},
 	})
 
 	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
 	mods := result.(policy.UpstreamRequestHeaderModifications)
 	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
 
-	if claims["appName"] != "MyMobileApp" {
-		t.Errorf("expected appName=MyMobileApp, got %v", claims["appName"])
+	if claims["clientName"] != "MyService" {
+		t.Errorf("expected clientName=MyService, got %v", claims["clientName"])
 	}
 }
 
@@ -1025,5 +991,36 @@ func TestContextClaims_NilAuthContext(t *testing.T) {
 		if ok || resolved != "" {
 			t.Errorf("resolveClaimValue(%q) with nil AuthContext: expected (\"\", false), got (%q, %v)", v, resolved, ok)
 		}
+	}
+}
+
+func TestCustomClaims_RestrictedClaimsOverrideWithWarn(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{
+		"iss": "https://custom-issuer.example.com",
+		"sub": "overridden-subject",
+		"env": "production", // non-restricted, must also be present
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["iss"] != "https://custom-issuer.example.com" {
+		t.Errorf("iss must be overridden by customClaims, got %v", claims["iss"])
+	}
+	if claims["sub"] != "overridden-subject" {
+		t.Errorf("sub must be overridden by customClaims, got %v", claims["sub"])
+	}
+	if claims["env"] != "production" {
+		t.Errorf("non-restricted claim env must still be set, got %v", claims["env"])
 	}
 }

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -1519,8 +1519,9 @@ func TestDialect_PrefixesForwardedClaims(t *testing.T) {
 	}
 }
 
-func TestDialect_DoesNotAffectStandardOrConfiguredClaims(t *testing.T) {
-	// dialect must not affect sub, scope, or explicitly configured claimMappings/customClaims.
+func TestDialect_PrefixesConfiguredClaims(t *testing.T) {
+	// dialect must prefix customClaims and claimMappings destinations as well as auto-forwarded claims.
+	// Standard claims (sub, scope, iss, etc.) set by the policy itself must never be prefixed.
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := newTestPolicy()
 	params := baseParams(keyPEM)
@@ -1540,20 +1541,26 @@ func TestDialect_DoesNotAffectStandardOrConfiguredClaims(t *testing.T) {
 	mods := result.(policy.UpstreamRequestHeaderModifications)
 	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
 
-	// Standard claims must use their standard names (no prefix).
+	// Standard claims must use their standard names — never prefixed.
 	if claims["sub"] != "alice" {
 		t.Errorf("sub must not be prefixed, got %v", claims["sub"])
 	}
 	if claims["scope"] != "read" {
 		t.Errorf("scope must not be prefixed, got %v", claims["scope"])
 	}
-	// customClaims must use their configured name (no prefix).
-	if claims["org"] != "acme" {
-		t.Errorf("customClaim 'org' must not be prefixed by dialect, got %v", claims["org"])
+	// customClaims destination must be prefixed.
+	if claims["http://wso2.org/claims/org"] != "acme" {
+		t.Errorf("customClaim 'org' must be prefixed, got %v", claims["http://wso2.org/claims/org"])
 	}
-	// claimMappings must use their configured destination name (no prefix).
-	if claims["clientEmail"] != "alice@example.com" {
-		t.Errorf("claimMapping destination 'clientEmail' must not be prefixed by dialect, got %v", claims["clientEmail"])
+	if _, present := claims["org"]; present {
+		t.Errorf("bare customClaim key 'org' must not appear when dialect is set")
+	}
+	// claimMappings destination must be prefixed.
+	if claims["http://wso2.org/claims/clientEmail"] != "alice@example.com" {
+		t.Errorf("claimMapping destination 'clientEmail' must be prefixed, got %v", claims["http://wso2.org/claims/clientEmail"])
+	}
+	if _, present := claims["clientEmail"]; present {
+		t.Errorf("bare claimMapping destination 'clientEmail' must not appear when dialect is set")
 	}
 }
 

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -812,6 +812,135 @@ func TestTokenCache_EvictExpired(t *testing.T) {
 	}
 }
 
+// ─── Cache Key Strategy Tests ────────────────────────────────────────────────
+
+func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
+	// Different jti on same subject/issuer must produce separate cache entries.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp.example.com",
+		TokenId: "token-aaa",
+	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp.example.com",
+		TokenId: "token-bbb",
+	}), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("different jti must produce separate cache entries, got %d", count)
+	}
+}
+
+func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
+	// Same jti must hit the cache regardless of other fields.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	authCtx := &policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz",
+	}
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 1 {
+		t.Errorf("same jti must share one cache entry, got %d", count)
+	}
+}
+
+func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
+	// Without jti, tokens from different issuers with the same subject must not collide.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp-a.example.com",
+	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp-b.example.com",
+	}), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("same subject from different issuers (no jti) must produce separate cache entries, got %d", count)
+	}
+}
+
+func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
+	// Different API key ApplicationIDs must produce separate cache entries.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "apikey",
+		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "App One"},
+	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "apikey",
+		Properties: map[string]string{"ApplicationID": "app-002", "ApplicationName": "App Two"},
+	}), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("different ApplicationIDs must produce separate cache entries, got %d", count)
+	}
+}
+
+func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
+	// Same ApplicationID must share one cache entry regardless of other metadata.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "apikey",
+		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "First Call"},
+	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "apikey",
+		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "Second Call"},
+	}), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 1 {
+		t.Errorf("same ApplicationID must share one cache entry, got %d", count)
+	}
+}
+
+func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
+	// Multiple unauthenticated requests to the same API must share one cache entry.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 1 {
+		t.Errorf("multiple unauthenticated requests must share one cache entry, got %d", count)
+	}
+}
+
 // ─── Context Claims Tests ─────────────────────────────────────────────────────
 
 func TestContextClaims_StaticPassthrough(t *testing.T) {

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -136,26 +136,9 @@ func TestMode(t *testing.T) {
 	}
 }
 
-func TestNoAuthContext_RequireAuth(t *testing.T) {
-	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
-	params := baseParams(keyPEM)
-	params["requireAuthentication"] = true
-
-	reqCtx := newRequestContext(nil)
-	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
-
-	resp, ok := result.(policy.ImmediateResponse)
-	if !ok {
-		t.Fatalf("expected ImmediateResponse, got %T", result)
-	}
-	if resp.StatusCode != 401 {
-		t.Errorf("expected status 401, got %d", resp.StatusCode)
-	}
-}
 
 func TestNoAuthContext_NoRequireAuth(t *testing.T) {
-	_, keyPEM := generateRSAKey(t)
+	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
@@ -166,28 +149,34 @@ func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
 	}
-	if len(mods.HeadersToSet) != 0 {
-		t.Errorf("expected no headers set for unauthenticated pass-through, got %v", mods.HeadersToSet)
+	tokenStr, ok := mods.HeadersToSet[defaultHeader]
+	if !ok || tokenStr == "" {
+		t.Fatalf("expected backend JWT to be generated even without auth context")
+	}
+
+	// Parse without verification to inspect claims (we have the key, use it).
+	claims := decodeJWT(t, tokenStr, &rsaKey.PublicKey)
+
+	// System claims must be present.
+	if claims["iss"] != "https://gateway.example.com" {
+		t.Errorf("expected iss=https://gateway.example.com, got %v", claims["iss"])
+	}
+	if _, ok := claims["iat"]; !ok {
+		t.Error("iat claim must be present")
+	}
+	if _, ok := claims["exp"]; !ok {
+		t.Error("exp claim must be present")
+	}
+
+	// Auth-derived claims must be absent when there is no auth context.
+	if _, ok := claims["sub"]; ok {
+		t.Errorf("sub must be absent when no auth context, got %v", claims["sub"])
+	}
+	if _, ok := claims["auth_type"]; ok {
+		t.Errorf("auth_type must be absent when no auth context, got %v", claims["auth_type"])
 	}
 }
 
-func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
-	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
-	params := baseParams(keyPEM)
-	params["requireAuthentication"] = true
-
-	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: false, AuthType: "jwt"})
-	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
-
-	resp, ok := result.(policy.ImmediateResponse)
-	if !ok {
-		t.Fatalf("expected ImmediateResponse, got %T", result)
-	}
-	if resp.StatusCode != 401 {
-		t.Errorf("expected status 401, got %d", resp.StatusCode)
-	}
-}
 
 func TestGeneratesJWTWithSubject(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -1,0 +1,553 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package backendjwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+func generateRSAKey(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return key, string(pemBytes)
+}
+
+func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECDSA key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal ECDSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: der,
+	})
+	return key, string(pemBytes)
+}
+
+func newRequestContext(authCtx *policy.AuthContext) *policy.RequestHeaderContext {
+	return &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:   "test-request-id",
+			Metadata:    make(map[string]interface{}),
+			AuthContext: authCtx,
+		},
+		Headers: policy.NewHeaders(map[string][]string{}),
+		Path:    "/api/test",
+		Method:  "GET",
+	}
+}
+
+func baseParams(pemKey string) map[string]interface{} {
+	return map[string]interface{}{
+		"signingKey": map[string]interface{}{
+			"inline": pemKey,
+		},
+		"algorithm":   "RS256",
+		"issuer":      "https://gateway.example.com",
+		"tokenExpiry": "15m",
+	}
+}
+
+func decodeJWT(t *testing.T, tokenStr string, verifyKey interface{}) jwt.MapClaims {
+	t.Helper()
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		return verifyKey, nil
+	})
+	if err != nil {
+		t.Fatalf("parse/verify JWT: %v", err)
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("claims are not MapClaims")
+	}
+	return claims
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+func TestGetPolicySingleton(t *testing.T) {
+	p1, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	if err != nil {
+		t.Fatalf("GetPolicy returned error: %v", err)
+	}
+	p2, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	if err != nil {
+		t.Fatalf("GetPolicy returned error: %v", err)
+	}
+	if p1 != p2 {
+		t.Error("GetPolicy must return the same singleton instance")
+	}
+}
+
+func TestMode(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	mode := p.Mode()
+	if mode.RequestHeaderMode != policy.HeaderModeProcess {
+		t.Errorf("expected RequestHeaderMode=HeaderModeProcess, got %v", mode.RequestHeaderMode)
+	}
+	if mode.RequestBodyMode != policy.BodyModeSkip {
+		t.Errorf("expected RequestBodyMode=BodyModeSkip, got %v", mode.RequestBodyMode)
+	}
+	if mode.ResponseHeaderMode != policy.HeaderModeSkip {
+		t.Errorf("expected ResponseHeaderMode=HeaderModeSkip, got %v", mode.ResponseHeaderMode)
+	}
+	if mode.ResponseBodyMode != policy.BodyModeSkip {
+		t.Errorf("expected ResponseBodyMode=BodyModeSkip, got %v", mode.ResponseBodyMode)
+	}
+}
+
+func TestNoAuthContext_RequireAuth(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["requireAuthentication"] = true
+
+	reqCtx := newRequestContext(nil)
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", result)
+	}
+	if resp.StatusCode != 401 {
+		t.Errorf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestNoAuthContext_NoRequireAuth(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(nil)
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("expected no headers set for unauthenticated pass-through, got %v", mods.HeadersToSet)
+	}
+}
+
+func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["requireAuthentication"] = true
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: false, AuthType: "jwt"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", result)
+	}
+	if resp.StatusCode != 401 {
+		t.Errorf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestGeneratesJWTWithSubject(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Issuer:        "https://idp.example.com",
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	tokenStr, ok := mods.HeadersToSet[defaultHeader]
+	if !ok {
+		t.Fatalf("expected header %q to be set", defaultHeader)
+	}
+
+	claims := decodeJWT(t, tokenStr, &rsaKey.PublicKey)
+	if claims["sub"] != "alice" {
+		t.Errorf("expected sub=alice, got %v", claims["sub"])
+	}
+	if claims["auth_type"] != "jwt" {
+		t.Errorf("expected auth_type=jwt, got %v", claims["auth_type"])
+	}
+	if claims["iss"] != "https://gateway.example.com" {
+		t.Errorf("expected iss=https://gateway.example.com, got %v", claims["iss"])
+	}
+	if claims["original_iss"] != "https://idp.example.com" {
+		t.Errorf("expected original_iss=https://idp.example.com, got %v", claims["original_iss"])
+	}
+}
+
+func TestCustomClaims(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{
+		"env":     "production",
+		"version": "v2",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "basic",
+		Subject:       "bob",
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["env"] != "production" {
+		t.Errorf("expected env=production, got %v", claims["env"])
+	}
+	if claims["version"] != "v2" {
+		t.Errorf("expected version=v2, got %v", claims["version"])
+	}
+}
+
+func TestClaimMappings(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["claimMappings"] = map[string]interface{}{
+		"app_id":  "application_id",
+		"dept":    "department",
+		"missing": "should_not_appear",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "apikey",
+		Subject:       "carol",
+		Properties: map[string]string{
+			"app_id": "app-xyz-123",
+			"dept":   "engineering",
+		},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["application_id"] != "app-xyz-123" {
+		t.Errorf("expected application_id=app-xyz-123, got %v", claims["application_id"])
+	}
+	if claims["department"] != "engineering" {
+		t.Errorf("expected department=engineering, got %v", claims["department"])
+	}
+	if _, present := claims["should_not_appear"]; present {
+		t.Error("claim for missing property key must not appear in token")
+	}
+}
+
+func TestTokenExpiry(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["tokenExpiry"] = "5m"
+
+	// Truncate to whole seconds: iat/exp are Unix timestamps (second precision).
+	before := time.Now().Truncate(time.Second)
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "dave"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	after := time.Now().Truncate(time.Second).Add(time.Second)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	expRaw, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatal("exp claim missing or not a number")
+	}
+	iatRaw, ok := claims["iat"].(float64)
+	if !ok {
+		t.Fatal("iat claim missing or not a number")
+	}
+
+	expTime := time.Unix(int64(expRaw), 0)
+	iatTime := time.Unix(int64(iatRaw), 0)
+	diff := expTime.Sub(iatTime)
+
+	if diff < 4*time.Minute || diff > 6*time.Minute {
+		t.Errorf("expected exp-iat≈5m, got %v", diff)
+	}
+	if iatTime.Before(before) || iatTime.After(after) {
+		t.Errorf("iat %v is outside [%v, %v]", iatTime, before, after)
+	}
+}
+
+func TestRS256Signing(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rs256-user"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+
+	tokenStr, ok := mods.HeadersToSet[defaultHeader]
+	if !ok {
+		t.Fatal("no JWT header set")
+	}
+
+	// Verify the token header uses RS256
+	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse unverified: %v", err)
+	}
+	if token.Method != jwt.SigningMethodRS256 {
+		t.Errorf("expected RS256 signing method, got %v", token.Method.Alg())
+	}
+
+	// Verify signature using the public key
+	decodeJWT(t, tokenStr, &rsaKey.PublicKey)
+}
+
+func TestES256Signing(t *testing.T) {
+	ecKey, keyPEM := generateECKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"inline": keyPEM},
+		"algorithm":  "ES256",
+		"issuer":     "https://gateway.example.com",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "ec-user"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+
+	tokenStr, ok := mods.HeadersToSet[defaultHeader]
+	if !ok {
+		t.Fatal("no JWT header set")
+	}
+
+	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse unverified: %v", err)
+	}
+	if token.Method != jwt.SigningMethodES256 {
+		t.Errorf("expected ES256 signing method, got %v", token.Method.Alg())
+	}
+
+	decodeJWT(t, tokenStr, &ecKey.PublicKey)
+}
+
+func TestCustomHeader(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+	params["header"] = "x-custom-backend-token"
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "frank"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+
+	if _, ok := mods.HeadersToSet[defaultHeader]; ok {
+		t.Errorf("default header %q must not be set when custom header is configured", defaultHeader)
+	}
+	if _, ok := mods.HeadersToSet["x-custom-backend-token"]; !ok {
+		t.Error("custom header x-custom-backend-token must be set")
+	}
+}
+
+func TestInvalidPrivateKey(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{
+			"inline": "not-a-valid-pem-key",
+		},
+		"algorithm": "RS256",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "grace"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse on invalid key, got %T", result)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestMismatchedAlgorithmAndKey(t *testing.T) {
+	_, rsaKeyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"inline": rsaKeyPEM},
+		"algorithm":  "ES256", // wrong: RSA key with ECDSA algorithm
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "henry"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse on key/algorithm mismatch, got %T", result)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestValidate_MissingKey(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	err := p.Validate(map[string]interface{}{})
+	if err == nil {
+		t.Error("Validate must return error when signingKey is absent")
+	}
+}
+
+func TestValidate_InvalidKeyMaterial(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	err := p.Validate(map[string]interface{}{
+		"signingKey": map[string]interface{}{
+			"inline": "-----BEGIN RSA PRIVATE KEY-----\nbaddata\n-----END RSA PRIVATE KEY-----",
+		},
+	})
+	if err == nil {
+		t.Error("Validate must return error for invalid key material")
+	}
+}
+
+func TestValidate_ValidKey(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	err := p.Validate(map[string]interface{}{
+		"signingKey": map[string]interface{}{"inline": keyPEM},
+	})
+	if err != nil {
+		t.Errorf("Validate must not return error for valid key: %v", err)
+	}
+}
+
+func TestKeyFilePath(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	f, err := os.CreateTemp("", "backend-jwt-test-key-*.pem")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(keyPEM); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	f.Close()
+
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"path": f.Name()},
+		"algorithm":  "RS256",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "irene"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+}
+
+func TestKeyCaching(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "judy"}
+
+	// Call twice; second call should hit the cache (no observable difference, but must not error).
+	for i := 0; i < 2; i++ {
+		reqCtx := newRequestContext(authCtx)
+		result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+		if _, ok := result.(policy.UpstreamRequestHeaderModifications); !ok {
+			t.Fatalf("call %d: expected UpstreamRequestHeaderModifications, got %T", i+1, result)
+		}
+	}
+
+	// Verify only one key is cached.
+	p.keyMu.RLock()
+	count := len(p.keyCache)
+	p.keyMu.RUnlock()
+	if count != 1 {
+		t.Errorf("expected 1 cached key, got %d", count)
+	}
+}
+
+func TestAudienceAndCredentialID(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "apikey",
+		Subject:       "ken",
+		Audience:      []string{"service-a", "service-b"},
+		CredentialID:  "client-abc",
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["credential_id"] != "client-abc" {
+		t.Errorf("expected credential_id=client-abc, got %v", claims["credential_id"])
+	}
+	audRaw, ok := claims["aud"]
+	if !ok {
+		t.Fatal("aud claim missing")
+	}
+	_ = audRaw // audience is present; exact type depends on JWT library serialisation
+}

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -426,6 +426,42 @@ func TestInvalidPrivateKey(t *testing.T) {
 }
 
 
+func TestValidate_TokenExpiry_Invalid(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	err := p.Validate(map[string]interface{}{
+		"signingKey":  map[string]interface{}{"inline": keyPEM},
+		"tokenExpiry": "notaduration",
+	})
+	if err == nil {
+		t.Error("Validate must return error for unparseable tokenExpiry")
+	}
+}
+
+func TestValidate_TokenExpiry_Zero(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	err := p.Validate(map[string]interface{}{
+		"signingKey":  map[string]interface{}{"inline": keyPEM},
+		"tokenExpiry": "0s",
+	})
+	if err == nil {
+		t.Error("Validate must return error for zero tokenExpiry")
+	}
+}
+
+func TestValidate_TokenExpiry_Negative(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	err := p.Validate(map[string]interface{}{
+		"signingKey":  map[string]interface{}{"inline": keyPEM},
+		"tokenExpiry": "-5m",
+	})
+	if err == nil {
+		t.Error("Validate must return error for negative tokenExpiry")
+	}
+}
+
 func TestValidate_MissingKey(t *testing.T) {
 	p := newTestPolicy()
 	err := p.Validate(map[string]interface{}{})
@@ -1132,6 +1168,30 @@ func TestContextClaims_AuthProperty(t *testing.T) {
 
 	if claims["clientName"] != "MyService" {
 		t.Errorf("expected clientName=MyService, got %v", claims["clientName"])
+	}
+}
+
+func TestContextClaims_AuthProperty_MixedCaseKey(t *testing.T) {
+	// Properties keys are case-sensitive; the $ctx: prefix must not be lowercased
+	// past the fixed "auth.property." boundary.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"role": "$ctx:auth.property.ClientRole"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "quinn",
+		Properties:    map[string]string{"ClientRole": "admin"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["role"] != "admin" {
+		t.Errorf("mixed-case property key: expected role=admin, got %v", claims["role"])
 	}
 }
 

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -49,22 +49,6 @@ func generateRSAKey(t *testing.T) (*rsa.PrivateKey, string) {
 	return key, string(pemBytes)
 }
 
-func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("generate ECDSA key: %v", err)
-	}
-	der, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		t.Fatalf("marshal ECDSA key: %v", err)
-	}
-	pemBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: der,
-	})
-	return key, string(pemBytes)
-}
 
 func newRequestContext(authCtx *policy.AuthContext) *policy.RequestHeaderContext {
 	return &policy.RequestHeaderContext{
@@ -84,7 +68,7 @@ func baseParams(pemKey string) map[string]interface{} {
 		"signingKey": map[string]interface{}{
 			"inline": pemKey,
 		},
-		"algorithm":   "RS256",
+		"algorithm":   "SHA256withRSA",
 		"issuer":      "https://gateway.example.com",
 		"tokenExpiry": "15m",
 	}
@@ -103,6 +87,20 @@ func decodeJWT(t *testing.T, tokenStr string, verifyKey interface{}) jwt.MapClai
 		t.Fatal("claims are not MapClaims")
 	}
 	return claims
+}
+
+func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECDSA key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal ECDSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+	return key, string(pemBytes)
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -326,12 +324,12 @@ func TestTokenExpiry(t *testing.T) {
 	}
 }
 
-func TestRS256Signing(t *testing.T) {
+func TestSHA256withRSASigning(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
-	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rs256-user"})
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rsa-user"})
 	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
 	mods := result.(policy.UpstreamRequestHeaderModifications)
 
@@ -340,18 +338,16 @@ func TestRS256Signing(t *testing.T) {
 		t.Fatal("no JWT header set")
 	}
 
-	// Verify the token header uses RS256
 	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
 	if err != nil {
 		t.Fatalf("parse unverified: %v", err)
 	}
 	if token.Method != jwt.SigningMethodRS256 {
-		t.Errorf("expected RS256 signing method, got %v", token.Method.Alg())
+		t.Errorf("SHA256withRSA must produce RS256 token, got %v", token.Method.Alg())
 	}
-
-	// Verify signature using the public key
 	decodeJWT(t, tokenStr, &rsaKey.PublicKey)
 }
+
 
 func TestES256Signing(t *testing.T) {
 	ecKey, keyPEM := generateECKey(t)
@@ -370,7 +366,6 @@ func TestES256Signing(t *testing.T) {
 	if !ok {
 		t.Fatal("no JWT header set")
 	}
-
 	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
 	if err != nil {
 		t.Fatalf("parse unverified: %v", err)
@@ -378,8 +373,27 @@ func TestES256Signing(t *testing.T) {
 	if token.Method != jwt.SigningMethodES256 {
 		t.Errorf("expected ES256 signing method, got %v", token.Method.Alg())
 	}
-
 	decodeJWT(t, tokenStr, &ecKey.PublicKey)
+}
+
+func TestMismatchedAlgorithmAndKey(t *testing.T) {
+	_, ecKeyPEM := generateECKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"inline": ecKeyPEM},
+		"algorithm":  "SHA256withRSA", // EC key with RSA algorithm
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "henry"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse on key/algorithm mismatch, got %T", result)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+	}
 }
 
 func TestCustomHeader(t *testing.T) {
@@ -406,7 +420,7 @@ func TestInvalidPrivateKey(t *testing.T) {
 		"signingKey": map[string]interface{}{
 			"inline": "not-a-valid-pem-key",
 		},
-		"algorithm": "RS256",
+		"algorithm": "SHA256withRSA",
 	}
 
 	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "grace"})
@@ -421,25 +435,6 @@ func TestInvalidPrivateKey(t *testing.T) {
 	}
 }
 
-func TestMismatchedAlgorithmAndKey(t *testing.T) {
-	_, rsaKeyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
-	params := map[string]interface{}{
-		"signingKey": map[string]interface{}{"inline": rsaKeyPEM},
-		"algorithm":  "ES256", // wrong: RSA key with ECDSA algorithm
-	}
-
-	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "henry"})
-	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
-
-	resp, ok := result.(policy.ImmediateResponse)
-	if !ok {
-		t.Fatalf("expected ImmediateResponse on key/algorithm mismatch, got %T", result)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected status 500, got %d", resp.StatusCode)
-	}
-}
 
 func TestValidate_MissingKey(t *testing.T) {
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
@@ -487,7 +482,7 @@ func TestKeyFilePath(t *testing.T) {
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"path": f.Name()},
-		"algorithm":  "RS256",
+		"algorithm":  "SHA256withRSA",
 	}
 
 	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "irene"})
@@ -552,6 +547,93 @@ func TestAudienceAndCredentialID(t *testing.T) {
 	_ = audRaw // audience is present; exact type depends on JWT library serialisation
 }
 
+// ─── Algorithm Tests ──────────────────────────────────────────────────────────
+
+func TestAlgorithm_SHA256withRSA(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	params := map[string]interface{}{
+		"signingKey":  map[string]interface{}{"inline": keyPEM},
+		"algorithm":   "SHA256withRSA",
+		"issuer":      "https://gateway.example.com",
+		"tokenExpiry": "15m",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	tokenStr := mods.HeadersToSet[defaultHeader]
+	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse unverified: %v", err)
+	}
+	if token.Method != jwt.SigningMethodRS256 {
+		t.Errorf("SHA256withRSA must produce RS256 token, got %v", token.Method.Alg())
+	}
+	decodeJWT(t, tokenStr, &rsaKey.PublicKey)
+}
+
+func TestAlgorithm_NONE(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	params := map[string]interface{}{
+		"algorithm":   "NONE",
+		"tokenExpiry": "15m",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	tokenStr := mods.HeadersToSet[defaultHeader]
+	if tokenStr == "" {
+		t.Fatal("expected non-empty token for NONE algorithm")
+	}
+	token, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse unverified: %v", err)
+	}
+	if token.Method != jwt.SigningMethodNone {
+		t.Errorf("NONE algorithm must produce unsigned token, got alg=%v", token.Method.Alg())
+	}
+}
+
+func TestAlgorithm_NONE_ValidateSkipsKey(t *testing.T) {
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	err := p.Validate(map[string]interface{}{
+		"algorithm": "NONE",
+		// no signingKey — must not error
+	})
+	if err != nil {
+		t.Errorf("Validate with NONE algorithm must not require a signing key, got: %v", err)
+	}
+}
+
+func TestAlgorithm_UnknownReturns500(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"inline": keyPEM},
+		"algorithm":  "SuperAlgorithmXYZ",
+	}
+
+	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "bob"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	resp, ok := result.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("unknown algorithm must return 500, got %T", result)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+	}
+}
+
 // ─── Token Cache Tests ────────────────────────────────────────────────────────
 
 func TestTokenCache_HitReturnsSameToken(t *testing.T) {
@@ -604,7 +686,7 @@ func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
 	}
 }
 
-func TestTokenCache_MissOnDifferentOperation(t *testing.T) {
+func TestTokenCache_MissOnDifferentAPIContext(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
@@ -613,13 +695,13 @@ func TestTokenCache_MissOnDifferentOperation(t *testing.T) {
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "carol"}
 
-	makeCtx := func(operation string) *policy.RequestHeaderContext {
+	makeCtx := func(apiContext string) *policy.RequestHeaderContext {
 		return &policy.RequestHeaderContext{
 			SharedContext: &policy.SharedContext{
-				RequestID:     "test",
-				Metadata:      make(map[string]interface{}),
-				AuthContext:   authCtx,
-				OperationPath: operation,
+				RequestID:   "test",
+				Metadata:    make(map[string]interface{}),
+				AuthContext: authCtx,
+				APIContext:  apiContext,
 			},
 			Headers: policy.NewHeaders(map[string][]string{}),
 			Path:    "/api/v1",
@@ -627,15 +709,15 @@ func TestTokenCache_MissOnDifferentOperation(t *testing.T) {
 		}
 	}
 
-	p.OnRequestHeaders(context.Background(), makeCtx("/pets/{id}"), params)
-	p.OnRequestHeaders(context.Background(), makeCtx("/orders/{id}"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/petstore/v1"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/orders/v1"), params)
 
-	// Different operation paths → different cache keys → two separate cache entries.
+	// Different API contexts → different cache keys → two separate cache entries.
 	p.tokenMu.RLock()
 	count := len(p.tokenCache)
 	p.tokenMu.RUnlock()
 	if count != 2 {
-		t.Errorf("expected 2 cache entries for 2 different operation paths, got %d", count)
+		t.Errorf("expected 2 cache entries for 2 different API contexts, got %d", count)
 	}
 }
 
@@ -659,7 +741,7 @@ func TestTokenCache_MissOnDifferentCustomClaim(t *testing.T) {
 		_ = reqCtx
 		return map[string]interface{}{
 			"signingKey":   map[string]interface{}{"inline": keyPEM},
-			"algorithm":    "RS256",
+			"algorithm":    "SHA256withRSA",
 			"customClaims": map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"},
 		}
 	}

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -120,7 +120,7 @@ func TestGetPolicySingleton(t *testing.T) {
 }
 
 func TestMode(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	mode := p.Mode()
 	if mode.RequestHeaderMode != policy.HeaderModeProcess {
 		t.Errorf("expected RequestHeaderMode=HeaderModeProcess, got %v", mode.RequestHeaderMode)
@@ -138,7 +138,7 @@ func TestMode(t *testing.T) {
 
 func TestNoAuthContext_RequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["requireAuthentication"] = true
 
@@ -156,7 +156,7 @@ func TestNoAuthContext_RequireAuth(t *testing.T) {
 
 func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(nil)
@@ -173,7 +173,7 @@ func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 
 func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["requireAuthentication"] = true
 
@@ -191,7 +191,7 @@ func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
 
 func TestGeneratesJWTWithSubject(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -229,7 +229,7 @@ func TestGeneratesJWTWithSubject(t *testing.T) {
 
 func TestCustomClaims(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"env":     "production",
@@ -257,7 +257,7 @@ func TestCustomClaims(t *testing.T) {
 
 func TestTokenExpiry(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["tokenExpiry"] = "5m"
 
@@ -292,7 +292,7 @@ func TestTokenExpiry(t *testing.T) {
 
 func TestSHA256withRSASigning(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rsa-user"})
@@ -317,7 +317,7 @@ func TestSHA256withRSASigning(t *testing.T) {
 
 func TestES256Signing(t *testing.T) {
 	ecKey, keyPEM := generateECKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 		"algorithm":  "ES256",
@@ -344,7 +344,7 @@ func TestES256Signing(t *testing.T) {
 
 func TestMismatchedAlgorithmAndKey(t *testing.T) {
 	_, ecKeyPEM := generateECKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": ecKeyPEM},
 		"algorithm":  "SHA256withRSA", // EC key with RSA algorithm
@@ -364,7 +364,7 @@ func TestMismatchedAlgorithmAndKey(t *testing.T) {
 
 func TestCustomHeader(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["header"] = "x-custom-backend-token"
 
@@ -381,7 +381,7 @@ func TestCustomHeader(t *testing.T) {
 }
 
 func TestInvalidPrivateKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "not-a-valid-pem-key",
@@ -403,7 +403,7 @@ func TestInvalidPrivateKey(t *testing.T) {
 
 
 func TestValidate_MissingKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{})
 	if err == nil {
 		t.Error("Validate must return error when signingKey is absent")
@@ -411,7 +411,7 @@ func TestValidate_MissingKey(t *testing.T) {
 }
 
 func TestValidate_InvalidKeyMaterial(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "-----BEGIN RSA PRIVATE KEY-----\nbaddata\n-----END RSA PRIVATE KEY-----",
@@ -424,7 +424,7 @@ func TestValidate_InvalidKeyMaterial(t *testing.T) {
 
 func TestValidate_ValidKey(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 	})
@@ -445,7 +445,7 @@ func TestKeyFilePath(t *testing.T) {
 	}
 	f.Close()
 
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"path": f.Name()},
 		"algorithm":  "SHA256withRSA",
@@ -461,9 +461,47 @@ func TestKeyFilePath(t *testing.T) {
 	decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
 }
 
+func TestPEMFileCachedAfterFirstRead(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	f, err := os.CreateTemp("", "backend-jwt-pem-cache-*.pem")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(keyPEM); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	f.Close()
+
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := map[string]interface{}{
+		"signingKey": map[string]interface{}{"path": f.Name()},
+		"algorithm":  "SHA256withRSA",
+	}
+
+	// First call — populates pemCache.
+	reqCtx1 := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "user-a"})
+	p.OnRequestHeaders(context.Background(), reqCtx1, params)
+
+	p.keyMu.RLock()
+	_, cached := p.pemCache[f.Name()]
+	p.keyMu.RUnlock()
+	if !cached {
+		t.Fatal("expected PEM bytes to be cached after first path read")
+	}
+
+	// Delete the file — a second call must succeed using cached bytes.
+	os.Remove(f.Name())
+	reqCtx2 := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "user-b"})
+	result := p.OnRequestHeaders(context.Background(), reqCtx2, params)
+	if _, ok := result.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Errorf("expected success from pemCache after file deletion, got %T", result)
+	}
+}
+
 func TestKeyCaching(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "judy"}
@@ -488,7 +526,7 @@ func TestKeyCaching(t *testing.T) {
 
 func TestAudienceAndCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -517,7 +555,7 @@ func TestAudienceAndCredentialID(t *testing.T) {
 
 func TestAlgorithm_SHA256withRSA(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey":  map[string]interface{}{"inline": keyPEM},
 		"algorithm":   "SHA256withRSA",
@@ -544,7 +582,7 @@ func TestAlgorithm_SHA256withRSA(t *testing.T) {
 }
 
 func TestAlgorithm_NONE(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"algorithm":   "NONE",
 		"tokenExpiry": "15m",
@@ -571,7 +609,7 @@ func TestAlgorithm_NONE(t *testing.T) {
 }
 
 func TestAlgorithm_NONE_ValidateSkipsKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{
 		"algorithm": "NONE",
 		// no signingKey — must not error
@@ -583,7 +621,7 @@ func TestAlgorithm_NONE_ValidateSkipsKey(t *testing.T) {
 
 func TestAlgorithm_UnknownReturns500(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 		"algorithm":  "SuperAlgorithmXYZ",
@@ -606,6 +644,7 @@ func TestTokenCache_HitReturnsSameToken(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 	params := baseParams(keyPEM)
@@ -634,6 +673,7 @@ func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 	params := baseParams(keyPEM)
@@ -656,6 +696,7 @@ func TestTokenCache_MissOnDifferentAPIContext(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 	params := baseParams(keyPEM)
@@ -691,25 +732,15 @@ func TestTokenCache_MissOnDifferentCustomClaim(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "dave"}
 
-	makeParams := func(tenantHeader string) map[string]interface{} {
-		reqCtx := &policy.RequestHeaderContext{
-			SharedContext: &policy.SharedContext{
-				RequestID: "x", Metadata: make(map[string]interface{}), AuthContext: authCtx,
-			},
-			Headers: policy.NewHeaders(map[string][]string{"x-tenant-id": {tenantHeader}}),
-			Path:    "/api", Method: "GET",
-		}
-		// We need to call OnRequestHeaders with this reqCtx; params carry the customClaims config.
-		_ = reqCtx
-		return map[string]interface{}{
-			"signingKey":   map[string]interface{}{"inline": keyPEM},
-			"algorithm":    "SHA256withRSA",
-			"customClaims": map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"},
-		}
+	params := map[string]interface{}{
+		"signingKey":   map[string]interface{}{"inline": keyPEM},
+		"algorithm":    "SHA256withRSA",
+		"customClaims": map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"},
 	}
 
 	makeReqCtx := func(tenantHeader string) *policy.RequestHeaderContext {
@@ -722,8 +753,8 @@ func TestTokenCache_MissOnDifferentCustomClaim(t *testing.T) {
 		}
 	}
 
-	r1 := p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), makeParams("acme"))
-	r2 := p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), makeParams("globex"))
+	r1 := p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), params)
+	r2 := p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), params)
 
 	tok1 := r1.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
 	tok2 := r2.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
@@ -739,6 +770,7 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 	// same token string, making "different string" an unreliable expiry signal.
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 
@@ -766,6 +798,7 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 func TestTokenCache_EvictExpired(t *testing.T) {
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		pemCache:   make(map[string][]byte),
 		tokenCache: make(map[string]cachedToken),
 	}
 	now := time.Now()
@@ -794,7 +827,7 @@ func TestTokenCache_EvictExpired(t *testing.T) {
 
 func TestContextClaims_StaticPassthrough(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"env": "production"}
 
@@ -810,7 +843,7 @@ func TestContextClaims_StaticPassthrough(t *testing.T) {
 
 func TestContextClaims_RequestPath(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"req_path": "$ctx:request.path"}
 
@@ -836,7 +869,7 @@ func TestContextClaims_RequestPath(t *testing.T) {
 
 func TestContextClaims_RequestHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -862,7 +895,7 @@ func TestContextClaims_RequestHeader(t *testing.T) {
 
 func TestContextClaims_APIName(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"api": "$ctx:api.name"}
 
@@ -889,7 +922,7 @@ func TestContextClaims_APIName(t *testing.T) {
 
 func TestContextClaims_AuthCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"clientId": "$ctx:auth.credential_id"}
 
@@ -911,7 +944,7 @@ func TestContextClaims_AuthCredentialID(t *testing.T) {
 
 func TestContextClaims_AuthProperty(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"clientName": "$ctx:auth.property.client_name"}
 
@@ -933,7 +966,7 @@ func TestContextClaims_AuthProperty(t *testing.T) {
 
 func TestContextClaims_MissingHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -951,7 +984,7 @@ func TestContextClaims_MissingHeader(t *testing.T) {
 
 func TestContextClaims_UnknownVariable(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"x": "$ctx:unknown.variable.name"}
 
@@ -996,7 +1029,7 @@ func TestContextClaims_NilAuthContext(t *testing.T) {
 
 func TestCustomClaims_RestrictedClaimsOverrideWithWarn(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"iss": "https://custom-issuer.example.com",

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -122,7 +122,7 @@ func TestGetPolicySingleton(t *testing.T) {
 }
 
 func TestMode(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	mode := p.Mode()
 	if mode.RequestHeaderMode != policy.HeaderModeProcess {
 		t.Errorf("expected RequestHeaderMode=HeaderModeProcess, got %v", mode.RequestHeaderMode)
@@ -140,7 +140,7 @@ func TestMode(t *testing.T) {
 
 func TestNoAuthContext_RequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["requireAuthentication"] = true
 
@@ -158,7 +158,7 @@ func TestNoAuthContext_RequireAuth(t *testing.T) {
 
 func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(nil)
@@ -175,7 +175,7 @@ func TestNoAuthContext_NoRequireAuth(t *testing.T) {
 
 func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["requireAuthentication"] = true
 
@@ -193,7 +193,7 @@ func TestUnauthenticatedAuthContext_RequireAuth(t *testing.T) {
 
 func TestGeneratesJWTWithSubject(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -231,7 +231,7 @@ func TestGeneratesJWTWithSubject(t *testing.T) {
 
 func TestCustomClaims(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{
 		"env":     "production",
@@ -258,7 +258,7 @@ func TestCustomClaims(t *testing.T) {
 
 func TestClaimMappings(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["claimMappings"] = map[string]interface{}{
 		"app_id":  "application_id",
@@ -293,7 +293,7 @@ func TestClaimMappings(t *testing.T) {
 
 func TestTokenExpiry(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["tokenExpiry"] = "5m"
 
@@ -328,7 +328,7 @@ func TestTokenExpiry(t *testing.T) {
 
 func TestRS256Signing(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "rs256-user"})
@@ -355,7 +355,7 @@ func TestRS256Signing(t *testing.T) {
 
 func TestES256Signing(t *testing.T) {
 	ecKey, keyPEM := generateECKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 		"algorithm":  "ES256",
@@ -384,7 +384,7 @@ func TestES256Signing(t *testing.T) {
 
 func TestCustomHeader(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["header"] = "x-custom-backend-token"
 
@@ -401,7 +401,7 @@ func TestCustomHeader(t *testing.T) {
 }
 
 func TestInvalidPrivateKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "not-a-valid-pem-key",
@@ -423,7 +423,7 @@ func TestInvalidPrivateKey(t *testing.T) {
 
 func TestMismatchedAlgorithmAndKey(t *testing.T) {
 	_, rsaKeyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": rsaKeyPEM},
 		"algorithm":  "ES256", // wrong: RSA key with ECDSA algorithm
@@ -442,7 +442,7 @@ func TestMismatchedAlgorithmAndKey(t *testing.T) {
 }
 
 func TestValidate_MissingKey(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{})
 	if err == nil {
 		t.Error("Validate must return error when signingKey is absent")
@@ -450,7 +450,7 @@ func TestValidate_MissingKey(t *testing.T) {
 }
 
 func TestValidate_InvalidKeyMaterial(t *testing.T) {
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{
 			"inline": "-----BEGIN RSA PRIVATE KEY-----\nbaddata\n-----END RSA PRIVATE KEY-----",
@@ -463,7 +463,7 @@ func TestValidate_InvalidKeyMaterial(t *testing.T) {
 
 func TestValidate_ValidKey(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	err := p.Validate(map[string]interface{}{
 		"signingKey": map[string]interface{}{"inline": keyPEM},
 	})
@@ -484,7 +484,7 @@ func TestKeyFilePath(t *testing.T) {
 	}
 	f.Close()
 
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := map[string]interface{}{
 		"signingKey": map[string]interface{}{"path": f.Name()},
 		"algorithm":  "RS256",
@@ -502,7 +502,7 @@ func TestKeyFilePath(t *testing.T) {
 
 func TestKeyCaching(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "judy"}
@@ -527,7 +527,7 @@ func TestKeyCaching(t *testing.T) {
 
 func TestAudienceAndCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 
 	reqCtx := newRequestContext(&policy.AuthContext{
@@ -552,11 +552,201 @@ func TestAudienceAndCredentialID(t *testing.T) {
 	_ = audRaw // audience is present; exact type depends on JWT library serialisation
 }
 
+// ─── Token Cache Tests ────────────────────────────────────────────────────────
+
+func TestTokenCache_HitReturnsSameToken(t *testing.T) {
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+	params := baseParams(keyPEM)
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", CredentialID: "client-1"}
+
+	result1 := p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+	result2 := p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+
+	mods1 := result1.(policy.UpstreamRequestHeaderModifications)
+	mods2 := result2.(policy.UpstreamRequestHeaderModifications)
+	tok1 := mods1.HeadersToSet[defaultHeader]
+	tok2 := mods2.HeadersToSet[defaultHeader]
+
+	if tok1 == "" || tok2 == "" {
+		t.Fatal("expected non-empty tokens")
+	}
+	if tok1 != tok2 {
+		t.Error("cache hit must return the same signed token string")
+	}
+
+	// Verify the cached token is a valid JWT.
+	decodeJWT(t, tok1, &rsaKey.PublicKey)
+}
+
+func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+	params := baseParams(keyPEM)
+
+	r1 := p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice",
+	}), params)
+	r2 := p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "bob",
+	}), params)
+
+	tok1 := r1.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
+	tok2 := r2.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
+	if tok1 == tok2 {
+		t.Error("different subjects must produce different tokens (separate cache entries)")
+	}
+}
+
+func TestTokenCache_MissOnDifferentOperation(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+	params := baseParams(keyPEM)
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "carol"}
+
+	makeCtx := func(operation string) *policy.RequestHeaderContext {
+		return &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{
+				RequestID:     "test",
+				Metadata:      make(map[string]interface{}),
+				AuthContext:   authCtx,
+				OperationPath: operation,
+			},
+			Headers: policy.NewHeaders(map[string][]string{}),
+			Path:    "/api/v1",
+			Method:  "GET",
+		}
+	}
+
+	p.OnRequestHeaders(context.Background(), makeCtx("/pets/{id}"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/orders/{id}"), params)
+
+	// Different operation paths → different cache keys → two separate cache entries.
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("expected 2 cache entries for 2 different operation paths, got %d", count)
+	}
+}
+
+func TestTokenCache_MissOnDifferentCustomClaim(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "dave"}
+
+	makeParams := func(tenantHeader string) map[string]interface{} {
+		reqCtx := &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{
+				RequestID: "x", Metadata: make(map[string]interface{}), AuthContext: authCtx,
+			},
+			Headers: policy.NewHeaders(map[string][]string{"x-tenant-id": {tenantHeader}}),
+			Path:    "/api", Method: "GET",
+		}
+		// We need to call OnRequestHeaders with this reqCtx; params carry the customClaims config.
+		_ = reqCtx
+		return map[string]interface{}{
+			"signingKey":   map[string]interface{}{"inline": keyPEM},
+			"algorithm":    "RS256",
+			"customClaims": map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"},
+		}
+	}
+
+	makeReqCtx := func(tenantHeader string) *policy.RequestHeaderContext {
+		return &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{
+				RequestID: "x", Metadata: make(map[string]interface{}), AuthContext: authCtx,
+			},
+			Headers: policy.NewHeaders(map[string][]string{"x-tenant-id": {tenantHeader}}),
+			Path:    "/api", Method: "GET",
+		}
+	}
+
+	r1 := p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), makeParams("acme"))
+	r2 := p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), makeParams("globex"))
+
+	tok1 := r1.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
+	tok2 := r2.(policy.UpstreamRequestHeaderModifications).HeadersToSet[defaultHeader]
+	if tok1 == tok2 {
+		t.Error("different resolved custom claim values must produce different cache entries")
+	}
+}
+
+func TestTokenCache_ExpiryRespected(t *testing.T) {
+	// Verify getCachedToken returns miss for an expired entry and hit for a live one.
+	// We test this at the helper level (not via OnRequestHeaders) because RSA PKCS1v15
+	// is deterministic — re-signing the same claims in the same second produces the
+	// same token string, making "different string" an unreliable expiry signal.
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+
+	p.putCachedToken("key-a", "sentinel-live", time.Hour)
+	p.putCachedToken("key-b", "sentinel-expired", time.Hour)
+
+	// Expire key-b.
+	p.tokenMu.Lock()
+	v := p.tokenCache["key-b"]
+	v.expiresAt = time.Now().Add(-time.Second)
+	p.tokenCache["key-b"] = v
+	p.tokenMu.Unlock()
+
+	got, ok := p.getCachedToken("key-a")
+	if !ok || got != "sentinel-live" {
+		t.Errorf("expected cache hit for live entry, got (%q, %v)", got, ok)
+	}
+
+	got, ok = p.getCachedToken("key-b")
+	if ok || got != "" {
+		t.Errorf("expected cache miss for expired entry, got (%q, %v)", got, ok)
+	}
+}
+
+func TestTokenCache_EvictExpired(t *testing.T) {
+	p := &BackendJWTPolicy{
+		keyCache:   make(map[[32]byte]crypto.PrivateKey),
+		tokenCache: make(map[string]cachedToken),
+	}
+	now := time.Now()
+
+	p.tokenMu.Lock()
+	p.tokenCache["expired"] = cachedToken{signed: "old", expiresAt: now.Add(-time.Second)}
+	p.tokenCache["live"] = cachedToken{signed: "current", expiresAt: now.Add(time.Hour)}
+	p.tokenMu.Unlock()
+
+	p.evictExpired()
+
+	p.tokenMu.RLock()
+	_, hasExpired := p.tokenCache["expired"]
+	_, hasLive := p.tokenCache["live"]
+	p.tokenMu.RUnlock()
+
+	if hasExpired {
+		t.Error("evictExpired must remove entries past their expiresAt")
+	}
+	if !hasLive {
+		t.Error("evictExpired must keep entries that have not yet expired")
+	}
+}
+
 // ─── Context Claims Tests ─────────────────────────────────────────────────────
 
 func TestContextClaims_StaticPassthrough(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"env": "production"}
 
@@ -572,7 +762,7 @@ func TestContextClaims_StaticPassthrough(t *testing.T) {
 
 func TestContextClaims_RequestPath(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"req_path": "$ctx:request.path"}
 
@@ -598,7 +788,7 @@ func TestContextClaims_RequestPath(t *testing.T) {
 
 func TestContextClaims_RequestHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -624,7 +814,7 @@ func TestContextClaims_RequestHeader(t *testing.T) {
 
 func TestContextClaims_APIName(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"api": "$ctx:api.name"}
 
@@ -651,7 +841,7 @@ func TestContextClaims_APIName(t *testing.T) {
 
 func TestContextClaims_AuthCredentialID(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"applicationId": "$ctx:auth.credential_id"}
 
@@ -673,7 +863,7 @@ func TestContextClaims_AuthCredentialID(t *testing.T) {
 
 func TestContextClaims_AuthProperty(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"appName": "$ctx:auth.property.application_name"}
 
@@ -695,7 +885,7 @@ func TestContextClaims_AuthProperty(t *testing.T) {
 
 func TestContextClaims_MissingHeader(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"tenant": "$ctx:request.header.x-tenant-id"}
 
@@ -713,7 +903,7 @@ func TestContextClaims_MissingHeader(t *testing.T) {
 
 func TestContextClaims_UnknownVariable(t *testing.T) {
 	rsaKey, keyPEM := generateRSAKey(t)
-	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey)}
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
 	params["customClaims"] = map[string]interface{}{"x": "$ctx:unknown.variable.name"}
 

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -681,7 +681,7 @@ func TestTokenCache_MissOnDifferentSubject(t *testing.T) {
 	}
 }
 
-func TestTokenCache_MissOnDifferentAPIContext(t *testing.T) {
+func TestTokenCache_MissOnDifferentPath(t *testing.T) {
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{
 		keyCache:   make(map[[32]byte]crypto.PrivateKey),
@@ -691,29 +691,55 @@ func TestTokenCache_MissOnDifferentAPIContext(t *testing.T) {
 	params := baseParams(keyPEM)
 	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "carol"}
 
-	makeCtx := func(apiContext string) *policy.RequestHeaderContext {
+	makeCtx := func(path string) *policy.RequestHeaderContext {
 		return &policy.RequestHeaderContext{
 			SharedContext: &policy.SharedContext{
 				RequestID:   "test",
 				Metadata:    make(map[string]interface{}),
 				AuthContext: authCtx,
-				APIContext:  apiContext,
 			},
 			Headers: policy.NewHeaders(map[string][]string{}),
-			Path:    "/api/v1",
+			Path:    path,
 			Method:  "GET",
 		}
 	}
 
-	p.OnRequestHeaders(context.Background(), makeCtx("/petstore/v1"), params)
-	p.OnRequestHeaders(context.Background(), makeCtx("/orders/v1"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/petstore/v1/pets"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/orders/v1/orders"), params)
 
-	// Different API contexts → different cache keys → two separate cache entries.
+	// Different paths → different cache keys → two separate cache entries.
 	p.tokenMu.RLock()
 	count := len(p.tokenCache)
 	p.tokenMu.RUnlock()
 	if count != 2 {
-		t.Errorf("expected 2 cache entries for 2 different API contexts, got %d", count)
+		t.Errorf("expected 2 cache entries for 2 different paths, got %d", count)
+	}
+}
+
+func TestTokenCache_QueryParamsIgnored(t *testing.T) {
+	// Requests to the same path with different query strings must share one cache entry.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
+
+	makeCtx := func(path string) *policy.RequestHeaderContext {
+		return &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{RequestID: "x", Metadata: make(map[string]interface{}), AuthContext: authCtx},
+			Headers:       policy.NewHeaders(map[string][]string{}),
+			Path:          path, Method: "GET",
+		}
+	}
+
+	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets?page=1&limit=10"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets?page=2&limit=10"), params)
+	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets"), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 1 {
+		t.Errorf("different query strings on the same path must share one cache entry, got %d", count)
 	}
 }
 
@@ -857,6 +883,33 @@ func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
 	}
 }
 
+func TestTokenCacheKey_JWT_SameJTI_DifferentHeaderMisses(t *testing.T) {
+	// Same jti but different resolved dynamic claim ($ctx:request.header.*) must not share a cache entry.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"tenantId": "$ctx:request.header.x-tenant-id"}
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
+
+	makeReqCtx := func(tenant string) *policy.RequestHeaderContext {
+		return &policy.RequestHeaderContext{
+			SharedContext: &policy.SharedContext{RequestID: "x", Metadata: make(map[string]interface{}), AuthContext: authCtx},
+			Headers:       policy.NewHeaders(map[string][]string{"x-tenant-id": {tenant}}),
+			Path:          "/api", Method: "GET",
+		}
+	}
+
+	p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), params)
+	p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("same jti with different dynamic header values must produce separate cache entries, got %d", count)
+	}
+}
+
 func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
 	// Without jti, tokens from different issuers with the same subject must not collide.
 	_, keyPEM := generateRSAKey(t)
@@ -902,25 +955,23 @@ func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
 }
 
 func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
-	// Same ApplicationID must share one cache entry regardless of other metadata.
+	// Identical auth context must share one cache entry.
 	_, keyPEM := generateRSAKey(t)
 	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
 	params := baseParams(keyPEM)
+	authCtx := &policy.AuthContext{
+		Authenticated: true, AuthType: "apikey",
+		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "MyApp"},
+	}
 
-	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
-		Authenticated: true, AuthType: "apikey",
-		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "First Call"},
-	}), params)
-	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
-		Authenticated: true, AuthType: "apikey",
-		Properties: map[string]string{"ApplicationID": "app-001", "ApplicationName": "Second Call"},
-	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
 	p.tokenMu.RLock()
 	count := len(p.tokenCache)
 	p.tokenMu.RUnlock()
 	if count != 1 {
-		t.Errorf("same ApplicationID must share one cache entry, got %d", count)
+		t.Errorf("identical auth context must share one cache entry, got %d", count)
 	}
 }
 
@@ -938,6 +989,25 @@ func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
 	p.tokenMu.RUnlock()
 	if count != 1 {
 		t.Errorf("multiple unauthenticated requests must share one cache entry, got %d", count)
+	}
+}
+
+func TestTokenCaching_Disabled_NoCacheEntries(t *testing.T) {
+	// With tokenCaching=false, repeated identical requests must not populate the cache.
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["tokenCaching"] = false
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "token-xyz"}
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 0 {
+		t.Errorf("tokenCaching=false must not populate the cache, got %d entries", count)
 	}
 }
 
@@ -1251,6 +1321,137 @@ func TestClaimMappings_RestrictedDestinationSkipped(t *testing.T) {
 
 	if claims["sub"] != "alice" {
 		t.Errorf("sub must equal AuthContext.Subject (alice) when claimMapping target is restricted, got %v", claims["sub"])
+	}
+}
+
+// ─── JWT Claims Passthrough Tests ─────────────────────────────────────────────
+
+func TestJWTClaimsPassthrough_PropertiesForwarded(t *testing.T) {
+	// All non-standard JWT claims in Properties must appear in the backend JWT
+	// under their original names when auth type is jwt.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"email": "alice@example.com", "role": "admin", "org": "acme"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["email"] != "alice@example.com" {
+		t.Errorf("email must be forwarded from Properties, got %v", claims["email"])
+	}
+	if claims["role"] != "admin" {
+		t.Errorf("role must be forwarded from Properties, got %v", claims["role"])
+	}
+	if claims["org"] != "acme" {
+		t.Errorf("org must be forwarded from Properties, got %v", claims["org"])
+	}
+}
+
+func TestJWTClaimsPassthrough_ScopesForwarded(t *testing.T) {
+	// Scopes must be forwarded as a space-delimited "scope" claim.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Scopes:        map[string]bool{"read": true, "write": true},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	scopeVal, ok := claims["scope"]
+	if !ok {
+		t.Fatal("scope claim must be present when AuthContext.Scopes is non-empty")
+	}
+	scopeStr, ok := scopeVal.(string)
+	if !ok {
+		t.Fatalf("scope claim must be a string, got %T", scopeVal)
+	}
+	// Values are sorted, so "read write" is deterministic.
+	if scopeStr != "read write" {
+		t.Errorf("expected scope=\"read write\", got %q", scopeStr)
+	}
+}
+
+func TestJWTClaimsPassthrough_CustomClaimsOverrideProperty(t *testing.T) {
+	// customClaims must override auto-forwarded Properties for the same key.
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+	params["customClaims"] = map[string]interface{}{"role": "superadmin"}
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "jwt",
+		Subject:       "alice",
+		Properties:    map[string]string{"role": "viewer"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if claims["role"] != "superadmin" {
+		t.Errorf("customClaims must override auto-forwarded Property, got %v", claims["role"])
+	}
+}
+
+func TestJWTClaimsPassthrough_NotForwardedForNonJWTAuth(t *testing.T) {
+	// Properties must NOT be auto-forwarded for non-JWT auth types (e.g. basic).
+	rsaKey, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	reqCtx := newRequestContext(&policy.AuthContext{
+		Authenticated: true,
+		AuthType:      "basic",
+		Subject:       "bob",
+		Properties:    map[string]string{"email": "bob@example.com"},
+	})
+
+	result := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	mods := result.(policy.UpstreamRequestHeaderModifications)
+	claims := decodeJWT(t, mods.HeadersToSet[defaultHeader], &rsaKey.PublicKey)
+
+	if _, present := claims["email"]; present {
+		t.Error("Properties must not be auto-forwarded for basic auth; use claimMappings or customClaims instead")
+	}
+}
+
+func TestTokenCacheKey_JWT_DifferentProperties_NoJTI(t *testing.T) {
+	// Without jti, tokens with same identity but different custom claims must produce
+	// separate cache entries (because the backend JWT content differs).
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{keyCache: make(map[[32]byte]crypto.PrivateKey), pemCache: make(map[string][]byte), tokenCache: make(map[string]cachedToken)}
+	params := baseParams(keyPEM)
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp.example.com",
+		Properties: map[string]string{"role": "viewer"},
+	}), params)
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp.example.com",
+		Properties: map[string]string{"role": "admin"},
+	}), params)
+
+	p.tokenMu.RLock()
+	count := len(p.tokenCache)
+	p.tokenMu.RUnlock()
+	if count != 2 {
+		t.Errorf("same identity but different Properties (no jti) must produce separate cache entries, got %d", count)
 	}
 }
 

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -19,7 +19,6 @@ package backendjwt
 
 import (
 	"context"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -31,6 +30,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/patrickmn/go-cache"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
@@ -105,9 +105,9 @@ func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
 
 func newTestPolicy() *BackendJWTPolicy {
 	return &BackendJWTPolicy{
-		keyCache:   make(map[[32]byte]crypto.PrivateKey),
-		pemCache:   make(map[string][]byte),
-		tokenCache: make(map[string]cachedToken),
+		keyCache:   cache.New(cache.NoExpiration, 0),
+		pemCache:   cache.New(cache.NoExpiration, 0),
+		tokenCache: cache.New(cache.NoExpiration, 5*time.Minute),
 	}
 }
 
@@ -543,10 +543,7 @@ func TestPEMFileCachedAfterFirstRead(t *testing.T) {
 	reqCtx1 := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "user-a"})
 	p.OnRequestHeaders(context.Background(), reqCtx1, params)
 
-	p.keyMu.RLock()
-	_, cached := p.pemCache[f.Name()]
-	p.keyMu.RUnlock()
-	if !cached {
+	if _, cached := p.pemCache.Get(f.Name()); !cached {
 		t.Fatal("expected PEM bytes to be cached after first path read")
 	}
 
@@ -576,10 +573,7 @@ func TestKeyCaching(t *testing.T) {
 	}
 
 	// Verify only one key is cached.
-	p.keyMu.RLock()
-	count := len(p.keyCache)
-	p.keyMu.RUnlock()
-	if count != 1 {
+	if count := p.keyCache.ItemCount(); count != 1 {
 		t.Errorf("expected 1 cached key, got %d", count)
 	}
 }
@@ -739,9 +733,7 @@ func TestTokenCache_MissOnDifferentPath(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeCtx("/orders/v1/orders"), params)
 
 	// Different paths → different cache keys → two separate cache entries.
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("expected 2 cache entries for 2 different paths, got %d", count)
 	}
@@ -766,9 +758,7 @@ func TestTokenCache_QueryParamsIgnored(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets?page=2&limit=10"), params)
 	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets"), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 1 {
 		t.Errorf("different query strings on the same path must share one cache entry, got %d", count)
 	}
@@ -813,14 +803,9 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 	p := newTestPolicy()
 
 	p.putCachedToken("key-a", "sentinel-live", time.Hour)
-	p.putCachedToken("key-b", "sentinel-expired", time.Hour)
-
-	// Expire key-b.
-	p.tokenMu.Lock()
-	v := p.tokenCache["key-b"]
-	v.expiresAt = time.Now().Add(-time.Second)
-	p.tokenCache["key-b"] = v
-	p.tokenMu.Unlock()
+	// Store key-b with a tiny TTL, then wait it out so go-cache treats it as expired.
+	p.tokenCache.Set("key-b", "sentinel-expired", time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	got, ok := p.getCachedToken("key-a")
 	if !ok || got != "sentinel-live" {
@@ -835,25 +820,19 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 
 func TestTokenCache_EvictExpired(t *testing.T) {
 	p := newTestPolicy()
-	now := time.Now()
 
-	p.tokenMu.Lock()
-	p.tokenCache["expired"] = cachedToken{signed: "old", expiresAt: now.Add(-time.Second)}
-	p.tokenCache["live"] = cachedToken{signed: "current", expiresAt: now.Add(time.Hour)}
-	p.tokenMu.Unlock()
+	// Tiny TTL → expires once we wait; long TTL → stays live.
+	p.tokenCache.Set("expired", "old", time.Millisecond)
+	p.tokenCache.Set("live", "current", time.Hour)
+	time.Sleep(10 * time.Millisecond)
 
-	p.evictExpired()
+	p.tokenCache.DeleteExpired()
 
-	p.tokenMu.RLock()
-	_, hasExpired := p.tokenCache["expired"]
-	_, hasLive := p.tokenCache["live"]
-	p.tokenMu.RUnlock()
-
-	if hasExpired {
-		t.Error("evictExpired must remove entries past their expiresAt")
+	if _, hasExpired := p.tokenCache.Get("expired"); hasExpired {
+		t.Error("DeleteExpired must remove entries past their expiry")
 	}
-	if !hasLive {
-		t.Error("evictExpired must keep entries that have not yet expired")
+	if _, hasLive := p.tokenCache.Get("live"); !hasLive {
+		t.Error("DeleteExpired must keep entries that have not yet expired")
 	}
 }
 
@@ -874,9 +853,7 @@ func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
 		TokenId: "token-bbb",
 	}), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("different jti must produce separate cache entries, got %d", count)
 	}
@@ -894,9 +871,7 @@ func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 1 {
 		t.Errorf("same jti must share one cache entry, got %d", count)
 	}
@@ -921,9 +896,7 @@ func TestTokenCacheKey_JWT_SameJTI_DifferentHeaderMisses(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), params)
 	p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("same jti with different dynamic header values must produce separate cache entries, got %d", count)
 	}
@@ -942,9 +915,7 @@ func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
 		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp-b.example.com",
 	}), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("same subject from different issuers (no jti) must produce separate cache entries, got %d", count)
 	}
@@ -965,9 +936,7 @@ func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
 		Properties: map[string]string{"ApplicationID": "app-002", "ApplicationName": "App Two"},
 	}), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("different ApplicationIDs must produce separate cache entries, got %d", count)
 	}
@@ -986,9 +955,7 @@ func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 1 {
 		t.Errorf("identical auth context must share one cache entry, got %d", count)
 	}
@@ -1003,9 +970,7 @@ func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 1 {
 		t.Errorf("multiple unauthenticated requests must share one cache entry, got %d", count)
 	}
@@ -1022,9 +987,7 @@ func TestTokenCaching_Disabled_NoCacheEntries(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 0 {
 		t.Errorf("tokenCaching=false must not populate the cache, got %d entries", count)
 	}
@@ -1490,9 +1453,7 @@ func TestTokenCacheKey_JWT_DifferentProperties_NoJTI(t *testing.T) {
 		Properties: map[string]string{"role": "admin"},
 	}), params)
 
-	p.tokenMu.RLock()
-	count := len(p.tokenCache)
-	p.tokenMu.RUnlock()
+	count := p.tokenCache.ItemCount()
 	if count != 2 {
 		t.Errorf("same identity but different Properties (no jti) must produce separate cache entries, got %d", count)
 	}

--- a/policies/backend-jwt/backendjwt_test.go
+++ b/policies/backend-jwt/backendjwt_test.go
@@ -25,13 +25,14 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/patrickmn/go-cache"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	"github.com/wso2/api-platform/sdk/core/utils/cache"
 )
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -105,10 +106,17 @@ func generateECKey(t *testing.T) (*ecdsa.PrivateKey, string) {
 
 func newTestPolicy() *BackendJWTPolicy {
 	return &BackendJWTPolicy{
-		keyCache:   cache.New(cache.NoExpiration, 0),
-		pemCache:   cache.New(cache.NoExpiration, 0),
-		tokenCache: cache.New(cache.NoExpiration, 5*time.Minute),
+		tokenCache:     newTokenCache(defaultCacheMaxSize),
+		currentMaxSize: defaultCacheMaxSize,
 	}
+}
+
+// tokenCount returns the number of entries currently held in the policy's token cache. The SDK
+// cache exposes no key iteration, but every cache-key test uses a dedicated policy instance
+// scoped to a single API (APIName ""), so the global entry count equals the number of distinct
+// tokens cached for that API. The apiName argument is retained for call-site readability.
+func tokenCount(p *BackendJWTPolicy, _ string) int {
+	return p.tokenCache.GetStats().Size
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -124,6 +132,82 @@ func TestGetPolicySingleton(t *testing.T) {
 	}
 	if p1 != p2 {
 		t.Error("GetPolicy must return the same singleton instance")
+	}
+}
+
+func TestGetPolicy_SystemParamsReadFlat(t *testing.T) {
+	// cacheMaxSize is a system parameter: the gateway resolves it from config.toml and
+	// injects it flat into params, at the same level as signingKey and algorithm — not
+	// nested under "systemParameters". GetPolicy applies it to the shared cache's maximum.
+	_, keyPEM := generateRSAKey(t)
+	params := baseParams(keyPEM)
+	params["cacheMaxSize"] = 75
+
+	origMax := ins.currentMaxSize
+	t.Cleanup(func() { ins.ensureTokenCache(origMax) })
+
+	if _, err := GetPolicy(policy.PolicyMetadata{APIName: "param-test-api"}, params); err != nil {
+		t.Fatalf("GetPolicy returned error: %v", err)
+	}
+
+	if max := ins.tokenCache.GetStats().MaxSize; max != 75 {
+		t.Errorf("expected shared cache maximum=75, got %d", max)
+	}
+}
+
+func TestGetPolicy_CacheMaxSizeIsGlobalDefault(t *testing.T) {
+	// cacheMaxSize=0 (or unset) maps to the default global bound rather than unbounded.
+	_, keyPEM := generateRSAKey(t)
+	params := baseParams(keyPEM) // no cacheMaxSize
+
+	origMax := ins.currentMaxSize
+	t.Cleanup(func() { ins.ensureTokenCache(origMax) })
+
+	if _, err := GetPolicy(policy.PolicyMetadata{APIName: "default-size-api"}, params); err != nil {
+		t.Fatalf("GetPolicy returned error: %v", err)
+	}
+
+	if max := ins.tokenCache.GetStats().MaxSize; max != defaultCacheMaxSize {
+		t.Errorf("expected shared cache maximum=%d (default), got %d", defaultCacheMaxSize, max)
+	}
+}
+
+func TestCacheMaxSize_GloballyBounded(t *testing.T) {
+	// The shared cache enforces a single global bound across all APIs: its LRU policy evicts
+	// the least-recently-used entries once full, so the total live entry count never exceeds
+	// the maximum regardless of how many APIs or distinct tokens are generated.
+	const maxSize = 5
+	_, keyPEM := generateRSAKey(t)
+	p := &BackendJWTPolicy{tokenCache: newTokenCache(maxSize), currentMaxSize: maxSize}
+	params := baseParams(keyPEM)
+
+	// Spread distinct tokens across several APIs — the bound is global, not per-API.
+	for _, api := range []string{"api-a", "api-b", "api-c"} {
+		for i := 0; i < 20; i++ {
+			authCtx := &policy.AuthContext{
+				Authenticated: true, AuthType: "jwt", Subject: "user", TokenId: fmt.Sprintf("tok-%d", i),
+			}
+			reqCtx := newRequestContext(authCtx)
+			reqCtx.APIName = api
+			p.OnRequestHeaders(context.Background(), reqCtx, params)
+		}
+	}
+
+	if total := p.tokenCache.GetStats().Size; total > maxSize {
+		t.Errorf("global maximum=%d must cap total entries across all APIs, got %d", maxSize, total)
+	}
+}
+
+func TestTokenCache_PopulatedOnFirstRequest(t *testing.T) {
+	_, keyPEM := generateRSAKey(t)
+	p := newTestPolicy()
+
+	p.OnRequestHeaders(context.Background(), newRequestContext(&policy.AuthContext{
+		Authenticated: true, AuthType: "jwt", Subject: "dave", TokenId: "tok-d",
+	}), baseParams(keyPEM))
+
+	if count := tokenCount(p, ""); count != 1 {
+		t.Errorf("expected 1 cached token after first request, got %d", count)
 	}
 }
 
@@ -540,7 +624,7 @@ func TestPEMFileCachedAfterFirstRead(t *testing.T) {
 	reqCtx1 := newRequestContext(&policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "user-a"})
 	p.OnRequestHeaders(context.Background(), reqCtx1, params)
 
-	if _, cached := p.pemCache.Get(f.Name()); !cached {
+	if _, cached := p.pemCache.Load(f.Name()); !cached {
 		t.Fatal("expected PEM bytes to be cached after first path read")
 	}
 
@@ -570,8 +654,10 @@ func TestKeyCaching(t *testing.T) {
 	}
 
 	// Verify only one key is cached.
-	if count := p.keyCache.ItemCount(); count != 1 {
-		t.Errorf("expected 1 cached key, got %d", count)
+	keyCount := 0
+	p.keyCache.Range(func(_, _ any) bool { keyCount++; return true })
+	if keyCount != 1 {
+		t.Errorf("expected 1 cached key, got %d", keyCount)
 	}
 }
 
@@ -730,7 +816,7 @@ func TestTokenCache_MissOnDifferentPath(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeCtx("/orders/v1/orders"), params)
 
 	// Different paths → different cache keys → two separate cache entries.
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("expected 2 cache entries for 2 different paths, got %d", count)
 	}
@@ -755,7 +841,7 @@ func TestTokenCache_QueryParamsIgnored(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets?page=2&limit=10"), params)
 	p.OnRequestHeaders(context.Background(), makeCtx("/api/v1/pets"), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 1 {
 		t.Errorf("different query strings on the same path must share one cache entry, got %d", count)
 	}
@@ -798,42 +884,129 @@ func TestTokenCache_ExpiryRespected(t *testing.T) {
 	// is deterministic — re-signing the same claims in the same second produces the
 	// same token string, making "different string" an unreliable expiry signal.
 	p := newTestPolicy()
+	ctx := context.Background()
 
-	p.putCachedToken("key-a", "sentinel-live", time.Hour)
-	// Store key-b with a tiny TTL, then wait it out so go-cache treats it as expired.
-	p.tokenCache.Set("key-b", "sentinel-expired", time.Millisecond)
+	p.putCachedToken(ctx, "key-a", "sentinel-live", time.Hour)
+	// key-b gets a tiny expiry (ttl → ~1ms), then we wait it out so it is past its window.
+	p.putCachedToken(ctx, "key-b", "sentinel-expired", 2*time.Millisecond)
 	time.Sleep(10 * time.Millisecond)
 
-	got, ok := p.getCachedToken("key-a")
+	got, ok := p.getCachedToken(ctx, "key-a")
 	if !ok || got != "sentinel-live" {
 		t.Errorf("expected cache hit for live entry, got (%q, %v)", got, ok)
 	}
 
-	got, ok = p.getCachedToken("key-b")
+	got, ok = p.getCachedToken(ctx, "key-b")
 	if ok || got != "" {
 		t.Errorf("expected cache miss for expired entry, got (%q, %v)", got, ok)
 	}
 }
 
-func TestTokenCache_EvictExpired(t *testing.T) {
+func TestTokenCache_ExpiredEntryRemovedOnRead(t *testing.T) {
+	// The SDK cache is created with ttl=0, so it never expires entries on its own clock; expiry
+	// is self-managed in getCachedToken, which deletes an entry past its window on read and
+	// reports a miss. After reading both, only the live entry should remain.
 	p := newTestPolicy()
+	ctx := context.Background()
 
-	// Tiny TTL → expires once we wait; long TTL → stays live.
-	p.tokenCache.Set("expired", "old", time.Millisecond)
-	p.tokenCache.Set("live", "current", time.Hour)
+	p.putCachedToken(ctx, "expired", "old", 2*time.Millisecond)
+	p.putCachedToken(ctx, "live", "current", time.Hour)
 	time.Sleep(10 * time.Millisecond)
 
-	p.tokenCache.DeleteExpired()
-
-	if _, hasExpired := p.tokenCache.Get("expired"); hasExpired {
-		t.Error("DeleteExpired must remove entries past their expiry")
+	if _, ok := p.getCachedToken(ctx, "expired"); ok {
+		t.Error("expired entry must be reported as a miss")
 	}
-	if _, hasLive := p.tokenCache.Get("live"); !hasLive {
-		t.Error("DeleteExpired must keep entries that have not yet expired")
+	if got, ok := p.getCachedToken(ctx, "live"); !ok || got != "current" {
+		t.Errorf("live entry must be a hit, got (%q, %v)", got, ok)
+	}
+	if size := p.tokenCache.GetStats().Size; size != 1 {
+		t.Errorf("expired entry must be deleted on read, leaving 1 entry, got %d", size)
+	}
+}
+
+func TestPutCachedToken_TTLNeverOutlivesToken(t *testing.T) {
+	// The cache TTL must always be strictly less than the token's own validity, otherwise
+	// the cache could serve a JWT whose exp has already passed. This must hold even for
+	// short expiries where the minCacheTTL (30s) floor would otherwise dominate.
+	p := newTestPolicy()
+	ctx := context.Background()
+
+	cases := []time.Duration{
+		5 * time.Second,  // half=2.5s; floor must NOT apply (would be 30s > 5s)
+		20 * time.Second, // half=10s;  floor must NOT apply (would be 30s > 20s)
+		30 * time.Second, // half=15s;  floor must NOT apply (30s == expiry is not strictly inside)
+		45 * time.Second, // half=22.5s; floor applies (30s < 45s) → 30s, still inside
+		90 * time.Second, // half=45s;  above the floor entirely
+		15 * time.Minute, // default; well above the floor
+	}
+
+	for _, exp := range cases {
+		p.putCachedToken(ctx, "k", "signed-token", exp)
+		entry, ok := p.tokenCache.Get(ctx, cache.CacheKey{Key: "k"})
+		if !ok {
+			t.Fatalf("expiry=%v: expected a cached entry", exp)
+		}
+		// The entry's remaining lifetime (≈ the configured cache TTL) must stay strictly below
+		// the token's own validity, so a cached token always has a safety margin before its exp.
+		if ttl := time.Until(entry.expiresAt); ttl >= exp {
+			t.Errorf("expiry=%v: cache TTL %v must be strictly less than token validity", exp, ttl)
+		}
+		_ = p.tokenCache.Delete(ctx, cache.CacheKey{Key: "k"})
 	}
 }
 
 // ─── Cache Key Strategy Tests ────────────────────────────────────────────────
+
+func TestTokenCacheKey_StaticClaimsAffectKey(t *testing.T) {
+	// The full configured claim set — including static (non-$ctx) customClaims and claimMappings
+	// destinations — must be folded into the cache key, so an API redeployed with different claim
+	// config never serves a token built from the old config.
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "tok-1"}
+	ns := keyNamespace{apiName: "api", algorithm: "SHA256withRSA"}
+
+	none := buildTokenCacheKey(ns, authCtx, "/api/test", "GET", resolvedClaims{})
+	gold := buildTokenCacheKey(ns, authCtx, "/api/test", "GET", resolvedClaims{stringClaims: map[string]string{"tier": "gold"}})
+	platinum := buildTokenCacheKey(ns, authCtx, "/api/test", "GET", resolvedClaims{stringClaims: map[string]string{"tier": "platinum"}})
+	// A non-string custom claim (rawClaims) must contribute too.
+	raw := buildTokenCacheKey(ns, authCtx, "/api/test", "GET", resolvedClaims{rawClaims: map[string]interface{}{"level": 5}})
+
+	if gold == platinum {
+		t.Error("different static claim values must produce different cache keys")
+	}
+	for name, k := range map[string]string{"gold": gold, "platinum": platinum, "raw": raw} {
+		if k == none {
+			t.Errorf("configuring a static claim (%s) must change the key versus no claims", name)
+		}
+	}
+}
+
+func TestTokenCacheKey_NamespaceFieldsAffectKey(t *testing.T) {
+	// apiName keeps each API's entries isolated; issuer/algorithm/dialect/excludedClaims are the
+	// token-shaping config folded into the key in place of the old generation-counter invalidation.
+	// Changing any one of them on redeploy must yield a different key (a cache miss), so a stale
+	// token built from the old config is never served.
+	authCtx := &policy.AuthContext{Authenticated: true, AuthType: "jwt", Subject: "alice", TokenId: "tok-1"}
+	base := keyNamespace{apiName: "api-a", issuer: "iss-a", algorithm: "SHA256withRSA", dialect: "", excluded: nil}
+	baseKey := buildTokenCacheKey(base, authCtx, "/api/test", "GET", resolvedClaims{})
+
+	variants := map[string]keyNamespace{
+		"apiName":        {apiName: "api-b", issuer: "iss-a", algorithm: "SHA256withRSA"},
+		"issuer":         {apiName: "api-a", issuer: "iss-b", algorithm: "SHA256withRSA"},
+		"algorithm":      {apiName: "api-a", issuer: "iss-a", algorithm: "ES256"},
+		"dialect":        {apiName: "api-a", issuer: "iss-a", algorithm: "SHA256withRSA", dialect: "http://wso2.org/claims/"},
+		"excludedClaims": {apiName: "api-a", issuer: "iss-a", algorithm: "SHA256withRSA", excluded: []string{"role"}},
+	}
+	for field, ns := range variants {
+		if got := buildTokenCacheKey(ns, authCtx, "/api/test", "GET", resolvedClaims{}); got == baseKey {
+			t.Errorf("changing %s must produce a different cache key", field)
+		}
+	}
+
+	// Same namespace + same identity must still hit the same key (no spurious fragmentation).
+	if buildTokenCacheKey(base, authCtx, "/api/test", "GET", resolvedClaims{}) != baseKey {
+		t.Error("identical namespace and identity must produce a stable key")
+	}
+}
 
 func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
 	// Different jti on same subject/issuer must produce separate cache entries.
@@ -850,7 +1023,7 @@ func TestTokenCacheKey_JWT_JTIRotation(t *testing.T) {
 		TokenId: "token-bbb",
 	}), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("different jti must produce separate cache entries, got %d", count)
 	}
@@ -868,7 +1041,7 @@ func TestTokenCacheKey_JWT_SameJTI_HitsCache(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 1 {
 		t.Errorf("same jti must share one cache entry, got %d", count)
 	}
@@ -893,7 +1066,7 @@ func TestTokenCacheKey_JWT_SameJTI_DifferentHeaderMisses(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), makeReqCtx("acme"), params)
 	p.OnRequestHeaders(context.Background(), makeReqCtx("globex"), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("same jti with different dynamic header values must produce separate cache entries, got %d", count)
 	}
@@ -912,7 +1085,7 @@ func TestTokenCacheKey_JWT_CrossIssuerNoJTI(t *testing.T) {
 		Authenticated: true, AuthType: "jwt", Subject: "alice", Issuer: "https://idp-b.example.com",
 	}), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("same subject from different issuers (no jti) must produce separate cache entries, got %d", count)
 	}
@@ -933,7 +1106,7 @@ func TestTokenCacheKey_APIKey_DifferentApplicationID(t *testing.T) {
 		Properties: map[string]string{"ApplicationID": "app-002", "ApplicationName": "App Two"},
 	}), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("different ApplicationIDs must produce separate cache entries, got %d", count)
 	}
@@ -952,7 +1125,7 @@ func TestTokenCacheKey_APIKey_SameApplicationID_HitsCache(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 1 {
 		t.Errorf("identical auth context must share one cache entry, got %d", count)
 	}
@@ -967,7 +1140,7 @@ func TestTokenCacheKey_NoAuth_SharedEntry(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(nil), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 1 {
 		t.Errorf("multiple unauthenticated requests must share one cache entry, got %d", count)
 	}
@@ -984,7 +1157,7 @@ func TestTokenCaching_Disabled_NoCacheEntries(t *testing.T) {
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 	p.OnRequestHeaders(context.Background(), newRequestContext(authCtx), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 0 {
 		t.Errorf("tokenCaching=false must not populate the cache, got %d entries", count)
 	}
@@ -1450,7 +1623,7 @@ func TestTokenCacheKey_JWT_DifferentProperties_NoJTI(t *testing.T) {
 		Properties: map[string]string{"role": "admin"},
 	}), params)
 
-	count := p.tokenCache.ItemCount()
+	count := tokenCount(p, "")
 	if count != 2 {
 		t.Errorf("same identity but different Properties (no jti) must produce separate cache entries, got %d", count)
 	}

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -8,5 +8,3 @@ require (
 )
 
 require github.com/patrickmn/go-cache v2.1.0+incompatible
-
-replace github.com/wso2/api-platform/sdk/core => /Users/dineth/Code/api-platform/sdk/core

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -4,7 +4,5 @@ go 1.26.2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.2.14
+	github.com/wso2/api-platform/sdk/core v0.2.16
 )
-
-require github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -4,5 +4,5 @@ go 1.26.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.2.4
+	github.com/wso2/api-platform/sdk/core v0.2.14
 )

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -7,4 +7,6 @@ require (
 	github.com/wso2/api-platform/sdk/core v0.2.14
 )
 
+require github.com/patrickmn/go-cache v2.1.0+incompatible
+
 replace github.com/wso2/api-platform/sdk/core => /Users/dineth/Code/api-platform/sdk/core

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -1,8 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/backend-jwt
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/wso2/api-platform/sdk/core v0.2.14
 )
+
+replace github.com/wso2/api-platform/sdk/core => /Users/dineth/Code/api-platform/sdk/core

--- a/policies/backend-jwt/go.mod
+++ b/policies/backend-jwt/go.mod
@@ -1,0 +1,8 @@
+module github.com/wso2/gateway-controllers/policies/backend-jwt
+
+go 1.26.1
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/wso2/api-platform/sdk/core v0.2.4
+)

--- a/policies/backend-jwt/go.sum
+++ b/policies/backend-jwt/go.sum
@@ -1,4 +1,2 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/backend-jwt/go.sum
+++ b/policies/backend-jwt/go.sum
@@ -1,0 +1,4 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
+github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/backend-jwt/go.sum
+++ b/policies/backend-jwt/go.sum
@@ -1,6 +1,2 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
-github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/backend-jwt/go.sum
+++ b/policies/backend-jwt/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/policies/backend-jwt/go.sum
+++ b/policies/backend-jwt/go.sum
@@ -2,3 +2,5 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -51,6 +51,14 @@ parameters:
       default: {}
       additionalProperties: {}
 
+    tokenExpiry:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: >-
+        Token validity as a Go duration string (e.g. "5m", "1h"). When set, overrides
+        the system-level tokenExpiry for this API. If omitted, the system default applies.
+      pattern: "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+
 systemParameters:
   type: object
   additionalProperties: false

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -29,6 +29,20 @@ parameters:
         If false, unauthenticated requests are forwarded without a backend JWT.
       default: false
 
+    claimMappings:
+      type: object
+      x-wso2-policy-advanced-param: false
+      description: >-
+        Maps upstream JWT claim names to backend JWT claim names. Key is the backend
+        JWT claim to set; value is the property key from the authenticated context
+        (populated by jwt-auth from the upstream JWT's custom claims). Claims mapped
+        to reserved names (iss, sub, aud, exp, iat) are skipped with a warning.
+        Missing source properties are silently skipped. Values are always strings.
+        customClaims take precedence if the same destination key appears in both.
+      default: {}
+      additionalProperties:
+        type: string
+
     customClaims:
       type: object
       x-wso2-policy-advanced-param: false
@@ -39,7 +53,8 @@ parameters:
         "$ctx:request.header.x-tenant-id" injects a request header value. See
         documentation for the full list of supported context variables. Non-resolvable
         context references are silently skipped. Non-string values (numbers, booleans)
-        are included as-is. These run last and can override any derived claim.
+        are included as-is. Claims targeting reserved names (iss, sub, aud, exp, iat)
+        are skipped with a warning. Runs after claimMappings and takes precedence.
       default: {}
       additionalProperties: {}
 

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -59,6 +59,32 @@ parameters:
         the system-level tokenExpiry for this API. If omitted, the system default applies.
       pattern: "^[0-9]+(ns|us|µs|ms|s|m|h)$"
 
+    dialect:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: >-
+        Namespace prefix applied to auto-forwarded original-JWT claims only. When set,
+        each claim forwarded from the incoming JWT's Properties is emitted as
+        "<dialect><claimName>" instead of "<claimName>" (e.g. "http://wso2.org/claims/"
+        turns "email" into "http://wso2.org/claims/email"). Does not affect standard
+        registered claims (sub, scope, etc.) nor explicitly configured claimMappings or
+        customClaims — those are emitted under the exact names the user configured.
+        Default "" leaves claim names unchanged.
+      default: ""
+
+    excludedClaims:
+      type: array
+      x-wso2-policy-advanced-param: true
+      description: >-
+        List of original-JWT claim names (matched by their original name, before any
+        dialect prefix is applied) that must not be forwarded into the backend JWT.
+        Applies only to auto-forwarded original-JWT claims (the Properties loop); it does
+        not affect standard registered claims, claimMappings, or customClaims. Default []
+        forwards all non-restricted claims.
+      default: []
+      items:
+        type: string
+
 systemParameters:
   type: object
   additionalProperties: false

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -29,18 +29,6 @@ parameters:
         If false, unauthenticated requests are forwarded without a backend JWT.
       default: false
 
-    claimMappings:
-      type: object
-      x-wso2-policy-advanced-param: false
-      description: >-
-        Maps AuthContext.Properties keys to JWT claim names in the generated token.
-        For example, {"app_id": "application_id"} adds an "application_id" claim
-        sourced from the authenticated context's "app_id" property. Keys that are
-        absent from the auth context are silently skipped.
-      default: {}
-      additionalProperties:
-        type: string
-
     customClaims:
       type: object
       x-wso2-policy-advanced-param: false

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -142,4 +142,4 @@ systemParameters:
       default: true
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.tokencaching}"
 
-  required: ["signingKey"]
+  required: []

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -45,9 +45,13 @@ parameters:
       type: object
       x-wso2-policy-advanced-param: false
       description: >-
-        Static claim name→value pairs to include in every generated token regardless
-        of the authenticated user. These override any derived claims with the same name.
-        For example, {"env": "production"}.
+        Claim name→value pairs added to every generated token. String values prefixed
+        with "$ctx:" are resolved from the request context at runtime — for example,
+        "$ctx:auth.credential_id" injects the authenticated credential ID, and
+        "$ctx:request.header.x-tenant-id" injects a request header value. See
+        documentation for the full list of supported context variables. Non-resolvable
+        context references are silently skipped. Non-string values (numbers, booleans)
+        are included as-is. These run last and can override any derived claim.
       default: {}
       additionalProperties: {}
 
@@ -61,6 +65,7 @@ systemParameters:
         Private key used to sign the generated JWT. Specify exactly one of 'inline'
         (PEM-encoded key string) or 'path' (path to a PEM key file).
       additionalProperties: false
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.signingkey}"
       oneOf:
         - required: ["inline"]
           not:
@@ -82,16 +87,19 @@ systemParameters:
         JWT signing algorithm. Must match the type of the configured private key:
         RS256/RS384/RS512 for RSA keys, ES256/ES384/ES512 for ECDSA keys.
       default: RS256
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.algorithm}"
       enum: ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
 
     issuer:
       type: string
       description: Value for the 'iss' claim in generated tokens. Identifies the gateway as the token issuer.
       default: ""
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.issuer}"
 
     tokenExpiry:
       type: string
       description: Validity duration of the generated token as a Go duration string (e.g. "15m", "1h").
       default: "15m"
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.tokenexpiry}"
 
   required: ["signingKey"]

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -63,13 +63,12 @@ parameters:
       type: string
       x-wso2-policy-advanced-param: true
       description: >-
-        Namespace prefix applied to auto-forwarded original-JWT claims only. When set,
-        each claim forwarded from the incoming JWT's Properties is emitted as
-        "<dialect><claimName>" instead of "<claimName>" (e.g. "http://wso2.org/claims/"
-        turns "email" into "http://wso2.org/claims/email"). Does not affect standard
-        registered claims (sub, scope, etc.) nor explicitly configured claimMappings or
-        customClaims — those are emitted under the exact names the user configured.
-        Default "" leaves claim names unchanged.
+        Namespace prefix applied to all user-configured and auto-forwarded claims. When
+        set, auto-forwarded original-JWT claims, claimMappings destinations, and
+        customClaims keys are all emitted as "<dialect><claimName>" (e.g.
+        "http://wso2.org/claims/" turns "email" into "http://wso2.org/claims/email").
+        Does not affect standard claims set by the policy itself (sub, iss, aud, scope,
+        etc.). Default "" leaves claim names unchanged.
       default: ""
 
     excludedClaims:

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -1,0 +1,97 @@
+name: backend-jwt
+version: v1.0.0
+description: |
+  Generates a signed JWT containing authenticated user information and injects it into the
+  upstream request header. Run this policy after an authentication policy (e.g. jwt-auth,
+  basic-auth, api-key-auth) to pass a gateway-signed assertion to backend services.
+
+  The generated JWT includes the subject, authentication type, issuer (if set), audience,
+  and any custom or mapped claims. Backend services can verify it using the corresponding
+  public key without needing access to the original client credential.
+
+parameters:
+  type: object
+  additionalProperties: false
+  properties:
+    header:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: Header name to inject the generated JWT into.
+      default: x-jwt-assertion
+      minLength: 1
+      pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+
+    requireAuthentication:
+      type: boolean
+      x-wso2-policy-advanced-param: false
+      description: >-
+        If true, requests without a valid authentication context are rejected with 401.
+        If false, unauthenticated requests are forwarded without a backend JWT.
+      default: false
+
+    claimMappings:
+      type: object
+      x-wso2-policy-advanced-param: false
+      description: >-
+        Maps AuthContext.Properties keys to JWT claim names in the generated token.
+        For example, {"app_id": "application_id"} adds an "application_id" claim
+        sourced from the authenticated context's "app_id" property. Keys that are
+        absent from the auth context are silently skipped.
+      default: {}
+      additionalProperties:
+        type: string
+
+    customClaims:
+      type: object
+      x-wso2-policy-advanced-param: false
+      description: >-
+        Static claim name→value pairs to include in every generated token regardless
+        of the authenticated user. These override any derived claims with the same name.
+        For example, {"env": "production"}.
+      default: {}
+      additionalProperties: {}
+
+systemParameters:
+  type: object
+  additionalProperties: false
+  properties:
+    signingKey:
+      type: object
+      description: >-
+        Private key used to sign the generated JWT. Specify exactly one of 'inline'
+        (PEM-encoded key string) or 'path' (path to a PEM key file).
+      additionalProperties: false
+      oneOf:
+        - required: ["inline"]
+          not:
+            required: ["path"]
+        - required: ["path"]
+          not:
+            required: ["inline"]
+      properties:
+        inline:
+          type: string
+          description: PEM-encoded RSA or ECDSA private key string.
+        path:
+          type: string
+          description: Path to a PEM-encoded RSA or ECDSA private key file (e.g. /etc/certs/backend-jwt.key).
+
+    algorithm:
+      type: string
+      description: >-
+        JWT signing algorithm. Must match the type of the configured private key:
+        RS256/RS384/RS512 for RSA keys, ES256/ES384/ES512 for ECDSA keys.
+      default: RS256
+      enum: ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
+
+    issuer:
+      type: string
+      description: Value for the 'iss' claim in generated tokens. Identifies the gateway as the token issuer.
+      default: ""
+
+    tokenExpiry:
+      type: string
+      description: Validity duration of the generated token as a Go duration string (e.g. "15m", "1h").
+      default: "15m"
+
+  required: ["signingKey"]

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -1,13 +1,14 @@
 name: backend-jwt
 version: v1.0.0
 description: |
-  Generates a signed JWT containing authenticated user information and injects it into the
-  upstream request header. Run this policy after an authentication policy (e.g. jwt-auth,
-  basic-auth, api-key-auth) to pass a gateway-signed assertion to backend services.
+  Generates a signed JWT and injects it into the upstream request header. Can be used
+  standalone or after an authentication policy (e.g. jwt-auth, basic-auth, api-key-auth).
 
-  The generated JWT includes the subject, authentication type, issuer (if set), audience,
-  and any custom or mapped claims. Backend services can verify it using the corresponding
-  public key without needing access to the original client credential.
+  When an auth policy has run, the generated JWT includes the subject, authentication type,
+  issuer, audience, and any custom or mapped claims. When no auth policy is present, only
+  system claims (iss, iat, exp) and non-auth custom claims are included. Backend services
+  can verify the JWT using the corresponding public key without needing access to the
+  original client credential.
 
 parameters:
   type: object
@@ -20,14 +21,6 @@ parameters:
       default: x-jwt-assertion
       minLength: 1
       pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
-
-    requireAuthentication:
-      type: boolean
-      x-wso2-policy-advanced-param: false
-      description: >-
-        If true, requests without a valid authentication context are rejected with 401.
-        If false, unauthenticated requests are forwarded without a backend JWT.
-      default: false
 
     claimMappings:
       type: object

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -73,7 +73,7 @@ systemParameters:
       type: string
       description: >-
         JWT signing algorithm. Must match the type of the configured private key:
-        RS256/RS384/RS512 for RSA keys, ES256/ES384/ES512 for ECDSA keys.
+        SHA256withRSA for RSA keys, ES256 for ECDSA keys, or NONE for unsigned tokens.
       default: SHA256withRSA
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.algorithm}"
       enum: ["SHA256withRSA", "ES256", "NONE"]

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -86,9 +86,9 @@ systemParameters:
       description: >-
         JWT signing algorithm. Must match the type of the configured private key:
         RS256/RS384/RS512 for RSA keys, ES256/ES384/ES512 for ECDSA keys.
-      default: RS256
+      default: SHA256withRSA
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.algorithm}"
-      enum: ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
+      enum: ["SHA256withRSA", "ES256", "NONE"]
 
     issuer:
       type: string

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -146,11 +146,10 @@ systemParameters:
       description: >-
         Maximum total number of tokens to hold in the cache across all APIs combined (a single
         global bound, not per-API). When the limit is reached, the cache evicts the
-        least-recently-used existing entries to make room for new tokens. Set to 0 (default) to use
-        the built-in default bound of 100000. Changing this value rebuilds the shared cache, which
-        flushes all currently cached tokens.
-      default: 0
-      minimum: 0
+        least-recently-used existing entries to make room for new tokens. Changing this value rebuilds the shared cache, which flushes all
+        currently cached tokens.
+      default: 100000
+      minimum: 1
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.cachemaxsize}"
 
   required: []

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -29,7 +29,7 @@ parameters:
         Maps upstream JWT claim names to backend JWT claim names. Key is the backend
         JWT claim to set; value is the property key from the authenticated context
         (populated by jwt-auth from the upstream JWT's custom claims). Claims mapped
-        to reserved names (iss, sub, aud, exp, iat) are skipped with a warning.
+        to reserved names (iss, sub, aud, exp, iat, nbf, jti) are skipped with a warning.
         Missing source properties are silently skipped. Values are always strings.
         customClaims take precedence if the same destination key appears in both.
       default: {}
@@ -46,7 +46,7 @@ parameters:
         "$ctx:request.header.x-tenant-id" injects a request header value. See
         documentation for the full list of supported context variables. Non-resolvable
         context references are silently skipped. Non-string values (numbers, booleans)
-        are included as-is. Claims targeting reserved names (iss, sub, aud, exp, iat)
+        are included as-is. Claims targeting reserved names (iss, sub, aud, exp, iat, nbf, jti)
         are skipped with a warning. Runs after claimMappings and takes precedence.
       default: {}
       additionalProperties: {}
@@ -140,5 +140,17 @@ systemParameters:
         request without a cache window.
       default: true
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.tokencaching}"
+
+    cacheMaxSize:
+      type: integer
+      description: >-
+        Maximum total number of tokens to hold in the cache across all APIs combined (a single
+        global bound, not per-API). When the limit is reached, the cache evicts the
+        least-recently-used existing entries to make room for new tokens. Set to 0 (default) to use
+        the built-in default bound of 100000. Changing this value rebuilds the shared cache, which
+        flushes all currently cached tokens.
+      default: 0
+      minimum: 0
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.cachemaxsize}"
 
   required: []

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -98,4 +98,14 @@ systemParameters:
       default: "15m"
       "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.tokenexpiry}"
 
+    tokenCaching:
+      type: boolean
+      description: >-
+        Whether to cache generated tokens. When true (default), tokens are cached for half
+        their expiry duration to avoid repeated signing on every request. Set to false to
+        disable caching — useful for debugging or when dynamic claims must reflect every
+        request without a cache window.
+      default: true
+      "wso2/defaultValue": "${config.policy_configurations.backendjwt_v1.tokencaching}"
+
   required: ["signingKey"]


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2131

This pull request introduces a new "Backend JWT" policy, which enables the gateway to generate and inject a signed JWT containing authenticated user information into upstream request headers. This policy is designed to work after authentication policies, allowing backend services to verify caller identity using the gateway's public key, without needing access to the original client credentials. The PR includes comprehensive documentation, configuration metadata, and policy definition files for seamless integration.

**Backend JWT Policy Introduction and Documentation:**
- Added a new policy, "Backend JWT", to the policy catalog in `docs/README.md`, describing its purpose and usage.
- Created detailed documentation in `docs/backend-jwt/v1.0/docs/backend-jwt.md`, covering how the policy works, claim handling, configuration options, caching behavior, dynamic context claims, and usage examples.
- Added policy metadata in `docs/backend-jwt/v1.0/metadata.json` with name, version, provider, categories, and a concise description.

**Policy Definition and Configuration:**
- Introduced the formal policy definition in `policies/backend-jwt/policy-definition.yaml`, specifying user and system parameters (e.g., header name, claim mappings, custom claims, signing key, algorithm, issuer, expiry, caching), including validation rules and documentation for each field.
- Added Go module definition for the policy implementation in `policies/backend-jwt/go.mod`, listing dependencies and a local SDK replacement for development.