### PR TITLE
feat(jwt-auth)!: add PS256/ES256 support, remove allowedAlgorithms param

### DIFF
--- a/docs/jwt-auth/v1.0/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.0/docs/jwt-authentication.md
@@ -14,7 +14,7 @@ The JWT Authentication policy validates JWT access tokens using one or more JWKS
 - Configurable issuer, audience, scope, and claim validation
 - Claim-to-header mappings for downstream services
 - Configurable JWKS cache and retry settings
-- Allowed signing algorithm allowlist
+- Fixed signing algorithm set: RS256, PS256, and ES256 (HMAC and `none` are rejected unconditionally)
 - Authorization header scheme enforcement and clock skew tolerance
 - Customizable error responses
 - Optional `userIdClaim` mapping for analytics
@@ -33,7 +33,6 @@ JWT Authentication requires two levels of configuration.
 | `jwksfetchtimeout` | string | No | `"5s"` | JWKS fetch timeout. |
 | `jwksfetchretrycount` | integer | No | `3` | JWKS fetch retry count. |
 | `jwksfetchretryinterval` | string | No | `"2s"` | JWKS fetch retry interval. |
-| `allowedalgorithms` | array | No | `["RS256", "ES256"]` | Allowed JWT signing algorithms. |
 | `leeway` | string | No | `"30s"` | Clock skew allowance for exp/nbf. |
 | `authheaderscheme` | string | No | `"Bearer"` | Expected authorization scheme prefix. |
 | `headername` | string | No | `"Authorization"` | Header name to extract the token from. |
@@ -64,7 +63,6 @@ jwkscachettl = "5m"
 jwksfetchtimeout = "5s"
 jwksfetchretrycount = 3
 jwksfetchretryinterval = "2s"
-allowedalgorithms = ["RS256", "ES256"]
 leeway = "30s"
 authheaderscheme = "Bearer"
 headername = "Authorization"

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -19,6 +19,9 @@ package jwtauth
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -51,6 +54,30 @@ var standardJWTClaims = map[string]bool{
 	"scope": true, "scp": true,
 }
 
