### PR TITLE
feat(ratelimit): bump basic-ratelimit and dependent policies to v1.1.0

### DIFF
--- a/policies/basic-ratelimit/basic_ratelimit.go
+++ b/policies/basic-ratelimit/basic_ratelimit.go
@@ -61,7 +61,7 @@ func (p *BasicRateLimitPolicy) Mode() policy.ProcessingMode {
 
 // transformToRatelimitParams converts the simple limits array to a full ratelimit
 // quota configuration with routename key extraction, and passes through system
-// parameters (algorithm, backend, redis, memory).
+// parameters (algorithm, backend, redis, memory, local).
 func transformToRatelimitParams(params map[string]interface{}, metadata policy.PolicyMetadata) map[string]interface{} {
 	limits, _ := params["limits"].([]interface{})
 
@@ -119,6 +119,9 @@ func transformToRatelimitParams(params map[string]interface{}, metadata policy.P
 	}
 	if memory, ok := params["memory"]; ok {
 		rlParams["memory"] = memory
+	}
+	if local, ok := params["local"]; ok {
+		rlParams["local"] = local
 	}
 
 	return rlParams

--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
 )
 
 require (

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -35,8 +37,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
 github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2 h1:9MGy1AcpdKMgb09ieIRTFa82G22wKViBX3V+JVPcyUI=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2/go.mod h1:O4HFXo0EspliFqRE6dL53BQyAyPEZFxCLic73Scngjw=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -67,7 +67,7 @@ systemParameters:
 
     redis:
       type: object
-      description: Redis configuration (only used when backend=redis)
+      description: Redis configuration (used when backend=redis or backend=redis-local-async)
       additionalProperties: false
       properties:
         host:

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-ratelimit
-version: v1.0.2
+version: v1.1.0
 description: |
   Limits request rates by restricting the number of requests allowed within one
   or more defined time windows.
@@ -57,8 +57,11 @@ systemParameters:
       type: string
       description: |
         Rate limit storage backend. 'memory' for in-memory storage (single-instance),
-        'redis' for distributed rate limiting across multiple gateway instances.
-      enum: ["memory", "redis"]
+        'redis' for exact distributed rate limiting (one Redis call per request), or
+        'redis-local-async' for distributed rate limiting with a local-first hot path
+        that reconciles with Redis asynchronously (lower latency and Redis load, with
+        bounded overshoot).
+      enum: ["memory", "redis", "redis-local-async"]
       default: "memory"
       "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
@@ -138,6 +141,15 @@ systemParameters:
           default: "3s"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
 
+        poolSize:
+          type: integer
+          description: |
+            Redis connection pool size for the shared client. 0 = go-redis default
+            (10 × GOMAXPROCS). One pool is shared per distinct Redis endpoint config.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.pool_size}"
+
     memory:
       type: object
       description: In-memory storage configuration (only used when backend=memory)
@@ -162,3 +174,48 @@ systemParameters:
             Use "0" to disable periodic cleanup.
           default: "5m"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"
+
+    local:
+      type: object
+      description: Configures the local-first hot path when backend is redis-local-async.
+      additionalProperties: false
+      properties:
+        syncInterval:
+          type: string
+          description: |
+            Specifies how often locally counted requests are flushed to Redis and the
+            authoritative count is read back. Lower values tighten accuracy (less
+            overshoot) at the cost of more Redis operations. Supports units ns, us, µs,
+            ms, s, m, h, including composite and fractional values (for example "500ms",
+            "1.5s", "1m30s").
+          default: "50ms"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.sync_interval}"
+
+        flushWorkers:
+          type: integer
+          description: |
+            Number of background flush workers shared by all redis-local-async limiters
+            in the process. 0 = auto (GOMAXPROCS/2, capped at 8). Only the first
+            registrant's value takes effect; a restart is required to change it.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.flush_workers}"
+
+        maxPipelineCommands:
+          type: integer
+          description: |
+            Maximum INCRBYs issued in a single Redis pipeline per flush; excess dirty keys
+            spill to the next flush tick.
+          minimum: 0
+          default: 5000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_pipeline_commands}"
+
+        maxLocalEntries:
+          type: integer
+          description: |
+            Maximum local key-state entries per limiter before eviction (carrying any
+            unflushed delta to Redis). Bounds memory under high/adversarial key
+            cardinality.
+          minimum: 0
+          default: 100000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_local_entries}"

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -35,8 +37,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
 github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2 h1:9MGy1AcpdKMgb09ieIRTFa82G22wKViBX3V+JVPcyUI=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2/go.mod h1:O4HFXo0EspliFqRE6dL53BQyAyPEZFxCLic73Scngjw=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
