### PR TITLE
[APIP] Add Opaque-token-auth policy (RFC 7662 introspection)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ All available policies, sorted alphabetically.
 | [Model Round Robin](./model-round-robin/v1.0/docs/model-round-robin.md) | AI | Implements round-robin load balancing for AI models. |
 | [Model Weighted Round Robin](./model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
 | [NeMo Guard Content Safety](./nvidia-nemoguard-content-safety/v0.9/docs/nvidia-nemoguard-content-safety.md) | Guardrails, AI | Validates request and/or response content using NVIDIA NeMo Guard (llama-3.1-nemoguard-8b-content-safety). |
+| [Opaque Token Auth](./opaque-token-auth/v1.0/docs/opaque-token-authentication.md) | Security, AI | Validates opaque OAuth 2.0 access tokens via RFC 7662 token introspection. |
 | [PII Masking Regex](./pii-masking-regex/v1.0/docs/pii-masking-regex.md) | Guardrails, AI | Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns. |
 | [Prompt Compressor](./prompt-compressor/v0.9/docs/prompt-compressor.md) | AI | Compresses selected prompt text in JSON request bodies before upstream LLM calls. |
 | [Prompt Decorator](./prompt-decorator/v1.0/docs/prompt-decorator.md) | AI | Dynamically modifies the prompt by applying custom decorations using a configured strategy. |

--- a/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
+++ b/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
@@ -17,7 +17,6 @@ Use this policy when your authorization server issues opaque (reference) tokens.
 - Custom CA / skip-TLS-verify options for the introspection endpoint
 - Short-lived caching of active responses, never beyond the token's `exp`
 - Configurable audience, scope, and required-claim validation
-- Claim-to-header mappings for downstream services
 - Authorization header scheme enforcement and clock skew tolerance
 - Customizable error responses
 - Optional `userIdClaim` mapping for analytics
@@ -29,7 +28,7 @@ Use this policy when your authorization server issues opaque (reference) tokens.
 2. It selects introspection providers (by the user-level `issuers` list, or all providers in order).
 3. For each selected provider, it POSTs `token` (and `token_type_hint`) to the introspection endpoint as `application/x-www-form-urlencoded`, authenticating itself with the configured client credentials or bearer token, until a provider reports the token `active`.
 4. Active responses are cached, keyed by a SHA-256 of the token, expiring at `min(introspectionCacheTtl, token exp)`. Inactive responses are never cached.
-5. The policy then enforces audiences, scopes, and required claims, populates the authentication context, and applies any claim-to-header mappings before forwarding upstream.
+5. The policy then enforces audiences, scopes, and required claims, and populates the authentication context before forwarding upstream.
 
 ## Configuration
 
@@ -104,7 +103,6 @@ skipTlsVerify = false
 | `audiences` | array | No | Acceptable audience values. The response must contain at least one. |
 | `requiredScopes` | array | No | Required scopes. Uses the space-delimited `scope` member or array `scp` member. |
 | `requiredClaims` | object | No | Map of claim name to expected value. |
-| `claimMappings` | object | No | Map of introspection response member to downstream header name. |
 | `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
 | `headerName` | string | No | Header name to extract the token from. Overrides `system.headerName`. Must be a valid HTTP header field name. |
 | `userIdClaim` | string | No | Member to extract the user ID for analytics. Defaults to `sub`. |
@@ -178,7 +176,7 @@ spec:
               - read:data
 ```
 
-### Example 3: Claim Mapping to Downstream Headers
+### Example 3: Required Claim Validation
 
 ```yaml
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
@@ -201,10 +199,8 @@ spec:
           params:
             issuers:
               - PrimaryIDP
-            claimMappings:
-              sub: X-User-ID
-              username: X-User-Name
-              client_id: X-Client-ID
+            requiredClaims:
+              tenant: acme-corp
 ```
 
 ### Example 4: Strip Token Before Forwarding to Upstream

--- a/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
+++ b/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
@@ -12,11 +12,11 @@ Use this policy when your authorization server issues opaque (reference) tokens.
 ## Features
 
 - Validates opaque access tokens via RFC 7662 token introspection
-- Supports multiple introspection providers with ordered fallback
+- Supports multiple introspection providers with ordered fallback and optional token-pattern routing
 - Gateway client authentication via `client_secret_basic`, `client_secret_post`, or a static bearer token
 - Custom CA / skip-TLS-verify options for the introspection endpoint
-- Short-lived caching of active responses, never beyond the token's `exp`
-- Configurable audience, scope, and required-claim validation
+- Short-lived caching of active and inactive responses, never beyond the token's `exp`
+- Configurable audience, scope (OR semantics), and required-claim validation
 - Authorization header scheme enforcement and clock skew tolerance
 - Customizable error responses
 - Optional `userIdClaim` mapping for analytics
@@ -27,7 +27,7 @@ Use this policy when your authorization server issues opaque (reference) tokens.
 1. The policy extracts the token from the configured authorization header.
 2. It selects introspection providers (by the user-level `issuers` list, or all providers in order).
 3. For each selected provider, it POSTs `token` (and `token_type_hint`) to the introspection endpoint as `application/x-www-form-urlencoded`, authenticating itself with the configured client credentials or bearer token, until a provider reports the token `active`.
-4. Active responses are cached, keyed by a SHA-256 of the token, expiring at `min(introspectionCacheTtl, token exp)`. Inactive responses are never cached.
+4. Active responses are cached per-provider, keyed by a SHA-256 of the provider name and token, expiring at `min(introspectionCacheTtl, token exp)`. Inactive (`active: false`) responses are cached separately for `introspectionNegativeCacheTtl`. Transport errors and non-200 responses are never cached.
 5. The policy then enforces audiences, scopes, and required claims, and populates the authentication context before forwarding upstream.
 
 ## Configuration
@@ -40,13 +40,14 @@ Opaque Token Authentication requires two levels of configuration.
 | --- | --- | --- | --- | --- |
 | `introspectionproviders` | ```IntrospectionProvider``` array | Yes | - | List of introspection endpoint definitions. |
 | `introspectioncachettl` | string | No | `"60s"` | Cache TTL for active introspection responses (never exceeds token `exp`). |
+| `introspectionnegativecachettl` | string | No | `"30s"` | Cache TTL for inactive (`active: false`) responses. Set to `"0s"` to disable. Transport errors are never cached regardless of this setting. |
 | `introspectiontimeout` | string | No | `"5s"` | Timeout for each introspection request. |
 | `introspectionretrycount` | integer | No | `2` | Introspection retry count on transient failures. |
 | `introspectionretryinterval` | string | No | `"1s"` | Interval between introspection retries. |
 | `leeway` | string | No | `"30s"` | Clock skew allowance for local exp/nbf re-checks. |
 | `authheaderscheme` | string | No | `"Bearer"` | Expected authorization scheme prefix. |
 | `headername` | string | No | `"Authorization"` | Header name to extract the token from. |
-| `onfailurestatuscode` | integer | No | `401` | HTTP status code on authentication failure. |
+| `onfailurestatuscode` | integer | No | `401` | HTTP status code on authentication failure. Must be `401` or `403`. |
 | `errormessageformat` | string | No | `"json"` | Error format: `"json"`, `"plain"`, or `"minimal"`. |
 | `errormessage` | string | No | `"Authentication failed"` | Error message body for failures. |
 
@@ -58,11 +59,12 @@ Each entry in `introspectionproviders` must include a unique `name` and an `intr
 | --- | --- | --- | --- |
 | `name` | string | Yes | Unique provider name (referenced by `user.issuers`). |
 | `issuer` | string | No | Optional issuer value for this provider (also matchable via `user.issuers`). |
+| `tokenPattern` | string | No | Regex matched against the raw token. When set, only tokens matching the pattern are sent to this provider. See [Token Pattern Routing](#token-pattern-routing). |
 | `introspection.uri` | string | Yes | RFC 7662 introspection endpoint URL. |
-| `introspection.clientId` | string | No | OAuth2 client id for gateway client authentication. |
+| `introspection.clientId` | string | No | OAuth2 client id for gateway client authentication. Mutually exclusive with `bearerToken`. |
 | `introspection.clientSecret` | string | No | OAuth2 client secret paired with `clientId`. |
 | `introspection.authStyle` | string | No | `"basic"` (client_secret_basic, default) or `"post"` (client_secret_post). |
-| `introspection.bearerToken` | string | No | Static bearer token used instead of client credentials. |
+| `introspection.bearerToken` | string | No | Static bearer token used instead of client credentials. Mutually exclusive with `clientId`. |
 | `introspection.tokenTypeHint` | string | No | `token_type_hint` sent with the request (default `access_token`). |
 | `introspection.certificatePath` | string | No | CA cert path for a self-signed introspection endpoint. |
 | `introspection.skipTlsVerify` | boolean | No | Skip TLS verification (use with caution). |
@@ -100,14 +102,14 @@ skipTlsVerify = false
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `issuers` | array | No | List of provider names (or issuer values) to use. If omitted, providers are tried in order until one reports the token active. |
-| `audiences` | array | No | Acceptable audience values. The response must contain at least one. |
-| `requiredScopes` | array | No | Required scopes. Uses the space-delimited `scope` member or array `scp` member. |
-| `requiredClaims` | object | No | Map of claim name to expected value. |
-| `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
+| `audiences` | array | No | Acceptable audience values. The token must contain at least one of the listed values in its `aud` claim. |
+| `requiredScopes` | array | No | Required scopes (OR semantics — the token must contain at least one). Checked against the space-delimited `scope` member or array `scp` member. |
+| `requiredClaims` | object | No | Map of claim name to expected value. All entries must match (AND semantics). |
+| `authHeaderPrefix` | string | No | Overrides `system.authHeaderScheme` for this route only. |
 | `headerName` | string | No | Header name to extract the token from. Overrides `system.headerName`. Must be a valid HTTP header field name. |
-| `userIdClaim` | string | No | Member to extract the user ID for analytics. Defaults to `sub`. |
-| `forwardToken` | boolean | No | If `true` (default), the token is forwarded to the upstream after successful validation. Set to `false` to strip the token header before proxying. |
-| `forwardedTokenHeader` | string | No | Header name used to forward the token to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. Has no effect when `forwardToken` is `false`. |
+| `userIdClaim` | string | No | Introspection response member to use as the user ID for analytics. Defaults to `sub`. |
+| `forwardToken` | boolean | No | If `true` (default), the token is forwarded to the upstream. If `false`, the authorization header is stripped before proxying. |
+| `forwardedTokenHeader` | string | No | Header name under which the token is forwarded when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. By default, the original `Authorization` header is removed and the full header value (e.g. `Bearer <token>`) is re-sent under `x-forwarded-authorization`. Has no effect when `forwardToken` is `false`. |
 
 **Note:**
 
@@ -231,10 +233,38 @@ spec:
             forwardToken: false
 ```
 
+## Token Pattern Routing
+
+When multiple introspection providers are configured, the gateway tries them in order by default. Setting `tokenPattern` on a provider restricts it to tokens whose raw value matches the regex, so each provider only receives the tokens it can validate.
+
+This is recommended whenever providers issue tokens with distinguishable formats (for example, a UUID-prefixed token for one IdP and an `opaque_` prefixed token for another). It improves performance by avoiding unnecessary introspection calls and improves cache efficiency by ensuring tokens are always routed to the same provider, producing stable per-provider cache keys.
+
+```toml
+[[policy_configurations.opaquetokenauth_v1.introspectionproviders]]
+name = "AsgardeoIDP"
+tokenPattern = "^[0-9a-f]{8}-"   # UUID-like prefix
+
+[policy_configurations.opaquetokenauth_v1.introspectionproviders.introspection]
+uri = "https://asgardeo.example.com/oauth2/introspect"
+clientId = "gateway-client"
+clientSecret = "gateway-secret"
+
+[[policy_configurations.opaquetokenauth_v1.introspectionproviders]]
+name = "LocalIDP"
+tokenPattern = "^opaque_"         # local token format
+
+[policy_configurations.opaquetokenauth_v1.introspectionproviders.introspection]
+uri = "https://idp.internal/oauth2/introspect"
+bearerToken = "introspect-secret"
+```
+
+Providers without a `tokenPattern` match all tokens and act as a fallback for any token that does not match a pattern-restricted provider.
+
 ## Notes
 
 - **Transport security:** Always use HTTPS introspection endpoints. RFC 7662 mandates TLS for the introspection request; `skipTlsVerify` should only be used for testing or trusted internal endpoints.
 - **Caching vs. revocation latency:** A longer `introspectionCacheTtl` reduces load on the authorization server but increases the window during which a revoked token is still accepted. Cached entries never outlive the token's `exp`. Tune the TTL to your revocation requirements.
+- **Negative caching:** By default, inactive (`active: false`) responses are cached for `introspectionNegativeCacheTtl` (`"30s"`). This reduces load for repeated requests with invalid tokens. Set to `"0s"` to disable if your use case requires re-checking every request.
 - **Provider fallback:** When no `issuers` are configured, every provider is tried in order until one reports the token active. Constrain this with `issuers` (or per-provider `issuer` values) to avoid presenting tokens to unintended authorization servers.
 
 ## Related Policies

--- a/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
+++ b/docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md
@@ -1,0 +1,246 @@
+---
+title: "Overview"
+---
+# Opaque Token Authentication
+
+## Overview
+
+The Opaque Token Authentication policy validates opaque OAuth 2.0 access tokens — reference tokens that carry no inline claims — by calling an authorization server's [RFC 7662](https://www.rfc-editor.org/rfc/rfc7662.html) token introspection endpoint. The gateway forwards the bearer token to the introspection endpoint, authenticates itself, and admits the request only when the response reports `active: true`. It is typically applied to operations that require bearer token authentication before requests are forwarded upstream.
+
+Use this policy when your authorization server issues opaque (reference) tokens. For self-contained JWT access tokens validated locally against JWKS, use the JWT Authentication policy instead.
+
+## Features
+
+- Validates opaque access tokens via RFC 7662 token introspection
+- Supports multiple introspection providers with ordered fallback
+- Gateway client authentication via `client_secret_basic`, `client_secret_post`, or a static bearer token
+- Custom CA / skip-TLS-verify options for the introspection endpoint
+- Short-lived caching of active responses, never beyond the token's `exp`
+- Configurable audience, scope, and required-claim validation
+- Claim-to-header mappings for downstream services
+- Authorization header scheme enforcement and clock skew tolerance
+- Customizable error responses
+- Optional `userIdClaim` mapping for analytics
+- Optional forwarding of the token to the upstream under a configurable header name
+
+## How it Works
+
+1. The policy extracts the token from the configured authorization header.
+2. It selects introspection providers (by the user-level `issuers` list, or all providers in order).
+3. For each selected provider, it POSTs `token` (and `token_type_hint`) to the introspection endpoint as `application/x-www-form-urlencoded`, authenticating itself with the configured client credentials or bearer token, until a provider reports the token `active`.
+4. Active responses are cached, keyed by a SHA-256 of the token, expiring at `min(introspectionCacheTtl, token exp)`. Inactive responses are never cached.
+5. The policy then enforces audiences, scopes, and required claims, populates the authentication context, and applies any claim-to-header mappings before forwarding upstream.
+
+## Configuration
+
+Opaque Token Authentication requires two levels of configuration.
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `introspectionproviders` | ```IntrospectionProvider``` array | Yes | - | List of introspection endpoint definitions. |
+| `introspectioncachettl` | string | No | `"60s"` | Cache TTL for active introspection responses (never exceeds token `exp`). |
+| `introspectiontimeout` | string | No | `"5s"` | Timeout for each introspection request. |
+| `introspectionretrycount` | integer | No | `2` | Introspection retry count on transient failures. |
+| `introspectionretryinterval` | string | No | `"1s"` | Interval between introspection retries. |
+| `leeway` | string | No | `"30s"` | Clock skew allowance for local exp/nbf re-checks. |
+| `authheaderscheme` | string | No | `"Bearer"` | Expected authorization scheme prefix. |
+| `headername` | string | No | `"Authorization"` | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | HTTP status code on authentication failure. |
+| `errormessageformat` | string | No | `"json"` | Error format: `"json"`, `"plain"`, or `"minimal"`. |
+| `errormessage` | string | No | `"Authentication failed"` | Error message body for failures. |
+
+#### IntrospectionProvider Configuration
+
+Each entry in `introspectionproviders` must include a unique `name` and an `introspection` configuration whose `uri` is required.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Unique provider name (referenced by `user.issuers`). |
+| `issuer` | string | No | Optional issuer value for this provider (also matchable via `user.issuers`). |
+| `introspection.uri` | string | Yes | RFC 7662 introspection endpoint URL. |
+| `introspection.clientId` | string | No | OAuth2 client id for gateway client authentication. |
+| `introspection.clientSecret` | string | No | OAuth2 client secret paired with `clientId`. |
+| `introspection.authStyle` | string | No | `"basic"` (client_secret_basic, default) or `"post"` (client_secret_post). |
+| `introspection.bearerToken` | string | No | Static bearer token used instead of client credentials. |
+| `introspection.tokenTypeHint` | string | No | `token_type_hint` sent with the request (default `access_token`). |
+| `introspection.certificatePath` | string | No | CA cert path for a self-signed introspection endpoint. |
+| `introspection.skipTlsVerify` | boolean | No | Skip TLS verification (use with caution). |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.opaquetokenauth_v1]
+introspectioncachettl = "60s"
+introspectiontimeout = "5s"
+introspectionretrycount = 2
+introspectionretryinterval = "1s"
+leeway = "30s"
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed"
+
+[[policy_configurations.opaquetokenauth_v1.introspectionproviders]]
+name = "PrimaryIDP"
+issuer = "https://idp.example.com/oauth2/token"
+
+[policy_configurations.opaquetokenauth_v1.introspectionproviders.introspection]
+uri = "https://idp.example.com/oauth2/introspect"
+clientId = "gateway-client"
+clientSecret = "gateway-secret"
+authStyle = "basic"
+tokenTypeHint = "access_token"
+skipTlsVerify = false
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `issuers` | array | No | List of provider names (or issuer values) to use. If omitted, providers are tried in order until one reports the token active. |
+| `audiences` | array | No | Acceptable audience values. The response must contain at least one. |
+| `requiredScopes` | array | No | Required scopes. Uses the space-delimited `scope` member or array `scp` member. |
+| `requiredClaims` | object | No | Map of claim name to expected value. |
+| `claimMappings` | object | No | Map of introspection response member to downstream header name. |
+| `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
+| `headerName` | string | No | Header name to extract the token from. Overrides `system.headerName`. Must be a valid HTTP header field name. |
+| `userIdClaim` | string | No | Member to extract the user ID for analytics. Defaults to `sub`. |
+| `forwardToken` | boolean | No | If `true` (default), the token is forwarded to the upstream after successful validation. Set to `false` to strip the token header before proxying. |
+| `forwardedTokenHeader` | string | No | Header name used to forward the token to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. Has no effect when `forwardToken` is `false`. |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: opaque-token-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/opaque-token-auth@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Opaque Token Authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: opaque-token-basic-api
+spec:
+  displayName: Opaque Token Basic API
+  version: v1.0
+  context: /opaque-basic/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /health
+    - method: GET
+      path: /protected
+      policies:
+        - name: opaque-token-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+```
+
+### Example 2: Audience and Scope Validation
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: opaque-token-audience-api
+spec:
+  displayName: Opaque Token Audience API
+  version: v1.0
+  context: /opaque-audience/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: opaque-token-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            audiences:
+              - "test-audience"
+            requiredScopes:
+              - read:data
+```
+
+### Example 3: Claim Mapping to Downstream Headers
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: opaque-token-claims-api
+spec:
+  displayName: Opaque Token Claims API
+  version: v1.0
+  context: /opaque-claims/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /profile
+      policies:
+        - name: opaque-token-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            claimMappings:
+              sub: X-User-ID
+              username: X-User-Name
+              client_id: X-Client-ID
+```
+
+### Example 4: Strip Token Before Forwarding to Upstream
+
+By default, the token is forwarded to the upstream after successful validation under the `x-forwarded-authorization` header. Set `forwardToken: false` to strip it before proxying.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: opaque-token-strip-api
+spec:
+  displayName: Opaque Token Strip API
+  version: v1.0
+  context: /opaque-strip/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: opaque-token-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: false
+```
+
+## Notes
+
+- **Transport security:** Always use HTTPS introspection endpoints. RFC 7662 mandates TLS for the introspection request; `skipTlsVerify` should only be used for testing or trusted internal endpoints.
+- **Caching vs. revocation latency:** A longer `introspectionCacheTtl` reduces load on the authorization server but increases the window during which a revoked token is still accepted. Cached entries never outlive the token's `exp`. Tune the TTL to your revocation requirements.
+- **Provider fallback:** When no `issuers` are configured, every provider is tried in order until one reports the token active. Constrain this with `issuers` (or per-provider `issuer` values) to avoid presenting tokens to unintended authorization servers.
+
+## Related Policies
+
+- **JWT Authentication** — validates self-contained JWT access tokens locally via JWKS providers.

--- a/docs/opaque-token-auth/v1.0/metadata.json
+++ b/docs/opaque-token-auth/v1.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "opaque-token-auth",
+  "displayName": "Opaque Token Auth",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI"
+  ],
+  "description": "Validates opaque OAuth 2.0 access tokens via RFC 7662 token introspection.\nSystem-level configuration holds introspection providers, gateway client authentication, and caching behavior.\nUser-level configuration holds per-route assertions (selected issuers, audiences, scopes, claims and mappings)."
+}

