### PR TITLE
Enhance JWT Auth Policy with improved scope validation and tests

### DIFF
--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1477,21 +1477,24 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 			"tokenScopes", scopes,
 			"requiredScopes", userRequiredScopes,
 		)
+		found := false
 		for _, requiredScope := range userRequiredScopes {
-			found := false
 			for _, tokenScope := range scopes {
 				if tokenScope == requiredScope {
 					found = true
 					break
 				}
 			}
-			if !found {
-				slog.Debug("JWT Auth Policy: Required scope not found",
-					"missingScope", requiredScope,
-					"tokenScopes", scopes,
-				)
-				return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("required scope '%s' not found", requiredScope))
+			if found {
+				break
 			}
+		}
+		if !found {
+			slog.Debug("JWT Auth Policy: No required scope found",
+				"requiredScopes", userRequiredScopes,
+				"tokenScopes", scopes,
+			)
+			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("none of the required scopes %v found", userRequiredScopes))
 		}
 		slog.Debug("JWT Auth Policy: Scope validation passed")
 	}

--- a/policies/jwt-auth/jwtauth_hardening_test.go
+++ b/policies/jwt-auth/jwtauth_hardening_test.go
@@ -68,6 +68,51 @@ func TestJWTAuthPolicy_HappyPath_AudienceArray_AndScpArray(t *testing.T) {
 	assertAuthSuccess(t, ctx, action)
 }
 
+func TestJWTAuthPolicy_RequiredScopes_OR_MatchesOne(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	// Token has only "read"; policy requires either "read" or "admin". OR
+	// semantics means one match is enough.
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub":   "user-123",
+		"iss":   "https://issuer.example.com",
+		"scope": "read",
+	})
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["issuers"] = []interface{}{"km-primary"}
+	params["requiredScopes"] = []interface{}{"read", "admin"}
+
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
+	assertAuthSuccess(t, ctx, action)
+}
+
+func TestJWTAuthPolicy_RequiredScopes_OR_MatchesNone(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	// Token has neither of the required scopes → auth fails.
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub":   "user-123",
+		"iss":   "https://issuer.example.com",
+		"scope": "read",
+	})
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["issuers"] = []interface{}{"km-primary"}
+	params["requiredScopes"] = []interface{}{"write", "admin"}
+
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
+	assertAuthFailure(t, ctx, action, 401)
+}
+
 func TestJWTAuthPolicy_HappyPath_CustomHeaderName_AndPrefix(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -30,7 +30,7 @@ parameters:
     requiredScopes:
       type: array
       x-wso2-policy-advanced-param: true
-      description: Specifies scopes that must exist in the token from `scope` (space-delimited) or `scp` (array) claims.
+      description: Specifies scopes to check against the token's `scope` (space-delimited) or `scp` (array) claims. At least one of the listed scopes must be present in the token.
       default: []
       items:
         type: string

--- a/policies/mcp-authz/mcp-authz.go
+++ b/policies/mcp-authz/mcp-authz.go
@@ -511,7 +511,7 @@ func (p *McpAuthzPolicy) checkClaims(requiredClaims map[string]string, authCtx *
 	return true
 }
 
-// checkScopes verifies that all required scopes are present in the AuthContext
+// checkScopes verifies that at least one of the required scopes is present in the AuthContext
 func (p *McpAuthzPolicy) checkScopes(requiredScopes []string, authCtx *policy.AuthContext) (bool, []string) {
 	found := false
 	var matchedScope string

--- a/policies/mcp-authz/policy-definition.yaml
+++ b/policies/mcp-authz/policy-definition.yaml
@@ -47,7 +47,7 @@ parameters:
           requiredScopes:
             type: array
             x-wso2-policy-advanced-param: false
-            description: Require OAuth scopes for this rule; every listed scope must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
+            description: Require OAuth scopes for this rule; at least one of the listed scopes must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
             default: []
             items:
               type: string
@@ -94,7 +94,7 @@ parameters:
           requiredScopes:
             type: array
             x-wso2-policy-advanced-param: false
-            description: Require OAuth scopes for this rule; every listed scope must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
+            description: Require OAuth scopes for this rule; at least one of the listed scopes must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
             default: []
             items:
               type: string
@@ -141,7 +141,7 @@ parameters:
           requiredScopes:
             type: array
             x-wso2-policy-advanced-param: false
-            description: Require OAuth scopes for this rule; every listed scope must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
+            description: Require OAuth scopes for this rule; at least one of the listed scopes must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
             default: []
             items:
               type: string
@@ -188,7 +188,7 @@ parameters:
           requiredScopes:
             type: array
             x-wso2-policy-advanced-param: false
-            description: Require OAuth scopes for this rule; every listed scope must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
+            description: Require OAuth scopes for this rule; at least one of the listed scopes must exist in token `scope` or `scp`, and if claims are also set, both scopes and claims must pass.
             default: []
             items:
               type: string


### PR DESCRIPTION
This pull request updates the JWT Auth Policy to clarify and enforce the semantics of required scopes: the policy now treats the `requiredScopes` parameter as an OR list, meaning authentication succeeds if any one of the required scopes is present in the token. The tests are updated to verify this behavior, ensuring both the success and failure cases are covered.

**Behavior change:**

* The `JwtAuthPolicy` scope validation logic in `jwtauth.go` now requires that at least one of the scopes in `requiredScopes` is present in the token (OR semantics), instead of requiring all scopes to be present (AND semantics). The error message is also updated to reflect this logic.

**Testing improvements:**

* Added `TestJWTAuthPolicy_RequiredScopes_OR_MatchesOne` to verify that authentication succeeds when the token contains any one of the required scopes.
* Added `TestJWTAuthPolicy_RequiredScopes_OR_MatchesNone` to verify that authentication fails when the token contains none of the required scopes.