### PR TITLE
Improve Set-Header Policy to Support Header Appending

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ All available policies, sorted alphabetically.
 | [Semantic Prompt Guard](./semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md) | Guardrails, AI | Blocks or allows prompts based on semantic similarity to configured allow/deny phrase embeddings. |
 | [Semantic Tool Filtering](./semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md) | Guardrails, AI | Dynamically filters the tools provided within an API request based on their semantic relevance to the user query. |
 | [Sentence Count Guardrail](./sentence-count-guardrail/v1.0/docs/sentence-count.md) | Guardrails, AI | Validates the sentence count of request or response body content. |
-| [Set Headers](./set-headers/v1.0/docs/set-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to set arbitrary headers to either the request or the response. |
+| [Set Headers](./set-headers/v1.1/docs/set-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to set or append arbitrary headers to either the request or the response. |
 | [Subscription Validation](./subscription-validation/v1.0/docs/subscription-validation.md) | Security | Validates that incoming requests are associated with an active subscription for the target API. |
 | [Token Based Ratelimit](./token-based-ratelimit/v1.0/docs/token-based-ratelimit.md) | AI | A specialized rate limiting policy for LLM APIs that enforces usage quotas based on token counts. |
 | [URL Guardrail](./url-guardrail/v1.0/docs/url.md) | Guardrails, AI | Validates URLs found in request or response body content. |

--- a/docs/set-headers/v1.1/docs/set-headers.md
+++ b/docs/set-headers/v1.1/docs/set-headers.md
@@ -1,0 +1,508 @@
+---
+title: "Overview"
+---
+# Set Headers
+
+## Overview
+
+The Set Headers policy dynamically sets or appends HTTP headers on incoming requests before they are forwarded to upstream services, and/or on outgoing responses before they are returned to clients. The behavior is controlled by the `mode` parameter:
+
+- **`set` mode (default):** Headers are set/replaced. Existing headers with the same name are overwritten with the new value.
+- **`append` mode:** Configured values are appended to the header, preserving any existing values for that header.
+
+The `mode` parameter applies to the whole policy instance — it governs both the request and response phases together. Per-header or per-phase mode selection is not supported; attach the policy more than once (for example, at different levels) if you need different modes.
+
+## Features
+
+- Sets or appends custom headers on requests before forwarding to upstream services
+- Sets or appends custom headers on responses before returning to clients
+- Supports both request and response phases independently or simultaneously
+- **Selectable behavior via `mode`**: overwrite existing headers (`set`) or add to them (`append`)
+- Proper header name normalization (lowercase conversion for HTTP/2 compatibility)
+- Static value assignment with support for special characters and complex values
+- Works with any HTTP method and request type
+- Last-value-wins behavior for duplicate header names in `set` mode; all values preserved in order in `append` mode
+- Comprehensive validation of header configurations
+
+## Configuration
+
+The Set Headers policy can be configured for request phase, response phase, or both.
+This policy does not require system-level configuration and operates entirely based on the configured header arrays.
+
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `mode` | string | No | `set` | Controls how configured headers are applied. `set` overwrites any existing header with the same name; `append` adds the configured value while preserving existing values. Applies to both the request and response phases. Allowed values: `set`, `append`. |
+| `request` | object | No | - | Specifies request-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+| `response` | object | No | - | Specifies response-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+
+### Request / Response Header Configuration
+
+Each header entry in the `request.headers` or `response.headers` array must contain:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | The name of the HTTP header to set. Header names are automatically normalized to lowercase for consistency. Must match pattern `^[a-zA-Z0-9-_]+$` and be between 1 and 256 characters. |
+| `value` | string | Yes | The value of the HTTP header to set. Can be static text, empty string, or contain special characters and complex values. Maximum length is 8192 characters. |
+
+**Note:**
+At least one of `request` or `response` must be specified in the policy configuration. The policy will fail validation if both are omitted. If `mode` is specified, it must be either `set` or `append`.
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: set-headers
+  gomodule: github.com/wso2/gateway-controllers/policies/set-headers@v1
+```
+
+## Reference Scenarios:
+
+### Example 1: Setting Request Headers for Authentication
+
+Set authentication headers on all requests sent to upstream:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        request:
+          headers:
+            - name: X-API-Key
+              value: "12345-abcde-67890-fghij"
+            - name: X-Client-Version
+              value: "1.2.3"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Request transformation (header set):**
+
+Original client request
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+User-Agent: WeatherApp/1.0
+```
+
+Resulting upstream request
+```http
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+User-Agent: WeatherApp/1.0
+x-api-key: 12345-abcde-67890-fghij
+x-client-version: 1.2.3
+```
+
+### Example 2: Setting Response Headers for Security
+
+Set security headers on all responses returned to clients:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        response:
+          headers:
+            - name: X-Content-Type-Options
+              value: "nosniff"
+            - name: X-Frame-Options
+              value: "DENY"
+            - name: X-XSS-Protection
+              value: "1; mode=block"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Response transformation (header set):**
+
+Original upstream response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 256
+x-content-type-options: nosniff
+x-frame-options: DENY
+x-xss-protection: 1; mode=block
+
+{"temperature": 22, "humidity": 65}
+```
+
+### Example 3: Setting Headers on Both Request and Response
+
+Set headers on both requests (for upstream) and responses (for clients):
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        request:
+          headers:
+            - name: X-Source
+              value: "api-gateway"
+            - name: X-Request-ID
+              value: "req-12345"
+        response:
+          headers:
+            - name: X-Cache-Status
+              value: "HIT"
+            - name: X-Server-Version
+              value: "2.1.0"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Bidirectional transformation sample:**
+
+Incoming client request headers
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+```
+
+Forwarded upstream request headers
+```http
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+x-source: api-gateway
+x-request-id: req-12345
+```
+
+Returned upstream response headers
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+Final client response headers
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+x-cache-status: HIT
+x-server-version: 2.1.0
+```
+
+### Example 4: Route-Specific Headers
+
+Apply different headers to different routes:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: set-headers
+          version: v1
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "weather-query"
+            response:
+              headers:
+                - name: X-Data-Source
+                  value: "weather-service"
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: set-headers
+          version: v1
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "alert-query"
+            response:
+              headers:
+                - name: X-Real-Time
+                  value: "true"
+    - method: POST
+      path: /alerts/active
+      policies:
+        - name: set-headers
+          version: v1
+          params:
+            request:
+              headers:
+                - name: X-Operation-Type
+                  value: "alert-create"
+            response:
+              headers:
+                - name: X-Processing-Mode
+                  value: "sync"
+```
+
+**Route-level transformation sample:**
+
+For `GET /{country_code}/{city}`
+```http
+Request to upstream includes: x-operation-type: weather-query
+Response to client includes: x-data-source: weather-service
+```
+
+For `GET /alerts/active`
+```http
+Request to upstream includes: x-operation-type: alert-query
+Response to client includes: x-real-time: true
+```
+
+For `POST /alerts/active`
+```http
+Request to upstream includes: x-operation-type: alert-create
+Response to client includes: x-processing-mode: sync
+```
+
+### Example 5: Overwriting Existing Headers (Set Behavior)
+
+Demonstrate the default `set` behavior where existing headers with the same name are replaced. The `mode` parameter is omitted here, so it defaults to `set`:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        mode: set
+        response:
+          headers:
+            - name: Cache-Control
+              value: "public, max-age=3600"
+            - name: Server
+              value: "API-Gateway/2.1.0"
+            - name: Content-Type
+              value: "application/json; charset=utf-8"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Response transformation (header overwrite):**
+
+Original upstream response
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Server: Apache/2.4.41
+Cache-Control: no-cache
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response (headers overwritten)
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Server: API-Gateway/2.1.0
+Cache-Control: public, max-age=3600
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+### Example 6: Appending Headers (Append Behavior)
+
+Set `mode: append` to add header values without removing values already present on the request or response. This is useful for multi-valued headers such as `Vary`, `Via`, or custom headers that accumulate context as a request passes through intermediaries.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: set-headers
+      version: v1
+      params:
+        mode: append
+        request:
+          headers:
+            - name: Via
+              value: "1.1 api-gateway"
+        response:
+          headers:
+            - name: Vary
+              value: "Accept-Encoding"
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+**Request transformation (header append):**
+
+Original client request
+```http
+GET /weather/v1.0/US/NewYork HTTP/1.1
+Host: api-gateway.company.com
+Accept: application/json
+Via: 1.0 client-proxy
+```
+
+Resulting upstream request (value appended, existing value preserved)
+```http
+GET /api/v2/US/NewYork HTTP/1.1
+Host: sample-backend:5000
+Accept: application/json
+via: 1.0 client-proxy, 1.1 api-gateway
+```
+
+**Response transformation (header append):**
+
+Original upstream response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Accept
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+Resulting client response (value appended, existing value preserved)
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+vary: Accept, Accept-Encoding
+Content-Length: 256
+
+{"temperature": 22, "humidity": 65}
+```
+
+When the same header name is configured multiple times in `append` mode, all configured values are appended in the order they appear in the array. For example, configuring `X-Roles: editor` and `X-Roles: viewer` on a request that already carries `X-Roles: admin` results in `x-roles: admin, editor, viewer`.
+
+
+## How it Works
+
+* The policy reads the `mode` parameter (defaulting to `set`) to decide whether configured headers overwrite or append.
+* It reads `request.headers` and `response.headers` arrays and applies them independently on the request and response flows, using the selected mode for both.
+* Header names are normalized (trimmed and lowercased) before application to ensure consistent behavior across HTTP versions.
+* In `set` mode, headers are applied using set semantics: if a header already exists, its value is replaced rather than appended. If the same header is configured multiple times in the same array, the last configured value wins.
+* In `append` mode, configured values are appended to existing headers, preserving any values already present. If the same header is configured multiple times in the same array, all configured values are appended in order.
+* Request flow modifies outbound headers to upstream; response flow modifies outbound headers to clients.
+* If no headers are configured for a flow, that flow passes through without header modification.
+
+
+## Limitations
+
+1. **Policy-Wide Mode**: The `mode` parameter applies to the entire policy instance (both request and response phases). Mixing set and append behavior within a single policy instance is not supported — attach the policy multiple times if different modes are required.
+2. **No Conditional Logic**: Header setting/appending is static per policy configuration and cannot be conditional on runtime content.
+3. **Configuration Dependency**: At least one of `request` or `response` must be configured; omitting both fails validation.
+4. **Ordering Sensitivity**: Policy order affects final header values when combined with other header manipulation policies.
+5. **Header Constraints Apply**: Header names and values must satisfy schema constraints (name pattern `^[a-zA-Z0-9-_]+$`, name max length 256, value max length 8192).
+
+
+## Notes
+
+**Security and Data Handling**
+
+Avoid placing secrets, credentials, or personally identifiable data in headers unless strictly necessary, since headers can be logged or forwarded across multiple intermediaries. Validate and sanitize dynamic header values before injecting them to reduce header injection risks. For response headers exposed to clients, ensure values do not reveal sensitive internal topology or implementation details. When using `append` mode, be aware that values accumulate alongside any existing values, which may include client-supplied data.
+
+**Performance and Operational Impact**
+
+Header setting is lightweight and local, but excessive or oversized headers increase request/response size and can impact proxy or load balancer limits. Keep header sets minimal and purposeful, especially on high-throughput APIs. Monitor for rejected requests caused by upstream or intermediary header-size constraints. Note that `append` mode can grow a header's overall size, particularly when it already carries values.
+
+**Operational Best Practices**
+
+Use clear naming conventions and document which headers are enforced at API level versus operation level to avoid conflicts. Apply route-specific policies when different operations require different header contracts. Choose `append` mode only for headers whose semantics permit multiple values (for example, `Vary`, `Via`, `Accept`); use the default `set` mode for single-valued headers like `content-type`, `cache-control`, and `server`. Test the selected behavior explicitly to ensure downstream systems and clients behave as expected.

--- a/docs/set-headers/v1.1/metadata.json
+++ b/docs/set-headers/v1.1/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "set-headers",
+  "displayName": "Set Headers",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "Transformation",
+    "MCP",
+    "WebSub",
+    "WebBroker"
+  ],
+  "description": "This policy provides the capability to set or append arbitrary headers to either the request or the response.\nIn set mode (the default) configuring the same header overwrites the existing header value, while in append mode the configured values are added while preserving any existing values."
+}

--- a/policies/set-headers/go.mod
+++ b/policies/set-headers/go.mod
@@ -2,4 +2,4 @@ module github.com/wso2/gateway-controllers/policies/set-headers
 
 go 1.26.1
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.5

--- a/policies/set-headers/policy-definition.yaml
+++ b/policies/set-headers/policy-definition.yaml
@@ -1,13 +1,28 @@
 name: set-headers
-version: v1.0.1
+version: v1.1.0
 description: |
-  Sets configured headers on requests and/or responses. If the same header is set
-  multiple times, the latest configured value overwrites earlier values.
+  Sets or appends configured headers on requests and/or responses. In "set" mode
+  (the default), an existing header with the same name is overwritten; if the same
+  header is configured multiple times, the latest configured value overwrites
+  earlier values. In "append" mode, configured values are appended while
+  preserving any existing header values.
 
 parameters:
   type: object
   additionalProperties: false
   properties:
+    mode:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        Specifies how configured headers are applied. "set" overwrites any existing
+        header with the same name; "append" adds the configured value while
+        preserving existing values. Applies to both request and response phases.
+      enum:
+      - set
+      - append
+      default: set
+
     request:
       type: object
       additionalProperties: false

--- a/policies/set-headers/setheaders.go
+++ b/policies/set-headers/setheaders.go
@@ -25,13 +25,21 @@ import (
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
-// HeaderEntry represents a single header to be set
+// Mode values controlling how configured headers are applied.
+const (
+	// ModeSet overwrites any existing header with the configured value.
+	ModeSet = "set"
+	// ModeAppend appends the configured value, preserving any existing values.
+	ModeAppend = "append"
+)
+
+// HeaderEntry represents a single header to be set or appended
 type HeaderEntry struct {
 	Name  string
 	Value string
 }
 
-// SetHeadersPolicy implements header setting for both request and response
+// SetHeadersPolicy implements header setting/appending for both request and response
 type SetHeadersPolicy struct{}
 
 var ins = &SetHeadersPolicy{}
@@ -56,6 +64,11 @@ func (p *SetHeadersPolicy) Mode() policy.ProcessingMode {
 
 // Validate validates the policy configuration parameters
 func (p *SetHeadersPolicy) Validate(params map[string]interface{}) error {
+	// Mode is optional; when present it must be either "set" or "append".
+	if err := p.validateMode(params); err != nil {
+		return err
+	}
+
 	// At least one of request.headers or response.headers must be specified.
 	// Legacy flat keys are also accepted for runtime compatibility.
 	requestHeadersRaw, hasRequestHeaders, err := p.getPhaseHeaders(params, "request", "requestHeaders")
@@ -86,6 +99,32 @@ func (p *SetHeadersPolicy) Validate(params map[string]interface{}) error {
 	}
 
 	return nil
+}
+
+// validateMode validates the optional top-level "mode" parameter.
+func (p *SetHeadersPolicy) validateMode(params map[string]interface{}) error {
+	modeRaw, ok := params["mode"]
+	if !ok {
+		return nil
+	}
+	mode, ok := modeRaw.(string)
+	if !ok {
+		return fmt.Errorf("mode must be a string")
+	}
+	if mode != ModeSet && mode != ModeAppend {
+		return fmt.Errorf("mode must be either '%s' or '%s'", ModeSet, ModeAppend)
+	}
+	return nil
+}
+
+// getMode returns the configured mode, defaulting to ModeSet when absent or invalid.
+func (p *SetHeadersPolicy) getMode(params map[string]interface{}) string {
+	if modeRaw, ok := params["mode"]; ok {
+		if mode, ok := modeRaw.(string); ok && mode == ModeAppend {
+			return ModeAppend
+		}
+	}
+	return ModeSet
 }
 
 // getPhaseHeaders extracts headers for a phase, supporting both nested
@@ -187,6 +226,9 @@ func (p *SetHeadersPolicy) parseHeaderEntries(headersRaw interface{}) []HeaderEn
 // Returns map[string]string for SetHeaders (overwrites existing headers)
 // Multiple headers with the same name will have the last value win (map behavior)
 func (p *SetHeadersPolicy) convertToSetHeaderMap(entries []HeaderEntry) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
 	headerMap := make(map[string]string)
 	for _, entry := range entries {
 		headerMap[entry.Name] = entry.Value // Last value wins for duplicate names
@@ -194,44 +236,62 @@ func (p *SetHeadersPolicy) convertToSetHeaderMap(entries []HeaderEntry) map[stri
 	return headerMap
 }
 
-// buildRequestHeaders extracts and parses request headers from params.
+// convertToAppendHeaderMap converts header entries to a map for AppendHeaders
+// (appends to existing headers). Multiple entries with the same name are all
+// kept, preserving their configured order.
+func (p *SetHeadersPolicy) convertToAppendHeaderMap(entries []HeaderEntry) map[string][]string {
+	if len(entries) == 0 {
+		return nil
+	}
+	headerMap := make(map[string][]string)
+	for _, entry := range entries {
+		headerMap[entry.Name] = append(headerMap[entry.Name], entry.Value)
+	}
+	return headerMap
+}
+
+// buildRequestHeaderEntries extracts and parses request header entries from params.
 // Returns nil if no headers are configured.
-func (p *SetHeadersPolicy) buildRequestHeaders(params map[string]interface{}) map[string]string {
+func (p *SetHeadersPolicy) buildRequestHeaderEntries(params map[string]interface{}) []HeaderEntry {
 	headersRaw, ok, err := p.getPhaseHeaders(params, "request", "requestHeaders")
 	if err != nil || !ok {
 		return nil
 	}
-	entries := p.parseHeaderEntries(headersRaw)
-	if len(entries) == 0 {
-		return nil
-	}
-	return p.convertToSetHeaderMap(entries)
+	return p.parseHeaderEntries(headersRaw)
 }
 
-// OnRequestHeaders sets headers on the request (v2alpha.RequestHeaderPolicy).
+// OnRequestHeaders sets or appends headers on the request (v2alpha.RequestHeaderPolicy).
 func (p *SetHeadersPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
+	entries := p.buildRequestHeaderEntries(params)
+	if p.getMode(params) == ModeAppend {
+		return policy.UpstreamRequestHeaderModifications{
+			HeadersToAppend: p.convertToAppendHeaderMap(entries),
+		}
+	}
 	return policy.UpstreamRequestHeaderModifications{
-		HeadersToSet: p.buildRequestHeaders(params),
+		HeadersToSet: p.convertToSetHeaderMap(entries),
 	}
 }
 
-// buildResponseHeaders extracts and parses response headers from params.
+// buildResponseHeaderEntries extracts and parses response header entries from params.
 // Returns nil if no headers are configured.
-func (p *SetHeadersPolicy) buildResponseHeaders(params map[string]interface{}) map[string]string {
+func (p *SetHeadersPolicy) buildResponseHeaderEntries(params map[string]interface{}) []HeaderEntry {
 	headersRaw, ok, err := p.getPhaseHeaders(params, "response", "responseHeaders")
 	if err != nil || !ok {
 		return nil
 	}
-	entries := p.parseHeaderEntries(headersRaw)
-	if len(entries) == 0 {
-		return nil
-	}
-	return p.convertToSetHeaderMap(entries)
+	return p.parseHeaderEntries(headersRaw)
 }
 
-// OnResponseHeaders sets headers on the response (v2alpha.ResponseHeaderPolicy).
+// OnResponseHeaders sets or appends headers on the response (v2alpha.ResponseHeaderPolicy).
 func (p *SetHeadersPolicy) OnResponseHeaders(ctx context.Context, respCtx *policy.ResponseHeaderContext, params map[string]interface{}) policy.ResponseHeaderAction {
+	entries := p.buildResponseHeaderEntries(params)
+	if p.getMode(params) == ModeAppend {
+		return policy.DownstreamResponseHeaderModifications{
+			HeadersToAppend: p.convertToAppendHeaderMap(entries),
+		}
+	}
 	return policy.DownstreamResponseHeaderModifications{
-		HeadersToSet: p.buildResponseHeaders(params),
+		HeadersToSet: p.convertToSetHeaderMap(entries),
 	}
 }

--- a/policies/set-headers/setheaders_test.go
+++ b/policies/set-headers/setheaders_test.go
@@ -763,6 +763,392 @@ func TestSetHeadersPolicy_OnResponseHeaders_NestedHeaders(t *testing.T) {
 	}
 }
 
+// ─── Mode parameter tests ────────────────────────────────────────────────────
+
+func TestSetHeadersPolicy_Validate_ModeSet(t *testing.T) {
+	p := &SetHeadersPolicy{}
+
+	params := map[string]interface{}{
+		"mode": "set",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Request-Header",
+				"value": "request-value",
+			},
+		},
+	}
+
+	err := p.Validate(params)
+	if err != nil {
+		t.Errorf("Expected no error for mode 'set', got: %v", err)
+	}
+}
+
+func TestSetHeadersPolicy_Validate_ModeAppend(t *testing.T) {
+	p := &SetHeadersPolicy{}
+
+	params := map[string]interface{}{
+		"mode": "append",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Request-Header",
+				"value": "request-value",
+			},
+		},
+	}
+
+	err := p.Validate(params)
+	if err != nil {
+		t.Errorf("Expected no error for mode 'append', got: %v", err)
+	}
+}
+
+func TestSetHeadersPolicy_Validate_InvalidModeValue(t *testing.T) {
+	p := &SetHeadersPolicy{}
+
+	params := map[string]interface{}{
+		"mode": "merge", // Not a supported mode
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Request-Header",
+				"value": "request-value",
+			},
+		},
+	}
+
+	err := p.Validate(params)
+	if err == nil || !strings.Contains(err.Error(), "mode must be either 'set' or 'append'") {
+		t.Errorf("Expected 'mode must be either' error, got: %v", err)
+	}
+}
+
+func TestSetHeadersPolicy_Validate_InvalidModeType(t *testing.T) {
+	p := &SetHeadersPolicy{}
+
+	params := map[string]interface{}{
+		"mode": 123, // Not a string
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Request-Header",
+				"value": "request-value",
+			},
+		},
+	}
+
+	err := p.Validate(params)
+	if err == nil || !strings.Contains(err.Error(), "mode must be a string") {
+		t.Errorf("Expected 'mode must be a string' error, got: %v", err)
+	}
+}
+
+func TestSetHeadersPolicy_OnRequestHeaders_AppendMode(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{
+			"x-roles": "admin",
+		}),
+	}
+
+	params := map[string]interface{}{
+		"mode": "append",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Roles",
+				"value": "editor",
+			},
+		},
+	}
+
+	result := p.OnRequestHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers in HeadersToSet for append mode, got %d", len(mods.HeadersToSet))
+	}
+
+	if len(mods.HeadersToAppend) != 1 {
+		t.Errorf("Expected 1 header in HeadersToAppend, got %d", len(mods.HeadersToAppend))
+	}
+
+	values := mods.HeadersToAppend["x-roles"]
+	if len(values) != 1 || values[0] != "editor" {
+		t.Errorf("Expected 'x-roles' to append ['editor'], got %v", values)
+	}
+}
+
+func TestSetHeadersPolicy_OnRequestHeaders_AppendMode_DuplicateNames(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{}),
+	}
+
+	// In append mode duplicate names must all be preserved, in configured order,
+	// instead of last-value-wins.
+	params := map[string]interface{}{
+		"mode": "append",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Roles",
+				"value": "editor",
+			},
+			map[string]interface{}{
+				"name":  "X-Roles",
+				"value": "viewer",
+			},
+			map[string]interface{}{
+				"name":  "X-Other",
+				"value": "other-value",
+			},
+		},
+	}
+
+	result := p.OnRequestHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if len(mods.HeadersToAppend) != 2 {
+		t.Errorf("Expected 2 unique header names in HeadersToAppend, got %d", len(mods.HeadersToAppend))
+	}
+
+	roles := mods.HeadersToAppend["x-roles"]
+	if len(roles) != 2 || roles[0] != "editor" || roles[1] != "viewer" {
+		t.Errorf("Expected 'x-roles' to append ['editor', 'viewer'] in order, got %v", roles)
+	}
+
+	other := mods.HeadersToAppend["x-other"]
+	if len(other) != 1 || other[0] != "other-value" {
+		t.Errorf("Expected 'x-other' to append ['other-value'], got %v", other)
+	}
+}
+
+func TestSetHeadersPolicy_OnRequestHeaders_AppendMode_HeaderNameNormalization(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{}),
+	}
+
+	params := map[string]interface{}{
+		"mode": "append",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "  X-UPPER-CASE  ", // With spaces and uppercase
+				"value": "test-value",
+			},
+		},
+	}
+
+	result := p.OnRequestHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	values := mods.HeadersToAppend["x-upper-case"] // Should be trimmed and lowercase
+	if len(values) != 1 || values[0] != "test-value" {
+		t.Errorf("Expected header 'x-upper-case' to be normalized and appended, got headers: %v",
+			mods.HeadersToAppend)
+	}
+}
+
+func TestSetHeadersPolicy_OnResponseHeaders_AppendMode(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.ResponseHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseHeaders: createTestHeaders(map[string]string{
+			"vary": "Accept",
+		}),
+	}
+
+	params := map[string]interface{}{
+		"mode": "append",
+		"responseHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "Vary",
+				"value": "Accept-Encoding",
+			},
+		},
+	}
+
+	result := p.OnResponseHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.DownstreamResponseHeaderModifications)
+	if !ok {
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", result)
+	}
+
+	if len(mods.HeadersToSet) != 0 {
+		t.Errorf("Expected no headers in HeadersToSet for append mode, got %d", len(mods.HeadersToSet))
+	}
+
+	values := mods.HeadersToAppend["vary"]
+	if len(values) != 1 || values[0] != "Accept-Encoding" {
+		t.Errorf("Expected 'vary' to append ['Accept-Encoding'], got %v", values)
+	}
+}
+
+func TestSetHeadersPolicy_OnRequestHeaders_ExplicitSetMode(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{}),
+	}
+
+	params := map[string]interface{}{
+		"mode": "set",
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Custom-Header",
+				"value": "custom-value",
+			},
+		},
+	}
+
+	result := p.OnRequestHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if len(mods.HeadersToAppend) != 0 {
+		t.Errorf("Expected no headers in HeadersToAppend for set mode, got %d", len(mods.HeadersToAppend))
+	}
+
+	if mods.HeadersToSet["x-custom-header"] != "custom-value" {
+		t.Errorf("Expected 'x-custom-header' to be set to 'custom-value', got '%s'",
+			mods.HeadersToSet["x-custom-header"])
+	}
+}
+
+func TestSetHeadersPolicy_OnRequestHeaders_DefaultModeIsSet(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	ctx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{}),
+	}
+
+	// No mode key — must behave exactly like mode "set"
+	params := map[string]interface{}{
+		"requestHeaders": []interface{}{
+			map[string]interface{}{
+				"name":  "X-Custom-Header",
+				"value": "custom-value",
+			},
+		},
+	}
+
+	result := p.OnRequestHeaders(context.Background(), ctx, params)
+
+	mods, ok := result.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", result)
+	}
+
+	if len(mods.HeadersToAppend) != 0 {
+		t.Errorf("Expected no headers in HeadersToAppend when mode is absent, got %d", len(mods.HeadersToAppend))
+	}
+
+	if mods.HeadersToSet["x-custom-header"] != "custom-value" {
+		t.Errorf("Expected default mode to set 'x-custom-header' to 'custom-value', got '%s'",
+			mods.HeadersToSet["x-custom-header"])
+	}
+}
+
+func TestSetHeadersPolicy_AppendMode_NestedConfiguration(t *testing.T) {
+	p := &SetHeadersPolicy{}
+
+	params := map[string]interface{}{
+		"mode": "append",
+		"request": map[string]interface{}{
+			"headers": []interface{}{
+				map[string]interface{}{
+					"name":  "X-Nested-Request",
+					"value": "nested-request-value",
+				},
+			},
+		},
+		"response": map[string]interface{}{
+			"headers": []interface{}{
+				map[string]interface{}{
+					"name":  "X-Nested-Response",
+					"value": "nested-response-value",
+				},
+			},
+		},
+	}
+
+	if err := p.Validate(params); err != nil {
+		t.Errorf("Expected no error for nested append configuration, got: %v", err)
+	}
+
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		Headers: createTestHeaders(map[string]string{}),
+	}
+
+	reqResult := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	reqMods, ok := reqResult.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Errorf("Expected UpstreamRequestHeaderModifications, got %T", reqResult)
+	}
+
+	reqValues := reqMods.HeadersToAppend["x-nested-request"]
+	if len(reqValues) != 1 || reqValues[0] != "nested-request-value" {
+		t.Errorf("Expected nested request header to be appended, got %v", reqMods.HeadersToAppend)
+	}
+
+	respCtx := &policy.ResponseHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-1",
+			Metadata:  map[string]interface{}{},
+		},
+		ResponseHeaders: createTestHeaders(map[string]string{}),
+	}
+
+	respResult := p.OnResponseHeaders(context.Background(), respCtx, params)
+	respMods, ok := respResult.(policy.DownstreamResponseHeaderModifications)
+	if !ok {
+		t.Errorf("Expected DownstreamResponseHeaderModifications, got %T", respResult)
+	}
+
+	respValues := respMods.HeadersToAppend["x-nested-response"]
+	if len(respValues) != 1 || respValues[0] != "nested-response-value" {
+		t.Errorf("Expected nested response header to be appended, got %v", respMods.HeadersToAppend)
+	}
+}
+
 func TestSetHeadersPolicy_Validate_NestedConfiguration(t *testing.T) {
 	p := &SetHeadersPolicy{}
 


### PR DESCRIPTION
## Purpose
Currently the api-platform only supports setting or removing the headers. However, there are valid use-cases where a user might need to append a value to an already existing header. This PR adds the relevant modifications required for the set-header policy to support header appending as well. 

A new attribute called `mode` has being introduced which can be set to `set` or `append`(for both request and response flows) and based on the mode, the engine will perform the respective operation while processing the request

- Relevant SDK Changes: https://github.com/wso2/api-platform/pull/2189
- Related to: https://github.com/wso2/api-platform/issues/2103 