### PR TITLE
[APIP] Populate TokenId with hashed API-key

### DIFF
--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -19,6 +19,8 @@ package apikey
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -228,6 +230,7 @@ func (p *APIKeyPolicy) authenticate(
 			"ApplicationName": resolvedKey.ApplicationName,
 			"ApplicationID":   resolvedKey.ApplicationID,
 		},
+		TokenId: func() string { h := sha256.Sum256([]byte(providedKey)); return hex.EncodeToString(h[:]) }(),
 	}
 	if shared.Metadata == nil {
 		shared.Metadata = make(map[string]interface{})

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -230,7 +230,7 @@ func (p *APIKeyPolicy) authenticate(
 			"ApplicationName": resolvedKey.ApplicationName,
 			"ApplicationID":   resolvedKey.ApplicationID,
 		},
-		TokenId: func() string { h := sha256.Sum256([]byte(providedKey)); return hex.EncodeToString(h[:]) }(),
+		TokenId: generateTokenID(providedKey),
 	}
 	if shared.Metadata == nil {
 		shared.Metadata = make(map[string]interface{})
@@ -252,6 +252,11 @@ func (p *APIKeyPolicy) failAuth(shared *policy.SharedContext, statusCode int, er
 		Headers:    v1resp.Headers,
 		Body:       v1resp.Body,
 	}
+}
+
+func generateTokenID(key string) string {
+    h := sha256.Sum256([]byte(key))
+    return hex.EncodeToString(h[:])
 }
 
 // buildErrorResponse constructs the ImmediateResponse body and headers for an auth failure.

--- a/policies/api-key-auth/go.mod
+++ b/policies/api-key-auth/go.mod
@@ -1,8 +1,8 @@
 module github.com/wso2/gateway-controllers/policies/api-key-auth
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71
-	github.com/wso2/api-platform/sdk/core v0.2.4
+	github.com/wso2/api-platform/sdk/core v0.2.14
 )

--- a/policies/api-key-auth/go.sum
+++ b/policies/api-key-auth/go.sum
@@ -6,7 +6,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71 h1:vnK2p6QV2kqOhs2iFpuYKVV6jpu8/Q1QuVz14UlQsn0=
 github.com/wso2/api-platform/common v0.0.0-20260326194347-3d85c50eae71/go.mod h1:Tv4pznkS1TK3tJvUmbgGD40Efdv063aaHG/J0TDkAzQ=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v1.0.3
+version: v1.0.4
 description: |
   Secures APIs by validating API keys in incoming requests. API keys are
   provided through a configured HTTP header.


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2131
This pull request introduces an enhancement to the API key authentication policy by including a hashed token identifier in the authentication process, along with dependency updates and a version bump.

**API Key Authentication Enhancements:**

* Added a new field `TokenId` to the authentication context, which stores a SHA-256 hash of the provided API key for improved traceability and security. (`policies/api-key-auth/apikey.go`)
* Imported the `crypto/sha256` and `encoding/hex` packages to support the hashing functionality. (`policies/api-key-auth/apikey.go`)

**Dependency and Version Updates:**

* Updated the Go version to 1.26.2 and bumped the `github.com/wso2/api-platform/sdk/core` dependency to v0.2.14. (`policies/api-key-auth/go.mod`)
* Incremented the policy version from v1.0.3 to v1.0.4 in `policy-definition.yaml`.