+++ b/policies/llm-cost-based-ratelimit/llm_cost_based_ratelimit.go
@@ -444,6 +444,7 @@ func (p *LLMCostRateLimitPolicy) resolveDelegate(providerName string, params map
 		"backend":         params["backend"],
 		"redis":           params["redis"],
 		"memory":          params["memory"],
+		"local":           params["local"],
 	})
 
 	// Fast path: reuse existing delegate if config hasn't changed.
@@ -637,7 +638,7 @@ func transformToRatelimitParams(params map[string]interface{}) map[string]interf
 	}
 
 	// Copy through system parameters
-	for _, key := range []string{"algorithm", "backend", "redis", "memory"} {
+	for _, key := range []string{"algorithm", "backend", "redis", "memory", "local"} {
 		if val, ok := params[key]; ok {
 			rlParams[key] = val
 		}

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -104,7 +104,7 @@ systemParameters:
 
     redis:
       type: object
-      description: Redis configuration (only used when backend=redis)
+      description: Redis configuration (used when backend=redis or backend=redis-local-async)
       additionalProperties: false
       properties:
         host:

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v1.0.3
+version: v1.1.0
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost
@@ -94,8 +94,11 @@ systemParameters:
       type: string
       description: |
         Rate limit storage backend. 'memory' for in-memory storage (single-instance),
-        'redis' for distributed rate limiting across multiple gateway instances.
-      enum: ["memory", "redis"]
+        'redis' for exact distributed rate limiting (one Redis call per request), or
+        'redis-local-async' for distributed rate limiting with a local-first hot path
+        that reconciles with Redis asynchronously (lower latency and Redis load, with
+        bounded overshoot).
+      enum: ["memory", "redis", "redis-local-async"]
       default: "memory"
       "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
@@ -143,6 +146,14 @@ systemParameters:
           type: string
           default: "3s"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
+        poolSize:
+          type: integer
+          description: |
+            Redis connection pool size for the shared client. 0 = go-redis default
+            (10 × GOMAXPROCS). One pool is shared per distinct Redis endpoint config.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.pool_size}"
 
     memory:
       type: object
@@ -157,3 +168,45 @@ systemParameters:
           type: string
           default: "5m"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"
+
+    local:
+      type: object
+      description: Configures the local-first hot path when backend is redis-local-async.
+      additionalProperties: false
+      properties:
+        syncInterval:
+          type: string
+          description: |
+            Specifies how often locally counted requests are flushed to Redis and the
+            authoritative count is read back. Lower values tighten accuracy (less
+            overshoot) at the cost of more Redis operations. Supports units ns, us, µs,
+            ms, s, m, h, including composite and fractional values (for example "500ms",
+            "1.5s", "1m30s").
+          default: "50ms"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.sync_interval}"
+        flushWorkers:
+          type: integer
+          description: |
+            Number of background flush workers shared by all redis-local-async limiters
+            in the process. 0 = auto (GOMAXPROCS/2, capped at 8). Only the first
+            registrant's value takes effect; a restart is required to change it.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.flush_workers}"
+        maxPipelineCommands:
+          type: integer
+          description: |
+            Maximum INCRBYs issued in a single Redis pipeline per flush; excess dirty keys
+            spill to the next flush tick.
+          minimum: 0
+          default: 5000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_pipeline_commands}"
+        maxLocalEntries:
+          type: integer
+          description: |
+            Maximum local key-state entries per limiter before eviction (carrying any
+            unflushed delta to Redis). Bounds memory under high/adversarial key
+            cardinality.
+          minimum: 0
+          default: 100000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_local_entries}"