--- a/policies/opaque-token-auth/go.mod
+++ b/policies/opaque-token-auth/go.mod
@@ -1,5 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/opaque-token-auth
 
-go 1.26.1
+go 1.26.2
 
 require github.com/wso2/api-platform/sdk/core v0.2.4
+
+// TODO: temporary — the cache utility (utils/cache) is not yet in a published
+// SDK release. Remove this replace and bump the require above to the released
+// version before merging.
+replace github.com/wso2/api-platform/sdk/core => ../../../api-platform/sdk/core

--- a/policies/opaque-token-auth/go.mod
+++ b/policies/opaque-token-auth/go.mod
@@ -2,9 +2,4 @@ module github.com/wso2/gateway-controllers/policies/opaque-token-auth
 
 go 1.26.2
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
-
-// TODO: temporary — the cache utility (utils/cache) is not yet in a published
-// SDK release. Remove this replace and bump the require above to the released
-// version before merging.
-replace github.com/wso2/api-platform/sdk/core => ../../../api-platform/sdk/core
+require github.com/wso2/api-platform/sdk/core v0.2.16

--- a/policies/opaque-token-auth/go.mod
+++ b/policies/opaque-token-auth/go.mod
@@ -1,0 +1,5 @@
+module github.com/wso2/gateway-controllers/policies/opaque-token-auth
+
+go 1.26.1
+
+require github.com/wso2/api-platform/sdk/core v0.2.4

--- a/policies/opaque-token-auth/go.sum
+++ b/policies/opaque-token-auth/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
+github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/opaque-token-auth/go.sum
+++ b/policies/opaque-token-auth/go.sum
@@ -1,2 +1,0 @@
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/opaque-token-auth/go.sum
+++ b/policies/opaque-token-auth/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.16 h1:mIUOjrfX6gJNsntddYo+J70e7BHgrGC6DT3ZOVnVKZE=
+github.com/wso2/api-platform/sdk/core v0.2.16/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -247,14 +247,12 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 		}
 	}
 
-	// Scope assertion.
+	// Scope assertion: passes when the token contains at least one required scope (OR).
 	if len(userRequiredScopes) > 0 {
 		scopes := parseScopes(result.raw["scope"], result.raw["scp"])
-		for _, required := range userRequiredScopes {
-			if !contains(scopes, required) {
-				slog.Debug("Opaque Token Auth Policy: Required scope not found", "missingScope", required)
-				return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("required scope '%s' not found", required))
-			}
+		if !anyMatch(userRequiredScopes, scopes) {
+			slog.Debug("Opaque Token Auth Policy: No required scope found in token", "requiredScopes", userRequiredScopes)
+			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "token does not contain any required scope")
 		}
 	}
 
@@ -287,9 +285,11 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 		slog.Debug("Opaque Token Auth Policy: Introspection cache hit", "provider", provider.Name)
 		return cached.result, nil
 	}
+	slog.Debug("Opaque Token Auth Policy: Introspection cache miss", "provider", provider.Name)
 
 	var lastErr error
 	for attempt := 0; attempt <= retryCount; attempt++ {
+		slog.Debug("Opaque Token Auth Policy: Introspection attempt", "provider", provider.Name, "attempt", attempt+1, "maxAttempts", retryCount+1)
 		result, err := p.doIntrospect(ctx, token, provider, timeout)
 		if err == nil {
 			var expiresAt time.Time
@@ -304,10 +304,12 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 				expiresAt = time.Now().Add(negativeCacheTtl)
 			}
 			if !expiresAt.IsZero() && expiresAt.After(time.Now()) {
+				slog.Debug("Opaque Token Auth Policy: Caching introspection result", "provider", provider.Name, "active", result.Active, "expiresAt", expiresAt)
 				_ = p.cache.Set(ctx, cacheKey, &cachedIntrospection{result: result, expiresAt: expiresAt})
 			}
 			return result, nil
 		}
+		slog.Debug("Opaque Token Auth Policy: Introspection attempt failed", "provider", provider.Name, "attempt", attempt+1, "error", err)
 		lastErr = err
 		if attempt < retryCount {
 			select {
@@ -343,12 +345,19 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
+	authMethod := "none"
 	switch {
 	case provider.BearerToken != "":
 		req.Header.Set("Authorization", "Bearer "+provider.BearerToken)
+		authMethod = "bearer"
+	case provider.AuthStyle == "post" && provider.ClientID != "":
+		// credentials already added to form body above
+		authMethod = "client_secret_post"
 	case provider.AuthStyle != "post" && provider.ClientID != "":
 		req.SetBasicAuth(provider.ClientID, provider.ClientSecret)
+		authMethod = "client_secret_basic"
 	}
+	slog.Debug("Opaque Token Auth Policy: Sending introspection request", "provider", provider.Name, "uri", provider.URI, "authMethod", authMethod, "timeout", timeout)
 
 	client := &http.Client{Timeout: timeout}
 	if provider.httpTransport != nil {
@@ -360,6 +369,7 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 		return nil, fmt.Errorf("introspection request failed: %w", err)
 	}
 	defer resp.Body.Close()
+	slog.Debug("Opaque Token Auth Policy: Received introspection response", "provider", provider.Name, "status", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("introspection endpoint returned status %d", resp.StatusCode)
@@ -374,11 +384,13 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse introspection response: %w", err)
 	}
+	// Best-effort: populate typed convenience fields (active, exp, sub, etc.).
+	// Errors are ignored because polymorphic members like scope/aud may not match
+	// the struct field types; raw is the authoritative source for all claim access.
 	var result IntrospectionResult
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse introspection response: %w", err)
-	}
+	_ = json.Unmarshal(body, &result)
 	result.raw = raw
+	slog.Debug("Opaque Token Auth Policy: Parsed introspection result", "provider", provider.Name, "active", result.Active, "sub", result.Sub, "exp", result.Exp)
 	return &result, nil
 }
 
@@ -397,6 +409,7 @@ func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedCo
 		}
 	}
 
