### PR TITLE
fix(ratelimit): key stale-limiter cleanup by attachment level to stop cross-route bucket eviction

### DIFF
--- a/policies/advanced-ratelimit/apiname_scope_sharing_test.go
+++ b/policies/advanced-ratelimit/apiname_scope_sharing_test.go
@@ -1,0 +1,207 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// apiScopedParams returns a global advanced-ratelimit config: apiname-keyed, limit 5/1h.
+func apiScopedParams() map[string]interface{} {
+	return map[string]interface{}{
+		"backend":   "memory",
+		"algorithm": "fixed-window",
+		"quotas": []interface{}{
+			map[string]interface{}{
+				"name":   "request-limit",
+				"limits": []interface{}{map[string]interface{}{"limit": float64(5), "duration": "1h"}},
+			},
+		},
+		"keyExtraction": []interface{}{map[string]interface{}{"type": "apiname"}},
+	}
+}
+
+func reqCtxForAPI(apiName string) *policy.RequestHeaderContext {
+	return &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			Metadata:   map[string]interface{}{},
+			APIName:    apiName,
+			APIVersion: "v1.0",
+			APIId:      "api-id",
+			APIContext: "/" + apiName,
+		},
+		Headers: policy.NewHeaders(map[string][]string{}),
+		Path:    "/chat/completions",
+		Method:  "GET",
+	}
+}
+
+// allowed drives one request through the header phase and reports whether it was allowed.
+func allowed(t *testing.T, p policy.Policy, apiName string) bool {
+	t.Helper()
+	rl := p.(*RateLimitPolicy)
+	action := rl.OnRequestHeaders(context.Background(), reqCtxForAPI(apiName), nil)
+	switch action.(type) {
+	case policy.ImmediateResponse:
+		return false
+	default:
+		return true
+	}
+}
+
+// TestReproApiNameBucketShared mirrors llm-provider-wide-ratelimit scenarios 9/10:
+// one API ("mix") with two operations (chat, embeddings), both carrying the same
+// global apiname-keyed advanced-ratelimit (limit 5). Exhausting one operation must
+// exhaust the shared bucket for the other.
+func TestReproApiNameBucketShared(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	const api = "Mix RateLimit Provider"
+	mdChat := policy.PolicyMetadata{RouteName: "GET|/mix/chat/completions|*", APIName: api, APIVersion: "v1.0"}
+	mdEmb := policy.PolicyMetadata{RouteName: "GET|/mix/embeddings|*", APIName: api, APIVersion: "v1.0"}
+
+	// State-of-the-World build: every route's factory runs.
+	pChat, err := GetPolicy(mdChat, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build chat: %v", err)
+	}
+	pEmb, err := GetPolicy(mdEmb, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build emb: %v", err)
+	}
+
+	limChat := pChat.(*RateLimitPolicy).quotas[0].Limiter
+	limEmb := pEmb.(*RateLimitPolicy).quotas[0].Limiter
+	if limChat != limEmb {
+		t.Fatalf("BUG: chat and embeddings did not share the apiname limiter (separate instances)")
+	}
+
+	// Exhaust via chat: 5 allowed, 6th denied.
+	for i := 1; i <= 5; i++ {
+		if !allowed(t, pChat, api) {
+			t.Fatalf("chat request %d should be allowed", i)
+		}
+	}
+	if allowed(t, pChat, api) {
+		t.Fatalf("chat request 6 should be denied (limit 5)")
+	}
+
+	// KEY ASSERTION: embeddings shares the now-exhausted global bucket.
+	if allowed(t, pEmb, api) {
+		t.Fatalf("BUG: embeddings allowed despite shared apiname bucket being exhausted by chat")
+	}
+}
+
+// TestReproDistinctApisDistinctLimiters asserts two DIFFERENT APIs that happen to use
+// the same apiname-scoped quota shape get DISTINCT limiter instances. On code that never
+// reads metadata.APIName the cache key is apiScope:"" for both, so they collapse onto one
+// shared instance — this test fails until apiName is taken from metadata.
+func TestReproDistinctApisDistinctLimiters(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	pA, err := GetPolicy(policy.PolicyMetadata{RouteName: "GET|/a/x|*", APIName: "API A", APIVersion: "v1"}, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build A: %v", err)
+	}
+	pB, err := GetPolicy(policy.PolicyMetadata{RouteName: "GET|/b/x|*", APIName: "API B", APIVersion: "v1"}, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build B: %v", err)
+	}
+
+	if pA.(*RateLimitPolicy).quotas[0].Limiter == pB.(*RateLimitPolicy).quotas[0].Limiter {
+		t.Fatalf("BUG: two distinct APIs share one limiter instance (apiName not read from metadata)")
+	}
+}
+
+// rebuildAll simulates the policy-engine's State-of-the-World rebuild: on every chain
+// update it re-runs the factory for ALL currently-known routes.
+func rebuildAll(t *testing.T, mds []policy.PolicyMetadata) {
+	t.Helper()
+	for _, md := range mds {
+		if _, err := GetPolicy(md, apiScopedParams()); err != nil {
+			t.Fatalf("rebuild %s: %v", md.RouteName, err)
+		}
+	}
+}
+
+// TestReproCrossProviderReset checks the realistic multi-provider sequence. Because the
+// factory never reads metadata.APIName, every provider with the same quota shape collapses
+// to ONE shared limiter instance (cache key apiScope:""). When a second provider deploys,
+// the State-of-the-World rebuild re-runs the factory for ALL routes; if the shared
+// instance's refcount is mismanaged it gets Closed+recreated, resetting the first
+// provider's already-accumulated counter.
+func TestReproCrossProviderReset(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	const apiA = "Provider A"
+	const apiB = "Provider B"
+	aChat := policy.PolicyMetadata{RouteName: "GET|/a/chat/completions|*", APIName: apiA, APIVersion: "v1.0"}
+	aEmb := policy.PolicyMetadata{RouteName: "GET|/a/embeddings|*", APIName: apiA, APIVersion: "v1.0"}
+	bChat := policy.PolicyMetadata{RouteName: "GET|/b/chat/completions|*", APIName: apiB, APIVersion: "v1.0"}
+	bEmb := policy.PolicyMetadata{RouteName: "GET|/b/embeddings|*", APIName: apiB, APIVersion: "v1.0"}
+
+	// Deploy provider A (SotW build of A's routes).
+	rebuildAll(t, []policy.PolicyMetadata{aChat, aEmb})
+
+	// Consume 4 of A's 5 via its chat route.
+	pAChat, _ := GetPolicy(aChat, apiScopedParams())
+	for i := 1; i <= 4; i++ {
+		if !allowed(t, pAChat, apiA) {
+			t.Fatalf("A chat request %d should be allowed", i)
+		}
+	}
+
+	// Deploy provider B → State-of-the-World rebuild of ALL routes (A's + B's).
+	rebuildAll(t, []policy.PolicyMetadata{aChat, aEmb, bChat, bEmb})
+
+	// A should have only 1 token left (4 consumed, limit 5). If the rebuild reset
+	// A's shared counter, this 2nd request after rebuild would wrongly be allowed.
+	pAChat2, _ := GetPolicy(aChat, apiScopedParams())
+	if !allowed(t, pAChat2, apiA) {
+		t.Fatalf("A chat request 5 should be allowed (1 remained)")
+	}
+	if allowed(t, pAChat2, apiA) {
+		t.Fatalf("BUG: A chat request 6 should be denied — provider A's counter was reset by provider B's deploy")
+	}
+}
+
+// TestReproApiNameBucketSurvivesRebuild adds the State-of-the-World rebuild that the
+// policy-engine performs on EVERY deploy: all routes' factories re-run. The shared
+// counter must survive (not reset).
+func TestReproApiNameBucketSurvivesRebuild(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	const api = "Mix RateLimit Provider"
+	mdChat := policy.PolicyMetadata{RouteName: "GET|/mix/chat/completions|*", APIName: api, APIVersion: "v1.0"}
+	mdEmb := policy.PolicyMetadata{RouteName: "GET|/mix/embeddings|*", APIName: api, APIVersion: "v1.0"}
+
+	pChat, _ := GetPolicy(mdChat, apiScopedParams())
+	_, _ = GetPolicy(mdEmb, apiScopedParams())
+
+	// Consume 3 on chat.
+	for i := 1; i <= 3; i++ {
+		if !allowed(t, pChat, api) {
+			t.Fatalf("chat request %d should be allowed", i)
+		}
+	}
+
+	// A later, unrelated deploy triggers a State-of-the-World rebuild: all routes re-run.
+	pChat2, _ := GetPolicy(mdChat, apiScopedParams())
+	pEmb2, _ := GetPolicy(mdEmb, apiScopedParams())
+
+	// After rebuild the shared bucket already has 3 consumed; only 2 should remain.
+	if !allowed(t, pChat2, api) {
+		t.Fatalf("post-rebuild chat request 4 should be allowed (2 remain)")
+	}
+	if !allowed(t, pEmb2, api) {
+		t.Fatalf("post-rebuild emb request 5 should be allowed (1 remains)")
+	}
+	if allowed(t, pEmb2, api) {
+		t.Fatalf("BUG: post-rebuild request 6 should be denied — counter was reset by the rebuild")
+	}
+}