--- a/policies/mcp-ratelimit/go.mod
+++ b/policies/mcp-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
 )
 
 require (

--- a/policies/mcp-ratelimit/go.sum
+++ b/policies/mcp-ratelimit/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -32,8 +34,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
 github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2 h1:9MGy1AcpdKMgb09ieIRTFa82G22wKViBX3V+JVPcyUI=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2/go.mod h1:O4HFXo0EspliFqRE6dL53BQyAyPEZFxCLic73Scngjw=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/policies/mcp-ratelimit/mcp-ratelimit.go
+++ b/policies/mcp-ratelimit/mcp-ratelimit.go
@@ -115,7 +115,7 @@ func GetPolicy(metadata policy.PolicyMetadata, params map[string]any) (policy.Po
 	}
 
 	p.systemParams = make(map[string]any)
-	for _, key := range []string{"algorithm", "backend", "redis", "memory", "headers"} {
+	for _, key := range []string{"algorithm", "backend", "redis", "memory", "local", "headers"} {
 		if v, ok := params[key]; ok {
 			p.systemParams[key] = v
 		}

--- a/policies/mcp-ratelimit/policy-definition.yaml
+++ b/policies/mcp-ratelimit/policy-definition.yaml
@@ -520,7 +520,7 @@ systemParameters:
 
     redis:
       type: object
-      description: Redis configuration (only used when backend=redis).
+      description: Redis configuration (used when backend=redis or backend=redis-local-async)
       additionalProperties: false
       properties:
         host:

--- a/policies/mcp-ratelimit/policy-definition.yaml
+++ b/policies/mcp-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-ratelimit
-version: v1.0.0
+version: v1.1.0
 description: |
   Applies rate limits to MCP traffic per tool, resource, prompt, or JSON-RPC method.
   Each entry targets a capability by name (or "*") and declares one or more
@@ -510,9 +510,11 @@ systemParameters:
     backend:
       type: string
       description: |
-        Storage backend: memory for single-instance limits or redis for
-        distributed limits.
-      enum: ["memory", "redis"]
+        Storage backend: memory for single-instance limits, redis for exact
+        distributed limits (one Redis call per request), or redis-local-async for
+        distributed limits with a local-first hot path that reconciles with Redis
+        asynchronously (lower latency and Redis load, with bounded overshoot).
+      enum: ["memory", "redis", "redis-local-async"]
       default: "memory"
       "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
@@ -564,6 +566,14 @@ systemParameters:
           type: string
           default: "3s"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.write_timeout}"
+        poolSize:
+          type: integer
+          description: |
+            Redis connection pool size for the shared client. 0 = go-redis default
+            (10 × GOMAXPROCS). One pool is shared per distinct Redis endpoint config.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.pool_size}"
 
     memory:
       type: object
@@ -580,6 +590,48 @@ systemParameters:
           type: string
           default: "5m"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanup_interval}"
+
+    local:
+      type: object
+      description: Configures the local-first hot path when backend is redis-local-async.
+      additionalProperties: false
+      properties:
+        syncInterval:
+          type: string
+          description: |
+            Specifies how often locally counted requests are flushed to Redis and the
+            authoritative count is read back. Lower values tighten accuracy (less
+            overshoot) at the cost of more Redis operations. Supports units ns, us, µs,
+            ms, s, m, h, including composite and fractional values (for example "500ms",
+            "1.5s", "1m30s").
+          default: "50ms"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.sync_interval}"
+        flushWorkers:
+          type: integer
+          description: |
+            Number of background flush workers shared by all redis-local-async limiters
+            in the process. 0 = auto (GOMAXPROCS/2, capped at 8). Only the first
+            registrant's value takes effect; a restart is required to change it.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.flush_workers}"
+        maxPipelineCommands:
+          type: integer
+          description: |
+            Maximum INCRBYs issued in a single Redis pipeline per flush; excess dirty keys
+            spill to the next flush tick.
+          minimum: 0
+          default: 5000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_pipeline_commands}"
+        maxLocalEntries:
+          type: integer
+          description: |
+            Maximum local key-state entries per limiter before eviction (carrying any
+            unflushed delta to Redis). Bounds memory under high/adversarial key
+            cardinality.
+          minimum: 0
+          default: 100000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_local_entries}"
 
     headers:
       type: object

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
 	golang.org/x/sync v0.20.0
 )
 

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -35,8 +37,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
 github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2 h1:9MGy1AcpdKMgb09ieIRTFa82G22wKViBX3V+JVPcyUI=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.0.2/go.mod h1:O4HFXo0EspliFqRE6dL53BQyAyPEZFxCLic73Scngjw=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -139,7 +139,7 @@ systemParameters:
 
     redis:
       type: object
-      description: Redis configuration (only used when backend=redis)
+      description: Redis configuration (used when backend=redis or backend=redis-local-async)
       additionalProperties: false
       properties:
         host:

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v1.0.3
+version: v1.1.0
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the
@@ -128,8 +128,12 @@ systemParameters:
     backend:
       type: string
       description: |