+	slog.Debug("Opaque Token Auth Policy: Building auth context", "subject", subject, "issuer", result.Iss, "clientId", result.ClientID, "forwardToken", forwardToken, "forwardedTokenHeader", forwardedTokenHeader)
 	shared.AuthContext = &policy.AuthContext{
 		Authenticated: true,
 		AuthType:      AuthType,
@@ -548,10 +561,12 @@ func (p *OpaqueTokenAuthPolicy) getProviders(params map[string]interface{}) ([]*
 	if h == p.provHash {
 		providers := p.providers
 		p.provMu.RUnlock()
+		slog.Debug("Opaque Token Auth Policy: Using cached provider list", "count", len(providers))
 		return providers, nil
 	}
 	p.provMu.RUnlock()
 
+	slog.Debug("Opaque Token Auth Policy: Introspection provider config changed, rebuilding provider list")
 	providers, err := parseIntrospectionProviders(params)
 	if err != nil {
 		return nil, err
@@ -562,8 +577,10 @@ func (p *OpaqueTokenAuthPolicy) getProviders(params map[string]interface{}) ([]*
 	if h != p.provHash {
 		p.provHash = h
 		p.providers = providers
+		slog.Debug("Opaque Token Auth Policy: Provider list rebuilt", "count", len(providers))
 	} else {
 		providers = p.providers
+		slog.Debug("Opaque Token Auth Policy: Provider list already rebuilt by another goroutine", "count", len(providers))
 	}
 	p.provMu.Unlock()
 	return providers, nil
@@ -686,21 +703,31 @@ func parseAudience(audClaim interface{}) []string {
 	return []string{}
 }
 
-// parseScopes parses scopes from a space-delimited `scope` string and/or an
-// array `scp` value.
+// parseScopes parses scopes from `scope` and/or `scp` introspection members.
+// Each can be either a space-delimited string or an array of strings.
 func parseScopes(scopeClaim, scpClaim interface{}) []string {
 	var scopes []string
-	if scopeStr, ok := scopeClaim.(string); ok {
-		scopes = append(scopes, strings.Fields(scopeStr)...)
-	}
-	if scpArr, ok := scpClaim.([]interface{}); ok {
-		for _, s := range scpArr {
-			if sStr, ok := s.(string); ok {
-				scopes = append(scopes, sStr)
+	scopes = append(scopes, parseScopeValue(scopeClaim)...)
+	scopes = append(scopes, parseScopeValue(scpClaim)...)
+	return scopes
+}
+
+// parseScopeValue accepts a scope value that is either a space-delimited string
+// or an array of strings.
+func parseScopeValue(v interface{}) []string {
+	switch val := v.(type) {
+	case string:
+		return strings.Fields(val)
+	case []interface{}:
+		result := make([]string, 0, len(val))
+		for _, s := range val {
+			if str, ok := s.(string); ok {
+				result = append(result, str)
 			}
 		}
+		return result
 	}
-	return scopes
+	return nil
 }
 
 // buildScopesMap converts scope/scp values into a set for AuthContext.Scopes.

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -66,16 +66,16 @@ var standardIntrospectionClaims = map[string]bool{
 // token introspection, caching active responses to reduce load on the
 // authorization server.
 type OpaqueTokenAuthPolicy struct {
-	// cache stores active introspection results keyed by sha256(providerURI \x00 token).
+	// cache stores introspection results keyed by sha256(providerName \x00 token).
 	// The SDK cache is constructed with no TTL (entries are bounded by their own
 	// expiresAt, which is min(configured TTL, token exp)) and an LRU size cap.
 	cache cache.Cache[*cachedIntrospection]
 
-	// provMu guards provHash and providers so they are rebuilt only when the
-	// introspectionProviders config actually changes (typically once, at startup).
-	provMu    sync.RWMutex
-	provHash  string
+	// provOnce ensures the provider list is parsed exactly once from config.toml,
+	// which is loaded at startup and does not change at runtime.
+	provOnce  sync.Once
 	providers []*IntrospectionProvider
+	provErr   error
 }
 
 // cachedIntrospection holds an active introspection result with its expiry.
@@ -398,7 +398,7 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 	var result IntrospectionResult
 	_ = json.Unmarshal(body, &result)
 	result.raw = raw
-	slog.Debug("Opaque Token Auth Policy: Parsed introspection result", "provider", provider.Name, "active", result.Active, "sub", result.Sub, "exp", result.Exp)
+	slog.Debug("Opaque Token Auth Policy: Parsed introspection result", "provider", provider.Name, "active", result.Active, "exp", result.Exp)
 	return &result, nil
 }
 
@@ -417,7 +417,7 @@ func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedCo
 		}
 	}
 
-	slog.Debug("Opaque Token Auth Policy: Building auth context", "subject", subject, "issuer", result.Iss, "clientId", result.ClientID, "forwardToken", forwardToken, "forwardedTokenHeader", forwardedTokenHeader)
+	slog.Debug("Opaque Token Auth Policy: Building auth context", "issuer", result.Iss, "forwardToken", forwardToken, "forwardedTokenHeader", forwardedTokenHeader)
 	shared.AuthContext = &policy.AuthContext{
 		Authenticated: true,
 		AuthType:      AuthType,
@@ -473,6 +473,7 @@ func (p *OpaqueTokenAuthPolicy) handleAuthFailureHeaders(shared *policy.SharedCo
 		headers["content-type"] = "text/plain"
 	case "minimal":
 		body = "Unauthorized"
+		headers["content-type"] = "text/plain"
 	default:
 		errResponse := map[string]interface{}{
 			"error":   "Unauthorized",
@@ -503,6 +504,7 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 	}
 
 	providers := make([]*IntrospectionProvider, 0, len(list))
+	seenNames := make(map[string]struct{}, len(list))
 	for _, item := range list {
 		pm, ok := item.(map[string]interface{})
 		if !ok {
@@ -513,6 +515,10 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 			slog.Debug("Opaque Token Auth Policy: Skipping provider with empty name")
 			continue
 		}
+		if _, exists := seenNames[name]; exists {
+			return nil, fmt.Errorf("duplicate introspection provider name %q", name)
+		}
+		seenNames[name] = struct{}{}
 		introspection, ok := pm["introspection"].(map[string]interface{})
 		if !ok {
 			slog.Debug("Opaque Token Auth Policy: Skipping provider without introspection config", "name", name)
@@ -547,6 +553,10 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 			tokenRegexp:   tokenRegexp,
 		}
 
+		if provider.BearerToken != "" && provider.ClientID != "" {
+			return nil, fmt.Errorf("provider %q: bearerToken and clientId are mutually exclusive", name)
+		}
+
 		certPath := getString(introspection["certificatePath"])
 		skipTlsVerify := getBool(introspection["skipTlsVerify"])
 		if certPath != "" || skipTlsVerify {
@@ -562,47 +572,14 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 	return providers, nil
 }
 
-// getProviders returns the parsed provider list, rebuilding it only when the
-// introspectionProviders config has changed. Rebuilds are rare (typically once,
-// at startup); all other calls return the cached slice under a read lock.
+// getProviders returns the provider list, parsing it exactly once from the
+// startup config. config.toml is not reloaded at runtime so this is safe.
 func (p *OpaqueTokenAuthPolicy) getProviders(params map[string]interface{}) ([]*IntrospectionProvider, error) {
-	h := configHash(params["introspectionProviders"])
-
-	p.provMu.RLock()
-	if h == p.provHash {
-		providers := p.providers
-		p.provMu.RUnlock()
-		slog.Debug("Opaque Token Auth Policy: Using cached provider list", "count", len(providers))
-		return providers, nil
-	}
-	p.provMu.RUnlock()
-
-	slog.Debug("Opaque Token Auth Policy: Introspection provider config changed, rebuilding provider list")
-	providers, err := parseIntrospectionProviders(params)
-	if err != nil {
-		return nil, err
-	}
-
-	p.provMu.Lock()
-	// Re-check: another goroutine may have already updated while we were parsing.
-	if h != p.provHash {
-		p.provHash = h
-		p.providers = providers
-		slog.Debug("Opaque Token Auth Policy: Provider list rebuilt", "count", len(providers))
-	} else {
-		providers = p.providers
-		slog.Debug("Opaque Token Auth Policy: Provider list already rebuilt by another goroutine", "count", len(providers))
-	}
-	p.provMu.Unlock()
-	return providers, nil
-}
-
-// configHash returns a hex SHA-256 of the JSON-marshalled value, used to detect
-// introspectionProviders config changes without a deep equality check.
-func configHash(v interface{}) string {
-	b, _ := json.Marshal(v)
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	p.provOnce.Do(func() {
+		p.providers, p.provErr = parseIntrospectionProviders(params)
+		slog.Debug("Opaque Token Auth Policy: Provider list parsed", "count", len(p.providers))
+	})
+	return p.providers, p.provErr
 }
 
 // selectProviders narrows the provider list by the user-supplied issuers (matched

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -31,15 +31,21 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	"github.com/wso2/api-platform/sdk/core/utils/cache"
 )
 
 const (
 	// AuthType identifies this authentication mechanism in AuthContext.
 	AuthType = "opaque"
+
+	// cacheName labels the introspection cache in SDK cache statistics.
+	cacheName = "opaque-token-introspection"
+
+	// cacheMaxSize bounds the number of cached introspection results (LRU eviction).
+	cacheMaxSize = 10000
 )
 
 // standardIntrospectionClaims lists RFC 7662 introspection response members that
@@ -54,8 +60,10 @@ var standardIntrospectionClaims = map[string]bool{
 // token introspection, caching active responses to reduce load on the
 // authorization server.
 type OpaqueTokenAuthPolicy struct {
-	cacheMutex sync.RWMutex
-	cacheStore map[string]*cachedIntrospection // key = sha256(providerURI \x00 token)
+	// cache stores active introspection results keyed by sha256(providerURI \x00 token).
+	// The SDK cache is constructed with no TTL (entries are bounded by their own
+	// expiresAt, which is min(configured TTL, token exp)) and an LRU size cap.
+	cache cache.Cache[*cachedIntrospection]
 }
 
 // cachedIntrospection holds an active introspection result with its expiry.
@@ -97,7 +105,7 @@ type IntrospectionResult struct {
 }
 
 var ins = &OpaqueTokenAuthPolicy{
-	cacheStore: make(map[string]*cachedIntrospection),
+	cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy),
 }
 
 // GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
@@ -256,15 +264,14 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 		return nil, fmt.Errorf("invalid introspection retry count: %d", retryCount)
 	}
 
-	cacheKey := introspectionCacheKey(provider.URI, token)
+	cacheKey := cache.CacheKey{Key: introspectionCacheKey(provider.URI, token)}
 
-	p.cacheMutex.RLock()
-	if cached, ok := p.cacheStore[cacheKey]; ok && time.Now().Before(cached.expiresAt) {
-		p.cacheMutex.RUnlock()
+	// The SDK cache has no TTL of its own; each entry carries its own expiresAt
+	// (bounded by the token's exp), so a stale hit is treated as a miss.
+	if cached, ok := p.cache.Get(ctx, cacheKey); ok && time.Now().Before(cached.expiresAt) {
 		slog.Debug("Opaque Token Auth Policy: Introspection cache hit", "provider", provider.Name)
 		return cached.result, nil
 	}
-	p.cacheMutex.RUnlock()
 
 	var lastErr error
 	for attempt := 0; attempt <= retryCount; attempt++ {
@@ -278,9 +285,7 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 					}
 				}
 				if expiresAt.After(time.Now()) {
-					p.cacheMutex.Lock()
-					p.cacheStore[cacheKey] = &cachedIntrospection{result: result, expiresAt: expiresAt}
-					p.cacheMutex.Unlock()
+					_ = p.cache.Set(ctx, cacheKey, &cachedIntrospection{result: result, expiresAt: expiresAt})
 				}
 			}
 			return result, nil

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -166,7 +166,6 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	userAudiences := getStringArrayParam(params, "audiences", []string{})
 	userRequiredScopes := getStringArrayParam(params, "requiredScopes", []string{})
 	userRequiredClaims := getStringMapParam(params, "requiredClaims", map[string]string{})
-	userClaimMappings := getStringMapParam(params, "claimMappings", map[string]string{})
 	userIdClaim := getStringParam(params, "userIdClaim", "sub")
 	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
 	forwardToken := getBoolParam(params, "forwardToken", true)
@@ -274,7 +273,7 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	}
 
 	slog.Debug("Opaque Token Auth Policy: All validations passed, authentication successful")
-	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, result, token, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, result, token, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
 }
 
 // introspect returns the (possibly cached) introspection result for a token at a
@@ -405,7 +404,7 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 
 // handleAuthSuccessHeaders populates AuthContext and request-header modifications
 // after a successful introspection.
-func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, result *IntrospectionResult, token string, claimMappings map[string]string,
+func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, result *IntrospectionResult, token string,
 	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
 
 	subject := result.Sub
@@ -447,15 +446,6 @@ func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedCo
 	} else if canonicalOut != canonicalIn {
 		modifications.HeadersToSet[canonicalOut] = authHeaderValue
 		modifications.HeadersToRemove = []string{canonicalIn}
-	}
-
-	for claimName, outHeader := range claimMappings {
-		if claimValue, ok := result.raw[claimName]; ok {
-			if forwardToken && http.CanonicalHeaderKey(outHeader) == canonicalOut {
-				continue
-			}
-			modifications.HeadersToSet[outHeader] = claimValueToString(claimValue)
-		}
 	}
 
 	return modifications

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -653,18 +653,12 @@ func buildTLSConfig(certPath string, skipTlsVerify bool) (*tls.Config, error) {
 	return cfg, nil
 }
 
-// introspectionCacheKey returns a hex SHA-256 keyed on the provider identity
-// (URI + auth style + client id + bearer token) and the raw token, so cached
-// results cannot cross providers that share a URI but differ in credentials.
+// introspectionCacheKey returns a hex SHA-256 keyed on the provider name and
+// the raw token, scoped per-provider so negative cache entries from one
+// provider do not suppress introspection attempts at another.
 func introspectionCacheKey(provider *IntrospectionProvider, token string) string {
 	h := sha256.New()
-	h.Write([]byte(provider.URI))
-	h.Write([]byte{0})
-	h.Write([]byte(provider.AuthStyle))
-	h.Write([]byte{0})
-	h.Write([]byte(provider.ClientID))
-	h.Write([]byte{0})
-	h.Write([]byte(provider.BearerToken))
+	h.Write([]byte(provider.Name))
 	h.Write([]byte{0})
 	h.Write([]byte(token))
 	return hex.EncodeToString(h.Sum(nil))

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -47,15 +47,18 @@ const (
 	cacheName = "opaque-token-introspection"
 
 	// cacheMaxSize bounds the number of cached introspection results (LRU eviction).
-	cacheMaxSize = 10000
+	cacheMaxSize = 100000
 )
 
 // standardIntrospectionClaims lists RFC 7662 introspection response members that
-// are surfaced as typed AuthContext fields and therefore excluded from Properties.
+// are surfaced as typed AuthContext fields or are status-only booleans, excluded
+// from Properties. username and token_type are intentionally omitted so they flow
+// into Properties — WSO2/Asgardeo always returns username, and jwt-auth does not
+// exclude these members either.
 var standardIntrospectionClaims = map[string]bool{
 	"active": true, "scope": true, "scp": true, "client_id": true,
-	"username": true, "token_type": true, "exp": true, "iat": true,
-	"nbf": true, "sub": true, "aud": true, "iss": true, "jti": true,
+	"exp": true, "iat": true, "nbf": true,
+	"sub": true, "aud": true, "iss": true, "jti": true,
 }
 
 // OpaqueTokenAuthPolicy validates opaque OAuth 2.0 access tokens via RFC 7662
@@ -144,12 +147,14 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	errorMessage := getStringParam(params, "errorMessage", "Authentication failed")
 	leewayStr := getStringParam(params, "leeway", "30s")
 	cacheTtlStr := getStringParam(params, "introspectionCacheTtl", "60s")
+	negativeCacheTtlStr := getStringParam(params, "introspectionNegativeCacheTtl", "30s")
 	timeoutStr := getStringParam(params, "introspectionTimeout", "5s")
 	retryCount := getIntParam(params, "introspectionRetryCount", 2)
 	retryIntervalStr := getStringParam(params, "introspectionRetryInterval", "1s")
 
 	leeway := parseDurationOrDefault(leewayStr, 30*time.Second)
 	cacheTtl := parseDurationOrDefault(cacheTtlStr, 60*time.Second)
+	negativeCacheTtl := parseDurationOrDefault(negativeCacheTtlStr, 30*time.Second)
 	timeout := parseDurationOrDefault(timeoutStr, 5*time.Second)
 	retryInterval := parseDurationOrDefault(retryIntervalStr, time.Second)
 
@@ -201,7 +206,7 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	var result *IntrospectionResult
 	var lastErr error
 	for _, provider := range selected {
-		res, err := p.introspect(ctx, token, provider, cacheTtl, timeout, retryCount, retryInterval)
+		res, err := p.introspect(ctx, token, provider, cacheTtl, negativeCacheTtl, timeout, retryCount, retryInterval)
 		if err != nil {
 			slog.Debug("Opaque Token Auth Policy: Introspection call failed", "provider", provider.Name, "error", err)
 			lastErr = err
@@ -266,8 +271,10 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 }
 
 // introspect returns the (possibly cached) introspection result for a token at a
-// provider. Only active responses are cached, bounded by min(TTL, token exp).
-func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, provider *IntrospectionProvider, cacheTtl, timeout time.Duration, retryCount int, retryInterval time.Duration) (*IntrospectionResult, error) {
+// provider. Active responses are cached bounded by min(cacheTtl, token exp).
+// Inactive (active:false) HTTP-200 responses are cached for negativeCacheTtl when
+// > 0; transport errors and non-200 responses are never cached.
+func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, provider *IntrospectionProvider, cacheTtl, negativeCacheTtl, timeout time.Duration, retryCount int, retryInterval time.Duration) (*IntrospectionResult, error) {
 	if retryCount < 0 {
 		return nil, fmt.Errorf("invalid introspection retry count: %d", retryCount)
 	}
@@ -285,16 +292,19 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 	for attempt := 0; attempt <= retryCount; attempt++ {
 		result, err := p.doIntrospect(ctx, token, provider, timeout)
 		if err == nil {
+			var expiresAt time.Time
 			if result.Active {
-				expiresAt := time.Now().Add(cacheTtl)
+				expiresAt = time.Now().Add(cacheTtl)
 				if result.Exp > 0 {
 					if tokenExp := time.Unix(result.Exp, 0); tokenExp.Before(expiresAt) {
 						expiresAt = tokenExp
 					}
 				}
-				if expiresAt.After(time.Now()) {
-					_ = p.cache.Set(ctx, cacheKey, &cachedIntrospection{result: result, expiresAt: expiresAt})
-				}
+			} else if negativeCacheTtl > 0 {
+				expiresAt = time.Now().Add(negativeCacheTtl)
+			}
+			if !expiresAt.IsZero() && expiresAt.After(time.Now()) {
+				_ = p.cache.Set(ctx, cacheKey, &cachedIntrospection{result: result, expiresAt: expiresAt})
 			}
 			return result, nil
 		}

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -105,7 +105,7 @@ type IntrospectionResult struct {
 }
 
 var ins = &OpaqueTokenAuthPolicy{
-	cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy),
+	cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy, slog.Default()),
 }
 
 // GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
@@ -254,7 +254,7 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	}
 
 	slog.Debug("Opaque Token Auth Policy: All validations passed, authentication successful")
-	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, result, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, result, token, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
 }
 
 // introspect returns the (possibly cached) introspection result for a token at a
@@ -362,7 +362,7 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 
 // handleAuthSuccessHeaders populates AuthContext and request-header modifications
 // after a successful introspection.
-func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, result *IntrospectionResult, claimMappings map[string]string,
+func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, result *IntrospectionResult, token string, claimMappings map[string]string,
 	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
 
 	subject := result.Sub
@@ -383,8 +383,12 @@ func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedCo
 		Audience:      parseAudience(result.raw["aud"]),
 		Scopes:        buildScopesMap(result.raw),
 		CredentialID:  result.ClientID,
-		Properties:    buildProperties(result.raw),
-		Previous:      shared.AuthContext,
+		// TokenId is a SHA-256 fingerprint of the opaque token: a stable, globally
+		// unique, non-reversible identifier (the raw token is a bearer secret and must
+		// not be propagated). Downstream policies such as backend-jwt use it as a cache key.
+		TokenId:    tokenFingerprint(token),
+		Properties: buildProperties(result.raw),
+		Previous:   shared.AuthContext,
 	}
 
 	modifications := policy.UpstreamRequestHeaderModifications{
@@ -556,6 +560,14 @@ func introspectionCacheKey(uri, token string) string {
 	h.Write([]byte{0})
 	h.Write([]byte(token))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// tokenFingerprint returns a hex SHA-256 of the token, used as AuthContext.TokenId.
+// Unlike introspectionCacheKey it is not provider-scoped, so the same token yields
+// the same downstream cache key regardless of which provider validated it.
+func tokenFingerprint(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }
 
 // ─── Generic helpers ─────────────────────────────────────────────────────────

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -88,12 +89,14 @@ type cachedIntrospection struct {
 type IntrospectionProvider struct {
 	Name          string           // Unique provider name (referenced by user `issuers`)
 	Issuer        string           // Optional issuer value (also matchable via `issuers`)
+	TokenPattern  string           // Optional regex; when set, only tokens matching it are sent to this provider
 	URI           string           // RFC 7662 introspection endpoint URL
 	ClientID      string           // OAuth2 client id for client authentication
 	ClientSecret  string           // OAuth2 client secret for client authentication
 	AuthStyle     string           // "basic" (client_secret_basic) | "post" (client_secret_post)
 	BearerToken   string           // Static bearer token alternative to client credentials
 	TokenTypeHint string           // RFC 7662 token_type_hint (default "access_token")
+	tokenRegexp   *regexp.Regexp   // Compiled TokenPattern; nil when TokenPattern is ""
 	httpTransport *http.Transport  // Reused across requests for TCP connection pooling; nil = DefaultTransport
 }
 
@@ -200,6 +203,12 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 	if token == "" {
 		slog.Debug("Opaque Token Auth Policy: Failed to extract token from authorization header", "authHeaderScheme", authHeaderScheme)
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid authorization header format")
+	}
+
+	selected = filterProvidersByToken(selected, token)
+	if len(selected) == 0 {
+		slog.Debug("Opaque Token Auth Policy: No provider tokenPattern matches token")
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "no introspection provider matches token pattern")
 	}
 
 	// Introspect against each selected provider until one reports the token active.
@@ -525,15 +534,27 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 			continue
 		}
 
+		tokenPattern := getString(pm["tokenPattern"])
+		var tokenRegexp *regexp.Regexp
+		if tokenPattern != "" {
+			compiled, err := regexp.Compile(tokenPattern)
+			if err != nil {
+				return nil, fmt.Errorf("provider %q: invalid tokenPattern: %w", name, err)
+			}
+			tokenRegexp = compiled
+		}
+
 		provider := &IntrospectionProvider{
 			Name:          name,
 			Issuer:        getString(pm["issuer"]),
+			TokenPattern:  tokenPattern,
 			URI:           uri,
 			ClientID:      getString(introspection["clientId"]),
 			ClientSecret:  getString(introspection["clientSecret"]),
 			AuthStyle:     getString(introspection["authStyle"]),
 			BearerToken:   getString(introspection["bearerToken"]),
 			TokenTypeHint: getStringOrDefault(introspection["tokenTypeHint"], "access_token"),
+			tokenRegexp:   tokenRegexp,
 		}
 
 		certPath := getString(introspection["certificatePath"])
@@ -607,6 +628,18 @@ func selectProviders(providers []*IntrospectionProvider, issuers []string) []*In
 		}
 	}
 	return selected
