### PR TITLE
Add configuration to strip the token value prefix when forwarding the…

### DIFF
--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -104,8 +104,8 @@ skipTlsVerify = false
 | `headerName` | string | No | Header name to extract the token from (e.g., `"Authorization"`). Overrides `system.headerName`. Must be a valid HTTP header field name (non-empty, no spaces or control characters). |
 | `userIdClaim` | string | No | Claim name to extract user ID for analytics. Defaults to `sub`. |
 | `forwardToken` | boolean | No | If `true` (default), the JWT is forwarded to the upstream after successful validation. Set to `false` to strip the token header before proxying. |
-| `forwardedTokenHeader` | string | No | Header name used to forward the JWT to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. By default the full header value (including the scheme prefix) is forwarded; set `forwardTokenValue` to `true` to forward only the bare token value. Has no effect when `forwardToken` is `false`. |
-| `forwardTokenValue` | boolean | No | Controls what is forwarded under `forwardedTokenHeader` when `forwardToken` is `true`. If `true`, only the bare token value (with the scheme prefix such as `Bearer` stripped) is forwarded. If `false` (default), the full header value including the prefix is forwarded. Has no effect when `forwardToken` is `false`. |
+| `forwardedTokenHeader` | string | No | Header name used to forward the JWT to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. By default the full header value (including the scheme prefix) is forwarded; set `forwardTokenStripScheme` to `true` to forward only the bare token value. Has no effect when `forwardToken` is `false`. |
+| `forwardTokenStripScheme` | boolean | No | Controls what is forwarded under `forwardedTokenHeader` when `forwardToken` is `true`. If `true`, only the bare token value (with the scheme prefix such as `Bearer` stripped) is forwarded. If `false` (default), the full header value including the prefix is forwarded. Has no effect when `forwardToken` is `false`. |
 
 
 **Note:**
@@ -319,7 +319,7 @@ spec:
 
 ### Example 8: Forward the Token Value Without the Scheme Prefix
 
-Some upstreams expect the raw token value without the `Bearer` (or other) scheme prefix. Set `forwardTokenValue: true` to forward the bare token under `forwardedTokenHeader` instead of the full header value. For example, an incoming `Authorization: Bearer eyJ...` results in the upstream receiving `X-JWT-Token: eyJ...`.
+Some upstreams expect the raw token value without the `Bearer` (or other) scheme prefix. Set `forwardTokenStripScheme: true` to forward the bare token under `forwardedTokenHeader` instead of the full header value. For example, an incoming `Authorization: Bearer eyJ...` results in the upstream receiving `X-JWT-Token: eyJ...`.
 
 ```yaml
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
@@ -343,6 +343,6 @@ spec:
             issuers:
               - PrimaryIDP
             forwardToken: true
-            forwardTokenValue: true
+            forwardTokenStripScheme: true
             forwardedTokenHeader: X-JWT-Token
 ```

--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -18,7 +18,7 @@ The JWT Authentication policy validates JWT access tokens using one or more JWKS
 - Authorization header scheme enforcement and clock skew tolerance
 - Customizable error responses
 - Optional `userIdClaim` mapping for analytics
-- Optional forwarding of the JWT to the upstream under a configurable header name
+- Optional forwarding of the JWT to the upstream under a configurable header name, as either the full header value or the bare token value (scheme prefix stripped)
 
 ## Configuration
 
@@ -104,7 +104,8 @@ skipTlsVerify = false
 | `headerName` | string | No | Header name to extract the token from (e.g., `"Authorization"`). Overrides `system.headerName`. Must be a valid HTTP header field name (non-empty, no spaces or control characters). |
 | `userIdClaim` | string | No | Claim name to extract user ID for analytics. Defaults to `sub`. |
 | `forwardToken` | boolean | No | If `true` (default), the JWT is forwarded to the upstream after successful validation. Set to `false` to strip the token header before proxying. |
-| `forwardedTokenHeader` | string | No | Header name used to forward the JWT to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. Has no effect when `forwardToken` is `false`. |
+| `forwardedTokenHeader` | string | No | Header name used to forward the JWT to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. By default the full header value (including the scheme prefix) is forwarded; set `forwardTokenValue` to `true` to forward only the bare token value. Has no effect when `forwardToken` is `false`. |
+| `forwardTokenValue` | boolean | No | Controls what is forwarded under `forwardedTokenHeader` when `forwardToken` is `true`. If `true`, only the bare token value (with the scheme prefix such as `Bearer` stripped) is forwarded. If `false` (default), the full header value including the prefix is forwarded. Has no effect when `forwardToken` is `false`. |
 
 
 **Note:**