--- a/policies/advanced-ratelimit/apiname_scope_sharing_test.go
+++ b/policies/advanced-ratelimit/apiname_scope_sharing_test.go
@@ -22,6 +22,82 @@ func apiScopedParams() map[string]interface{} {
 	}
 }
 
+// basicOpParams returns an OPERATION-level advanced-ratelimit config with no keyExtraction,
+// so it is routename-scoped (limit 3/1h). This models the per-operation basic-ratelimit in
+// llm-provider-wide-ratelimit scenarios 9/10 that is attached ONLY to /chat/completions,
+// alongside the apiname-scoped global quota.
+func basicOpParams() map[string]interface{} {
+	return map[string]interface{}{
+		"backend":   "memory",
+		"algorithm": "fixed-window",
+		"quotas": []interface{}{
+			map[string]interface{}{
+				"name":   "default",
+				"limits": []interface{}{map[string]interface{}{"limit": float64(3), "duration": "1h"}},
+			},
+		},
+	}
+}
+
+// TestReproMixedGlobalAndOperationSharing is the exact topology of llm-provider-wide-ratelimit
+// scenarios 9/10 that the other apiname tests miss: the /chat/completions route carries BOTH the
+// apiname-scoped global quota AND a separate routename-scoped operation quota, while /embeddings
+// carries only the global.
+//
+// The two policies on /chat/completions share the same baseCacheKey (same route + shared params;
+// the quota set is not part of baseCacheKey), so without the AttachedTo-aware reconcileKey they
+// land in the same stale-cleanup bucket. Building the operation policy then evicts (Close()s) the
+// global apiname limiter that /embeddings still references, breaking cross-route sharing —
+// /embeddings then gets a fresh independent bucket. The non-deterministic IT failure is made
+// deterministic here by ordering the operation build before the embeddings build.
+func TestReproMixedGlobalAndOperationSharing(t *testing.T) {
+	clearCaches()
+	defer clearCaches()
+
+	const api = "Mix RateLimit Provider"
+	// The API-level global policy is materialised into each route's chain with AttachedTo=LevelAPI;
+	// the operation policy is attached at the route level (AttachedTo=LevelRoute). Same route name,
+	// different attachment level — exactly how the controller emits them (restapi.go:260 vs :290).
+	mdChatGlobal := policy.PolicyMetadata{RouteName: "GET|/mix/chat/completions|*", APIName: api, APIVersion: "v1.0", AttachedTo: policy.LevelAPI}
+	mdChatOp := policy.PolicyMetadata{RouteName: "GET|/mix/chat/completions|*", APIName: api, APIVersion: "v1.0", AttachedTo: policy.LevelRoute}
+	mdEmbGlobal := policy.PolicyMetadata{RouteName: "GET|/mix/embeddings|*", APIName: api, APIVersion: "v1.0", AttachedTo: policy.LevelAPI}
+
+	// State-of-the-World build: chat's global, then chat's operation policy, then emb's global.
+	pChatGlobal, err := GetPolicy(mdChatGlobal, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build chat global: %v", err)
+	}
+	if _, err := GetPolicy(mdChatOp, basicOpParams()); err != nil {
+		t.Fatalf("build chat operation: %v", err)
+	}
+	pEmbGlobal, err := GetPolicy(mdEmbGlobal, apiScopedParams())
+	if err != nil {
+		t.Fatalf("build emb global: %v", err)
+	}
+
+	limChat := pChatGlobal.(*RateLimitPolicy).quotas[0].Limiter
+	limEmb := pEmbGlobal.(*RateLimitPolicy).quotas[0].Limiter
+	if limChat != limEmb {
+		t.Fatalf("BUG: chat and embeddings do not share the apiname global limiter after the " +
+			"operation policy attached to chat (separate instances) — the operation policy evicted the shared limiter")
+	}
+
+	// Exhaust the shared global (limit 5) via chat's global policy.
+	for i := 1; i <= 5; i++ {
+		if !allowed(t, pChatGlobal, api) {
+			t.Fatalf("chat global request %d should be allowed", i)
+		}
+	}
+	if allowed(t, pChatGlobal, api) {
+		t.Fatalf("chat global request 6 should be denied (limit 5)")
+	}
+
+	// KEY ASSERTION: embeddings shares the now-exhausted global bucket.
+	if allowed(t, pEmbGlobal, api) {
+		t.Fatalf("BUG: embeddings allowed despite shared apiname bucket exhausted by chat")
+	}
+}
+
 func reqCtxForAPI(apiName string) *policy.RequestHeaderContext {
 	return &policy.RequestHeaderContext{
 		SharedContext: &policy.SharedContext{

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -139,10 +139,13 @@ func GetPolicy(
 		routeName = "unknown-route"
 	}
 
-	// Extract API metadata for scope-based caching
-	apiId := ""
-	apiName := ""
-	apiVersion := ""
+	// Extract API metadata for scope-based caching. These feed getBaseCacheKey /
+	// getQuotaCacheKey so that apiname-scoped quotas share one limiter per API (and,
+	// crucially, do NOT collide across different APIs that happen to use the same
+	// quota shape — without this the cache key degenerates to "apiScope:" for everyone).
+	apiId := metadata.APIId
+	apiName := metadata.APIName
+	apiVersion := metadata.APIVersion
 
 	// Parse onRateLimitExceeded (optional)
 	statusCode := 429

--- a/policies/advanced-ratelimit/ratelimit.go
+++ b/policies/advanced-ratelimit/ratelimit.go
@@ -55,8 +55,11 @@ type limiterCache struct {
 	mu sync.Mutex
 	// byQuotaKey maps quota cache keys to limiter entries with reference counts
 	byQuotaKey map[string]*limiterEntry
-	// quotaKeysByBaseKey tracks which quota keys exist for each base cache key
-	// This enables automatic cleanup of stale limiters when quota configurations change
+	// quotaKeysByBaseKey tracks which quota keys exist for each policy instance, keyed by a
+	// reconcileKey (see reconcileKeyFor) rather than the bare baseCacheKey. This enables
+	// automatic cleanup of stale limiters when a policy instance's quota configuration changes,
+	// without one policy instance evicting a limiter that another instance on the same route
+	// legitimately shares.
 	quotaKeysByBaseKey map[string]map[string]struct{}
 }
 
@@ -325,12 +328,21 @@ func GetPolicy(
 			desiredQuotaKeys[quotaCacheKey] = struct{}{}
 		}
 
+		// reconcileKey identifies THIS policy instance's limiter bucket for the stale-cleanup
+		// bookkeeping below. It must be unique per policy instance on a route: an API-level
+		// (global) policy and a route-level (operation) policy attached to the same route must
+		// NOT share a reconciliation bucket, or building one would evict (Close) the other's
+		// cached limiter — non-deterministically breaking apiname-scoped cross-route sharing.
+		// baseCacheKey alone collides for them (it hashes route + shared params, not the
+		// attachment level), so we extend it with AttachedTo.
+		reconcileKey := reconcileKeyFor(baseCacheKey, metadata.AttachedTo)
+
 		// Single lock for all cache operations - ensures atomicity
 		globalLimiterCache.mu.Lock()
 		defer globalLimiterCache.mu.Unlock()
 
-		// Get previous quota keys for this baseKey (may be nil)
-		oldQuotaKeys := globalLimiterCache.quotaKeysByBaseKey[baseCacheKey]
+		// Get previous quota keys for this policy instance (may be nil)
+		oldQuotaKeys := globalLimiterCache.quotaKeysByBaseKey[reconcileKey]
 
 		// Reconcile: process each quota
 		for _, info := range quotaInfos {
@@ -415,8 +427,8 @@ func GetPolicy(
 			}
 		}
 
-		// Update the index with current quota keys for this baseKey
-		globalLimiterCache.quotaKeysByBaseKey[baseCacheKey] = desiredQuotaKeys
+		// Update the index with current quota keys for this policy instance
+		globalLimiterCache.quotaKeysByBaseKey[reconcileKey] = desiredQuotaKeys
 	}
 
 	// Log quota details including cost extraction status
@@ -1181,6 +1193,19 @@ func getBaseCacheKey(routeName, apiName, algorithm, backend string, params map[s
 	}
 
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// reconcileKeyFor derives the bookkeeping key under which a policy instance's active quota cache
+// keys are tracked for stale-limiter cleanup. It extends baseCacheKey with the policy's attachment
+// level so that two rate-limit policies on the SAME route but attached at different levels — an
+// API-level (global) quota and a route-level (operation) quota — do NOT share a cleanup bucket and
+// evict each other's cached limiters. baseCacheKey alone collides for them: it hashes route +
+// shared params but not the attachment, so building the operation policy would treat the global
+// policy's shared apiname limiter as "stale" and Close it (breaking cross-route sharing). AttachedTo
+// is stable across config reloads, so a limit-only change to a single policy still reuses its bucket
+// and cleans up its old limiter (unlike keying on the mutable quota set).
+func reconcileKeyFor(baseCacheKey string, attachedTo policy.Level) string {
+	return baseCacheKey + "|attachedTo:" + string(attachedTo)
 }
 
 // getQuotaCacheKey produces final key per quota using base + quota-specific config.


### PR DESCRIPTION
## Purpose

The shared apiname-scoped rate-limit bucket was non-deterministically lost when a route carried both an API-level (global) quota and a route-level (operation) quota, because both hashed to the same baseCacheKey and evicted each other's cached limiter during stale-limiter reconciliation. reconcileKeyFor now folds in metadata.AttachedTo so global and operation policy instances on the same route get separate cleanup buckets, verified deterministic (20x, -race) via TestReproMixedGlobalAndOperationSharing.

- Resolves: https://github.com/wso2/api-platform/issues/2317