-        Rate limit storage backend. 'memory' or 'redis'.
-      enum: ["memory", "redis"]
+        Rate limit storage backend. 'memory' for in-memory storage (single-instance),
+        'redis' for exact distributed rate limiting (one Redis call per request), or
+        'redis-local-async' for distributed rate limiting with a local-first hot path
+        that reconciles with Redis asynchronously (lower latency and Redis load, with
+        bounded overshoot).
+      enum: ["memory", "redis", "redis-local-async"]
       default: "memory"
       "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.backend}"
 
@@ -183,6 +187,14 @@ systemParameters:
             example "1s", "1m", "1h", or "24h".
           default: "3s"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.writetimeout}"
+        poolSize:
+          type: integer
+          description: |
+            Redis connection pool size for the shared client. 0 = go-redis default
+            (10 × GOMAXPROCS). One pool is shared per distinct Redis endpoint config.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.redis.pool_size}"
 
     memory:
       type: object
@@ -200,3 +212,45 @@ systemParameters:
             "0" to disable cleanup.
           default: "5m"
           "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.memory.cleanupinterval}"
+
+    local:
+      type: object
+      description: Configures the local-first hot path when backend is redis-local-async.
+      additionalProperties: false
+      properties:
+        syncInterval:
+          type: string
+          description: |
+            Specifies how often locally counted requests are flushed to Redis and the
+            authoritative count is read back. Lower values tighten accuracy (less
+            overshoot) at the cost of more Redis operations. Supports units ns, us, µs,
+            ms, s, m, h, including composite and fractional values (for example "500ms",
+            "1.5s", "1m30s").
+          default: "50ms"
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.sync_interval}"
+        flushWorkers:
+          type: integer
+          description: |
+            Number of background flush workers shared by all redis-local-async limiters
+            in the process. 0 = auto (GOMAXPROCS/2, capped at 8). Only the first
+            registrant's value takes effect; a restart is required to change it.
+          minimum: 0
+          default: 0
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.flush_workers}"
+        maxPipelineCommands:
+          type: integer
+          description: |
+            Maximum INCRBYs issued in a single Redis pipeline per flush; excess dirty keys
+            spill to the next flush tick.
+          minimum: 0
+          default: 5000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_pipeline_commands}"
+        maxLocalEntries:
+          type: integer
+          description: |
+            Maximum local key-state entries per limiter before eviction (carrying any
+            unflushed delta to Redis). Bounds memory under high/adversarial key
+            cardinality.
+          minimum: 0
+          default: 100000
+          "wso2/defaultValue": "${config.policy_configurations.ratelimit_v1.local.max_local_entries}"

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -360,7 +360,7 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 		"quotas": quotas,
 	}
 
-	for _, key := range []string{"algorithm", "backend", "redis", "memory"} {
+	for _, key := range []string{"algorithm", "backend", "redis", "memory", "local"} {
 		if val, ok := params[key]; ok {
 			rlParams[key] = val
 		}


### PR DESCRIPTION
## Purpose

PR #203 released `advanced-ratelimit v1.1.0` with the `redis-local-async` backend, shared Redis client registry, and cross-limiter batched flushes.
This PR completes the follow-up called out in that PR description: bumping the four dependent policies to consume `v1.1.0`, exposing the new backend and tuning parameters through each policy's definition, and forwarding the `local` config block to the advanced-ratelimit engine.

## Approach

- Bump `advanced-ratelimit` dependency `v1.0.2 → v1.1.0` in `go.mod`/`go.sum` for `basic-ratelimit`, `mcp-ratelimit`, `llm-cost-based-ratelimit`, and `token-based-ratelimit`
- Add `redis-local-async` to the `backend` enum in all four `policy-definition.yaml` files
- Add `redis.poolSize` and `local.*` system params (`syncInterval`, `flushWorkers`, `maxPipelineCommands`, `maxLocalEntries`) to all four `policy-definition.yaml` files
- Forward the `local` config block through to the advanced-ratelimit engine in each policy's Go source (`basic_ratelimit.go`, `mcp-ratelimit.go`, `llm_cost_based_ratelimit.go`, `token_based_ratelimit.go`)
- Include `local` in `llm-cost-based-ratelimit`'s delegate cache key so a change to `local.*` config correctly triggers a delegate rebuild
- Bump policy versions: `basic-ratelimit v1.0.2→v1.1.0`, `mcp-ratelimit v1.0.0→v1.1.0`, `llm-cost-based-ratelimit v1.0.3→v1.1.0`, `token-based-ratelimit v1.0.3→v1.1.0`

## Related Issues

Related #203

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)