@@ -314,4 +315,34 @@ spec:
               - PrimaryIDP
             forwardToken: true
             forwardedTokenHeader: X-Backend-Authorization
+```
+
+### Example 8: Forward the Token Value Without the Scheme Prefix
+
+Some upstreams expect the raw token value without the `Bearer` (or other) scheme prefix. Set `forwardTokenValue: true` to forward the bare token under `forwardedTokenHeader` instead of the full header value. For example, an incoming `Authorization: Bearer eyJ...` results in the upstream receiving `X-JWT-Token: eyJ...`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-token-value-api
+spec:
+  displayName: JWT Auth Token Value API
+  version: v1.0
+  context: /jwt-auth-token-value/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: true
+            forwardTokenValue: true
+            forwardedTokenHeader: X-JWT-Token
 ```

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1311,7 +1311,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
 	forwardToken := getBoolParam(params, "forwardToken", true)
 	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
-	forwardTokenValue := getBoolParam(params, "forwardTokenValue", false)
+	forwardTokenStripScheme := getBoolParam(params, "forwardTokenStripScheme", false)
 
 	slog.Debug("JWT Auth Policy: User configuration loaded",
 		"issuers", userIssuers,
@@ -1321,7 +1321,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		"claimMappingsCount", len(userClaimMappings),
 		"userIdClaim", userIdClaim,
 		"authHeaderPrefix", userAuthHeaderPrefix,
-		"forwardTokenValue", forwardTokenValue,
+		"forwardTokenStripScheme", forwardTokenStripScheme,
 	)
 
 	if userAuthHeaderPrefix != "" {
@@ -1460,13 +1460,13 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	slog.Debug("JWT Auth Policy: All validations passed, authentication successful")
 
 	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, authHeader, token,
-		forwardToken, forwardedTokenHeader, forwardTokenValue)
+		forwardToken, forwardedTokenHeader, forwardTokenStripScheme)
 }
 
 // handleAuthSuccessHeaders handles successful JWT authentication in the header phase.
 func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, claims jwt.MapClaims, claimMappings map[string]string,
 	userIdClaim string, headerName string, authHeaderValue string, tokenValue string, forwardToken bool, forwardedTokenHeader string,