+}
+
+// filterProvidersByToken drops providers whose tokenPattern does not match token.
+// Providers with no pattern (tokenRegexp == nil) match all tokens.
+func filterProvidersByToken(providers []*IntrospectionProvider, token string) []*IntrospectionProvider {
+	var out []*IntrospectionProvider
+	for _, p := range providers {
+		if p.tokenRegexp == nil || p.tokenRegexp.MatchString(token) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // buildTLSConfig builds a TLS config from an optional custom CA certificate file

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
@@ -64,6 +65,12 @@ type OpaqueTokenAuthPolicy struct {
 	// The SDK cache is constructed with no TTL (entries are bounded by their own
 	// expiresAt, which is min(configured TTL, token exp)) and an LRU size cap.
 	cache cache.Cache[*cachedIntrospection]
+
+	// provMu guards provHash and providers so they are rebuilt only when the
+	// introspectionProviders config actually changes (typically once, at startup).
+	provMu    sync.RWMutex
+	provHash  string
+	providers []*IntrospectionProvider
 }
 
 // cachedIntrospection holds an active introspection result with its expiry.
@@ -75,15 +82,15 @@ type cachedIntrospection struct {
 // IntrospectionProvider describes an authorization server's introspection
 // endpoint and how the gateway authenticates itself to it.
 type IntrospectionProvider struct {
-	Name          string      // Unique provider name (referenced by user `issuers`)
-	Issuer        string      // Optional issuer value (also matchable via `issuers`)
-	URI           string      // RFC 7662 introspection endpoint URL
-	ClientID      string      // OAuth2 client id for client authentication
-	ClientSecret  string      // OAuth2 client secret for client authentication
-	AuthStyle     string      // "basic" (client_secret_basic) | "post" (client_secret_post)
-	BearerToken   string      // Static bearer token alternative to client credentials
-	TokenTypeHint string      // RFC 7662 token_type_hint (default "access_token")
-	tlsConfig     *tls.Config // Cached TLS config (custom CA / skip verify)
+	Name          string           // Unique provider name (referenced by user `issuers`)
+	Issuer        string           // Optional issuer value (also matchable via `issuers`)
+	URI           string           // RFC 7662 introspection endpoint URL
+	ClientID      string           // OAuth2 client id for client authentication
+	ClientSecret  string           // OAuth2 client secret for client authentication
+	AuthStyle     string           // "basic" (client_secret_basic) | "post" (client_secret_post)
+	BearerToken   string           // Static bearer token alternative to client credentials
+	TokenTypeHint string           // RFC 7662 token_type_hint (default "access_token")
+	httpTransport *http.Transport  // Reused across requests for TCP connection pooling; nil = DefaultTransport
 }
 
 // IntrospectionResult is the RFC 7662 introspection response. Typed fields cover
@@ -160,7 +167,7 @@ func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 		authHeaderScheme = userAuthHeaderPrefix
 	}
 
-	providers, err := parseIntrospectionProviders(params)
+	providers, err := p.getProviders(params)
 	if err != nil {
 		slog.Debug("Opaque Token Auth Policy: Failed to parse introspection providers", "error", err)
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("invalid introspection configuration: %v", err))
@@ -329,8 +336,8 @@ func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, 
 	}
 
 	client := &http.Client{Timeout: timeout}
-	if provider.tlsConfig != nil {
-		client.Transport = &http.Transport{TLSClientConfig: provider.tlsConfig}
+	if provider.httpTransport != nil {
+		client.Transport = provider.httpTransport
 	}
 
 	resp, err := client.Do(req)
@@ -508,12 +515,51 @@ func parseIntrospectionProviders(params map[string]interface{}) ([]*Introspectio
 			if err != nil {
 				return nil, fmt.Errorf("provider %q: %w", name, err)
 			}
-			provider.tlsConfig = tlsConfig
+			provider.httpTransport = &http.Transport{TLSClientConfig: tlsConfig}
 		}
 
 		providers = append(providers, provider)
 	}
 	return providers, nil
+}
+
+// getProviders returns the parsed provider list, rebuilding it only when the
+// introspectionProviders config has changed. Rebuilds are rare (typically once,
+// at startup); all other calls return the cached slice under a read lock.
+func (p *OpaqueTokenAuthPolicy) getProviders(params map[string]interface{}) ([]*IntrospectionProvider, error) {
+	h := configHash(params["introspectionProviders"])
+
+	p.provMu.RLock()
+	if h == p.provHash {
+		providers := p.providers
+		p.provMu.RUnlock()
+		return providers, nil
+	}
+	p.provMu.RUnlock()
+
+	providers, err := parseIntrospectionProviders(params)
+	if err != nil {
+		return nil, err
+	}
+
+	p.provMu.Lock()
+	// Re-check: another goroutine may have already updated while we were parsing.
+	if h != p.provHash {
+		p.provHash = h
+		p.providers = providers
+	} else {
+		providers = p.providers
+	}
+	p.provMu.Unlock()
+	return providers, nil
+}
+
+// configHash returns a hex SHA-256 of the JSON-marshalled value, used to detect
+// introspectionProviders config changes without a deep equality check.
+func configHash(v interface{}) string {
+	b, _ := json.Marshal(v)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 // selectProviders narrows the provider list by the user-supplied issuers (matched

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -1,0 +1,766 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package opaquetokenauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+const (
+	// AuthType identifies this authentication mechanism in AuthContext.
+	AuthType = "opaque"
+)
+
+// standardIntrospectionClaims lists RFC 7662 introspection response members that
+// are surfaced as typed AuthContext fields and therefore excluded from Properties.
+var standardIntrospectionClaims = map[string]bool{
+	"active": true, "scope": true, "scp": true, "client_id": true,
+	"username": true, "token_type": true, "exp": true, "iat": true,
+	"nbf": true, "sub": true, "aud": true, "iss": true, "jti": true,
+}
+
+// OpaqueTokenAuthPolicy validates opaque OAuth 2.0 access tokens via RFC 7662
+// token introspection, caching active responses to reduce load on the
+// authorization server.
+type OpaqueTokenAuthPolicy struct {
+	cacheMutex sync.RWMutex
+	cacheStore map[string]*cachedIntrospection // key = sha256(providerURI \x00 token)
+}
+
+// cachedIntrospection holds an active introspection result with its expiry.
+type cachedIntrospection struct {
+	result    *IntrospectionResult
+	expiresAt time.Time // min(now+TTL, token exp)
+}
+
+// IntrospectionProvider describes an authorization server's introspection
+// endpoint and how the gateway authenticates itself to it.
+type IntrospectionProvider struct {
+	Name          string      // Unique provider name (referenced by user `issuers`)
+	Issuer        string      // Optional issuer value (also matchable via `issuers`)
+	URI           string      // RFC 7662 introspection endpoint URL
+	ClientID      string      // OAuth2 client id for client authentication
+	ClientSecret  string      // OAuth2 client secret for client authentication
+	AuthStyle     string      // "basic" (client_secret_basic) | "post" (client_secret_post)
+	BearerToken   string      // Static bearer token alternative to client credentials
+	TokenTypeHint string      // RFC 7662 token_type_hint (default "access_token")
+	tlsConfig     *tls.Config // Cached TLS config (custom CA / skip verify)
+}
+
+// IntrospectionResult is the RFC 7662 introspection response. Typed fields cover
+// the registered members; raw retains every member for claim mappings/properties.
+type IntrospectionResult struct {
+	Active    bool        `json:"active"`
+	Scope     string      `json:"scope"`
+	ClientID  string      `json:"client_id"`
+	Username  string      `json:"username"`
+	TokenType string      `json:"token_type"`
+	Exp       int64       `json:"exp"`
+	Iat       int64       `json:"iat"`
+	Nbf       int64       `json:"nbf"`
+	Sub       string      `json:"sub"`
+	Aud       interface{} `json:"aud"` // string or []string
+	Iss       string      `json:"iss"`
+	Jti       string      `json:"jti"`
+	raw       map[string]interface{}
+}
+
+var ins = &OpaqueTokenAuthPolicy{
+	cacheStore: make(map[string]*cachedIntrospection),
+}
+
+// GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	return ins, nil
+}
+
+func (p *OpaqueTokenAuthPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeProcess,
+		RequestBodyMode:    policy.BodyModeSkip,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// OnRequestHeaders performs opaque token introspection in the request header phase.
+func (p *OpaqueTokenAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
+	slog.Debug("Opaque Token Auth Policy: OnRequestHeaders started")
+
+	headerName := getStringParam(params, "headerName", "Authorization")
+	authHeaderScheme := getStringParam(params, "authHeaderScheme", "Bearer")
+	onFailureStatusCode := getIntParam(params, "onFailureStatusCode", 401)
+	errorMessageFormat := getStringParam(params, "errorMessageFormat", "json")
+	errorMessage := getStringParam(params, "errorMessage", "Authentication failed")
+	leewayStr := getStringParam(params, "leeway", "30s")
+	cacheTtlStr := getStringParam(params, "introspectionCacheTtl", "60s")
+	timeoutStr := getStringParam(params, "introspectionTimeout", "5s")
+	retryCount := getIntParam(params, "introspectionRetryCount", 2)
+	retryIntervalStr := getStringParam(params, "introspectionRetryInterval", "1s")
+
+	leeway := parseDurationOrDefault(leewayStr, 30*time.Second)
+	cacheTtl := parseDurationOrDefault(cacheTtlStr, 60*time.Second)
+	timeout := parseDurationOrDefault(timeoutStr, 5*time.Second)
+	retryInterval := parseDurationOrDefault(retryIntervalStr, time.Second)
+
+	// User/route-level assertions.
+	userIssuers := getStringArrayParam(params, "issuers", []string{})
+	userAudiences := getStringArrayParam(params, "audiences", []string{})
+	userRequiredScopes := getStringArrayParam(params, "requiredScopes", []string{})
+	userRequiredClaims := getStringMapParam(params, "requiredClaims", map[string]string{})
+	userClaimMappings := getStringMapParam(params, "claimMappings", map[string]string{})
+	userIdClaim := getStringParam(params, "userIdClaim", "sub")
+	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
+	forwardToken := getBoolParam(params, "forwardToken", true)
+	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
+
+	if userAuthHeaderPrefix != "" {
+		authHeaderScheme = userAuthHeaderPrefix
+	}
+
+	providers, err := parseIntrospectionProviders(params)
+	if err != nil {
+		slog.Debug("Opaque Token Auth Policy: Failed to parse introspection providers", "error", err)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("invalid introspection configuration: %v", err))
+	}
+	if len(providers) == 0 {
+		slog.Debug("Opaque Token Auth Policy: No introspection providers configured")
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "introspection providers not configured")
+	}
+
+	selected := selectProviders(providers, userIssuers)
+	if len(selected) == 0 {
+		slog.Debug("Opaque Token Auth Policy: No provider matches configured issuers", "issuers", userIssuers)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "no introspection provider matches configured issuers")
+	}
+
+	authHeaders := reqCtx.Headers.Get(strings.ToLower(headerName))
+	if len(authHeaders) == 0 {
+		slog.Debug("Opaque Token Auth Policy: Missing authorization header", "headerName", headerName)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "missing authorization header")
+	}
+	authHeader := authHeaders[0]
+
+	token := extractToken(authHeader, authHeaderScheme)
+	if token == "" {
+		slog.Debug("Opaque Token Auth Policy: Failed to extract token from authorization header", "authHeaderScheme", authHeaderScheme)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid authorization header format")
+	}
+
+	// Introspect against each selected provider until one reports the token active.
+	var result *IntrospectionResult
+	var lastErr error
+	for _, provider := range selected {
+		res, err := p.introspect(ctx, token, provider, cacheTtl, timeout, retryCount, retryInterval)
+		if err != nil {
+			slog.Debug("Opaque Token Auth Policy: Introspection call failed", "provider", provider.Name, "error", err)
+			lastErr = err
+			continue
+		}
+		if res.Active {
+			slog.Debug("Opaque Token Auth Policy: Token reported active", "provider", provider.Name)
+			result = res
+			break
+		}
+		slog.Debug("Opaque Token Auth Policy: Token reported inactive", "provider", provider.Name)
+	}
+
+	if result == nil {
+		reason := "token inactive or unrecognized"
+		if lastErr != nil {
+			reason = fmt.Sprintf("introspection failed: %v", lastErr)
+		}
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, reason)
+	}
+
+	// Defense-in-depth: re-check nbf/exp locally with leeway. The authorization
+	// server is authoritative, but cached entries are bounded only by exp.
+	now := time.Now()
+	if result.Exp > 0 && now.After(time.Unix(result.Exp, 0).Add(leeway)) {
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "token expired")
+	}
+	if result.Nbf > 0 && now.Before(time.Unix(result.Nbf, 0).Add(-leeway)) {
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "token not yet valid")
+	}
+
+	// Audience assertion.
+	if len(userAudiences) > 0 {
+		aud := parseAudience(result.raw["aud"])
+		if !anyMatch(userAudiences, aud) {
+			slog.Debug("Opaque Token Auth Policy: No valid audience found", "tokenAudiences", aud)
+			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "no valid audience found in token")
+		}
+	}
+
+	// Scope assertion.
+	if len(userRequiredScopes) > 0 {
+		scopes := parseScopes(result.raw["scope"], result.raw["scp"])
+		for _, required := range userRequiredScopes {
+			if !contains(scopes, required) {
+				slog.Debug("Opaque Token Auth Policy: Required scope not found", "missingScope", required)
+				return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("required scope '%s' not found", required))
+			}
+		}
+	}
+
+	// Required-claim assertions.
+	for claimName, expectedValue := range userRequiredClaims {
+		if claimValueToString(result.raw[claimName]) != expectedValue {
+			slog.Debug("Opaque Token Auth Policy: Required claim validation failed", "claimName", claimName)
+			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("claim '%s' validation failed", claimName))
+		}
+	}
+
+	slog.Debug("Opaque Token Auth Policy: All validations passed, authentication successful")
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, result, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
+}
+
+// introspect returns the (possibly cached) introspection result for a token at a
+// provider. Only active responses are cached, bounded by min(TTL, token exp).
+func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, provider *IntrospectionProvider, cacheTtl, timeout time.Duration, retryCount int, retryInterval time.Duration) (*IntrospectionResult, error) {
+	if retryCount < 0 {
+		return nil, fmt.Errorf("invalid introspection retry count: %d", retryCount)
+	}
+
+	cacheKey := introspectionCacheKey(provider.URI, token)
+
+	p.cacheMutex.RLock()
+	if cached, ok := p.cacheStore[cacheKey]; ok && time.Now().Before(cached.expiresAt) {
+		p.cacheMutex.RUnlock()
+		slog.Debug("Opaque Token Auth Policy: Introspection cache hit", "provider", provider.Name)
+		return cached.result, nil
+	}
+	p.cacheMutex.RUnlock()
+
+	var lastErr error
+	for attempt := 0; attempt <= retryCount; attempt++ {
+		result, err := p.doIntrospect(ctx, token, provider, timeout)
+		if err == nil {
+			if result.Active {
+				expiresAt := time.Now().Add(cacheTtl)
+				if result.Exp > 0 {
+					if tokenExp := time.Unix(result.Exp, 0); tokenExp.Before(expiresAt) {
+						expiresAt = tokenExp
+					}
+				}
+				if expiresAt.After(time.Now()) {
+					p.cacheMutex.Lock()
+					p.cacheStore[cacheKey] = &cachedIntrospection{result: result, expiresAt: expiresAt}
+					p.cacheMutex.Unlock()
+				}
+			}
+			return result, nil
+		}
+		lastErr = err
+		if attempt < retryCount {
+			time.Sleep(retryInterval)
+		}
+	}
+
+	if lastErr == nil {
+		return nil, fmt.Errorf("introspection failed: no attempts executed")
+	}
+	return nil, lastErr
+}
+
+// doIntrospect performs a single RFC 7662 introspection POST request.
+func (p *OpaqueTokenAuthPolicy) doIntrospect(ctx context.Context, token string, provider *IntrospectionProvider, timeout time.Duration) (*IntrospectionResult, error) {
+	form := url.Values{}
+	form.Set("token", token)
+	if provider.TokenTypeHint != "" {
+		form.Set("token_type_hint", provider.TokenTypeHint)
+	}
+	if provider.AuthStyle == "post" && provider.ClientID != "" {
+		form.Set("client_id", provider.ClientID)
+		form.Set("client_secret", provider.ClientSecret)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.URI, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build introspection request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	switch {
+	case provider.BearerToken != "":
+		req.Header.Set("Authorization", "Bearer "+provider.BearerToken)
+	case provider.AuthStyle != "post" && provider.ClientID != "":
+		req.SetBasicAuth(provider.ClientID, provider.ClientSecret)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	if provider.tlsConfig != nil {
+		client.Transport = &http.Transport{TLSClientConfig: provider.tlsConfig}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("introspection request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("introspection endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read introspection response: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse introspection response: %w", err)
+	}
+	var result IntrospectionResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse introspection response: %w", err)
+	}
+	result.raw = raw
+	return &result, nil
+}
+
+// handleAuthSuccessHeaders populates AuthContext and request-header modifications
+// after a successful introspection.
+func (p *OpaqueTokenAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, result *IntrospectionResult, claimMappings map[string]string,
+	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
+
+	subject := result.Sub
+	if userIdClaim != "" && userIdClaim != "sub" {
+		if v, ok := result.raw[userIdClaim]; ok {
+			candidate := strings.TrimSpace(claimValueToString(v))
+			if candidate != "" && candidate != "null" {
+				subject = candidate
+			}
+		}
+	}
+
+	shared.AuthContext = &policy.AuthContext{
+		Authenticated: true,
+		AuthType:      AuthType,
+		Subject:       subject,
+		Issuer:        result.Iss,
+		Audience:      parseAudience(result.raw["aud"]),
+		Scopes:        buildScopesMap(result.raw),
+		CredentialID:  result.ClientID,
+		Properties:    buildProperties(result.raw),
+		Previous:      shared.AuthContext,
+	}
+
+	modifications := policy.UpstreamRequestHeaderModifications{
+		HeadersToSet: make(map[string]string),
+	}
+
+	canonicalIn := http.CanonicalHeaderKey(headerName)
+	canonicalOut := http.CanonicalHeaderKey(forwardedTokenHeader)
+
+	if !forwardToken {
+		modifications.HeadersToRemove = []string{canonicalIn}
+	} else if canonicalOut != canonicalIn {
+		modifications.HeadersToSet[canonicalOut] = authHeaderValue
+		modifications.HeadersToRemove = []string{canonicalIn}
+	}
+
+	for claimName, outHeader := range claimMappings {
+		if claimValue, ok := result.raw[claimName]; ok {
+			if forwardToken && http.CanonicalHeaderKey(outHeader) == canonicalOut {
+				continue
+			}
+			modifications.HeadersToSet[outHeader] = claimValueToString(claimValue)
+		}
+	}
+
+	return modifications
+}
+
+// handleAuthFailureHeaders sets an unauthenticated AuthContext and returns an
+// immediate error response.
+func (p *OpaqueTokenAuthPolicy) handleAuthFailureHeaders(shared *policy.SharedContext, statusCode int, errorFormat, errorMessage, reason string) policy.RequestHeaderAction {
+	slog.Debug("Opaque Token Auth Policy: Authentication failed", "statusCode", statusCode, "reason", reason)
+
+	shared.AuthContext = &policy.AuthContext{
+		Authenticated: false,
+		AuthType:      AuthType,
+		Previous:      shared.AuthContext,
+	}
+
+	headers := map[string]string{
+		"content-type": "application/json",
+	}
+
+	var body string
+	switch errorFormat {
+	case "plain":
+		body = errorMessage
+		headers["content-type"] = "text/plain"
+	case "minimal":
+		body = "Unauthorized"
+	default:
+		errResponse := map[string]interface{}{
+			"error":   "Unauthorized",
+			"message": errorMessage,
+		}
+		bodyBytes, _ := json.Marshal(errResponse)
+		body = string(bodyBytes)
+	}
+
+	return policy.ImmediateResponse{
+		StatusCode: statusCode,
+		Headers:    headers,
+		Body:       []byte(body),
+	}
+}
+
+// ─── Configuration parsing ───────────────────────────────────────────────────
+
+// parseIntrospectionProviders builds the provider list from the system params.
+func parseIntrospectionProviders(params map[string]interface{}) ([]*IntrospectionProvider, error) {
+	raw, ok := params["introspectionProviders"]
+	if !ok {
+		return nil, nil
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("introspectionProviders must be an array")
+	}
+
+	providers := make([]*IntrospectionProvider, 0, len(list))
+	for _, item := range list {
+		pm, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name := getString(pm["name"])
+		if name == "" {
+			slog.Debug("Opaque Token Auth Policy: Skipping provider with empty name")
+			continue
+		}
+		introspection, ok := pm["introspection"].(map[string]interface{})
+		if !ok {
+			slog.Debug("Opaque Token Auth Policy: Skipping provider without introspection config", "name", name)
+			continue
+		}
+		uri := getString(introspection["uri"])
+		if uri == "" {
+			slog.Debug("Opaque Token Auth Policy: Skipping provider without introspection uri", "name", name)
+			continue
+		}
+
+		provider := &IntrospectionProvider{
+			Name:          name,
+			Issuer:        getString(pm["issuer"]),
+			URI:           uri,
+			ClientID:      getString(introspection["clientId"]),
+			ClientSecret:  getString(introspection["clientSecret"]),
+			AuthStyle:     getString(introspection["authStyle"]),
+			BearerToken:   getString(introspection["bearerToken"]),
+			TokenTypeHint: getStringOrDefault(introspection["tokenTypeHint"], "access_token"),
+		}
+
+		certPath := getString(introspection["certificatePath"])
+		skipTlsVerify := getBool(introspection["skipTlsVerify"])
+		if certPath != "" || skipTlsVerify {
+			tlsConfig, err := buildTLSConfig(certPath, skipTlsVerify)
+			if err != nil {
+				return nil, fmt.Errorf("provider %q: %w", name, err)
+			}
+			provider.tlsConfig = tlsConfig
+		}
+
+		providers = append(providers, provider)
+	}
+	return providers, nil
+}
+
+// selectProviders narrows the provider list by the user-supplied issuers (matched
+// against provider name or issuer). With no issuers configured, all are returned.
+func selectProviders(providers []*IntrospectionProvider, issuers []string) []*IntrospectionProvider {
+	if len(issuers) == 0 {
+		return providers
+	}
+	var selected []*IntrospectionProvider
+	for _, provider := range providers {
+		if contains(issuers, provider.Name) || (provider.Issuer != "" && contains(issuers, provider.Issuer)) {
+			selected = append(selected, provider)
+		}
+	}
+	return selected
+}
+
+// buildTLSConfig builds a TLS config from an optional custom CA certificate file
+// and an optional skip-verify flag.
+func buildTLSConfig(certPath string, skipTlsVerify bool) (*tls.Config, error) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if certPath != "" {
+		certData, err := os.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificate file: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(certData) {
+			return nil, fmt.Errorf("failed to parse PEM certificate from %s", certPath)
+		}
+		cfg.RootCAs = caCertPool
+	}
+	if skipTlsVerify {
+		cfg.InsecureSkipVerify = true
+	}
+	return cfg, nil
+}
+
+// introspectionCacheKey returns a hex SHA-256 of the provider URI and token so
+// raw tokens are never held as map keys and results never cross providers.
+func introspectionCacheKey(uri, token string) string {
+	h := sha256.New()
+	h.Write([]byte(uri))
+	h.Write([]byte{0})
+	h.Write([]byte(token))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ─── Generic helpers ─────────────────────────────────────────────────────────
+
+func parseDurationOrDefault(s string, def time.Duration) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		slog.Debug("Opaque Token Auth Policy: Failed to parse duration, using default", "value", s, "default", def)
+		return def
+	}
+	return d
+}
+
+// extractToken extracts the token from an authorization header value.
+func extractToken(authHeader, scheme string) string {
+	authHeader = strings.TrimSpace(authHeader)
+	if scheme != "" {
+		parts := strings.Fields(authHeader)
+		if len(parts) == 2 && strings.EqualFold(parts[0], scheme) {
+			return parts[1]
+		}
+		return ""
+	}
+	parts := strings.Fields(authHeader)
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return parts[0]
+}
+
+// parseAudience parses an audience value which can be a string or array.
+func parseAudience(audClaim interface{}) []string {
+	if audStr, ok := audClaim.(string); ok {
+		return []string{audStr}
+	}
+	if audArr, ok := audClaim.([]interface{}); ok {
+		var result []string
+		for _, a := range audArr {
+			if aStr, ok := a.(string); ok {
+				result = append(result, aStr)
+			}
+		}
+		return result
+	}
+	return []string{}
+}
+
+// parseScopes parses scopes from a space-delimited `scope` string and/or an
+// array `scp` value.
+func parseScopes(scopeClaim, scpClaim interface{}) []string {
+	var scopes []string
+	if scopeStr, ok := scopeClaim.(string); ok {
+		scopes = append(scopes, strings.Fields(scopeStr)...)
+	}
+	if scpArr, ok := scpClaim.([]interface{}); ok {
+		for _, s := range scpArr {
+			if sStr, ok := s.(string); ok {
+				scopes = append(scopes, sStr)
+			}
+		}
+	}
+	return scopes
+}
+
+// buildScopesMap converts scope/scp values into a set for AuthContext.Scopes.
+func buildScopesMap(raw map[string]interface{}) map[string]bool {
+	scopes := parseScopes(raw["scope"], raw["scp"])
+	if len(scopes) == 0 {
+		return nil
+	}
+	result := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		result[s] = true
+	}
+	return result
+}
+
+// buildProperties extracts non-standard members into AuthContext.Properties.
+func buildProperties(raw map[string]interface{}) map[string]string {
+	var props map[string]string
+	for k, v := range raw {
+		if standardIntrospectionClaims[k] {
+			continue
+		}
+		if props == nil {
+			props = make(map[string]string)
+		}
+		props[k] = claimValueToString(v)
+	}
+	return props
+}
+
+func contains(list []string, target string) bool {
+	for _, v := range list {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
+func anyMatch(a, b []string) bool {
+	for _, x := range a {
+		if contains(b, x) {
+			return true
+		}
+	}
+	return false
+}
+
+func getString(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func getStringOrDefault(v interface{}, def string) string {
+	if s, ok := v.(string); ok && s != "" {
+		return s
+	}
+	return def
+}
+
+func getBool(v interface{}) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+func getBoolParam(params map[string]interface{}, key string, defaultValue bool) bool {
+	if v, ok := params[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return defaultValue
+}
+
+func getStringParam(params map[string]interface{}, key, defaultValue string) string {
+	if v, ok := params[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return defaultValue
+}
+
+func getIntParam(params map[string]interface{}, key string, defaultValue int) int {
+	if v, ok := params[key]; ok {
+		if i, ok := v.(int); ok {
+			return i
+		}
+		if f, ok := v.(float64); ok {
+			return int(f)
+		}
+	}
+	return defaultValue
+}
+
+func getStringArrayParam(params map[string]interface{}, key string, defaultValue []string) []string {
+	if v, ok := params[key]; ok {
+		if arr, ok := v.([]interface{}); ok {
+			var result []string
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					result = append(result, s)
+				}
+			}
+			if len(result) > 0 {
+				return result
+			}
+		}
+	}
+	return defaultValue
+}
+
+func getStringMapParam(params map[string]interface{}, key string, defaultValue map[string]string) map[string]string {
+	if v, ok := params[key]; ok {
+		if m, ok := v.(map[string]interface{}); ok {
+			result := make(map[string]string)
+			for k, val := range m {
+				if s, ok := val.(string); ok {
+					result[k] = s
+				}
+			}
+			if len(result) > 0 {
+				return result
+			}
+		}
+	}
+	return defaultValue
+}
+
+func claimValueToString(v interface{}) string {
+	switch val := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return val
+	case float64:
+		return fmt.Sprintf("%v", int64(val))
+	case bool:
+		return fmt.Sprintf("%v", val)
+	default:
+		bytes, _ := json.Marshal(val)
+		return string(bytes)
+	}
+}

--- a/policies/opaque-token-auth/opaquetokenauth.go
+++ b/policies/opaque-token-auth/opaquetokenauth.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -271,7 +272,7 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 		return nil, fmt.Errorf("invalid introspection retry count: %d", retryCount)
 	}
 
-	cacheKey := cache.CacheKey{Key: introspectionCacheKey(provider.URI, token)}
+	cacheKey := cache.CacheKey{Key: introspectionCacheKey(provider, token)}
 
 	// The SDK cache has no TTL of its own; each entry carries its own expiresAt
 	// (bounded by the token's exp), so a stale hit is treated as a miss.
@@ -299,7 +300,11 @@ func (p *OpaqueTokenAuthPolicy) introspect(ctx context.Context, token string, pr
 		}
 		lastErr = err
 		if attempt < retryCount {
-			time.Sleep(retryInterval)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryInterval):
+			}
 		}
 	}
 
