### PR TITLE
[APIP] Populate additional fields in AuthContext using Jwt-Auth policy

### DIFF
--- a/policies/jwt-auth/go.mod
+++ b/policies/jwt-auth/go.mod
@@ -4,5 +4,5 @@ go 1.26.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.2.4
+	github.com/wso2/api-platform/sdk/core v0.2.14
 )

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1465,6 +1465,7 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
+	jti, _ := claims["jti"].(string)
 
 	subject := sub
 	if userIdClaim != "" && userIdClaim != "sub" {
@@ -1484,6 +1485,7 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 		Audience:      parseAudience(claims["aud"]),
 		Scopes:        buildScopesMap(claims),
 		Properties:    buildProperties(claims),
+		TokenId:       jti,
 		Previous:      shared.AuthContext,
 	}
 

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1466,6 +1466,7 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 	jti, _ := claims["jti"].(string)
+	credential_id, _ := claims["client_id"].(string)
 
 	subject := sub
 	if userIdClaim != "" && userIdClaim != "sub" {
@@ -1486,6 +1487,7 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 		Scopes:        buildScopesMap(claims),
 		Properties:    buildProperties(claims),
 		TokenId:       jti,
+		CredentialID:  credential_id,
 		Previous:      shared.AuthContext,
 	}
 

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.0.4
+version: v1.0.5
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2131
Populate TokenId in AuthContext with jti, and Credential ID with client_id from the Jwt-Auth policy
