### PR TITLE
feat(mcp-auth)!: bump to v1.1.0, remove allowedAlgorithms param

### DIFF
--- a/docs/mcp-auth/v1.0/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v1.0/docs/mcp-authentication.md
@@ -32,7 +32,6 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 | `jwksFetchTimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
 | `jwksFetchRetryCount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
 | `jwksFetchRetryInterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
-| `allowedAlgorithms` | string array | No | - | jwtauth_v1 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
 | `leeway` | string | No | - | jwtauth_v1 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
 | `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
 | `headerName` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
@@ -69,7 +68,6 @@ jwksCacheTtl = "5m"
 jwksFetchTimeout = "5s"
 jwksFetchRetryCount = 3
 jwksFetchRetryInterval = "2s"
-allowedAlgorithms = ["RS256", "ES256"]
 leeway = "30s"
 authHeaderScheme = "Bearer"
 headerName = "Authorization"

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -6,6 +6,4 @@ require github.com/wso2/api-platform/sdk/core v0.2.14
 
 require github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0
 
-replace github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0 => ../jwt-auth
-
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -1,9 +1,11 @@
 module github.com/wso2/gateway-controllers/policies/mcp-auth
 
-go 1.26.1
+go 1.26.2
 
-require github.com/wso2/api-platform/sdk/core v0.2.4
+require github.com/wso2/api-platform/sdk/core v0.2.14
 
-require github.com/wso2/gateway-controllers/policies/jwt-auth v1.0.1
+require github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0
+
+replace github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0 => ../jwt-auth
 
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/policies/mcp-auth/go.sum
+++ b/policies/mcp-auth/go.sum
@@ -2,3 +2,5 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
 github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0 h1:8NDu++azRvqf0rO5uYN5HlgvuQG47gAWJFuz7XGYrBQ=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0/go.mod h1:wLDwZ0793wAj2eRS1zzS/yxUf33810NmbKqV/vsfmbo=

--- a/policies/mcp-auth/go.sum
+++ b/policies/mcp-auth/go.sum
@@ -1,6 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.0.1 h1:L1blzbpfmFhsQMfRVU5m0TdLEM+wjpCXbJgLrvfikYQ=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.0.1/go.mod h1:FEyeLDfbVAli6b3MueYRMnVvZXwtcZXw3JI2FCAIZdI=
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v1.0.3
+version: v1.1.0
 description: |
   Secure Model Context Protocol traffic by validating bearer access tokens for MCP resources using the underlying JWT authentication runtime.
 
@@ -195,13 +195,6 @@ systemParameters:
       type: string
       description: Interval between JWKS fetch retries, e.g., "2s".
       "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwksfetchretryinterval}"
-
-    allowedAlgorithms:
-      type: array
-      description: Allowed JWT signing algorithms (e.g., ["RS256","ES256"]).
-      items:
-        type: string
-      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.allowedalgorithms}"
 
     leeway:
       type: string


### PR DESCRIPTION
## Purpose

Remove the `allowedAlgorithms` system parameter from the mcp-auth policy and bump it to v1.1.0, aligning it with the jwt-auth v1.1.0 change that enforces a fixed signing algorithm set in code.

The parameter was previously forwarded to the underlying jwt-auth runtime, which no longer accepts it.

## Approach

- Remove `allowedAlgorithms` system parameter from `policy-definition.yaml` and docs
- Bump jwt-auth dependency from v1.0.1 to v1.1.0
- Bump sdk/core dependency from v0.2.4 to v0.2.14
- Bump mcp-auth policy version from v1.0.3 to v1.1.0
- Note: `go.mod` retains a `replace` directive for jwt-auth v1.1.0 until that version is tagged and published; it must be removed before the final release

## Related Issues

Resolves wso2/api-platform#2450

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)