@@ -598,11 +603,18 @@ func buildTLSConfig(certPath string, skipTlsVerify bool) (*tls.Config, error) {
 	return cfg, nil
 }
 
-// introspectionCacheKey returns a hex SHA-256 of the provider URI and token so
-// raw tokens are never held as map keys and results never cross providers.
-func introspectionCacheKey(uri, token string) string {
+// introspectionCacheKey returns a hex SHA-256 keyed on the provider identity
+// (URI + auth style + client id + bearer token) and the raw token, so cached
+// results cannot cross providers that share a URI but differ in credentials.
+func introspectionCacheKey(provider *IntrospectionProvider, token string) string {
 	h := sha256.New()
-	h.Write([]byte(uri))
+	h.Write([]byte(provider.URI))
+	h.Write([]byte{0})
+	h.Write([]byte(provider.AuthStyle))
+	h.Write([]byte{0})
+	h.Write([]byte(provider.ClientID))
+	h.Write([]byte{0})
+	h.Write([]byte(provider.BearerToken))
 	h.Write([]byte{0})
 	h.Write([]byte(token))
 	return hex.EncodeToString(h.Sum(nil))
@@ -819,7 +831,7 @@ func claimValueToString(v interface{}) string {
 	case string:
 		return val
 	case float64:
-		return fmt.Sprintf("%v", int64(val))
+		return strconv.FormatFloat(val, 'f', -1, 64)
 	case bool:
 		return fmt.Sprintf("%v", val)
 	default:

--- a/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
@@ -282,6 +282,9 @@ func TestErrorMessageFormats(t *testing.T) {
 		params["errorMessageFormat"] = "minimal"
 		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
 		ir := assertFailure(t, reqCtx, action, 401)
+		if ir.Headers["content-type"] != "text/plain" {
+			t.Errorf("content-type = %q, want text/plain", ir.Headers["content-type"])
+		}
 		if string(ir.Body) != "Unauthorized" {
 			t.Errorf("body = %q, want Unauthorized", string(ir.Body))
 		}

--- a/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
@@ -163,13 +163,15 @@ func TestCacheKeyedPerToken(t *testing.T) {
 	}
 }
 
-func TestInactiveNotCached(t *testing.T) {
+func TestInactiveNotCachedWhenNegativeCacheTtlIsZero(t *testing.T) {
 	var calls int64
 	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&calls, 1)
 		activeResponder(map[string]interface{}{"active": false})(w, r)
 	})
 	params := baseParams(provider("idp", srv.URL, nil))
+	// Explicitly disable negative caching: inactive results must not be cached.
+	params["introspectionNegativeCacheTtl"] = "0s"
 	p := newPolicy()
 
 	for i := 0; i < 2; i++ {
@@ -177,7 +179,7 @@ func TestInactiveNotCached(t *testing.T) {
 		assertFailure(t, reqCtx, action, 401)
 	}
 	if got := atomic.LoadInt64(&calls); got != 2 {
-		t.Errorf("calls = %d, want 2 (inactive results not cached)", got)
+		t.Errorf("calls = %d, want 2 (inactive results not cached when negativeCacheTtl=0)", got)
 	}
 }
 

--- a/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_hardening_test.go
@@ -1,0 +1,312 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package opaquetokenauth
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func writeCertPEM(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+	return path
+}
+
+func TestEndpoint5xxRetriesThenFails(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionRetryCount"] = 2
+	params["introspectionRetryInterval"] = "1ms"
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Errorf("introspection attempts = %d, want 3 (1 + 2 retries)", got)
+	}
+}
+
+func TestRetryEventualSuccess(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt64(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionRetryCount"] = 3
+	params["introspectionRetryInterval"] = "1ms"
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Errorf("attempts = %d, want 3", got)
+	}
+}
+
+func TestCacheHitSingleCall(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	p := newPolicy()
+
+	for i := 0; i < 3; i++ {
+		reqCtx, action := execute(t, p, params, bearerHeader("same-token"))
+		assertSuccess(t, reqCtx, action)
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Errorf("introspection calls = %d, want 1 (cached)", got)
+	}
+}
+
+func TestCacheExpiryRefetch(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionCacheTtl"] = "20ms"
+	p := newPolicy()
+
+	reqCtx, action := execute(t, p, params, bearerHeader("same-token"))
+	assertSuccess(t, reqCtx, action)
+	time.Sleep(40 * time.Millisecond)
+	reqCtx, action = execute(t, p, params, bearerHeader("same-token"))
+	assertSuccess(t, reqCtx, action)
+
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("introspection calls = %d, want 2 (cache expired)", got)
+	}
+}
+
+func TestCacheNotUsedPastExp(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		// exp == now: cache window collapses to zero, but still valid within leeway.
+		activeResponder(map[string]interface{}{"active": true, "sub": "u", "exp": time.Now().Unix()})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionCacheTtl"] = "60s" // large TTL, but exp bounds it
+	p := newPolicy()
+
+	for i := 0; i < 2; i++ {
+		reqCtx, action := execute(t, p, params, bearerHeader("same-token"))
+		assertSuccess(t, reqCtx, action)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("introspection calls = %d, want 2 (not cached past exp)", got)
+	}
+}
+
+func TestCacheKeyedPerToken(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		_ = r.ParseForm()
+		// Echo the presented token as the subject so we can detect cross-token leakage.
+		activeResponder(map[string]interface{}{"active": true, "sub": r.PostFormValue("token")})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	p := newPolicy()
+
+	reqCtx, action := execute(t, p, params, bearerHeader("token-A"))
+	assertSuccess(t, reqCtx, action)
+	if reqCtx.AuthContext.Subject != "token-A" {
+		t.Fatalf("first subject = %q, want token-A", reqCtx.AuthContext.Subject)
+	}
+
+	reqCtx, action = execute(t, p, params, bearerHeader("token-B"))
+	assertSuccess(t, reqCtx, action)
+	if reqCtx.AuthContext.Subject != "token-B" {
+		t.Errorf("second subject = %q, want token-B (no cache leakage)", reqCtx.AuthContext.Subject)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("calls = %d, want 2 (distinct tokens)", got)
+	}
+}
+
+func TestInactiveNotCached(t *testing.T) {
+	var calls int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		activeResponder(map[string]interface{}{"active": false})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	p := newPolicy()
+
+	for i := 0; i < 2; i++ {
+		reqCtx, action := execute(t, p, params, bearerHeader("same-token"))
+		assertFailure(t, reqCtx, action, 401)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("calls = %d, want 2 (inactive results not cached)", got)
+	}
+}
+
+func TestExpiredBeyondLeewayFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "exp": time.Now().Add(-time.Hour).Unix(),
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestExpiredWithinLeewaySucceeds(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "exp": time.Now().Add(-10 * time.Second).Unix(),
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["leeway"] = "30s"
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+}
+
+func TestNotYetValidBeyondLeewayFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "nbf": time.Now().Add(time.Hour).Unix(),
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestTLSCustomCASucceeds(t *testing.T) {
+	srv := httptest.NewTLSServer(activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	t.Cleanup(srv.Close)
+	certPath := writeCertPEM(t, srv.Certificate())
+
+	params := baseParams(provider("idp", srv.URL, map[string]interface{}{"certificatePath": certPath}))
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+}
+
+func TestTLSSkipVerifySucceeds(t *testing.T) {
+	srv := httptest.NewTLSServer(activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	t.Cleanup(srv.Close)
+
+	params := baseParams(provider("idp", srv.URL, map[string]interface{}{"skipTlsVerify": true}))
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+}
+
+func TestTLSUntrustedFails(t *testing.T) {
+	srv := httptest.NewTLSServer(activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	t.Cleanup(srv.Close)
+
+	params := baseParams(provider("idp", srv.URL, nil)) // no CA, no skip → cert untrusted
+	params["introspectionRetryCount"] = 0
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestErrorMessageFormats(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": false}))
+
+	t.Run("json", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["errorMessageFormat"] = "json"
+		params["errorMessage"] = "nope"
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		ir := assertFailure(t, reqCtx, action, 401)
+		if ir.Headers["content-type"] != "application/json" {
+			t.Errorf("content-type = %q", ir.Headers["content-type"])
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(ir.Body, &parsed); err != nil {
+			t.Fatalf("body not json: %v", err)
+		}
+		if parsed["message"] != "nope" {
+			t.Errorf("message = %v, want nope", parsed["message"])
+		}
+	})
+	t.Run("plain", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["errorMessageFormat"] = "plain"
+		params["errorMessage"] = "denied"
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		ir := assertFailure(t, reqCtx, action, 401)
+		if ir.Headers["content-type"] != "text/plain" {
+			t.Errorf("content-type = %q", ir.Headers["content-type"])
+		}
+		if string(ir.Body) != "denied" {
+			t.Errorf("body = %q, want denied", string(ir.Body))
+		}
+	})
+	t.Run("minimal", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["errorMessageFormat"] = "minimal"
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		ir := assertFailure(t, reqCtx, action, 401)
+		if string(ir.Body) != "Unauthorized" {
+			t.Errorf("body = %q, want Unauthorized", string(ir.Body))
+		}
+	})
+}
+
+func TestOnFailureStatusCode(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": false}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["onFailureStatusCode"] = 403
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 403)
+}
+
+func TestAuthContextSetOnFailure(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": false}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, _ := execute(t, newPolicy(), params, bearerHeader("tok"))
+	if reqCtx.AuthContext == nil {
+		t.Fatal("AuthContext should be set on failure")
+	}
+	if reqCtx.AuthContext.AuthType != AuthType {
+		t.Errorf("AuthType = %q, want %q", reqCtx.AuthContext.AuthType, AuthType)
+	}
+	if reqCtx.AuthContext.Authenticated {
+		t.Error("Authenticated should be false")
+	}
+}

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -26,12 +26,15 @@ import (
 	"testing"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	"github.com/wso2/api-platform/sdk/core/utils/cache"
 )
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
 func newPolicy() *OpaqueTokenAuthPolicy {
-	return &OpaqueTokenAuthPolicy{cacheStore: make(map[string]*cachedIntrospection)}
+	return &OpaqueTokenAuthPolicy{
+		cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy),
+	}
 }
 
 // activeResponder writes the given introspection claims as a JSON response.

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -328,19 +328,52 @@ func TestClaimMappings(t *testing.T) {
 }
 
 func TestScopeEnforcement(t *testing.T) {
-	srv := newServer(t, activeResponder(map[string]interface{}{
-		"active": true, "sub": "u", "scope": "read",
-	}))
+	// All four scope formats: scope/scp × string/array.
+	formats := []struct {
+		name   string
+		claims map[string]interface{}
+	}{
+		{"scope as string", map[string]interface{}{"active": true, "sub": "u", "scope": "read write"}},
+		{"scope as array", map[string]interface{}{"active": true, "sub": "u", "scope": []interface{}{"read", "write"}}},
+		{"scp as string", map[string]interface{}{"active": true, "sub": "u", "scp": "read write"}},
+		{"scp as array", map[string]interface{}{"active": true, "sub": "u", "scp": []interface{}{"read", "write"}}},
+	}
+	for _, tc := range formats {
+		t.Run(tc.name+"/pass", func(t *testing.T) {
+			srv := newServer(t, activeResponder(tc.claims))
+			params := baseParams(provider("idp", srv.URL, nil))
+			params["requiredScopes"] = []interface{}{"read"}
+			reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+			assertSuccess(t, reqCtx, action)
+		})
+		t.Run(tc.name+"/fail", func(t *testing.T) {
+			srv := newServer(t, activeResponder(tc.claims))
+			params := baseParams(provider("idp", srv.URL, nil))
+			params["requiredScopes"] = []interface{}{"admin"}
+			reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+			assertFailure(t, reqCtx, action, 401)
+		})
+	}
 
-	t.Run("pass", func(t *testing.T) {
+	// OR semantics: token has "read"; requiring ["read","admin"] passes because
+	// at least one required scope is present.
+	t.Run("OR semantics/one match passes", func(t *testing.T) {
+		srv := newServer(t, activeResponder(map[string]interface{}{
+			"active": true, "sub": "u", "scope": "read",
+		}))
 		params := baseParams(provider("idp", srv.URL, nil))
-		params["requiredScopes"] = []interface{}{"read"}
+		params["requiredScopes"] = []interface{}{"read", "admin"}
 		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
 		assertSuccess(t, reqCtx, action)
 	})
-	t.Run("fail", func(t *testing.T) {
+
+	// OR semantics: token has neither required scope → fails.
+	t.Run("OR semantics/no match fails", func(t *testing.T) {
+		srv := newServer(t, activeResponder(map[string]interface{}{
+			"active": true, "sub": "u", "scope": "read",
+		}))
 		params := baseParams(provider("idp", srv.URL, nil))
-		params["requiredScopes"] = []interface{}{"admin"}
+		params["requiredScopes"] = []interface{}{"write", "admin"}
 		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
 		assertFailure(t, reqCtx, action, 401)
 	})

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -314,19 +314,6 @@ func TestForwardTokenMoved(t *testing.T) {
 	}
 }
 
-func TestClaimMappings(t *testing.T) {
-	srv := newServer(t, activeResponder(map[string]interface{}{
-		"active": true, "sub": "u", "username": "alice",
-	}))
-	params := baseParams(provider("idp", srv.URL, nil))
-	params["claimMappings"] = map[string]interface{}{"username": "X-User-Name"}
-
-	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
-	mods := assertSuccess(t, reqCtx, action)
-	if mods.HeadersToSet["X-User-Name"] != "alice" {
-		t.Errorf("X-User-Name = %q, want alice", mods.HeadersToSet["X-User-Name"])
-	}
-}
 
 func TestScopeEnforcement(t *testing.T) {
 	// All four scope formats: scope/scp × string/array.

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -19,7 +19,10 @@ package opaquetokenauth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -33,7 +36,7 @@ import (
 
 func newPolicy() *OpaqueTokenAuthPolicy {
 	return &OpaqueTokenAuthPolicy{
-		cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy),
+		cache: cache.NewInMemoryCache[*cachedIntrospection](cacheName, cacheMaxSize, 0, cache.LRUEvictionPolicy, slog.Default()),
 	}
 }
 
@@ -146,6 +149,34 @@ func TestActiveTokenSucceeds(t *testing.T) {
 	}
 	if ac.Properties["org"] != "acme" {
 		t.Errorf("Properties[org] = %q, want acme", ac.Properties["org"])
+	}
+}
+
+func TestTokenIdIsTokenSha256(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u", "jti": "ignored-jti"}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("opaque-xyz"))
+	assertSuccess(t, reqCtx, action)
+
+	want := sha256.Sum256([]byte("opaque-xyz"))
+	if got := reqCtx.AuthContext.TokenId; got != hex.EncodeToString(want[:]) {
+		t.Errorf("TokenId = %q, want sha256(token) %q", got, hex.EncodeToString(want[:]))
+	}
+}
+
+func TestTokenIdDiffersPerToken(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	p := newPolicy()
+
+	reqCtxA, actionA := execute(t, p, params, bearerHeader("token-A"))
+	assertSuccess(t, reqCtxA, actionA)
+	reqCtxB, actionB := execute(t, p, params, bearerHeader("token-B"))
+	assertSuccess(t, reqCtxB, actionB)
+
+	if reqCtxA.AuthContext.TokenId == reqCtxB.AuthContext.TokenId {
+		t.Errorf("TokenId should differ per token, both = %q", reqCtxA.AuthContext.TokenId)
 	}
 }
 

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync/atomic"
 	"testing"
 
@@ -562,6 +563,131 @@ func TestNegativeCachingNotAppliedOnTransportError(t *testing.T) {
 	if got := atomic.LoadInt64(&serverCalls); got != 2 {
 		t.Errorf("introspection endpoint called %d times, want 2 (errors must not be cached)", got)
 	}
+}
+
+// ─── Token pattern routing ────────────────────────────────────────────────────
+
+func TestTokenPatternRoutesToMatchingProvider(t *testing.T) {
+	var localCount, asgardeoCount int64
+	localSrv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&localCount, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "local-user"})(w, r)
+	})
+	asgardeoSrv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&asgardeoCount, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "asgardeo-user"})(w, r)
+	})
+
+	localProvider := provider("local-mock", localSrv.URL, nil)
+	localProvider["tokenPattern"] = "^opaque_"
+	asgardeoProvider := provider("asgardeo", asgardeoSrv.URL, nil)
+	asgardeoProvider["tokenPattern"] = "^[0-9a-f]{8}-" // UUID-like prefix
+
+	params := baseParams(localProvider, asgardeoProvider)
+
+	t.Run("opaque prefix routes to local", func(t *testing.T) {
+		atomic.StoreInt64(&localCount, 0)
+		atomic.StoreInt64(&asgardeoCount, 0)
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("opaque_abc123"))
+		assertSuccess(t, reqCtx, action)
+		if reqCtx.AuthContext.Subject != "local-user" {
+			t.Errorf("Subject = %q, want local-user", reqCtx.AuthContext.Subject)
+		}
+		if atomic.LoadInt64(&localCount) != 1 {
+			t.Errorf("local provider calls = %d, want 1", localCount)
+		}
+		if atomic.LoadInt64(&asgardeoCount) != 0 {
+			t.Errorf("asgardeo provider should not be called, got %d calls", asgardeoCount)
+		}
+	})
+
+	t.Run("UUID prefix routes to asgardeo", func(t *testing.T) {
+		atomic.StoreInt64(&localCount, 0)
+		atomic.StoreInt64(&asgardeoCount, 0)
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+		assertSuccess(t, reqCtx, action)
+		if reqCtx.AuthContext.Subject != "asgardeo-user" {
+			t.Errorf("Subject = %q, want asgardeo-user", reqCtx.AuthContext.Subject)
+		}
+		if atomic.LoadInt64(&localCount) != 0 {
+			t.Errorf("local provider should not be called, got %d calls", localCount)
+		}
+		if atomic.LoadInt64(&asgardeoCount) != 1 {
+			t.Errorf("asgardeo provider calls = %d, want 1", asgardeoCount)
+		}
+	})
+}
+
+func TestTokenPatternNoMatchFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	p := provider("idp", srv.URL, nil)
+	p["tokenPattern"] = "^opaque_" // only matches tokens starting with "opaque_"
+	params := baseParams(p)
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("jwt.does.not.match"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestTokenPatternAbsentMatchesAll(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	// No tokenPattern set — provider should accept any token (backward compat).
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("any-token-shape"))
+	assertSuccess(t, reqCtx, action)
+}
+
+func TestTokenPatternInvalidRegexFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true}))
+	p := provider("idp", srv.URL, nil)
+	p["tokenPattern"] = "[invalid(regex"
+	params := baseParams(p)
+
+	// Invalid regex → parseIntrospectionProviders errors → auth failure.
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+// TestFilterProvidersByToken exercises the helper directly.
+func TestFilterProvidersByToken(t *testing.T) {
+	withPattern := func(pattern string) *IntrospectionProvider {
+		re, _ := regexp.Compile(pattern)
+		return &IntrospectionProvider{TokenPattern: pattern, tokenRegexp: re}
+	}
+	noPattern := &IntrospectionProvider{}
+
+	all := []*IntrospectionProvider{
+		withPattern("^opaque_"),
+		withPattern("^uuid-"),
+		noPattern,
+	}
+
+	t.Run("opaque token selects matching + no-pattern", func(t *testing.T) {
+		got := filterProvidersByToken(all, "opaque_abc")
+		if len(got) != 2 {
+			t.Fatalf("got %d providers, want 2", len(got))
+		}
+		if got[0].TokenPattern != "^opaque_" {
+			t.Errorf("first provider pattern = %q, want ^opaque_", got[0].TokenPattern)
+		}
+		if got[1].TokenPattern != "" {
+			t.Errorf("second provider should be the no-pattern one")
+		}
+	})
+
+	t.Run("unmatched token selects only no-pattern", func(t *testing.T) {
+		got := filterProvidersByToken(all, "other-token")
+		if len(got) != 1 || got[0].TokenPattern != "" {
+			t.Errorf("got %d providers, want only the no-pattern provider", len(got))
+		}
+	})
+
+	t.Run("all have patterns and none match returns empty", func(t *testing.T) {
+		got := filterProvidersByToken(all[:2], "other-token")
+		if len(got) != 0 {
+			t.Errorf("got %d providers, want 0", len(got))
+		}
+	})
 }
 
 // ─── Identity claims surfaced in Properties ───────────────────────────────────

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -459,3 +459,109 @@ func TestGetPolicy(t *testing.T) {
 		t.Fatalf("GetPolicy returned (%v, %v)", p, err)
 	}
 }
