### PR TITLE
fix(mcp-auth): do not enforce requiredScopes, advertise only

### DIFF
--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -492,8 +493,12 @@ func (p *McpAuthPolicy) handleAuth(ctx context.Context, reqCtx *policy.RequestCo
 		sessionId = sessionIds[0]
 	}
 
+	// requiredScopes are not to be enforced
+	jwtParams := maps.Clone(params)
+	delete(jwtParams, "requiredScopes")
+
 	slog.Debug("MCP Auth Policy: Delegating authentication to JWT Auth Policy")
-	jwtPolicy, err := jwtauth.GetPolicy(policy.PolicyMetadata{}, params)
+	jwtPolicy, err := jwtauth.GetPolicy(policy.PolicyMetadata{}, jwtParams)
 	if err != nil {
 		return p.handleAuthFailure(reqCtx.SharedContext, 500, "json", fmt.Sprintf("jwtauth.GetPolicy unavailable: %s", err))
 	}
@@ -511,7 +516,7 @@ func (p *McpAuthPolicy) handleAuth(ctx context.Context, reqCtx *policy.RequestCo
 		Scheme:        reqCtx.Scheme,
 		Vhost:         reqCtx.Vhost,
 	}
-	headerAction := hrp.OnRequestHeaders(ctx, headerCtx, params)
+	headerAction := hrp.OnRequestHeaders(ctx, headerCtx, jwtParams)
 	if ir, ok := headerAction.(policy.ImmediateResponse); ok {
 		slog.Debug("MCP Auth Policy: Authentication failed in JWT Auth Policy, handling failure")
 		reqCtx.SharedContext.AuthContext = &policy.AuthContext{

--- a/policies/mcp-auth/mcp-auth_test.go
+++ b/policies/mcp-auth/mcp-auth_test.go
@@ -562,6 +562,66 @@ func TestOnRequestBody_Delegation_Success_SetsAuthContextAuthType(t *testing.T) 
 	}
 }
 
+// TestOnRequestBody_RequiredScopes_NotEnforced: requiredScopes are advertise-only, so a token missing them still authenticates. Regression test for wso2/api-platform#2589.
+func TestOnRequestBody_RequiredScopes_NotEnforced(t *testing.T) {
+	privateKey, publicKey := generateRSATestKeys(t)
+	jwksServer := createMcpTestJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	// Token carries only "read" — missing "write" and "admin".
+	token := createMcpTestToken(t, privateKey, map[string]interface{}{
+		"sub":   "user123",
+		"iss":   "https://issuer.example.com",
+		"scope": "read",
+	})
+
+	p := createTestPolicy()
+	p.RequiredScopes = []string{"read", "write", "admin"}
+
+	ctx := createMockRequestBodyContext(map[string][]string{
+		"authorization": {fmt.Sprintf("Bearer %s", token)},
+	})
+	ctx.Method = "POST"
+	ctx.Path = "/mcp"
+	ctx.OperationPath = "/mcp"
+
+	params := map[string]any{
+		"headerName":          "Authorization",
+		"authHeaderScheme":    "Bearer",
+		"onFailureStatusCode": 401,
+		"errorMessageFormat":  "json",
+		"allowedAlgorithms":   []any{"RS256"},
+		// Present in params as at runtime; the policy must strip it before delegating.
+		"requiredScopes": []any{"read", "write", "admin"},
+		"keyManagers": []any{
+			map[string]any{
+				"name":   "test-issuer",
+				"issuer": "https://issuer.example.com",
+				"jwks": map[string]any{
+					"remote": map[string]any{
+						"uri": jwksServer.URL + "/jwks.json",
+					},
+				},
+			},
+		},
+	}
+
+	action := p.OnRequestBody(context.Background(), ctx, params)
+
+	// Must NOT be rejected: requiredScopes are advertised, not enforced, by mcp-auth.
+	if _, ok := action.(policy.ImmediateResponse); ok {
+		t.Fatalf("Expected success despite missing scopes (advertise-only), but got auth failure")
+	}
+	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
+		t.Fatal("Expected token to authenticate successfully even though it lacks configured requiredScopes")
+	}
+
+	// The original params map must be left untouched (no in-place deletion).
+	if _, ok := params["requiredScopes"]; !ok {
+		t.Error("Expected params[\"requiredScopes\"] to be preserved; policy must copy, not mutate")
+	}
+}
+
 func createMockRequestBodyContext(headers map[string][]string) *policy.RequestContext {
 	if headers == nil {
 		headers = map[string][]string{}


### PR DESCRIPTION
## Problem

Fixes wso2/api-platform#2589

The `mcp-auth` policy is documented to treat `requiredScopes` as **advertisement-only** — the scopes are published so an MCP client knows what to request when obtaining a token, but they are **not** meant to be enforced at invoke time (that is the job of the separate `mcp-authz` policy).

In practice they *were* being enforced. `mcp-auth` delegates token authentication to the JWT Auth policy and forwarded its entire `params` map unchanged:

```go
// policies/mcp-auth/mcp-auth.go (handleAuth)
jwtPolicy, err := jwtauth.GetPolicy(policy.PolicyMetadata{}, params)   // params includes requiredScopes
...
headerAction := hrp.OnRequestHeaders(ctx, headerCtx, params)          // same params, not stripped
```

Since JWT Auth v1.1.0 (commit `471467e`, "Enhance JWT Auth Policy: Improve scope validation logic") reads `requiredScopes` and rejects any token missing one of them:

```go
// policies/jwt-auth/jwtauth.go
userRequiredScopes := getStringArrayParam(params, "requiredScopes", []string{})
...
if len(userRequiredScopes) > 0 {
    for _, requiredScope := range userRequiredScopes {
        if !found {
            return p.handleAuthFailureHeaders(..., "required scope '%s' not found")
        }
    }
}
```

…a valid token missing a configured scope is rejected (`ImmediateResponse`), which `mcp-auth` surfaces as an auth failure. This contradicts the documented behavior.

## Fix

Strip `requiredScopes` from a **copy** of `params` before delegating to JWT Auth. The original map is left untouched (no in-place mutation, safe under concurrent reuse).

Advertising is unaffected: both the protected-resource metadata (`scopes_supported`) and the `WWW-Authenticate` challenge read `p.RequiredScopes` (the struct field), not the forwarded params.

## Testing

- Added `TestOnRequestBody_RequiredScopes_NotEnforced`: a valid token missing configured `requiredScopes` now authenticates successfully. Verified non-vacuous — it **fails** without this change (token rejected) and **passes** with it, against the real published `jwt-auth v1.1.0`.
- Existing metadata test (`TestOnRequestHeaders_WellKnown_Success`) already asserts `scopes_supported` advertising, confirming advertising still works.
- `go test ./...` (23 pass), `go vet`, and `gofmt` all clean.

## Notes

- The documentation wording lives in the `wso2/api-platform` repo (`docs/ai-gateway/mcp/policies/mcp-authentication.md`); it already states "not enforced by this policy", so no doc change is required there — this PR makes the code match the docs.