### PR TITLE
Support stripping value-prefix in API key policy v1.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ All available policies, sorted alphabetically.
 | Policy | Categories | Description |
 |--------|------------|-------------|
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
-| [API Key Auth](./api-key-auth/v1.0/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
+| [API Key Auth](./api-key-auth/v1.1/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
 | [Backend JWT](./backend-jwt/v1.0/docs/backend-jwt.md) | Security | Generates a signed JWT containing authenticated user information and injects it into the upstream request header. |

--- a/docs/api-key-auth/v1.1/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.1/docs/apikey-authentication.md
@@ -11,6 +11,7 @@ The API Key Authentication policy validates API keys to secure APIs by verifying
 
 - Validates API keys from request headers
 - Configurable key extraction from headers (case-insensitive)
+- Optional value prefix stripping before validation (e.g., `Bearer `)
 - Pre-generated key validation against gateway-managed key lists
 - Request context enrichment with authentication metadata
 - Issuer-based key validation via system configuration
@@ -28,6 +29,7 @@ These parameters are configured per-API/route by the API developer:
 |-----------|------|----------|---------|-------------|
 | `key` | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters. |
 | `in` | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported. |
+| `value-prefix` | string | No | `""` | Advanced parameter. Optional prefix stripped from the header value before validation (e.g., `Bearer ` when the key is sent in an `Authorization` header). Matching and removal are case-insensitive. If the parameter is set but the header value does not start with the prefix, the request is rejected as malformed. Length: 1-64 characters. |
 
 ### System Parameters (config.toml)
 
@@ -189,11 +191,45 @@ spec:
       path: /alerts/active
 ```
 
+### Example 5: Stripping a Value Prefix
+
+Extract the API key from an `Authorization` header that carries a `Bearer ` prefix. The prefix is removed before validation, so a request sending `Authorization: Bearer <api-key>` is validated against `<api-key>`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: Authorization
+        in: header
+        value-prefix: "Bearer "
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
 ## How it Works
 
 - On each request, the gateway policy reads `key` and `in` from the policy configuration and validates that required parameters are present.
 
 - Based on `in`, it extracts the API key from a request header (case-insensitive header lookup).
+
+- If `value-prefix` is configured, the policy strips the prefix from the extracted value (case-insensitive) before validation. If the value does not start with the configured prefix, the resulting key is empty and the request is rejected as malformed.
 
 - If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
 

--- a/docs/api-key-auth/v1.1/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.1/docs/apikey-authentication.md
@@ -1,0 +1,220 @@
+---
+title: "Overview"
+---
+# API Key Authentication
+
+## Overview
+
+The API Key Authentication policy validates API keys to secure APIs by verifying pre-generated keys before allowing access to protected resources. This policy is essential for API security, supporting header-based key validation.
+
+## Features
+
+- Validates API keys from request headers
+- Configurable key extraction from headers (case-insensitive)
+- Pre-generated key validation against gateway-managed key lists
+- Request context enrichment with authentication metadata
+- Issuer-based key validation via system configuration
+- Streaming-compatible request processing (header-phase only)
+
+## Configuration
+
+The API Key Authentication policy uses a two-level configuration model. User parameters are configured per-API/route in the API definition YAML, and system parameters are resolved from gateway configuration.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters. |
+| `in` | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported. |
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `issuer` | string | No | `""` | Identifier of the portal associated with this gateway. Resolved from `config.toml` `[api_key] issuer` at startup. When set to a non-empty string, the policy rejects any API key whose issuer field is non-null and does not match this value. When empty or absent, the issuer check is skipped entirely. |
+
+#### Sample System Configuration
+
+```toml
+[api_key]
+issuer = "https://portal.example.com"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: api-key-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic API Key Authentication (Header)
+
+Apply API key authentication using a custom header
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 2: Default Header Name
+
+Use the default API-Key header name
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 3: Custom Header Name
+
+Use a custom header for API key authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 4: Route-Specific Authentication
+
+Apply different API key configurations to different routes
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: api-key-auth
+          version: v1
+          params:
+            key: X-API-Key
+            in: header
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: api-key-auth
+          version: v1
+          params:
+            key: Authorization
+            in: header
+    - method: POST
+      path: /alerts/active
+```
+
+## How it Works
+
+- On each request, the gateway policy reads `key` and `in` from the policy configuration and validates that required parameters are present.
+
+- Based on `in`, it extracts the API key from a request header (case-insensitive header lookup).
+
+- If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
+
+- For valid inputs, the policy calls the API key store validator using API and operation context (`apiId`, operation path, HTTP method) to determine whether the key is allowed for the target operation.
+
+- If an `issuer` is configured at the system level, the policy additionally verifies that the API key's issuer field matches the configured value. Keys with a non-null issuer that does not match are rejected.
+
+- On successful validation, the request continues upstream and authentication metadata is added to the shared context (`auth.success=true`, `auth.method=api-key`). The policy does not modify response traffic.
+
+- Key lifecycle and control-plane capabilities still apply, but are handled outside this gateway runtime policy: quota enforcement (including `remaining_api_key_quota` in key management APIs), key generation/regeneration, key format, secure hashing/storage, masking, access control, and audit logging.
+
+
+## Notes:
+
+- API keys offer a lightweight, secure authentication mechanism for internal services, partner and third-party integrations, legacy systems, development and testing environments, and service-to-service communication, providing a practical alternative to complex OAuth flows while ensuring controlled access through HTTPS-only transmission, secure hashing, masking, and constant-time validation.
+
+- Store API keys securely, never exposing them in client-side code, logs, or version control systems.
+
+- The platform enforces access control, audit logging, and quota limits to prevent abuse and support traceability. To maintain security over time, keys should be regenerated regularly, handled carefully in logs and query parameters, and revoked immediately if compromised.
+
+- Use clear, descriptive naming and maintain separate keys per environment (development, staging, production) to simplify management.
+
+- Always transmit API keys over HTTPS only and ensure logging practices do not inadvertently expose sensitive key material.
+

--- a/docs/api-key-auth/v1.1/metadata.json
+++ b/docs/api-key-auth/v1.1/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "api-key-auth",
   "displayName": "API Key Auth",
-  "version": "1.0",
+  "version": "1.1",
   "provider": "WSO2",
   "categories": [
     "Security",
@@ -9,5 +9,5 @@
     "WebSub",
     "WebBroker"
   ],
-  "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
+  "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers against a configured\nlist of valid keys and sets authentication metadata in the request context."
 }

--- a/docs/api-key-auth/v1.1/metadata.json
+++ b/docs/api-key-auth/v1.1/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "api-key-auth",
+  "displayName": "API Key Auth",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI",
+    "WebSub",
+    "WebBroker"
+  ],
+  "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers or query parameters against a configured\nlist of valid keys and sets authentication metadata in the request context."
+}

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -162,9 +162,17 @@ func (p *APIKeyPolicy) authenticate(
 			"missing or invalid 'in' configuration")
 	}
 
+	var valuePrefix string
+	if valuePrefixRaw, ok := params["value-prefix"]; ok {
+		if vp, ok := valuePrefixRaw.(string); ok {
+			valuePrefix = vp
+		}
+	}
+
 	issuer, _ := params["issuer"].(string)
 
-	slog.Debug("API Key Auth Policy: Configuration loaded", "keyName", keyName, "location", location)
+	slog.Debug("API Key Auth Policy: Configuration loaded",
+		"keyName", keyName, "location", location, "valuePrefix", valuePrefix)
 
 	var providedKey string
 	switch location {
@@ -186,9 +194,19 @@ func (p *APIKeyPolicy) authenticate(
 			"missing or invalid 'in' configuration")
 	}
 
+	if valuePrefix != "" {
+		originalLength := len(providedKey)
+		providedKey = stripPrefix(providedKey, valuePrefix)
+		slog.Debug("API Key Auth Policy: Processed value prefix",
+			"prefix", valuePrefix,
+			"originalLength", originalLength,
+			"processedLength", len(providedKey),
+		)
+	}
+
 	if providedKey == "" {
-		slog.Debug("API Key Auth Policy: No API key found", "location", location, "keyName", keyName)
-		return p.failAuth(shared, 401, "json", "Valid API key required", "missing API key")
+		slog.Debug("API Key Auth Policy: No API key found or API key is malformed", "location", location, "keyName", keyName)
+		return p.failAuth(shared, 401, "json", "Valid API key required", "missing or malformed API key")
 	}
 
 	apiId := shared.APIId
@@ -254,9 +272,19 @@ func (p *APIKeyPolicy) failAuth(shared *policy.SharedContext, statusCode int, er
 	}
 }
 
+// stripPrefix removes the specified prefix from the value (case-insensitive)
+// Returns the value with prefix removed, or empty string if prefix doesn't match
+func stripPrefix(value, prefix string) string {
+	// Do exact case-insensitive prefix matching
+	if len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix) {
+		return value[len(prefix):]
+	}
+	return ""
+}
+
 func generateTokenID(key string) string {
-    h := sha256.Sum256([]byte(key))
-    return hex.EncodeToString(h[:])
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
 }
 
 // buildErrorResponse constructs the ImmediateResponse body and headers for an auth failure.

--- a/policies/api-key-auth/apikey_test.go
+++ b/policies/api-key-auth/apikey_test.go
@@ -196,6 +196,131 @@ func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenValidationErrors(t *testing.T) {
 	assertUnauthorizedJSON(t, action)
 }
 
+func TestAPIKeyPolicy_OnRequestHeaders_SuccessWithValuePrefix(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("authorization"): {"Bearer header-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
+		"key":          "authorization",
+		"in":           "header",
+		"value-prefix": "Bearer ",
+	})
+
+	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
+		t.Fatalf("expected AuthContext.Authenticated=true")
+	}
+	if _, ok := action.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+}
+
+func TestAPIKeyPolicy_OnRequestHeaders_ValuePrefixIsCaseInsensitive(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	// Header sends "Bearer " while the configured prefix is "bearer ".
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("authorization"): {"Bearer header-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
+		"key":          "authorization",
+		"in":           "header",
+		"value-prefix": "bearer ",
+	})
+
+	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
+		t.Fatalf("expected AuthContext.Authenticated=true")
+	}
+	if _, ok := action.(policy.UpstreamRequestHeaderModifications); !ok {
+		t.Fatalf("expected UpstreamRequestHeaderModifications, got %T", action)
+	}
+}
+
+func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenValuePrefixMissing(t *testing.T) {
+	resetAPIKeyStore(t)
+	seedExternalAPIKey(t, "api-1", "header-secret", `["GET /orders"]`)
+
+	p := &APIKeyPolicy{}
+	// Header value does not carry the configured prefix, so stripping yields
+	// an empty key and the request must be rejected as malformed.
+	ctx := newRequestHeaderContext(t, "GET", "/orders", map[string][]string{
+		http.CanonicalHeaderKey("authorization"): {"header-secret"},
+	}, "api-1", "OrdersAPI", "v1", "/orders")
+
+	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
+		"key":          "authorization",
+		"in":           "header",
+		"value-prefix": "Bearer ",
+	})
+
+	assertUnauthorizedJSON(t, action)
+	if ctx.SharedContext.AuthContext == nil || ctx.SharedContext.AuthContext.Authenticated {
+		t.Fatalf("expected AuthContext.Authenticated=false")
+	}
+}
+
+func TestStripPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		prefix   string
+		expected string
+	}{
+		{
+			name:     "exact case match",
+			value:    "Bearer secret",
+			prefix:   "Bearer ",
+			expected: "secret",
+		},
+		{
+			name:     "case-insensitive match",
+			value:    "Bearer secret",
+			prefix:   "bearer ",
+			expected: "secret",
+		},
+		{
+			name:     "prefix not present",
+			value:    "secret",
+			prefix:   "Bearer ",
+			expected: "",
+		},
+		{
+			name:     "prefix longer than value",
+			value:    "Bea",
+			prefix:   "Bearer ",
+			expected: "",
+		},
+		{
+			name:     "prefix equals value",
+			value:    "Bearer ",
+			prefix:   "Bearer ",
+			expected: "",
+		},
+		{
+			name:     "mismatch after partial prefix",
+			value:    "Basic secret",
+			prefix:   "Bearer ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripPrefix(tt.value, tt.prefix)
+			if got != tt.expected {
+				t.Fatalf("unexpected value: got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractQueryParam(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v1.0.4
+version: v1.1.0
 description: |
   Secures APIs by validating API keys in incoming requests. API keys are
   provided through a configured HTTP header.
@@ -28,6 +28,16 @@ parameters:
       default: header
       enum:
         - "header"
+
+    value-prefix:
+      type: string
+      x-wso2-policy-advanced-param: true
+      description: |
+        Optional prefix that should be stripped from the API key value before validation.
+        Case-insensitive matching and removal.
+      validation:
+        minLength: 1
+        maxLength: 128
 
   required:
     - key


### PR DESCRIPTION
This pull request introduces support for value prefix stripping in the API Key Authentication policy, allowing API keys to be extracted from headers with prefixes (such as `Bearer ` in the `Authorization` header). The implementation is case-insensitive and includes updates to documentation, configuration, policy logic, and tests.

Related to - https://github.com/wso2/api-platform/issues/2563

**API Key Value Prefix Support:**

- Added the `value-prefix` parameter to the policy definition (`policy-definition.yaml`), enabling optional, case-insensitive stripping of a configured prefix from the API key value before validation. This is useful for scenarios where keys are sent as `Authorization: Bearer <api-key>`.
- Implemented the `stripPrefix` function in `apikey.go` to perform case-insensitive prefix removal and integrated it into the authentication flow. If the prefix is set but not present in the header value, the request is rejected as malformed. [[1]](diffhunk://#diff-89ad499b6ab886792718743f066c5ad8c0194a5aac1ace42a0e2e4e7c793e4eaR197-R209) [[2]](diffhunk://#diff-89ad499b6ab886792718743f066c5ad8c0194a5aac1ace42a0e2e4e7c793e4eaR275-R284)
- Updated logging in the policy to include information about the value prefix for easier debugging.

**Documentation and Metadata Updates:**

- Added comprehensive documentation in `docs/apikey-authentication.md` explaining the new `value-prefix` feature, configuration options, and usage scenarios, with examples for different header and prefix combinations.
- Updated the policy version to `v1.1.0` and added/updated metadata to reflect the new feature. [[1]](diffhunk://#diff-1363efa44564d1da59d09a8bf2a1f6e7769e86cae86c916886ac8f001d34791fL2-R2) [[2]](diffhunk://#diff-2ba76e688384583b3ad8bf076fb28b0825ff150e8ca2cc3b4b28a399c2e8c0a0R1-R13)

**Testing Enhancements:**

- Added unit tests to cover value prefix stripping, including case-insensitive matching, correct handling when the prefix is missing, and direct tests for the `stripPrefix` function.

These changes enhance the flexibility of API key authentication, supporting common patterns for sending API keys in HTTP headers.