+
+// ─── Negative caching tests ───────────────────────────────────────────────────
+
+func TestNegativeCachingCachesInactiveResponse(t *testing.T) {
+	var hitCount int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hitCount, 1)
+		activeResponder(map[string]interface{}{"active": false})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionNegativeCacheTtl"] = "30s"
+
+	p := newPolicy()
+	// First request — cache miss, hits the server.
+	reqCtx1, action1 := execute(t, p, params, bearerHeader("inactive-tok"))
+	assertFailure(t, reqCtx1, action1, 401)
+
+	// Second request with same token — should be served from negative cache.
+	reqCtx2, action2 := execute(t, p, params, bearerHeader("inactive-tok"))
+	assertFailure(t, reqCtx2, action2, 401)
+
+	if got := atomic.LoadInt64(&hitCount); got != 1 {
+		t.Errorf("introspection endpoint called %d times, want 1 (negative cache should serve second request)", got)
+	}
+}
+
+func TestNegativeCachingDisabledWhenZero(t *testing.T) {
+	var hitCount int64
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hitCount, 1)
+		activeResponder(map[string]interface{}{"active": false})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionNegativeCacheTtl"] = "0s"
+
+	p := newPolicy()
+	execute(t, p, params, bearerHeader("inactive-tok"))
+	execute(t, p, params, bearerHeader("inactive-tok"))
+
+	if got := atomic.LoadInt64(&hitCount); got != 2 {
+		t.Errorf("introspection endpoint called %d times, want 2 (negative cache disabled)", got)
+	}
+}
+
+func TestNegativeCachingNotAppliedOnTransportError(t *testing.T) {
+	// Use a server that closes connections immediately to simulate a transport error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close with a non-200 status to trigger the "status != 200" error path.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["introspectionNegativeCacheTtl"] = "30s"
+	params["introspectionRetryCount"] = 0
+
+	p := newPolicy()
+	// Both requests should hit the server — errors must not be negatively cached.
+	var serverCalls int64
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&serverCalls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	execute(t, p, params, bearerHeader("some-tok"))
+	execute(t, p, params, bearerHeader("some-tok"))
+
+	if got := atomic.LoadInt64(&serverCalls); got != 2 {
+		t.Errorf("introspection endpoint called %d times, want 2 (errors must not be cached)", got)
+	}
+}
+
+// ─── Identity claims surfaced in Properties ───────────────────────────────────
+
+func TestUsernameAndWSO2ClaimsInProperties(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active":     true,
+		"sub":        "550e8400-e29b-41d4-a716-446655440000",
+		"username":   "alice@example.com",
+		"token_type": "Bearer",
+		"org_id":     "org-123",
+		"org_handle": "acme-corp",
+		"aut":        "APPLICATION_USER",
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+
+	ac := reqCtx.AuthContext
+	if ac.Properties["username"] != "alice@example.com" {
+		t.Errorf("Properties[username] = %q, want alice@example.com", ac.Properties["username"])
+	}
+	if ac.Properties["token_type"] != "Bearer" {
+		t.Errorf("Properties[token_type] = %q, want Bearer", ac.Properties["token_type"])
+	}
+	if ac.Properties["org_handle"] != "acme-corp" {
+		t.Errorf("Properties[org_handle] = %q, want acme-corp", ac.Properties["org_handle"])
+	}
+	if ac.Properties["aut"] != "APPLICATION_USER" {
+		t.Errorf("Properties[aut] = %q, want APPLICATION_USER", ac.Properties["aut"])
+	}
+	if ac.Properties["org_id"] != "org-123" {
+		t.Errorf("Properties[org_id] = %q, want org-123", ac.Properties["org_id"])
+	}
+}