+// supportedAlgorithms is the fixed, code-enforced allowlist. Asymmetric only.
+// HMAC, none, EdDSA, and any other algorithm are rejected unconditionally.
+var supportedAlgorithms = []string{"RS256", "PS256", "ES256"}
+
+// signatureKeyFunc returns a jwt.Keyfunc that binds the token's signing method to the
+// actual key type. An RSA key may only verify RSA/PSS tokens; an EC key may only verify
+// ECDSA tokens. Any mismatch — including HMAC-confusion attacks — is rejected.
+func signatureKeyFunc(pubKey crypto.PublicKey) jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		switch pubKey.(type) {
+		case *rsa.PublicKey:
+			switch token.Method.(type) {
+			case *jwt.SigningMethodRSA, *jwt.SigningMethodRSAPSS:
+				return pubKey, nil
+			}
+		case *ecdsa.PublicKey:
+			if _, ok := token.Method.(*jwt.SigningMethodECDSA); ok {
+				return pubKey, nil
+			}
+		}
+		return nil, fmt.Errorf("signing method %q not permitted for key type %T", token.Header["alg"], pubKey)
+	}
+}
+
 // JwtAuthPolicy implements JWT Authentication with JWKS support
 type JwtAuthPolicy struct {
 	cacheMutex sync.RWMutex
@@ -61,7 +88,7 @@ type JwtAuthPolicy struct {
 
 // CachedJWKS stores cached JWKS data
 type CachedJWKS struct {
-	Keys map[string]*rsa.PublicKey
+	Keys map[string]crypto.PublicKey
 }
 
 // KeyManager represents a key manager with either remote JWKS or local certificate
@@ -89,7 +116,7 @@ type RemoteJWKS struct {
 type LocalCert struct {
 	Inline          string         // Inline PEM-encoded certificate
 	CertificatePath string         // Path to certificate file
-	PublicKey       *rsa.PublicKey // Parsed public key
+	PublicKey       crypto.PublicKey // Parsed public key (RSA or ECDSA)
 }
 
 // JWKSKeySet represents the JWKS response from server
@@ -105,6 +132,9 @@ type JWKSKey struct {
 	N   string `json:"n"`   // RSA modulus
 	E   string `json:"e"`   // RSA exponent
 	Alg string `json:"alg"` // Algorithm
+	Crv string `json:"crv"` // EC curve name (P-256, P-384, P-521)
+	X   string `json:"x"`   // EC x coordinate (base64url)
+	Y   string `json:"y"`   // EC y coordinate (base64url)
 }
 
 var ins = &JwtAuthPolicy{
@@ -134,14 +164,13 @@ func (p *JwtAuthPolicy) Mode() policy.ProcessingMode {
 
 // validateTokenWithSignature validates JWT signature using JWKS
 func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifiedToken *jwt.Token,
-	keyManagers map[string]*KeyManager, userIssuers []string, validateIssuer bool, allowedAlgorithms []string,
+	keyManagers map[string]*KeyManager, userIssuers []string, validateIssuer bool,
 	leeway time.Duration, cacheTTL time.Duration, fetchTimeout time.Duration, retryCount int, retryInterval time.Duration) (jwt.MapClaims, error) {
 
 	slog.Debug("JWT Auth Policy: Starting token signature validation",
 		"keyManagersCount", len(keyManagers),
 		"userIssuersCount", len(userIssuers),
 		"validateIssuer", validateIssuer,
-		"allowedAlgorithms", allowedAlgorithms,
 	)
 
 	unverifiedClaims, ok := unverifiedToken.Claims.(jwt.MapClaims)
@@ -149,36 +178,6 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 		slog.Debug("JWT Auth Policy: Invalid token claims format")
 		return nil, fmt.Errorf("invalid token claims format")
 	}
-
-	// Check allowed algorithms
-	alg, ok := unverifiedToken.Header["alg"].(string)
-	if !ok {
-		slog.Debug("JWT Auth Policy: Missing algorithm in token header")
-		return nil, fmt.Errorf("missing algorithm in token")
-	}
-
-	slog.Debug("JWT Auth Policy: Checking algorithm",
-		"tokenAlgorithm", alg,
-		"allowedAlgorithms", allowedAlgorithms,
-	)
-
-	algorithmAllowed := false
-	for _, allowed := range allowedAlgorithms {
-		if alg == allowed {
-			algorithmAllowed = true
-			break
-		}
-	}
-	if !algorithmAllowed {
-		slog.Debug("JWT Auth Policy: Algorithm not in allowed list",
-			"tokenAlgorithm", alg,
-		)
-		return nil, fmt.Errorf("algorithm '%s' not in allowed list", alg)
-	}
-
-	slog.Debug("JWT Auth Policy: Algorithm check passed",
-		"algorithm", alg,
-	)
 
 	// Validate exp and nbf with leeway
 	now := time.Now()
@@ -360,7 +359,7 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 		)
 	}
 
-	parser := jwt.NewParser(jwt.WithLeeway(leeway))
+	parser := jwt.NewParser(jwt.WithLeeway(leeway), jwt.WithValidMethods(supportedAlgorithms))
 
 	// Try to verify signature with applicable key managers
 	var lastErr error
@@ -382,9 +381,7 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 			slog.Debug("JWT Auth Policy: Attempting signature verification with local certificate",
 				"keyManager", km.Name,
 			)
-			verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
-				return km.JWKS.Local.PublicKey, nil
-			})
+			verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, signatureKeyFunc(km.JWKS.Local.PublicKey))
 
 			if err == nil {
 				// Signature verified successfully with local certificate
@@ -445,9 +442,7 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 					"kid", kid,
 				)
 				// Verify signature