-	forwardTokenValue bool) policy.RequestHeaderAction {
+	forwardTokenStripScheme bool) policy.RequestHeaderAction {
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 	jti, _ := claims["jti"].(string)
@@ -1506,15 +1506,15 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 		modifications.HeadersToRemove = []string{canonicalIn}
 	} else {
 		// Forward either the bare token or the full
-		// original header value, depending on forwardTokenValue.
+		// original header value, depending on forwardTokenStripScheme.
 		forwardValue := authHeaderValue
-		if forwardTokenValue {
+		if forwardTokenStripScheme {
 			forwardValue = tokenValue
 		}
 		if canonicalOut != canonicalIn {
 			modifications.HeadersToSet[canonicalOut] = forwardValue
 			modifications.HeadersToRemove = []string{canonicalIn}
-		} else if forwardTokenValue {
+		} else if forwardTokenStripScheme {
 			// Same header name, but the prefix must be stripped, so overwrite it.
 			modifications.HeadersToSet[canonicalOut] = forwardValue
 		}

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1311,6 +1311,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
 	forwardToken := getBoolParam(params, "forwardToken", true)
 	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
+	forwardTokenValue := getBoolParam(params, "forwardTokenValue", false)
 
 	slog.Debug("JWT Auth Policy: User configuration loaded",
 		"issuers", userIssuers,
@@ -1320,6 +1321,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		"claimMappingsCount", len(userClaimMappings),
 		"userIdClaim", userIdClaim,
 		"authHeaderPrefix", userAuthHeaderPrefix,
+		"forwardTokenValue", forwardTokenValue,
 	)
 
 	if userAuthHeaderPrefix != "" {
@@ -1457,12 +1459,14 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 
 	slog.Debug("JWT Auth Policy: All validations passed, authentication successful")
 
-	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, authHeader, forwardToken, forwardedTokenHeader)
+	return p.handleAuthSuccessHeaders(reqCtx.SharedContext, claims, userClaimMappings, userIdClaim, headerName, authHeader, token,
+		forwardToken, forwardedTokenHeader, forwardTokenValue)
 }
 
 // handleAuthSuccessHeaders handles successful JWT authentication in the header phase.
 func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, claims jwt.MapClaims, claimMappings map[string]string,
-	userIdClaim string, headerName string, authHeaderValue string, forwardToken bool, forwardedTokenHeader string) policy.RequestHeaderAction {
+	userIdClaim string, headerName string, authHeaderValue string, tokenValue string, forwardToken bool, forwardedTokenHeader string,
+	forwardTokenValue bool) policy.RequestHeaderAction {
 	sub, _ := claims["sub"].(string)
 	iss, _ := claims["iss"].(string)
 	jti, _ := claims["jti"].(string)
@@ -1500,9 +1504,20 @@ func (p *JwtAuthPolicy) handleAuthSuccessHeaders(shared *policy.SharedContext, c
 
 	if !forwardToken {
 		modifications.HeadersToRemove = []string{canonicalIn}
-	} else if canonicalOut != canonicalIn {
-		modifications.HeadersToSet[canonicalOut] = authHeaderValue
-		modifications.HeadersToRemove = []string{canonicalIn}
+	} else {
+		// Forward either the bare token or the full
+		// original header value, depending on forwardTokenValue.
+		forwardValue := authHeaderValue
+		if forwardTokenValue {
+			forwardValue = tokenValue
+		}
+		if canonicalOut != canonicalIn {
+			modifications.HeadersToSet[canonicalOut] = forwardValue
+			modifications.HeadersToRemove = []string{canonicalIn}
+		} else if forwardTokenValue {
+			// Same header name, but the prefix must be stripped, so overwrite it.
+			modifications.HeadersToSet[canonicalOut] = forwardValue
+		}
 	}
 
 	for claimName, headerName := range claimMappings {

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -207,9 +207,9 @@ func TestJWTAuthPolicy_ForwardTokenFalse(t *testing.T) {
 	}
 }
 
-// TestJWTAuthPolicy_ForwardTokenValue verifies that when forwardTokenValue is true,
+// TestJWTAuthPolicy_ForwardTokenStripScheme verifies that when forwardTokenStripScheme is true,
 // the bare token value (scheme prefix stripped) is forwarded under forwardedTokenHeader.
-func TestJWTAuthPolicy_ForwardTokenValue(t *testing.T) {
+func TestJWTAuthPolicy_ForwardTokenStripScheme(t *testing.T) {
 	privateKey, publicKey := generateTestKeys(t)
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()
@@ -231,7 +231,7 @@ func TestJWTAuthPolicy_ForwardTokenValue(t *testing.T) {
 		"errorMessageFormat":   "json",
 		"leeway":               "30s",
 		"allowedAlgorithms":    []interface{}{"RS256", "ES256"},
-		"forwardTokenValue":    true,
+		"forwardTokenStripScheme":    true,
 		"forwardedTokenHeader": "X-My-Token",
 		"keyManagers": []interface{}{
 			map[string]interface{}{
@@ -281,10 +281,10 @@ func TestJWTAuthPolicy_ForwardTokenValue(t *testing.T) {
 	}
 }
 
-// TestJWTAuthPolicy_ForwardTokenValueSameHeader verifies that when forwardTokenValue is
+// TestJWTAuthPolicy_ForwardTokenStripSchemeSameHeader verifies that when forwardTokenStripScheme is
 // true and the forwarded header equals the source header, the header is overwritten
 // in place with the prefix-stripped value (not removed).
-func TestJWTAuthPolicy_ForwardTokenValueSameHeader(t *testing.T) {
+func TestJWTAuthPolicy_ForwardTokenStripSchemeSameHeader(t *testing.T) {
 	privateKey, publicKey := generateTestKeys(t)
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()
@@ -304,7 +304,7 @@ func TestJWTAuthPolicy_ForwardTokenValueSameHeader(t *testing.T) {
 		"authHeaderScheme":     "Bearer",
 		"leeway":               "30s",
 		"allowedAlgorithms":    []interface{}{"RS256", "ES256"},
-		"forwardTokenValue":    true,
+		"forwardTokenStripScheme":    true,
 		"forwardedTokenHeader": "Authorization",
 		"keyManagers": []interface{}{
 			map[string]interface{}{
@@ -342,9 +342,9 @@ func TestJWTAuthPolicy_ForwardTokenValueSameHeader(t *testing.T) {
 	}
 }
 
-// TestJWTAuthPolicy_ForwardTokenValueDefaultOff verifies that with forwardTokenValue
+// TestJWTAuthPolicy_ForwardTokenStripSchemeDefaultOff verifies that with forwardTokenStripScheme
 // unset (default false), the full header value (including prefix) is forwarded.
-func TestJWTAuthPolicy_ForwardTokenValueDefaultOff(t *testing.T) {
+func TestJWTAuthPolicy_ForwardTokenStripSchemeDefaultOff(t *testing.T) {
 	privateKey, publicKey := generateTestKeys(t)
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()

--- a/policies/jwt-auth/jwtauth_test.go
+++ b/policies/jwt-auth/jwtauth_test.go
@@ -207,6 +207,197 @@ func TestJWTAuthPolicy_ForwardTokenFalse(t *testing.T) {
 	}
 }
 
+// TestJWTAuthPolicy_ForwardTokenValue verifies that when forwardTokenValue is true,
+// the bare token value (scheme prefix stripped) is forwarded under forwardedTokenHeader.
+func TestJWTAuthPolicy_ForwardTokenValue(t *testing.T) {
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://issuer.example.com",
+		"aud": "api-audience",
+	})
+
+	ctx := createMockRequestHeaderContext(map[string][]string{
+		"authorization": {fmt.Sprintf("Bearer %s", token)},
+	})
+
+	params := map[string]interface{}{
+		"headerName":           "Authorization",
+		"authHeaderScheme":     "Bearer",
+		"onFailureStatusCode":  401,
+		"errorMessageFormat":   "json",
+		"leeway":               "30s",
+		"allowedAlgorithms":    []interface{}{"RS256", "ES256"},
+		"forwardTokenValue":    true,
+		"forwardedTokenHeader": "X-My-Token",
+		"keyManagers": []interface{}{
+			map[string]interface{}{
+				"name":   "test-issuer",
+				"issuer": "https://issuer.example.com",
+				"jwks": map[string]interface{}{
+					"remote": map[string]interface{}{
+						"uri": jwksServer.URL + "/jwks.json",
+					},
+				},
+			},
+		},
+		"audiences": []interface{}{"api-audience"},
+	}
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("Failed to create policy: %v", err)
+	}
+
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+
+	modifications, ok := action.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+
+	// The forwarded header must carry the bare token, without the "Bearer " prefix.
+	got := modifications.HeadersToSet["X-My-Token"]
+	if got != token {
+		t.Errorf("Expected X-My-Token to be the bare token %q, got %q", token, got)
+	}
+	if strings.Contains(got, "Bearer") {
+		t.Errorf("Expected X-My-Token to not contain the scheme prefix, got %q", got)
+	}
+
+	// The original Authorization header must be removed (renamed).
+	foundRemoved := false
+	for _, h := range modifications.HeadersToRemove {
+		if strings.EqualFold(h, "Authorization") {
+			foundRemoved = true
+			break
+		}
+	}
+	if !foundRemoved {
+		t.Errorf("Expected Authorization header to be removed, HeadersToRemove=%v", modifications.HeadersToRemove)
+	}
+}
+
+// TestJWTAuthPolicy_ForwardTokenValueSameHeader verifies that when forwardTokenValue is
+// true and the forwarded header equals the source header, the header is overwritten
+// in place with the prefix-stripped value (not removed).
+func TestJWTAuthPolicy_ForwardTokenValueSameHeader(t *testing.T) {
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://issuer.example.com",
+		"aud": "api-audience",
+	})
+
+	ctx := createMockRequestHeaderContext(map[string][]string{
+		"authorization": {fmt.Sprintf("Bearer %s", token)},
+	})
+
+	params := map[string]interface{}{
+		"headerName":           "Authorization",
+		"authHeaderScheme":     "Bearer",
+		"leeway":               "30s",
+		"allowedAlgorithms":    []interface{}{"RS256", "ES256"},
+		"forwardTokenValue":    true,
+		"forwardedTokenHeader": "Authorization",
+		"keyManagers": []interface{}{
+			map[string]interface{}{
+				"name":   "test-issuer",
+				"issuer": "https://issuer.example.com",
+				"jwks": map[string]interface{}{
+					"remote": map[string]interface{}{
+						"uri": jwksServer.URL + "/jwks.json",
+					},
+				},
+			},
+		},
+		"audiences": []interface{}{"api-audience"},
+	}
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("Failed to create policy: %v", err)
+	}
+
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+
+	modifications, ok := action.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+
+	if got := modifications.HeadersToSet["Authorization"]; got != token {
+		t.Errorf("Expected Authorization to be overwritten with bare token %q, got %q", token, got)
+	}
+	for _, h := range modifications.HeadersToRemove {
+		if strings.EqualFold(h, "Authorization") {
+			t.Errorf("Did not expect Authorization to be removed when forwarded under the same name, HeadersToRemove=%v", modifications.HeadersToRemove)
+		}
+	}
+}
+
+// TestJWTAuthPolicy_ForwardTokenValueDefaultOff verifies that with forwardTokenValue
+// unset (default false), the full header value (including prefix) is forwarded.
+func TestJWTAuthPolicy_ForwardTokenValueDefaultOff(t *testing.T) {
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://issuer.example.com",
+		"aud": "api-audience",
+	})
+
+	ctx := createMockRequestHeaderContext(map[string][]string{
+		"authorization": {fmt.Sprintf("Bearer %s", token)},
+	})
+
+	params := map[string]interface{}{
+		"headerName":           "Authorization",
+		"authHeaderScheme":     "Bearer",
+		"leeway":               "30s",
+		"allowedAlgorithms":    []interface{}{"RS256", "ES256"},
+		"forwardedTokenHeader": "X-My-Token",
+		"keyManagers": []interface{}{
+			map[string]interface{}{
+				"name":   "test-issuer",
+				"issuer": "https://issuer.example.com",
+				"jwks": map[string]interface{}{
+					"remote": map[string]interface{}{
+						"uri": jwksServer.URL + "/jwks.json",
+					},
+				},
+			},
+		},
+		"audiences": []interface{}{"api-audience"},
+	}
+
+	p, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatalf("Failed to create policy: %v", err)
+	}
+
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+
+	modifications, ok := action.(policy.UpstreamRequestHeaderModifications)
+	if !ok {
+		t.Fatalf("Expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+
+	// Default behavior forwards the full header value, including the scheme prefix.
+	want := fmt.Sprintf("Bearer %s", token)
+	if got := modifications.HeadersToSet["X-My-Token"]; got != want {
+		t.Errorf("Expected X-My-Token to be the full header value %q, got %q", want, got)
+	}
+}
+
 // TestJWTAuthPolicy_MissingToken tests authentication failure when Authorization header is missing
 func TestJWTAuthPolicy_MissingToken(t *testing.T) {
 	// Create request context without Authorization header

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -92,11 +92,11 @@ parameters:
         `forwardToken` is true. If this differs from `headerName`, the original
         header is removed and the token is forwarded under this name instead. By
         default the full Authorization header value (including the scheme prefix)
-        is forwarded; set `forwardTokenValue` to true to forward only the bare
+        is forwarded; set `forwardTokenStripScheme` to true to forward only the bare
         token value. Has no effect when `forwardToken` is false.
       default: x-forwarded-authorization
 
-    forwardTokenValue:
+    forwardTokenStripScheme:
       type: boolean
       x-wso2-policy-advanced-param: true
       description: >-

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.0.5
+version: v1.0.6
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.
@@ -90,9 +90,22 @@ parameters:
       description: >-
         The header name used to forward the JWT to the upstream service when
         `forwardToken` is true. If this differs from `headerName`, the original
-        header is removed and the token is forwarded under this name instead.
-        Has no effect when `forwardToken` is false.
+        header is removed and the token is forwarded under this name instead. By
+        default the full Authorization header value (including the scheme prefix)
+        is forwarded; set `forwardTokenValue` to true to forward only the bare
+        token value. Has no effect when `forwardToken` is false.
       default: x-forwarded-authorization
+
+    forwardTokenValue:
+      type: boolean
+      x-wso2-policy-advanced-param: true
+      description: >-
+        Controls what is forwarded under `forwardedTokenHeader` when
+        `forwardToken` is true. If true, only the bare token value (with the
+        scheme prefix such as "Bearer" stripped) is forwarded. If false (the
+        default), the full Authorization header value including the prefix is
+        forwarded. Has no effect when `forwardToken` is false.
+      default: false
 
 systemParameters:          
   type: object


### PR DESCRIPTION
## Purpose
Add configuration to strip the token value prefix when forwarding the header

## Goals
Use case: Forward JWT as X-JWT-Assertion

The client sends the JWT in the standard Authorization: Bearer <token> header. The gateway validates the token, then forwards only the bare JWT (without the Bearer prefix) to the upstream under X-JWT-Assertion. The original Authorization header is removed so the backend receives the token in the header it expects.
```
params:
  issuers:
    - PrimaryIDP
  forwardToken: true
  forwardTokenValue: true
  forwardedTokenHeader: X-JWT-Assertion
```

**Example:**
Incoming: Authorization: Bearer eyJhbGciOiJSUzI1NiIs...
Upstream: X-JWT-Assertion: eyJhbGciOiJSUzI1NiIs...

## Approach
> Introduced a new configuration. 

## User stories
> Summary of user stories addressed by this change>

## Release note
> N/A

## Documentation
Added

## Training
N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Added
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Added a sample

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A