--- a/policies/opaque-token-auth/opaquetokenauth_test.go
+++ b/policies/opaque-token-auth/opaquetokenauth_test.go
@@ -1,0 +1,427 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package opaquetokenauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+func newPolicy() *OpaqueTokenAuthPolicy {
+	return &OpaqueTokenAuthPolicy{cacheStore: make(map[string]*cachedIntrospection)}
+}
+
+// activeResponder writes the given introspection claims as a JSON response.
+func activeResponder(claims map[string]interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(claims)
+	}
+}
+
+func newServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// provider builds a single introspection provider config map.
+func provider(name, uri string, introspectionExtra map[string]interface{}) map[string]interface{} {
+	introspection := map[string]interface{}{"uri": uri}
+	for k, v := range introspectionExtra {
+		introspection[k] = v
+	}
+	return map[string]interface{}{"name": name, "introspection": introspection}
+}
+
+// baseParams wraps providers into a params map.
+func baseParams(providers ...map[string]interface{}) map[string]interface{} {
+	list := make([]interface{}, 0, len(providers))
+	for _, p := range providers {
+		list = append(list, p)
+	}
+	return map[string]interface{}{"introspectionProviders": list}
+}
+
+func bearerHeader(token string) map[string][]string {
+	return map[string][]string{"authorization": {"Bearer " + token}}
+}
+
+func execute(t *testing.T, p *OpaqueTokenAuthPolicy, params map[string]interface{}, headers map[string][]string) (*policy.RequestHeaderContext, policy.RequestHeaderAction) {
+	t.Helper()
+	reqCtx := &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{},
+		Headers:       policy.NewHeaders(headers),
+	}
+	action := p.OnRequestHeaders(context.Background(), reqCtx, params)
+	return reqCtx, action
+}
+
+func assertSuccess(t *testing.T, reqCtx *policy.RequestHeaderContext, action policy.RequestHeaderAction) policy.UpstreamRequestHeaderModifications {
+	t.Helper()
+	mods, ok := action.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+	if reqCtx.AuthContext == nil || !reqCtx.AuthContext.Authenticated {
+		t.Fatalf("expected authenticated AuthContext, got %+v", reqCtx.AuthContext)
+	}
+	return mods
+}
+
+func assertFailure(t *testing.T, reqCtx *policy.RequestHeaderContext, action policy.RequestHeaderAction, statusCode int) policy.ImmediateResponse {
+	t.Helper()
+	ir, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", action)
+	}
+	if ir.StatusCode != statusCode {
+		t.Fatalf("expected status %d, got %d", statusCode, ir.StatusCode)
+	}
+	if reqCtx.AuthContext == nil || reqCtx.AuthContext.Authenticated {
+		t.Fatalf("expected unauthenticated AuthContext, got %+v", reqCtx.AuthContext)
+	}
+	return ir
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+func TestActiveTokenSucceeds(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active":    true,
+		"sub":       "user-123",
+		"iss":       "https://idp.example",
+		"client_id": "app-1",
+		"scope":     "read write",
+		"aud":       "my-api",
+		"org":       "acme",
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("opaque-abc"))
+	assertSuccess(t, reqCtx, action)
+
+	ac := reqCtx.AuthContext
+	if ac.AuthType != AuthType {
+		t.Errorf("AuthType = %q, want %q", ac.AuthType, AuthType)
+	}
+	if ac.Subject != "user-123" {
+		t.Errorf("Subject = %q, want user-123", ac.Subject)
+	}
+	if ac.Issuer != "https://idp.example" {
+		t.Errorf("Issuer = %q", ac.Issuer)
+	}
+	if ac.CredentialID != "app-1" {
+		t.Errorf("CredentialID = %q, want app-1", ac.CredentialID)
+	}
+	if !ac.Scopes["read"] || !ac.Scopes["write"] {
+		t.Errorf("Scopes = %v, want read+write", ac.Scopes)
+	}
+	if ac.Properties["org"] != "acme" {
+		t.Errorf("Properties[org] = %q, want acme", ac.Properties["org"])
+	}
+}
+
+func TestInactiveTokenFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": false}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("opaque-abc"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestClientSecretBasic(t *testing.T) {
+	var gotUser, gotPass string
+	var gotOK bool
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, gotOK = r.BasicAuth()
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, map[string]interface{}{
+		"clientId": "client-x", "clientSecret": "secret-y", "authStyle": "basic",
+	}))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if !gotOK || gotUser != "client-x" || gotPass != "secret-y" {
+		t.Errorf("basic auth = (%q,%q,%v), want (client-x,secret-y,true)", gotUser, gotPass, gotOK)
+	}
+}
+
+func TestClientSecretPost(t *testing.T) {
+	var gotClientID, gotSecret, gotAuthHeader string
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotClientID = r.PostFormValue("client_id")
+		gotSecret = r.PostFormValue("client_secret")
+		gotAuthHeader = r.Header.Get("Authorization")
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, map[string]interface{}{
+		"clientId": "client-x", "clientSecret": "secret-y", "authStyle": "post",
+	}))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if gotClientID != "client-x" || gotSecret != "secret-y" {
+		t.Errorf("post creds = (%q,%q), want (client-x,secret-y)", gotClientID, gotSecret)
+	}
+	if gotAuthHeader != "" {
+		t.Errorf("Authorization header should be empty for client_secret_post, got %q", gotAuthHeader)
+	}
+}
+
+func TestStaticBearerToken(t *testing.T) {
+	var gotAuth string
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, map[string]interface{}{
+		"bearerToken": "introspect-token",
+	}))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if gotAuth != "Bearer introspect-token" {
+		t.Errorf("Authorization = %q, want 'Bearer introspect-token'", gotAuth)
+	}
+}
+
+func TestTokenAndHintSent(t *testing.T) {
+	var gotToken, gotHint string
+	srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotToken = r.PostFormValue("token")
+		gotHint = r.PostFormValue("token_type_hint")
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q", r.Header.Get("Content-Type"))
+		}
+		activeResponder(map[string]interface{}{"active": true, "sub": "u"})(w, r)
+	})
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("opaque-xyz"))
+	assertSuccess(t, reqCtx, action)
+	if gotToken != "opaque-xyz" {
+		t.Errorf("token = %q, want opaque-xyz", gotToken)
+	}
+	if gotHint != "access_token" {
+		t.Errorf("token_type_hint = %q, want access_token (default)", gotHint)
+	}
+}
+
+func TestMissingHeaderFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	reqCtx, action := execute(t, newPolicy(), params, map[string][]string{})
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestWrongSchemeFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true}))
+	params := baseParams(provider("idp", srv.URL, nil))
+
+	headers := map[string][]string{"authorization": {"Basic dXNlcjpwYXNz"}}
+	reqCtx, action := execute(t, newPolicy(), params, headers)
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestForwardTokenStripped(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["forwardToken"] = false
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	mods := assertSuccess(t, reqCtx, action)
+	if !contains(mods.HeadersToRemove, "Authorization") {
+		t.Errorf("expected Authorization to be removed, got %v", mods.HeadersToRemove)
+	}
+}
+
+func TestForwardTokenMoved(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u"}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	// defaults: forwardToken true, forwardedTokenHeader x-forwarded-authorization
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	mods := assertSuccess(t, reqCtx, action)
+	if mods.HeadersToSet["X-Forwarded-Authorization"] != "Bearer tok" {
+		t.Errorf("forwarded header = %q, want 'Bearer tok'", mods.HeadersToSet["X-Forwarded-Authorization"])
+	}
+	if !contains(mods.HeadersToRemove, "Authorization") {
+		t.Errorf("expected original Authorization removed, got %v", mods.HeadersToRemove)
+	}
+}
+
+func TestClaimMappings(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "username": "alice",
+	}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["claimMappings"] = map[string]interface{}{"username": "X-User-Name"}
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	mods := assertSuccess(t, reqCtx, action)
+	if mods.HeadersToSet["X-User-Name"] != "alice" {
+		t.Errorf("X-User-Name = %q, want alice", mods.HeadersToSet["X-User-Name"])
+	}
+}
+
+func TestScopeEnforcement(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "scope": "read",
+	}))
+
+	t.Run("pass", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["requiredScopes"] = []interface{}{"read"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertSuccess(t, reqCtx, action)
+	})
+	t.Run("fail", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["requiredScopes"] = []interface{}{"admin"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertFailure(t, reqCtx, action, 401)
+	})
+}
+
+func TestAudienceEnforcement(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "aud": []interface{}{"api-a", "api-b"},
+	}))
+
+	t.Run("pass", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["audiences"] = []interface{}{"api-b"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertSuccess(t, reqCtx, action)
+	})
+	t.Run("fail", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["audiences"] = []interface{}{"api-c"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertFailure(t, reqCtx, action, 401)
+	})
+}
+
+func TestRequiredClaims(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{
+		"active": true, "sub": "u", "tenant": "acme",
+	}))
+
+	t.Run("pass", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["requiredClaims"] = map[string]interface{}{"tenant": "acme"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertSuccess(t, reqCtx, action)
+	})
+	t.Run("fail", func(t *testing.T) {
+		params := baseParams(provider("idp", srv.URL, nil))
+		params["requiredClaims"] = map[string]interface{}{"tenant": "other"}
+		reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+		assertFailure(t, reqCtx, action, 401)
+	})
+}
+
+func TestProviderFallback(t *testing.T) {
+	inactive := newServer(t, activeResponder(map[string]interface{}{"active": false}))
+	active := newServer(t, activeResponder(map[string]interface{}{"active": true, "sub": "u2"}))
+	params := baseParams(
+		provider("idp-a", inactive.URL, nil),
+		provider("idp-b", active.URL, nil),
+	)
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if reqCtx.AuthContext.Subject != "u2" {
+		t.Errorf("Subject = %q, want u2 (from second provider)", reqCtx.AuthContext.Subject)
+	}
+}
+
+func TestIssuerSelection(t *testing.T) {
+	var aCount, bCount int64
+	srvA := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&aCount, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "ua"})(w, r)
+	})
+	srvB := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&bCount, 1)
+		activeResponder(map[string]interface{}{"active": true, "sub": "ub"})(w, r)
+	})
+	params := baseParams(
+		provider("idp-a", srvA.URL, nil),
+		provider("idp-b", srvB.URL, nil),
+	)
+	params["issuers"] = []interface{}{"idp-b"}
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertSuccess(t, reqCtx, action)
+	if reqCtx.AuthContext.Subject != "ub" {
+		t.Errorf("Subject = %q, want ub", reqCtx.AuthContext.Subject)
+	}
+	if atomic.LoadInt64(&aCount) != 0 {
+		t.Errorf("provider idp-a should not be called, got %d calls", aCount)
+	}
+	if atomic.LoadInt64(&bCount) != 1 {
+		t.Errorf("provider idp-b calls = %d, want 1", bCount)
+	}
+}
+
+func TestNoProvidersConfiguredFails(t *testing.T) {
+	params := map[string]interface{}{}
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestIssuerSelectionNoMatchFails(t *testing.T) {
+	srv := newServer(t, activeResponder(map[string]interface{}{"active": true}))
+	params := baseParams(provider("idp", srv.URL, nil))
+	params["issuers"] = []interface{}{"nonexistent"}
+
+	reqCtx, action := execute(t, newPolicy(), params, bearerHeader("tok"))
+	assertFailure(t, reqCtx, action, 401)
+}
+
+func TestMode(t *testing.T) {
+	m := newPolicy().Mode()
+	if m.RequestHeaderMode != policy.HeaderModeProcess {
+		t.Errorf("RequestHeaderMode = %v, want PROCESS", m.RequestHeaderMode)
+	}
+	if m.RequestBodyMode != policy.BodyModeSkip || m.ResponseHeaderMode != policy.HeaderModeSkip || m.ResponseBodyMode != policy.BodyModeSkip {
+		t.Errorf("expected all non-request-header modes to be SKIP, got %+v", m)
+	}
+}
+
+func TestGetPolicy(t *testing.T) {
+	p, err := GetPolicy(policy.PolicyMetadata{}, nil)
+	if err != nil || p == nil {
+		t.Fatalf("GetPolicy returned (%v, %v)", p, err)
+	}
+}

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -49,16 +49,6 @@ parameters:
       additionalProperties:
         type: string
 
-    claimMappings:
-      type: object
-      x-wso2-policy-advanced-param: true
-      description: Maps introspection response members to upstream headers as `claimName -> headerName`.
-      default: {}
-      additionalProperties:
-        type: string
-        minLength: 1
-        pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
-
     authHeaderPrefix:
       type: string
       x-wso2-policy-advanced-param: true

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -36,7 +36,7 @@ parameters:
     requiredScopes:
       type: array
       x-wso2-policy-advanced-param: true
-      description: Scopes that must be present in the introspection response `scope` (space-delimited) or `scp` (array).
+      description: At least one of these scopes must be present in the introspection response `scope` or `scp` (OR semantics).
       default: []
       items:
         type: string

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -169,6 +169,12 @@ systemParameters:
       default: "60s"
       "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectioncachettl}"
 
+    introspectionNegativeCacheTtl:
+      type: string
+      description: Duration to cache inactive (active:false) introspection responses (e.g., "30s"). Set to "0s" to disable. Transport errors and non-200 responses are never negatively cached.
+      default: "30s"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectionnegativecachettl}"
+
     introspectionTimeout:
       type: string
       description: Timeout for each introspection HTTP request, e.g., "5s".

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -1,0 +1,215 @@
+name: opaque-token-auth
+version: v1.0.0
+description: |
+  Validates opaque OAuth 2.0 access tokens by calling an authorization server's
+  RFC 7662 token introspection endpoint. The gateway forwards the bearer token to
+  the introspection endpoint, authenticates itself, and admits the request only
+  when the response reports `active: true`. It can then enforce audiences, scopes,
+  and required claims, and propagate identity downstream. Active responses are
+  cached briefly (never beyond the token's `exp`) to reduce load on the
+  authorization server.
+
+parameters:
+  type: object
+  additionalProperties: false
+  properties:
+    # User-level parameters (per-route assertions / overrides)
+    issuers:
+      type: array
+      x-wso2-policy-advanced-param: true
+      description: >-
+        Selects which introspection providers to use by referencing their `name`
+        or `issuer` in `system.introspectionProviders`. If omitted, providers are
+        tried in order until one reports the token active.
+      default: []
+      items:
+        type: string
+
+    audiences:
+      type: array
+      x-wso2-policy-advanced-param: true
+      description: Accepted audience values. Validation succeeds only when at least one configured audience is present in the introspection response `aud`.
+      default: []
+      items:
+        type: string
+
+    requiredScopes:
+      type: array
+      x-wso2-policy-advanced-param: true
+      description: Scopes that must be present in the introspection response `scope` (space-delimited) or `scp` (array).
+      default: []
+      items:
+        type: string
+
+    requiredClaims:
+      type: object
+      x-wso2-policy-advanced-param: true
+      description: Required claim-value pairs as `claimName -> expectedValue`, matched against the introspection response.
+      default: {}
+      additionalProperties:
+        type: string
+
+    claimMappings:
+      type: object
+      x-wso2-policy-advanced-param: true
+      description: Maps introspection response members to upstream headers as `claimName -> headerName`.
+      default: {}
+      additionalProperties:
+        type: string
+
+    authHeaderPrefix:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: Route-level authorization scheme prefix (for example, "Bearer") that overrides `system.authHeaderScheme`.
+      default: Bearer
+
+    userIdClaim:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: >-
+        The introspection response member used to derive the user ID for
+        analytics. Defaults to "sub" when omitted.
+      default: sub
+
+    headerName:
+      type: string
+      x-wso2-policy-advanced-param: true
+      minLength: 1
+      pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+      description: Header name to extract the token from (for example "Authorization"); overrides `system.headerName`.
+      default: Authorization
+
+    forwardToken:
+      type: boolean
+      x-wso2-policy-advanced-param: true
+      description: >-
+        If true, the original authorization header (containing the token) is
+        forwarded to the upstream service after successful validation. If false,
+        the header is stripped before the request is proxied.
+      default: true
+
+    forwardedTokenHeader:
+      type: string
+      x-wso2-policy-advanced-param: true
+      minLength: 1
+      pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+      description: >-
+        The header name used to forward the token to the upstream service when
+        `forwardToken` is true. If this differs from `headerName`, the original
+        header is removed and the token is forwarded under this name instead. Has
+        no effect when `forwardToken` is false.
+      default: x-forwarded-authorization
+
+systemParameters:
+  type: object
+  additionalProperties: false
+  properties:
+    # System-level parameters (gateway-wide config)
+    introspectionProviders:
+      type: array
+      description: >-
+        List of authorization server introspection endpoints. Each entry must
+        include a unique `name` and an `introspection` configuration.
+      items:
+        type: object
+        additionalProperties: false
+        required: ["name", "introspection"]
+        properties:
+          name:
+            type: string
+            description: Unique name for this provider (referenced by `user.issuers`).
+          issuer:
+            type: string
+            description: Optional issuer value associated with this provider (also matchable via `user.issuers`).
+          introspection:
+            type: object
+            additionalProperties: false
+            required: ["uri"]
+            description: RFC 7662 token introspection endpoint configuration and gateway client authentication.
+            properties:
+              uri:
+                type: string
+                format: uri
+                description: Introspection endpoint URL (e.g., https://idp.example/oauth2/introspect).
+              clientId:
+                type: string
+                description: OAuth2 client id the gateway uses to authenticate to the introspection endpoint.
+              clientSecret:
+                type: string
+                description: OAuth2 client secret paired with `clientId`.
+              authStyle:
+                type: string
+                enum: ["basic", "post"]
+                default: basic
+                description: >-
+                  How client credentials are sent. "basic" uses HTTP Basic auth
+                  (client_secret_basic); "post" sends client_id/client_secret in
+                  the form body (client_secret_post).
+              bearerToken:
+                type: string
+                description: Static bearer token used to authenticate to the introspection endpoint instead of client credentials (RFC 7662 permits a separate access token).
+              tokenTypeHint:
+                type: string
+                default: access_token
+                description: RFC 7662 token_type_hint sent with the introspection request.
+              certificatePath:
+                type: string
+                description: Optional path to a CA certificate file for validating a self-signed introspection endpoint (e.g., /etc/certs/ca.pem).
+              skipTlsVerify:
+                type: boolean
+                default: false
+                description: If true, skip TLS certificate verification for the introspection endpoint. Use with caution, only for testing or trusted internal endpoints.
+
+    introspectionCacheTtl:
+      type: string
+      description: Duration to cache active introspection responses (e.g., "60s"). Cached entries never outlive the token's `exp`.
+      default: "60s"
+
+    introspectionTimeout:
+      type: string
+      description: Timeout for each introspection HTTP request, e.g., "5s".
+      default: "5s"
+
+    introspectionRetryCount:
+      type: integer
+      description: Number of retries for an introspection request on transient failures.
+      default: 2
+
+    introspectionRetryInterval:
+      type: string
+      description: Interval between introspection retries, e.g., "1s".
+      default: "1s"
+
+    leeway:
+      type: string
+      description: Clock skew allowance for local exp/nbf re-checks, e.g., "30s".
+      default: "30s"
+
+    authHeaderScheme:
+      type: string
+      description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, the scheme is enforced; if omitted, raw header values are accepted or known schemes stripped.
+      default: Bearer
+
+    headerName:
+      type: string
+      minLength: 1
+      pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
+      description: Header name to extract the token from (default "Authorization").
+      default: Authorization
+
+    onFailureStatusCode:
+      type: integer
+      description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
+      default: 401
+
+    errorMessageFormat:
+      type: string
+      description: Format of the error response on validation failure. Supported values are "json", "plain", or "minimal".
+      default: json
+
+    errorMessage:
+      type: string
+      description: Custom error message to include in the response body on authentication failure.
+      default: "Authentication failed"
+
+  required: ["introspectionProviders"]

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -123,6 +123,15 @@ systemParameters:
           issuer:
             type: string
             description: Optional issuer value associated with this provider (also matchable via `user.issuers`).
+          tokenPattern:
+            type: string
+            description: >-
+              Optional regular expression matched against the raw token string.
+              When set, only tokens that match are sent to this provider for
+              introspection. Providers with no pattern match all tokens. Use
+              this to route tokens to the correct authorization server based on
+              their format (e.g. a UUID prefix for one IdP, an "opaque_" prefix
+              for another).
           introspection:
             type: object
             additionalProperties: false

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -159,36 +159,43 @@ systemParameters:
                 type: boolean
                 default: false
                 description: If true, skip TLS certificate verification for the introspection endpoint. Use with caution, only for testing or trusted internal endpoints.
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectionproviders}"
 
     introspectionCacheTtl:
       type: string
       description: Duration to cache active introspection responses (e.g., "60s"). Cached entries never outlive the token's `exp`.
       default: "60s"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectioncachettl}"
 
     introspectionTimeout:
       type: string
       description: Timeout for each introspection HTTP request, e.g., "5s".
       default: "5s"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectiontimeout}"
 
     introspectionRetryCount:
       type: integer
       description: Number of retries for an introspection request on transient failures.
       default: 2
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectionretrycount}"
 
     introspectionRetryInterval:
       type: string
       description: Interval between introspection retries, e.g., "1s".
       default: "1s"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.introspectionretryinterval}"
 
     leeway:
       type: string
       description: Clock skew allowance for local exp/nbf re-checks, e.g., "30s".
       default: "30s"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.leeway}"
 
     authHeaderScheme:
       type: string
       description: Expected scheme prefix in the authorization header (e.g., "Bearer"). If set, the scheme is enforced; if omitted, raw header values are accepted or known schemes stripped.
       default: Bearer
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.authheaderscheme}"
 
     headerName:
       type: string