-				verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
-					return publicKey, nil
-				})
+				verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, signatureKeyFunc(publicKey))
 
 				if err != nil {
 					slog.Debug("JWT Auth Policy: Signature verification failed",
@@ -475,9 +470,7 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 					slog.Debug("JWT Auth Policy: Trying key from JWKS",
 						"keyId", keyId,
 					)
-					verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
-						return publicKey, nil
-					})
+					verifiedToken, err := parser.ParseWithClaims(tokenString, jwt.MapClaims{}, signatureKeyFunc(publicKey))
 
 					if err == nil {
 						// Signature verified successfully
@@ -683,9 +676,9 @@ func (p *JwtAuthPolicy) fetchJWKS(remote *RemoteJWKS, fetchTimeout time.Duration
 		"keysInResponse", len(keySet.Keys),
 	)
 
-	// Convert JWKS keys to RSA public keys
+	// Convert JWKS keys to public keys (RSA and EC supported)
 	cachedJWKS := &CachedJWKS{
-		Keys: make(map[string]*rsa.PublicKey),
+		Keys: make(map[string]crypto.PublicKey),
 	}
 
 	for _, key := range keySet.Keys {
@@ -695,39 +688,54 @@ func (p *JwtAuthPolicy) fetchJWKS(remote *RemoteJWKS, fetchTimeout time.Duration
 			"alg", key.Alg,
 			"use", key.Use,
 		)
-		if key.Kty != "RSA" {
-			slog.Debug("JWT Auth Policy: Skipping non-RSA key",
-				"kid", key.Kid,
-				"kty", key.Kty,
-			)
-			continue // Only support RSA for now
-		}
 		if key.Kid == "" {
 			slog.Debug("JWT Auth Policy: Skipping key without kid")
 			continue // Skip keys without kid
 		}
 
-		// Parse RSA public key from N and E
-		publicKey, err := parseRSAPublicKey(key.N, key.E)
-		if err != nil {
-			slog.Debug("JWT Auth Policy: Failed to parse RSA public key",
+		if key.Kty == "RSA" {
+			// Parse RSA public key from N and E
+			publicKey, err := parseRSAPublicKey(key.N, key.E)
+			if err != nil {
+				slog.Debug("JWT Auth Policy: Failed to parse RSA public key",
+					"kid", key.Kid,
+					"error", err,
+				)
+				continue // Skip invalid keys
+			}
+			cachedJWKS.Keys[key.Kid] = publicKey
+			slog.Debug("JWT Auth Policy: RSA public key parsed successfully",
 				"kid", key.Kid,
-				"error", err,
 			)
-			continue // Skip invalid keys
+		} else if key.Kty == "EC" {
+			// Parse EC public key from Crv, X, Y
+			publicKey, err := parseECPublicKey(key.Crv, key.X, key.Y)
+			if err != nil {
+				slog.Debug("JWT Auth Policy: Failed to parse EC public key",
+					"kid", key.Kid,
+					"crv", key.Crv,
+					"error", err,
+				)
+				continue // Skip invalid keys
+			}
+			cachedJWKS.Keys[key.Kid] = publicKey
+			slog.Debug("JWT Auth Policy: EC public key parsed successfully",
+				"kid", key.Kid,
+				"crv", key.Crv,
+			)
+		} else {
+			slog.Debug("JWT Auth Policy: Skipping key with unsupported kty",
+				"kid", key.Kid,
+				"kty", key.Kty,
+			)
 		}
-
-		cachedJWKS.Keys[key.Kid] = publicKey
-		slog.Debug("JWT Auth Policy: RSA public key parsed successfully",
-			"kid", key.Kid,
-		)
 	}
 
 	if len(cachedJWKS.Keys) == 0 {
-		slog.Debug("JWT Auth Policy: No valid RSA keys found in JWKS",
+		slog.Debug("JWT Auth Policy: No valid public keys found in JWKS",
 			"uri", remote.URI,
 		)
-		return nil, fmt.Errorf("no valid RSA keys found in JWKS")
+		return nil, fmt.Errorf("no valid public keys found in JWKS")
 	}
 
 	slog.Debug("JWT Auth Policy: JWKS processing complete",
@@ -781,6 +789,39 @@ func parseRSAPublicKey(nStr, eStr string) (*rsa.PublicKey, error) {
 	return &rsa.PublicKey{
 		N: n,
 		E: e,
+	}, nil
+}
+
+// parseECPublicKey parses an EC public key from JWKS curve name and base64url-encoded X/Y coordinates
+func parseECPublicKey(crv, xStr, yStr string) (*ecdsa.PublicKey, error) {
+	var curve elliptic.Curve
+	switch crv {
+	case "P-256":
+		curve = elliptic.P256()
+	case "P-384":
+		curve = elliptic.P384()
+	case "P-521":
+		curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("unsupported EC curve: %q", crv)
+	}
+
+	xBytes, err := decodeBase64URL(xStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EC x coordinate: %w", err)
+	}
+	yBytes, err := decodeBase64URL(yStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EC y coordinate: %w", err)
+	}
+
+	x := new(big.Int).SetBytes(xBytes)
+	y := new(big.Int).SetBytes(yBytes)
+
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
 	}, nil
 }
 
@@ -969,8 +1010,8 @@ func claimValueToString(v interface{}) string {
 	}
 }
 
-// getKeyIds returns a slice of key IDs from a map of RSA public keys
-func getKeyIds(keys map[string]*rsa.PublicKey) []string {
+// getKeyIds returns a slice of key IDs from a map of public keys
+func getKeyIds(keys map[string]crypto.PublicKey) []string {
 	ids := make([]string, 0, len(keys))
 	for id := range keys {
 		ids = append(ids, id)
@@ -1018,8 +1059,8 @@ func loadTLSConfig(certPath string) (*tls.Config, error) {
 	}, nil
 }
 
-// loadPublicKeyFromCertificate loads an RSA public key from a certificate file
-func loadPublicKeyFromCertificate(certPath string) (*rsa.PublicKey, error) {
+// loadPublicKeyFromCertificate loads a public key (RSA or ECDSA) from a certificate file
+func loadPublicKeyFromCertificate(certPath string) (crypto.PublicKey, error) {
 	slog.Debug("JWT Auth Policy: loadPublicKeyFromCertificate called",
 		"certPath", certPath,
 	)
@@ -1041,8 +1082,8 @@ func loadPublicKeyFromCertificate(certPath string) (*rsa.PublicKey, error) {
 	return parsePublicKeyFromString(string(certData))
 }
 
-// parsePublicKeyFromString parses an RSA public key from a PEM-encoded string
-func parsePublicKeyFromString(pemData string) (*rsa.PublicKey, error) {
+// parsePublicKeyFromString parses a public key (RSA or ECDSA) from a PEM-encoded string
+func parsePublicKeyFromString(pemData string) (crypto.PublicKey, error) {
 	slog.Debug("JWT Auth Policy: parsePublicKeyFromString called",
 		"dataLength", len(pemData),
 	)
@@ -1064,13 +1105,17 @@ func parsePublicKeyFromString(pemData string) (*rsa.PublicKey, error) {
 			"subject", cert.Subject.String(),
 			"issuer", cert.Issuer.String(),
 		)
-		// Extract public key from certificate
-		if publicKey, ok := cert.PublicKey.(*rsa.PublicKey); ok {
+		// Extract public key from certificate (RSA or ECDSA)
+		switch pub := cert.PublicKey.(type) {
+		case *rsa.PublicKey:
 			slog.Debug("JWT Auth Policy: Extracted RSA public key from certificate")
-			return publicKey, nil
+			return pub, nil
+		case *ecdsa.PublicKey:
+			slog.Debug("JWT Auth Policy: Extracted ECDSA public key from certificate")
+			return pub, nil
 		}
-		slog.Debug("JWT Auth Policy: Certificate does not contain RSA public key")
-		return nil, fmt.Errorf("certificate does not contain an RSA public key")
+		slog.Debug("JWT Auth Policy: Certificate does not contain a supported public key type")
+		return nil, fmt.Errorf("certificate does not contain a supported public key (RSA or ECDSA)")
 	}
 
 	slog.Debug("JWT Auth Policy: Not a certificate, trying to parse as public key directly",
@@ -1086,13 +1131,17 @@ func parsePublicKeyFromString(pemData string) (*rsa.PublicKey, error) {
 		return nil, fmt.Errorf("failed to parse public key from certificate data: %w", err)
 	}
 
-	if rsaPublicKey, ok := publicKey.(*rsa.PublicKey); ok {
+	switch pub := publicKey.(type) {
+	case *rsa.PublicKey:
 		slog.Debug("JWT Auth Policy: Parsed PKIX RSA public key successfully")
-		return rsaPublicKey, nil
+		return pub, nil
+	case *ecdsa.PublicKey:
+		slog.Debug("JWT Auth Policy: Parsed PKIX ECDSA public key successfully")
+		return pub, nil
 	}
 
-	slog.Debug("JWT Auth Policy: Parsed key is not RSA")
-	return nil, fmt.Errorf("certificate data does not contain an RSA public key")
+	slog.Debug("JWT Auth Policy: Parsed key is not a supported type")
+	return nil, fmt.Errorf("certificate data does not contain a supported public key (RSA or ECDSA)")
 }
 
 // OnRequestHeaders performs JWT validation in the request header phase.
@@ -1105,7 +1154,6 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	errorMessageFormat := getStringParam(params, "errorMessageFormat", "json")
 	errorMessage := getStringParam(params, "errorMessage", "Authentication failed")
 	leewayStr := getStringParam(params, "leeway", "30s")
-	allowedAlgorithms := getStringArrayParam(params, "allowedAlgorithms", []string{"RS256", "ES256"})
 	jwksCacheTtlStr := getStringParam(params, "jwksCacheTtl", "5m")
 	jwksFetchTimeoutStr := getStringParam(params, "jwksFetchTimeout", "5s")
 	jwksFetchRetryCount := getIntParam(params, "jwksFetchRetryCount", 3)
@@ -1119,7 +1167,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		"errorMessageFormat", errorMessageFormat,
 		"errorMessage", errorMessage,
 		"leeway", leewayStr,
-		"allowedAlgorithms", allowedAlgorithms,
+		"supportedAlgorithms", supportedAlgorithms,
 		"jwksCacheTtl", jwksCacheTtlStr,
 		"jwksFetchTimeout", jwksFetchTimeoutStr,
 		"jwksFetchRetryCount", jwksFetchRetryCount,
@@ -1247,7 +1295,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 
 						if inline != "" || certPath != "" {
 							localCert := &LocalCert{Inline: inline, CertificatePath: certPath}
-							var publicKey *rsa.PublicKey
+							var publicKey crypto.PublicKey
 							var certErr error
 							if inline != "" {
 								slog.Debug("JWT Auth Policy: Parsing inline certificate",
@@ -1371,7 +1419,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	)
 
 	claims, err := p.validateTokenWithSignature(token, unverifiedToken, keyManagers, userIssuers, validateIssuer,
-		allowedAlgorithms, leeway, jwksCacheTtl, jwksFetchTimeout, jwksFetchRetryCount, jwksFetchRetryInterval)
+		leeway, jwksCacheTtl, jwksFetchTimeout, jwksFetchRetryCount, jwksFetchRetryInterval)
 	if err != nil {
 		slog.Debug("JWT Auth Policy: Token validation failed",
 			"error", err,

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -20,6 +20,7 @@ package jwtauth
 import (
 	"context"
 	"crypto"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -795,13 +796,17 @@ func parseRSAPublicKey(nStr, eStr string) (*rsa.PublicKey, error) {
 // parseECPublicKey parses an EC public key from JWKS curve name and base64url-encoded X/Y coordinates
 func parseECPublicKey(crv, xStr, yStr string) (*ecdsa.PublicKey, error) {
 	var curve elliptic.Curve
+	var ecdhCurve ecdh.Curve
 	switch crv {
 	case "P-256":
 		curve = elliptic.P256()
+		ecdhCurve = ecdh.P256()
 	case "P-384":
 		curve = elliptic.P384()
+		ecdhCurve = ecdh.P384()
 	case "P-521":
 		curve = elliptic.P521()
+		ecdhCurve = ecdh.P521()
 	default:
 		return nil, fmt.Errorf("unsupported EC curve: %q", crv)
 	}
@@ -813,6 +818,16 @@ func parseECPublicKey(crv, xStr, yStr string) (*ecdsa.PublicKey, error) {
 	yBytes, err := decodeBase64URL(yStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode EC y coordinate: %w", err)
+	}
+
+	// Validate the point is on the curve using crypto/ecdh (uncompressed point: 0x04 || x || y).
+	byteLen := (curve.Params().BitSize + 7) / 8
+	point := make([]byte, 1+2*byteLen)
+	point[0] = 0x04
+	copy(point[1:1+byteLen], xBytes)
+	copy(point[1+byteLen:], yBytes)
+	if _, err := ecdhCurve.NewPublicKey(point); err != nil {
+		return nil, fmt.Errorf("EC point is not on curve %q: %w", crv, err)
 	}
 
 	x := new(big.Int).SetBytes(xBytes)

--- a/policies/jwt-auth/jwtauth_hardening_test.go
+++ b/policies/jwt-auth/jwtauth_hardening_test.go
@@ -1018,40 +1018,34 @@ func normalizeClaims(claims map[string]interface{}) map[string]interface{} {
 	return claims
 }
 
-// TestJWTAuthPolicy_Security_HMACConfusionRejected verifies the HMAC-confusion attack is blocked.
-// An attacker mints an HS256 token whose "secret" is the RSA public key bytes. The policy must
-// reject it because HS256 is not in the supported algorithm set.
+// TestJWTAuthPolicy_Security_HMACConfusionRejected verifies that HS256 tokens are rejected
+// because HS256 is not in the hardcoded supported algorithm set.
 func TestJWTAuthPolicy_Security_HMACConfusionRejected(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 
-	privateKey, publicKey := generateTestKeys(t)
+	_, publicKey := generateTestKeys(t)
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()
 
-	// Encode the RSA public key as DER bytes and use that as the HMAC secret.
 	pubDER, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
 		t.Fatalf("failed to marshal public key: %v", err)
 	}
 
 	claims := normalizeClaims(map[string]interface{}{
-		"sub": "attacker",
+		"sub": "user-123",
 		"iss": "https://issuer.example.com",
 	})
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
 	tok.Header["kid"] = "test-kid"
 	tokenString, err := tok.SignedString(pubDER)
 	if err != nil {
-		t.Fatalf("failed to sign HMAC-confusion token: %v", err)
+		t.Fatalf("failed to sign HS256 token: %v", err)
 	}
 
-	// Must be rejected: HS256 is not in the hardcoded supported set.
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
 	assertAuthFailure(t, ctx, action, 401)
-
-	// Sanity-check: a legitimately RS256-signed token still passes.
-	_ = privateKey // referenced to avoid unused-import warnings
 }
 
 // TestJWTAuthPolicy_Security_PS256Accepted verifies that PS256 (RSASSA-PSS) tokens are accepted
@@ -1176,35 +1170,29 @@ func TestJWTAuthPolicy_Security_ES256WithRSAKeyRejected(t *testing.T) {
 
 // TestJWTAuthPolicy_Security_UnsupportedAlgRejected verifies that algorithms outside the fixed
 // set (RS256, PS256, ES256) are rejected by WithValidMethods before the Keyfunc is reached.
+// RS384 is used: the JWKS key material matches the token's key, so the only reason for
+// rejection is that RS384 is not in supportedAlgorithms.
 func TestJWTAuthPolicy_Security_UnsupportedAlgRejected(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 
-	ecPriv, ecPub := generateTestECKeys(t)
-	jwksServer := createECJWKSServer(t, ecPub, "ec-kid")
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()
 
-	// ES384 is not in the hardcoded set; WithValidMethods should reject it.
 	claims := normalizeClaims(map[string]interface{}{
 		"sub": "user-123",
 		"iss": "https://issuer.example.com",
 	})
-	tok := jwt.NewWithClaims(jwt.SigningMethodES384, jwt.MapClaims(claims))
-	tok.Header["kid"] = "ec-kid"
-	// ES384 key must be P-384; using P-256 key will fail signing, so generate a P-384 key.
-	p384Priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS384, jwt.MapClaims(claims))
+	tok.Header["kid"] = "test-kid"
+	tokenString, err := tok.SignedString(privateKey)
 	if err != nil {
-		t.Fatalf("failed to generate P-384 key: %v", err)
-	}
-	tokenString, err := tok.SignedString(p384Priv)
-	if err != nil {
-		t.Fatalf("failed to sign ES384 token: %v", err)
+		t.Fatalf("failed to sign RS384 token: %v", err)
 	}
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
 	assertAuthFailure(t, ctx, action, 401)
-
-	_ = ecPriv // used for JWKS server
 }
 
 func writeJWKSResponse(t *testing.T, w http.ResponseWriter, publicKey *rsa.PublicKey, kid string) {

--- a/policies/jwt-auth/jwtauth_hardening_test.go
+++ b/policies/jwt-auth/jwtauth_hardening_test.go
@@ -3,9 +3,12 @@ package jwtauth
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -189,6 +192,9 @@ func TestJWTAuthPolicy_Negative_MissingAlgHeader(t *testing.T) {
 	assertAuthFailure(t, ctx, action, 401)
 }
 
+// TestJWTAuthPolicy_Negative_DisallowedAlgorithm verifies that algorithms outside the
+// hardcoded supported set (RS256, PS256, ES256) are rejected even when a valid key is present.
+// RS384 is chosen as a representative unsupported-but-parseable algorithm.
 func TestJWTAuthPolicy_Negative_DisallowedAlgorithm(t *testing.T) {
 	resetJWTAuthSingletonCache(t)
 
@@ -196,15 +202,20 @@ func TestJWTAuthPolicy_Negative_DisallowedAlgorithm(t *testing.T) {
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 	defer jwksServer.Close()
 
-	token := createTestToken(t, privateKey, map[string]interface{}{
+	// Mint an RS384 token (not in the hardcoded supportedAlgorithms set).
+	claims := normalizeClaims(map[string]interface{}{
 		"sub": "user-123",
 		"iss": "https://issuer.example.com",
 	})
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS384, jwt.MapClaims(claims))
+	tok.Header["kid"] = "test-kid"
+	tokenString, err := tok.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign RS384 token: %v", err)
+	}
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	params["allowedAlgorithms"] = []interface{}{"ES256"}
-
-	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
 	assertAuthFailure(t, ctx, action, 401)
 }
 
@@ -469,8 +480,6 @@ func TestJWTAuthPolicy_Security_AlgNoneRejected(t *testing.T) {
 	})
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	params["allowedAlgorithms"] = []interface{}{"RS256"}
-
 	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
 	assertAuthFailure(t, ctx, action, 401)
 }
@@ -837,7 +846,7 @@ func TestJWTAuthPolicy_Regression_claimValueToStringAndGetKeyIds(t *testing.T) {
 
 	key1 := &rsa.PublicKey{N: rsa.PublicKey{}.N, E: 65537}
 	key2 := &rsa.PublicKey{N: rsa.PublicKey{}.N, E: 65537}
-	keys := map[string]*rsa.PublicKey{
+	keys := map[string]crypto.PublicKey{
 		"kid-1": key1,
 		"kid-2": key2,
 	}
@@ -887,7 +896,6 @@ func newRemoteParams(jwksURI string) map[string]interface{} {
 		"errorMessageFormat":     "json",
 		"errorMessage":           "Authentication failed",
 		"leeway":                 "30s",
-		"allowedAlgorithms":      []interface{}{"RS256"},
 		"jwksCacheTtl":           "5m",
 		"jwksFetchTimeout":       "100ms",
 		"jwksFetchRetryCount":    0,
@@ -1008,6 +1016,195 @@ func normalizeClaims(claims map[string]interface{}) map[string]interface{} {
 		claims["iat"] = time.Now().Unix()
 	}
 	return claims
+}
+
+// TestJWTAuthPolicy_Security_HMACConfusionRejected verifies the HMAC-confusion attack is blocked.
+// An attacker mints an HS256 token whose "secret" is the RSA public key bytes. The policy must
+// reject it because HS256 is not in the supported algorithm set.
+func TestJWTAuthPolicy_Security_HMACConfusionRejected(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	// Encode the RSA public key as DER bytes and use that as the HMAC secret.
+	pubDER, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+
+	claims := normalizeClaims(map[string]interface{}{
+		"sub": "attacker",
+		"iss": "https://issuer.example.com",
+	})
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
+	tok.Header["kid"] = "test-kid"
+	tokenString, err := tok.SignedString(pubDER)
+	if err != nil {
+		t.Fatalf("failed to sign HMAC-confusion token: %v", err)
+	}
+
+	// Must be rejected: HS256 is not in the hardcoded supported set.
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
+	assertAuthFailure(t, ctx, action, 401)
+
+	// Sanity-check: a legitimately RS256-signed token still passes.
+	_ = privateKey // referenced to avoid unused-import warnings
+}
+
+// TestJWTAuthPolicy_Security_PS256Accepted verifies that PS256 (RSASSA-PSS) tokens are accepted
+// when the JWKS contains the corresponding RSA public key.
+func TestJWTAuthPolicy_Security_PS256Accepted(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	claims := normalizeClaims(map[string]interface{}{
+		"sub": "user-123",
+		"iss": "https://issuer.example.com",
+	})
+	tok := jwt.NewWithClaims(jwt.SigningMethodPS256, jwt.MapClaims(claims))
+	tok.Header["kid"] = "test-kid"
+	tokenString, err := tok.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign PS256 token: %v", err)
+	}
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
+	assertAuthSuccess(t, ctx, action)
+}
+
+// generateTestECKeys generates a P-256 ECDSA key pair for testing.
+func generateTestECKeys(t *testing.T) (*ecdsa.PrivateKey, *ecdsa.PublicKey) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate EC key: %v", err)
+	}
+	return privateKey, &privateKey.PublicKey
+}
+
+// createECJWKSServer creates a test HTTP server that serves a JWKS with a P-256 EC public key.
+func createECJWKSServer(t *testing.T, publicKey *ecdsa.PublicKey, kid string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jwks.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		xB64 := base64.RawURLEncoding.EncodeToString(publicKey.X.Bytes())
+		yB64 := base64.RawURLEncoding.EncodeToString(publicKey.Y.Bytes())
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "EC",
+					"kid": kid,
+					"use": "sig",
+					"alg": "ES256",
+					"crv": "P-256",
+					"x":   xB64,
+					"y":   yB64,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			t.Logf("failed to encode EC JWKS: %v", err)
+		}
+	}))
+	return server
+}
+
+// createES256Token mints an ES256 JWT signed with the given EC private key.
+func createES256Token(t *testing.T, privateKey *ecdsa.PrivateKey, claims map[string]interface{}, kid string) string {
+	t.Helper()
+	claims = normalizeClaims(claims)
+	tok := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims(claims))
+	tok.Header["kid"] = kid
+	tokenString, err := tok.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign ES256 token: %v", err)
+	}
+	return tokenString
+}
+
+// TestJWTAuthPolicy_Security_ES256Accepted verifies end-to-end ES256 support:
+// the JWKS parser stores an EC key, the Keyfunc binds it to ECDSA, and the token passes.
+func TestJWTAuthPolicy_Security_ES256Accepted(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	ecPriv, ecPub := generateTestECKeys(t)
+	jwksServer := createECJWKSServer(t, ecPub, "ec-kid")
+	defer jwksServer.Close()
+
+	token := createES256Token(t, ecPriv, map[string]interface{}{
+		"sub": "user-456",
+		"iss": "https://issuer.example.com",
+	}, "ec-kid")
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
+	assertAuthSuccess(t, ctx, action)
+}
+
+// TestJWTAuthPolicy_Security_ES256WithRSAKeyRejected verifies that an ES256 token is rejected
+// when the JWKS only contains an RSA key — the Keyfunc must refuse the method/key-type mismatch.
+func TestJWTAuthPolicy_Security_ES256WithRSAKeyRejected(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	// RSA JWKS
+	_, rsaPub := generateTestKeys(t)
+	rsaJWKSServer := createJWKSServer(t, rsaPub, "rsa-kid")
+	defer rsaJWKSServer.Close()
+
+	// EC private key — token claims ES256 but JWKS has RSA
+	ecPriv, _ := generateTestECKeys(t)
+	token := createES256Token(t, ecPriv, map[string]interface{}{
+		"sub": "user-789",
+		"iss": "https://issuer.example.com",
+	}, "rsa-kid") // deliberately uses the RSA kid so key lookup succeeds, Keyfunc must then reject
+
+	params := newRemoteParams(rsaJWKSServer.URL + "/jwks.json")
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", token))
+	assertAuthFailure(t, ctx, action, 401)
+}
+
+// TestJWTAuthPolicy_Security_UnsupportedAlgRejected verifies that algorithms outside the fixed
+// set (RS256, PS256, ES256) are rejected by WithValidMethods before the Keyfunc is reached.
+func TestJWTAuthPolicy_Security_UnsupportedAlgRejected(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	ecPriv, ecPub := generateTestECKeys(t)
+	jwksServer := createECJWKSServer(t, ecPub, "ec-kid")
+	defer jwksServer.Close()
+
+	// ES384 is not in the hardcoded set; WithValidMethods should reject it.
+	claims := normalizeClaims(map[string]interface{}{
+		"sub": "user-123",
+		"iss": "https://issuer.example.com",
+	})
+	tok := jwt.NewWithClaims(jwt.SigningMethodES384, jwt.MapClaims(claims))
+	tok.Header["kid"] = "ec-kid"
+	// ES384 key must be P-384; using P-256 key will fail signing, so generate a P-384 key.
+	p384Priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate P-384 key: %v", err)
+	}
+	tokenString, err := tok.SignedString(p384Priv)
+	if err != nil {
+		t.Fatalf("failed to sign ES384 token: %v", err)
+	}
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	ctx, action := executeOnRequestHeaders(t, params, authHeader("Authorization", "Bearer", tokenString))
+	assertAuthFailure(t, ctx, action, 401)
+
+	_ = ecPriv // used for JWKS server
 }
 
 func writeJWKSResponse(t *testing.T, w http.ResponseWriter, publicKey *rsa.PublicKey, kid string) {

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.0.5
+version: v1.1.0
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.
@@ -186,14 +186,6 @@ systemParameters:
       description: Interval between JWKS fetch retries, e.g., "2s".
       default: "2s"
       "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretryinterval}"
-
-    allowedAlgorithms:
-      type: array
-      description: Allowed JWT signing algorithms (e.g., ["RS256","ES256"]).
-      items:
-        type: string
-      default: ["RS256", "ES256"]
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.allowedalgorithms}"
 
     leeway:
       type: string


### PR DESCRIPTION
## Purpose

Add PS256 (RSASSA-PSS) and properly implement ES256 (ECDSA) support in the jwt-auth policy, and remove the operator-configurable `allowedAlgorithms` parameter in favour of a fixed, code-enforced set.

Previously, ES256 was listed in the default allowed algorithms but was non-functional — EC keys were silently dropped during JWKS parsing and local certificate loading only handled RSA keys. PS256 was not supported at all.

## Approach

- Hardcode the accepted signing algorithm set to RS256, PS256, and ES256
- Add `signatureKeyFunc` factory that binds the signing method to the actual key type, replacing three independent inline Keyfuncs
- Implement EC key support: `parseECPublicKey` helper, `kty=="EC"` branch in the JWKS parser, widen `CachedJWKS.Keys` and `LocalCert.PublicKey` from `*rsa.PublicKey` to `crypto.PublicKey`
- Remove the `allowedAlgorithms` system parameter (breaking change)
- Bump jwt-auth policy version to v1.1.0
- Add tests: PS256 accepted, ES256 end-to-end, algorithm rejection, key-type mismatch rejection

## Test

Tested on a live k3s cluster using a dedicated Go JWKS server serving both RSA (`rsa-kid`) and EC (`ec-kid`) keys:

| Token algorithm | Result |
|---|---|
| RS256 (RSA PKCS#1 v1.5) | ✅ HTTP 200 |
| PS256 (RSA-PSS) | ✅ HTTP 200 |
| ES256 (ECDSA P-256) | ✅ HTTP 200 |
| HS256 confusion attack | ✅ Blocked — HTTP 401 |
| RS384 (unsupported) | ✅ Blocked — HTTP 401 |

## Related Issues

Resolves wso2/api-platform#2449

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)