@@ -196,20 +203,24 @@ systemParameters:
       pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
       description: Header name to extract the token from (default "Authorization").
       default: Authorization
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.headername}"
 
     onFailureStatusCode:
       type: integer
       description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
       default: 401
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
       description: Format of the error response on validation failure. Supported values are "json", "plain", or "minimal".
       default: json
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.errormessageformat}"
 
     errorMessage:
       type: string
       description: Custom error message to include in the response body on authentication failure.
       default: "Authentication failed"
+      "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.errormessage}"
 
   required: ["introspectionProviders"]

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -56,6 +56,8 @@ parameters:
       default: {}
       additionalProperties:
         type: string
+        minLength: 1
+        pattern: "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"
 
     authHeaderPrefix:
       type: string
@@ -207,12 +209,14 @@ systemParameters:
 
     onFailureStatusCode:
       type: integer
+      enum: [401, 403]
       description: HTTP status code to return on authentication failure (401 for Unauthorized, 403 for Forbidden).
       default: 401
       "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.onfailurestatuscode}"
 
     errorMessageFormat:
       type: string
+      enum: ["json", "plain", "minimal"]
       description: Format of the error response on validation failure. Supported values are "json", "plain", or "minimal".
       default: json
       "wso2/defaultValue": "${config.policy_configurations.opaquetokenauth_v1.errormessageformat}"


### PR DESCRIPTION
This pull request adds a new "Opaque Token Auth" policy for validating opaque OAuth 2.0 access tokens using RFC 7662 token introspection. It introduces full documentation, metadata, and Go module setup for the new policy, enabling secure, configurable authentication for API routes that require bearer token validation.

**New Policy Addition:**

* Added the "Opaque Token Auth" policy, which validates opaque OAuth 2.0 access tokens by calling authorization server introspection endpoints per RFC 7662. This policy supports multiple providers, flexible authentication methods, caching, and detailed configuration options. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R59) [[2]](diffhunk://#diff-a03cd7eb7faceb392573f358f8ee7f6bc217246d6a4894afffe68721f7e7505dR1-R272)

**Documentation and Metadata:**

* Added comprehensive documentation for the new policy in `docs/opaque-token-auth/v1.0/docs/opaque-token-authentication.md`, including configuration options, usage scenarios, and security notes.
* Registered the policy in the main `docs/README.md` to make it discoverable in the policy list.
* Added a metadata file `docs/opaque-token-auth/v1.0/metadata.json` describing the policy for documentation tooling and UI integration.

**Codebase Setup:**

* Introduced a new Go module for the policy in `policies/opaque-token-auth/go.mod`, specifying dependencies and module path for integration into the gateway controllers.