### PR TITLE
[APIP GC] Add Cache for jwt-auth policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ All available policies, sorted alphabetically.
 | [Interceptor Service](./interceptor-service/v1.0/docs/interceptor-service.md) | Transformation | Invokes a user-defined HTTP interceptor service in the request and/or response phase. |
 | [JSON Schema Guardrail](./json-schema-guardrail/v1.0/docs/json-schema.md) | Guardrails, AI | Validates request or response body content against a JSON Schema. |
 | [JSON/XML Mediator](./json-xml-mediator/v1.0/docs/json-xml-mediator.md) | Transformation | Mediates request and response payloads between downstream and upstream JSON/XML formats. |
-| [JWT Auth](./jwt-auth/v1.0/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens using one or more JWKS providers (key managers). |
+| [JWT Auth](./jwt-auth/v1.2/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens included in API requests. |
 | [LLM Cost](./llm-cost/v1.0/docs/llm-cost.md) | AI | Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. |
 | [LLM Cost Based Ratelimit](./llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md) | AI | A specialized rate limiting policy that enforces monetary budget limits on LLM API usage. |
 | [Log Message](./log-message/v1.0/docs/log-message.md) | Logging, Analytics & Monitoring, MCP, WebSub, WebBroker | This policy provides the capability to log the payload and headers of a request/response. |

--- a/docs/jwt-auth/v1.2/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.2/docs/jwt-authentication.md
@@ -1,0 +1,373 @@
+---
+title: "Overview"
+---
+# JWT Authentication
+
+## Overview
+
+The JWT Authentication policy validates JWT access tokens using one or more JWKS (JSON Web Key Set) providers. It is typically applied to operations that require bearer token authentication before requests are forwarded upstream.
+
+## Features
+
+- Validates JWTs using multiple key managers (JWKS providers)
+- Supports remote JWKS endpoints and local certificates
+- Configurable issuer, audience, scope, and claim validation
+- Claim-to-header mappings for downstream services
+- Configurable JWKS cache and retry settings
+- Token verification result caching: successfully verified tokens skip re-verification on repeat presentation, and deterministically invalid tokens (expired or malformed) are also cached to absorb repeated bad requests without re-verifying them
+- Fixed signing algorithm set: RS256, PS256, and ES256 (HMAC and `none` are rejected unconditionally)
+- Authorization header scheme enforcement and clock skew tolerance
+- Customizable error responses
+- Optional `userIdClaim` mapping for analytics
+- Optional forwarding of the JWT to the upstream under a configurable header name, as either the full header value or the bare token value (scheme prefix stripped)
+
+## Configuration
+
+JWT Authentication requires two levels of configuration.
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `keymanagers` | ```KeyManager``` array | Yes | - | List of key manager definitions with JWKS configuration. |
+| `jwkscachettl` | string | No | `"5m"` | JWKS cache TTL. |
+| `jwksfetchtimeout` | string | No | `"5s"` | JWKS fetch timeout. |
+| `jwksfetchretrycount` | integer | No | `3` | JWKS fetch retry count. |
+| `jwksfetchretryinterval` | string | No | `"2s"` | JWKS fetch retry interval. |
+| `leeway` | string | No | `"30s"` | Clock skew allowance for exp/nbf. |
+| `authheaderscheme` | string | No | `"Bearer"` | Expected authorization scheme prefix. |
+| `headername` | string | No | `"Authorization"` | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | HTTP status code on authentication failure. |
+| `errormessageformat` | string | No | `"json"` | Error format: `"json"`, `"plain"`, or `"minimal"`. |
+| `errormessage` | string | No | `"Authentication failed"` | Error message body for failures. |
+| `validateissuer` | boolean | No | `true` | Validate the token `iss` claim against key managers. |
+| `tokencaching` | boolean | No | `true` | Whether to cache token verification verdicts (see [Token Verification Caching](#token-verification-caching) below). Set to `false` to force full re-verification on every request. |
+| `tokencachettl` | string | No | `"5m"` | Maximum duration a successfully verified token is trusted from cache. The actual cache expiry is the sooner of this value and the token's own `exp` claim (minus leeway). |
+| `negativecachettl` | string | No | `"30s"` | Duration a deterministically invalid verdict (expired or malformed token) is cached before re-verification is attempted again. |
+| `cachemaxsize` | integer | No | `100000` | Maximum total number of cached verdicts (successful and failed, combined) held across all APIs. Least-recently-used entries are evicted once the limit is reached. |
+
+#### KeyManager Configuration
+
+Each entry in `keymanagers` must include a unique `name` and either `jwks.remote` or `jwks.local`.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Unique key manager name. |
+| `issuer` | string | No | Optional issuer (`iss`) value for this key manager. |
+| `jwks.remote.uri` | string | Conditional | JWKS endpoint URL. Required if using remote JWKS. |
+| `jwks.remote.certificatePath` | string | No | CA cert path for self-signed JWKS endpoints. |
+| `jwks.remote.skipTlsVerify` | boolean | No | Skip TLS verification (use with caution). |
+| `jwks.local.inline` | string | Conditional | Inline PEM certificate or public key. |
+| `jwks.local.certificatePath` | string | Conditional | Path to certificate or public key file. |
+
+#### Token Verification Caching
+
+When `tokencaching` is enabled (the default), the policy caches the outcome of signature verification so that repeat presentations of the same token — under the same key manager and validation configuration — skip re-verification entirely (unverified parsing, key manager/certificate parsing, and signature checking).
+
+- **Successful verifications** are cached for up to `tokencachettl`, but never longer than the token's own `exp` claim (minus `leeway`) — so a live cache entry is always still within the token's validity window. This bounds how long a revoked token may still be accepted after it was last verified.
+- **Deterministically invalid tokens** — expired or structurally malformed only — are also cached, for the shorter `negativecachettl`, so repeated bad tokens are rejected without re-verifying them each time. Transient failures (e.g. a JWKS endpoint outage, an unrecognized `kid` during key rotation) and not-yet-valid (`nbf`) tokens are never cached, since those may resolve on a later attempt.
+- The cache is a single pool shared across all APIs on the gateway, bounded by `cachemaxsize`; entries are keyed by the token together with the key manager configuration, issuer validation settings, and the API identity, so a configuration change or redeploy is never served a stale verdict.
+- Set `tokencaching` to `false` to force full verification on every request — useful when debugging or when token validity must be checked against live state on every call.
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.jwtauth_v1]
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
+leeway = "30s"
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed"
+validateissuer = true
+tokencaching = true
+tokencachettl = "5m"
+negativecachettl = "30s"
+cachemaxsize = 100000
+
+[[policy_configurations.jwtauth_v1.keymanagers]]
+name = "PrimaryIDP"
+issuer = "https://idp.example.com/oauth2/token"
+
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
+uri = "https://idp.example.com/oauth2/jwks"
+skipTlsVerify = false
+
+[[policy_configurations.jwtauth_v1.keymanagers]]
+name = "SecondaryIDP"
+issuer = "https://auth.example.org/oauth2/token"
+
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
+uri = "https://auth.example.org/oauth2/jwks"
+skipTlsVerify = false
+```
+
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `issuers` | array | No | List of key manager names (or issuer values) to use. If omitted, runtime matches token `iss` or tries all key managers. |
+| `audiences` | array | No | Acceptable audience values. Token must contain at least one. |
+| `requiredScopes` | array | No | Required scopes. Uses space-delimited `scope` claim or array `scp` claim. |
+| `requiredClaims` | object | No | Map of claim name to expected value. |
+| `claimMappings` | object | No | Map of claim name to downstream header name. |
+| `authHeaderPrefix` | string | No | Overrides the configured authorization header scheme for this route. |
+| `headerName` | string | No | Header name to extract the token from (e.g., `"Authorization"`). Overrides `system.headerName`. Must be a valid HTTP header field name (non-empty, no spaces or control characters). |
+| `userIdClaim` | string | No | Claim name to extract user ID for analytics. Defaults to `sub`. |
+| `forwardToken` | boolean | No | If `true` (default), the JWT is forwarded to the upstream after successful validation. Set to `false` to strip the token header before proxying. |
+| `forwardedTokenHeader` | string | No | Header name used to forward the JWT to the upstream when `forwardToken` is `true`. Defaults to `x-forwarded-authorization`. If this differs from `headerName`, the original header is removed and the token is forwarded under this name instead. By default the full header value (including the scheme prefix) is forwarded; set `forwardTokenStripScheme` to `true` to forward only the bare token value. Has no effect when `forwardToken` is `false`. |
+| `forwardTokenStripScheme` | boolean | No | Controls what is forwarded under `forwardedTokenHeader` when `forwardToken` is `true`. If `true`, only the bare token value (with the scheme prefix such as `Bearer` stripped) is forwarded. If `false` (default), the full header value including the prefix is forwarded. Has no effect when `forwardToken` is `false`. |
+
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: jwt-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/jwt-auth@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic JWT Authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-basic-api
+spec:
+  displayName: JWT Auth Basic API
+  version: v1.0
+  context: /jwt-auth-basic/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /health
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+```
+
+### Example 2: Audience and Scope Validation
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-audience-api
+spec:
+  displayName: JWT Auth Audience API
+  version: v1.0
+  context: /jwt-auth-audience/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            audiences:
+              - "test-audience"
+            requiredScopes:
+              - read:data
+```
+
+### Example 3: Claim Mapping to Downstream Headers
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-claims-api
+spec:
+  displayName: JWT Auth Claims API
+  version: v1.0
+  context: /jwt-auth-claims/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /profile
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            claimMappings:
+              sub: X-User-ID
+              email: X-User-Email
+              role: X-User-Role
+```
+
+### Example 4: Custom Token Header
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-custom-header-api
+spec:
+  displayName: JWT Auth Custom Header API
+  version: v1.0
+  context: /jwt-auth-custom/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            headerName: X-API-Token
+```
+
+### Example 5: Custom User ID Claim for Analytics
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-claims-api
+spec:
+  displayName: JWT Auth Claims API
+  version: v1.0
+  context: /jwt-auth-claims/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /profile
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            claimMappings:
+              sub: X-User-ID
+              email: X-User-Email
+              role: X-User-Role
+            userIdClaim: username
+```
+
+### Example 6: Strip JWT Before Forwarding to Upstream
+
+By default, the JWT is forwarded to the upstream after successful validation under the `x-forwarded-authorization` header. Set `forwardToken: false` to strip it before proxying.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-strip-token-api
+spec:
+  displayName: JWT Auth Strip Token API
+  version: v1.0
+  context: /jwt-auth-strip/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: false
+```
+
+### Example 7: Forward JWT Under a Custom Header
+
+When `forwardToken` is `true` (the default), the validated JWT is forwarded to the upstream under the header named by `forwardedTokenHeader` (default `x-forwarded-authorization`). Use this to preserve the incoming `Authorization` header for other purposes, or to hand the token to a backend that expects a specific header name.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-forwarded-header-api
+spec:
+  displayName: JWT Auth Forwarded Header API
+  version: v1.0
+  context: /jwt-auth-forwarded/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: true
+            forwardedTokenHeader: X-Backend-Authorization
+```
+
+### Example 8: Forward the Token Value Without the Scheme Prefix
+
+Some upstreams expect the raw token value without the `Bearer` (or other) scheme prefix. Set `forwardTokenStripScheme: true` to forward the bare token under `forwardedTokenHeader` instead of the full header value. For example, an incoming `Authorization: Bearer eyJ...` results in the upstream receiving `X-JWT-Token: eyJ...`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: jwt-auth-token-value-api
+spec:
+  displayName: JWT Auth Token Value API
+  version: v1.0
+  context: /jwt-auth-token-value/$version
+  upstream:
+    main:
+      url: http://sample-backend:9080/api/v1
+  operations:
+    - method: GET
+      path: /protected
+      policies:
+        - name: jwt-auth
+          version: v1
+          params:
+            issuers:
+              - PrimaryIDP
+            forwardToken: true
+            forwardTokenStripScheme: true
+            forwardedTokenHeader: X-JWT-Token
+```
+
+### Example 9: Disable Token Verification Caching
+
+Token verification caching is enabled by default. To force full re-verification on every request — for example while debugging, or when tokens must be checked against live revocation state on every call — disable it at the system level.
+
+```toml
+[policy_configurations.jwtauth_v1]
+tokencaching = false
+```

--- a/docs/jwt-auth/v1.2/docs/jwt-authentication.md
+++ b/docs/jwt-auth/v1.2/docs/jwt-authentication.md
@@ -66,7 +66,7 @@ When `tokencaching` is enabled (the default), the policy caches the outcome of s
 
 - **Successful verifications** are cached for up to `tokencachettl`, but never longer than the token's own `exp` claim (minus `leeway`) — so a live cache entry is always still within the token's validity window. This bounds how long a revoked token may still be accepted after it was last verified.
 - **Deterministically invalid tokens** — expired or structurally malformed only — are also cached, for the shorter `negativecachettl`, so repeated bad tokens are rejected without re-verifying them each time. Transient failures (e.g. a JWKS endpoint outage, an unrecognized `kid` during key rotation) and not-yet-valid (`nbf`) tokens are never cached, since those may resolve on a later attempt.
-- The cache is a single pool shared across all APIs on the gateway, bounded by `cachemaxsize`; entries are keyed by the token together with the key manager configuration, issuer validation settings, and the API identity, so a configuration change or redeploy is never served a stale verdict.
+- The cache is a single pool shared across all APIs on the gateway, bounded by `cachemaxsize`; entries are keyed by the token together with the key manager configuration, issuer validation settings, the configured `issuers` list, `leeway`, and the API identity, so a configuration change or redeploy is never served a stale verdict.
 - Set `tokencaching` to `false` to force full verification on every request — useful when debugging or when token validity must be checked against live state on every call.
 
 #### Sample System Configuration

--- a/docs/jwt-auth/v1.2/metadata.json
+++ b/docs/jwt-auth/v1.2/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "jwt-auth",
+  "displayName": "JWT Auth",
+  "version": "1.2",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI",
+    "WebSub",
+    "WebBroker"
+  ],
+  "description": "Validates JWT access tokens included in API requests. The gateway verifies the token's signature, expiry, issuer, audience, scopes, and required claims."
+}

--- a/policies/jwt-auth/go.mod
+++ b/policies/jwt-auth/go.mod
@@ -4,5 +4,5 @@ go 1.26.2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.2.14
+	github.com/wso2/api-platform/sdk/core v0.2.16
 )

--- a/policies/jwt-auth/go.sum
+++ b/policies/jwt-auth/go.sum
@@ -1,4 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
-github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/api-platform/sdk/core v0.2.16 h1:mIUOjrfX6gJNsntddYo+J70e7BHgrGC6DT3ZOVnVKZE=
+github.com/wso2/api-platform/sdk/core v0.2.16/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -218,6 +218,10 @@ func (p *JwtAuthPolicy) ensureTokenCache(maxSize int) {
 	if p.tokenCache != nil && p.tokenCacheSize == maxSize {
 		return
 	}
+	slog.Debug("JWT Auth Policy: Rebuilding token verdict cache due to cacheMaxSize change, all cached verdicts flushed",
+		"previousMaxSize", p.tokenCacheSize,
+		"newMaxSize", maxSize,
+	)
 	p.tokenCache = newTokenCache(maxSize)
 	p.tokenCacheSize = maxSize
 }
@@ -245,6 +249,10 @@ func (p *JwtAuthPolicy) getCachedVerdict(ctx context.Context, key string) (cache
 		return cachedVerdict{}, false
 	}
 	if !time.Now().Before(v.expiresAt) {
+		slog.Debug("JWT Auth Policy: Cached verdict found but expired, evicting",
+			"cacheKey", key,
+			"expiresAt", v.expiresAt,
+		)
 		_ = tc.Delete(ctx, cacheKey)
 		return cachedVerdict{}, false
 	}
@@ -1493,16 +1501,26 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		cacheKey = buildTokenCacheKey(fingerprint, token)
 		if verdict, hit := p.getCachedVerdict(ctx, cacheKey); hit {
 			if verdict.ok {
-				slog.Debug("JWT Auth Policy: Token verdict cache hit (verified)")
+				slog.Debug("JWT Auth Policy: Token verdict cache hit (verified)",
+					"cacheKey", cacheKey,
+					"expiresAt", verdict.expiresAt,
+				)
 				return p.finishAuthentication(reqCtx, verdict.claims, onFailureStatusCode, errorMessageFormat, errorMessage,
 					userAudiences, userRequiredScopes, userRequiredClaims, userClaimMappings, userIdClaim,
 					headerName, authHeader, token, forwardToken, forwardedTokenHeader, forwardTokenStripScheme)
 			}
 			slog.Debug("JWT Auth Policy: Token verdict cache hit (failure)",
+				"cacheKey", cacheKey,
 				"reason", verdict.reason,
+				"expiresAt", verdict.expiresAt,
 			)
 			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, verdict.reason)
 		}
+		slog.Debug("JWT Auth Policy: Token verdict cache miss, proceeding to full verification",
+			"cacheKey", cacheKey,
+		)
+	} else {
+		slog.Debug("JWT Auth Policy: Token verdict caching disabled, performing full verification")
 	}
 
 	slog.Debug("JWT Auth Policy: Starting to parse key managers configuration")
@@ -1636,6 +1654,10 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 			"error", err,
 		)
 		if tokenCaching {
+			slog.Debug("JWT Auth Policy: Caching negative verdict (malformed token)",
+				"cacheKey", cacheKey,
+				"negativeCacheTtl", negativeCacheTtl,
+			)
 			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: "invalid token format", expiresAt: time.Now().Add(negativeCacheTtl)})
 		}
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid token format")
@@ -1655,7 +1677,15 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		)
 		failureReason := fmt.Sprintf("token validation failed: %v", err)
 		if tokenCaching && errors.Is(err, errTokenExpired) {
+			slog.Debug("JWT Auth Policy: Caching negative verdict (token expired)",
+				"cacheKey", cacheKey,
+				"negativeCacheTtl", negativeCacheTtl,
+			)
 			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: failureReason, expiresAt: time.Now().Add(negativeCacheTtl)})
+		} else if tokenCaching {
+			slog.Debug("JWT Auth Policy: Token validation failure not cached (not a conservatively-cacheable reason)",
+				"cacheKey", cacheKey,
+			)
 		}
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, failureReason)
 	}
@@ -1674,7 +1704,16 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 			}
 		}
 		if expiresAt.After(time.Now()) {
+			slog.Debug("JWT Auth Policy: Caching positive verdict",
+				"cacheKey", cacheKey,
+				"expiresAt", expiresAt,
+			)
 			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: true, claims: claims, expiresAt: expiresAt})
+		} else {
+			slog.Debug("JWT Auth Policy: Skipping positive cache write, computed expiry is not in the future",
+				"cacheKey", cacheKey,
+				"expiresAt", expiresAt,
+			)
 		}
 	}
 

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -18,34 +18,59 @@
 package jwtauth
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"math/big"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	"github.com/wso2/api-platform/sdk/core/utils/cache"
 )
 
 const (
 	AuthType = "jwt"
+
+	// defaultTokenCacheMaxSize bounds the total number of cached verdicts (positive and
+	// negative) across all APIs. The SDK cache fixes its size at construction, so a changed
+	// cacheMaxSize is applied by rebuilding the cache (see ensureTokenCache).
+	defaultTokenCacheMaxSize = 100_000
+
+	// defaultTokenCacheTtl caps how long a successfully verified token is trusted from cache,
+	// bounding the revocation/staleness window (see cachedVerdict).
+	defaultTokenCacheTtl = 5 * time.Minute
+
+	// defaultNegativeCacheTtl caps how long a deterministic verification failure (expired or
+	// malformed token) is served from cache without re-verification. Kept short since it is
+	// purely a DoS/retry-absorption optimization.
+	defaultNegativeCacheTtl = 30 * time.Second
 )
+
+// errTokenExpired is returned by validateTokenWithSignature's exp check so callers can
+// distinguish it, via errors.Is, from other verification failures: an expired token can never
+// become valid again, so (unlike e.g. a JWKS fetch error or a not-yet-valid nbf) it is safe to
+// negatively cache.
+var errTokenExpired = errors.New("token expired")
 
 // standardJWTClaims lists registered JWT claim names (RFC 7519) and common OAuth2 claims.
 // These are represented as typed fields on AuthContext and excluded from Properties.
@@ -85,11 +110,32 @@ type JwtAuthPolicy struct {
 	cacheStore map[string]*CachedJWKS
 	cacheTTLs  map[string]time.Time
 	httpClient *http.Client
+
+	// tokenCacheMu guards the tokenCache pointer and tokenCacheSize. The SDK cache fixes its
+	// size at construction (no live resize), so a changed cacheMaxSize is applied by swapping
+	// in a new cache. Reads take the RLock and copy the pointer so an in-flight request keeps
+	// using a consistent cache even if a concurrent deployment rebuilds it.
+	tokenCacheMu   sync.RWMutex
+	tokenCache     *cache.InMemoryCache[cachedVerdict] // shared verdict cache for all APIs; globally bounded by cacheMaxSize
+	tokenCacheSize int
 }
 
 // CachedJWKS stores cached JWKS data
 type CachedJWKS struct {
 	Keys map[string]crypto.PublicKey
+}
+
+// cachedVerdict stores the outcome of a signature verification, keyed by a hash of the
+// verification config and the raw token (see buildTokenCacheKey). ok=true is a successful
+// verification (claims holds the verified claim set); ok=false is a deterministic, permanently
+// invalid failure (expired or malformed token only — see errTokenExpired) that is safe to
+// short-circuit on repeat presentation. expiresAt is enforced on read (see getCachedVerdict)
+// since the SDK cache itself is created with ttl=0.
+type cachedVerdict struct {
+	ok        bool
+	claims    jwt.MapClaims
+	reason    string
+	expiresAt time.Time
 }
 
 // KeyManager represents a key manager with either remote JWKS or local certificate
@@ -144,13 +190,128 @@ var ins = &JwtAuthPolicy{
 	httpClient: &http.Client{
 		Timeout: 5 * time.Second,
 	},
+	tokenCache:     newTokenCache(defaultTokenCacheMaxSize),
+	tokenCacheSize: defaultTokenCacheMaxSize,
 }
 
-// GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
+// newTokenCache builds the shared verdict cache, globally bounded by maxSize across all APIs.
+// ttl is 0 because expiry is enforced per entry in getCachedVerdict; once full, the cache's LRU
+// policy evicts the least-recently-used entry across all APIs, enforcing a single global bound.
+func newTokenCache(maxSize int) *cache.InMemoryCache[cachedVerdict] {
+	return cache.NewInMemoryCache[cachedVerdict]("jwt-auth-validated-tokens", maxSize, 0, cache.LRUEvictionPolicy, slog.Default())
+}
+
+// ensureTokenCache (re)builds the shared token cache when the configured global size changes.
+// The SDK cache fixes its size at construction (there is no live resize), so applying a new
+// cacheMaxSize means replacing the cache, which flushes all entries. This happens only on the
+// first deployment or a genuine cacheMaxSize change — steady-state redeploys leave it untouched.
+func (p *JwtAuthPolicy) ensureTokenCache(maxSize int) {
+	p.tokenCacheMu.RLock()
+	if p.tokenCache != nil && p.tokenCacheSize == maxSize {
+		p.tokenCacheMu.RUnlock()
+		return
+	}
+	p.tokenCacheMu.RUnlock()
+
+	p.tokenCacheMu.Lock()
+	defer p.tokenCacheMu.Unlock()
+	if p.tokenCache != nil && p.tokenCacheSize == maxSize {
+		return
+	}
+	p.tokenCache = newTokenCache(maxSize)
+	p.tokenCacheSize = maxSize
+}
+
+// currentTokenCache returns the live token cache pointer under the read lock, so callers operate
+// on a consistent instance even if a concurrent deployment rebuilds the cache.
+func (p *JwtAuthPolicy) currentTokenCache() *cache.InMemoryCache[cachedVerdict] {
+	p.tokenCacheMu.RLock()
+	defer p.tokenCacheMu.RUnlock()
+	return p.tokenCache
+}
+
+// getCachedVerdict returns a previously cached verification verdict (positive or negative) if it
+// exists and has not yet expired. Because the SDK cache never expires entries on its own
+// (ttl=0), expiry is enforced here against the verdict's stored expiresAt: an entry past its
+// window is deleted and reported as a miss.
+func (p *JwtAuthPolicy) getCachedVerdict(ctx context.Context, key string) (cachedVerdict, bool) {
+	tc := p.currentTokenCache()
+	if tc == nil {
+		return cachedVerdict{}, false
+	}
+	cacheKey := cache.CacheKey{Key: key}
+	v, ok := tc.Get(ctx, cacheKey)
+	if !ok {
+		return cachedVerdict{}, false
+	}
+	if !time.Now().Before(v.expiresAt) {
+		_ = tc.Delete(ctx, cacheKey)
+		return cachedVerdict{}, false
+	}
+	return v, true
+}
+
+// putVerdict stores a verification verdict (positive or negative) under key. When the shared
+// cache is full, its LRU policy evicts the least-recently-used entry across all APIs to make room.
+func (p *JwtAuthPolicy) putVerdict(ctx context.Context, key string, verdict cachedVerdict) {
+	tc := p.currentTokenCache()
+	if tc == nil {
+		return
+	}
+	_ = tc.Set(ctx, cache.CacheKey{Key: key}, verdict)
+}
+
+// buildTokenCacheKey returns a cache key that is a complete function of the verification
+// verdict: fingerprint folds in everything that determines the verdict but is not part of the
+// token itself (API identity plus verification config), and the token supplies the rest. The
+// token is hashed (never stored or logged raw) to keep the bearer secret out of cache keys and
+// bound key length.
+func buildTokenCacheKey(fingerprint, token string) string {
+	sum := sha256.Sum256([]byte(fingerprint + "\x00" + token))
+	return fmt.Sprintf("%x", sum)
+}
+
+// tokenConfigFingerprint renders the token-shaping/verification configuration as a deterministic
+// string. apiId/apiName isolate the shared singleton cache per API even when two APIs would
+// otherwise see identical tokens. keyManagersRaw is JSON-marshalled as configured (not the
+// parsed/expensive form), so computing the fingerprint never requires cert/TLS parsing — that
+// parsing happens only on a cache miss. A redeploy that changes any of these fields yields a
+// different fingerprint (a cache miss), so a token is never trusted under stale config.
+func tokenConfigFingerprint(apiId, apiName string, keyManagersRaw interface{}, validateIssuer bool, issuers []string, leeway time.Duration) string {
+	kmBytes, err := json.Marshal(keyManagersRaw)
+	if err != nil {
+		// Should not happen for values decoded from JSON config, but never let a marshal
+		// failure silently collapse the fingerprint to a shared/colliding key.
+		kmBytes = []byte(fmt.Sprintf("%v", keyManagersRaw))
+	}
+	var buf bytes.Buffer
+	buf.WriteString(apiId)
+	buf.WriteByte('|')
+	buf.WriteString(apiName)
+	buf.WriteByte('|')
+	buf.Write(kmBytes)
+	buf.WriteByte('|')
+	buf.WriteString(strconv.FormatBool(validateIssuer))
+	buf.WriteByte('|')
+	buf.WriteString(strings.Join(issuers, ","))
+	buf.WriteByte('|')
+	buf.WriteString(leeway.String())
+	return buf.String()
+}
+
+// GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels). It applies the
+// global cacheMaxSize from systemParameters to the shared verdict cache. Redeploy invalidation
+// of individual entries is handled implicitly by the cache key (see tokenConfigFingerprint); a
+// changed cacheMaxSize additionally rebuilds the whole cache (see ensureTokenCache).
 func GetPolicy(
 	metadata policy.PolicyMetadata,
 	params map[string]interface{},
 ) (policy.Policy, error) {
+	maxSize := getIntParam(params, "cacheMaxSize", defaultTokenCacheMaxSize)
+	if maxSize <= 0 {
+		maxSize = defaultTokenCacheMaxSize
+	}
+	ins.ensureTokenCache(maxSize)
 	return ins, nil
 }
 
@@ -194,7 +355,7 @@ func (p *JwtAuthPolicy) validateTokenWithSignature(tokenString string, unverifie
 				"expTime", expTime,
 				"now", now,
 			)
-			return nil, fmt.Errorf("token expired")
+			return nil, errTokenExpired
 		}
 		slog.Debug("JWT Auth Policy: Token expiration check passed")
 	} else {
@@ -1174,6 +1335,9 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	jwksFetchRetryCount := getIntParam(params, "jwksFetchRetryCount", 3)
 	jwksFetchRetryIntervalStr := getStringParam(params, "jwksFetchRetryInterval", "2s")
 	validateIssuer := getBoolParam(params, "validateIssuer", true)
+	tokenCaching := getBoolParam(params, "tokenCaching", true)
+	tokenCacheTtlStr := getStringParam(params, "tokenCacheTtl", "5m")
+	negativeCacheTtlStr := getStringParam(params, "negativeCacheTtl", "30s")
 
 	slog.Debug("JWT Auth Policy: Configuration loaded",
 		"headerName", headerName,
@@ -1188,6 +1352,9 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		"jwksFetchRetryCount", jwksFetchRetryCount,
 		"jwksFetchRetryInterval", jwksFetchRetryIntervalStr,
 		"validateIssuer", validateIssuer,
+		"tokenCaching", tokenCaching,
+		"tokenCacheTtl", tokenCacheTtlStr,
+		"negativeCacheTtl", negativeCacheTtlStr,
 	)
 
 	leeway, err := time.ParseDuration(leewayStr)
@@ -1226,18 +1393,116 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		)
 		jwksFetchRetryInterval = 2 * time.Second
 	}
+	tokenCacheTtl, err := time.ParseDuration(tokenCacheTtlStr)
+	if err != nil {
+		slog.Debug("JWT Auth Policy: Failed to parse tokenCacheTtl duration, using default",
+			"tokenCacheTtlStr", tokenCacheTtlStr,
+			"error", err,
+			"defaultTokenCacheTtl", defaultTokenCacheTtl,
+		)
+		tokenCacheTtl = defaultTokenCacheTtl
+	}
+	negativeCacheTtl, err := time.ParseDuration(negativeCacheTtlStr)
+	if err != nil {
+		slog.Debug("JWT Auth Policy: Failed to parse negativeCacheTtl duration, using default",
+			"negativeCacheTtlStr", negativeCacheTtlStr,
+			"error", err,
+			"defaultNegativeCacheTtl", defaultNegativeCacheTtl,
+		)
+		negativeCacheTtl = defaultNegativeCacheTtl
+	}
 
 	slog.Debug("JWT Auth Policy: Parsed duration values",
 		"leeway", leeway,
 		"jwksCacheTtl", jwksCacheTtl,
 		"jwksFetchTimeout", jwksFetchTimeout,
 		"jwksFetchRetryInterval", jwksFetchRetryInterval,
+		"tokenCacheTtl", tokenCacheTtl,
+		"negativeCacheTtl", negativeCacheTtl,
 	)
 
 	keyManagersRaw, ok := params["keyManagers"]
 	if !ok {
 		slog.Debug("JWT Auth Policy: Key managers not configured in params")
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "key managers not configured")
+	}
+
+	userIssuers := getStringArrayParam(params, "issuers", []string{})
+	userAudiences := getStringArrayParam(params, "audiences", []string{})
+	userRequiredScopes := getStringArrayParam(params, "requiredScopes", []string{})
+	userRequiredClaims := getStringMapParam(params, "requiredClaims", map[string]string{})
+	userClaimMappings := getStringMapParam(params, "claimMappings", map[string]string{})
+	userIdClaim := getStringParam(params, "userIdClaim", "sub")
+	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
+	forwardToken := getBoolParam(params, "forwardToken", true)
+	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
+	forwardTokenStripScheme := getBoolParam(params, "forwardTokenStripScheme", false)
+
+	slog.Debug("JWT Auth Policy: User configuration loaded",
+		"issuers", userIssuers,
+		"audiences", userAudiences,
+		"requiredScopes", userRequiredScopes,
+		"requiredClaimsCount", len(userRequiredClaims),
+		"claimMappingsCount", len(userClaimMappings),
+		"userIdClaim", userIdClaim,
+		"authHeaderPrefix", userAuthHeaderPrefix,
+		"forwardTokenStripScheme", forwardTokenStripScheme,
+	)
+
+	if userAuthHeaderPrefix != "" {
+		slog.Debug("JWT Auth Policy: Overriding auth header scheme with user prefix",
+			"originalScheme", authHeaderScheme,
+			"newScheme", userAuthHeaderPrefix,
+		)
+		authHeaderScheme = userAuthHeaderPrefix
+	}
+
+	authHeaders := reqCtx.Headers.Get(strings.ToLower(headerName))
+	if len(authHeaders) == 0 {
+		slog.Debug("JWT Auth Policy: Missing authorization header",
+			"headerName", headerName,
+		)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "missing authorization header")
+	}
+
+	authHeader := authHeaders[0]
+	slog.Debug("JWT Auth Policy: Authorization header found",
+		"headerName", headerName,
+		"headerValueLength", len(authHeader),
+	)
+
+	token := extractToken(authHeader, authHeaderScheme)
+	if token == "" {
+		slog.Debug("JWT Auth Policy: Failed to extract token from authorization header",
+			"authHeaderScheme", authHeaderScheme,
+		)
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid authorization header format")
+	}
+
+	slog.Debug("JWT Auth Policy: Token extracted successfully",
+		"tokenLength", len(token),
+	)
+
+	// Cache boundary: everything above is cheap (header/param reads). Everything below —
+	// unverified parsing, key-manager/certificate/TLS parsing, and signature verification — is
+	// exactly what the verdict cache exists to skip on a repeat presentation of the same token
+	// under the same verification config (see tokenConfigFingerprint).
+	var cacheKey string
+	if tokenCaching {
+		fingerprint := tokenConfigFingerprint(reqCtx.APIId, reqCtx.APIName, keyManagersRaw, validateIssuer, userIssuers, leeway)
+		cacheKey = buildTokenCacheKey(fingerprint, token)
+		if verdict, hit := p.getCachedVerdict(ctx, cacheKey); hit {
+			if verdict.ok {
+				slog.Debug("JWT Auth Policy: Token verdict cache hit (verified)")
+				return p.finishAuthentication(reqCtx, verdict.claims, onFailureStatusCode, errorMessageFormat, errorMessage,
+					userAudiences, userRequiredScopes, userRequiredClaims, userClaimMappings, userIdClaim,
+					headerName, authHeader, token, forwardToken, forwardedTokenHeader, forwardTokenStripScheme)
+			}
+			slog.Debug("JWT Auth Policy: Token verdict cache hit (failure)",
+				"reason", verdict.reason,
+			)
+			return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, verdict.reason)
+		}
 	}
 
 	slog.Debug("JWT Auth Policy: Starting to parse key managers configuration")
@@ -1365,67 +1630,14 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		"count", len(keyManagers),
 	)
 
-	userIssuers := getStringArrayParam(params, "issuers", []string{})
-	userAudiences := getStringArrayParam(params, "audiences", []string{})
-	userRequiredScopes := getStringArrayParam(params, "requiredScopes", []string{})
-	userRequiredClaims := getStringMapParam(params, "requiredClaims", map[string]string{})
-	userClaimMappings := getStringMapParam(params, "claimMappings", map[string]string{})
-	userIdClaim := getStringParam(params, "userIdClaim", "sub")
-	userAuthHeaderPrefix := getStringParam(params, "authHeaderPrefix", "")
-	forwardToken := getBoolParam(params, "forwardToken", true)
-	forwardedTokenHeader := getStringParam(params, "forwardedTokenHeader", "x-forwarded-authorization")
-	forwardTokenStripScheme := getBoolParam(params, "forwardTokenStripScheme", false)
-
-	slog.Debug("JWT Auth Policy: User configuration loaded",
-		"issuers", userIssuers,
-		"audiences", userAudiences,
-		"requiredScopes", userRequiredScopes,
-		"requiredClaimsCount", len(userRequiredClaims),
-		"claimMappingsCount", len(userClaimMappings),
-		"userIdClaim", userIdClaim,
-		"authHeaderPrefix", userAuthHeaderPrefix,
-		"forwardTokenStripScheme", forwardTokenStripScheme,
-	)
-
-	if userAuthHeaderPrefix != "" {
-		slog.Debug("JWT Auth Policy: Overriding auth header scheme with user prefix",
-			"originalScheme", authHeaderScheme,
-			"newScheme", userAuthHeaderPrefix,
-		)
-		authHeaderScheme = userAuthHeaderPrefix
-	}
-
-	authHeaders := reqCtx.Headers.Get(strings.ToLower(headerName))
-	if len(authHeaders) == 0 {
-		slog.Debug("JWT Auth Policy: Missing authorization header",
-			"headerName", headerName,
-		)
-		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "missing authorization header")
-	}
-
-	authHeader := authHeaders[0]
-	slog.Debug("JWT Auth Policy: Authorization header found",
-		"headerName", headerName,
-		"headerValueLength", len(authHeader),
-	)
-
-	token := extractToken(authHeader, authHeaderScheme)
-	if token == "" {
-		slog.Debug("JWT Auth Policy: Failed to extract token from authorization header",
-			"authHeaderScheme", authHeaderScheme,
-		)
-		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid authorization header format")
-	}
-
-	slog.Debug("JWT Auth Policy: Token extracted successfully",
-		"tokenLength", len(token),
-	)
-
 	unverifiedToken, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
 	if err != nil {
 		slog.Debug("JWT Auth Policy: Failed to parse token",
 			"error", err,
 		)
+		if tokenCaching {
+			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: "invalid token format", expiresAt: time.Now().Add(negativeCacheTtl)})
+		}
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, "invalid token format")
 	}
 
@@ -1441,10 +1653,45 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		slog.Debug("JWT Auth Policy: Token validation failed",
 			"error", err,
 		)
+		if tokenCaching && errors.Is(err, errTokenExpired) {
+			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: "token expired", expiresAt: time.Now().Add(negativeCacheTtl)})
+		}
 		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("token validation failed: %v", err))
 	}
 
 	slog.Debug("JWT Auth Policy: Token signature validated successfully")
+
+	if tokenCaching {
+		// expiresAt is capped at the sooner of "now + tokenCacheTtl" and the token's own
+		// exp (minus leeway), so a live cache entry is always still within the token's
+		// validity window — a hit therefore needs no crypto or exp/nbf re-check.
+		expiresAt := time.Now().Add(tokenCacheTtl)
+		if expFloat, ok := claims["exp"].(float64); ok {
+			tokenExpiry := time.Unix(int64(expFloat), 0).Add(-leeway)
+			if tokenExpiry.Before(expiresAt) {
+				expiresAt = tokenExpiry
+			}
+		}
+		if expiresAt.After(time.Now()) {
+			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: true, claims: claims, expiresAt: expiresAt})
+		}
+	}
+
+	return p.finishAuthentication(reqCtx, claims, onFailureStatusCode, errorMessageFormat, errorMessage,
+		userAudiences, userRequiredScopes, userRequiredClaims, userClaimMappings, userIdClaim,
+		headerName, authHeader, token, forwardToken, forwardedTokenHeader, forwardTokenStripScheme)
+}
+
+// finishAuthentication runs the checks that must always be re-evaluated even on a verdict-cache
+// hit — audience, required scopes, required claims — since they depend on per-request config
+// deliberately kept out of the cache key, and then builds the upstream header modifications on
+// success. Shared by both the cache-hit and cache-miss paths in OnRequestHeaders so the two
+// converge on identical downstream behavior.
+func (p *JwtAuthPolicy) finishAuthentication(reqCtx *policy.RequestHeaderContext, claims jwt.MapClaims,
+	onFailureStatusCode int, errorMessageFormat, errorMessage string,
+	userAudiences, userRequiredScopes []string, userRequiredClaims, userClaimMappings map[string]string,
+	userIdClaim, headerName, authHeader, token string,
+	forwardToken bool, forwardedTokenHeader string, forwardTokenStripScheme bool) policy.RequestHeaderAction {
 
 	if len(userAudiences) > 0 {
 		aud := parseAudience(claims["aud"])

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1653,10 +1653,11 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		slog.Debug("JWT Auth Policy: Token validation failed",
 			"error", err,
 		)
+		failureReason := fmt.Sprintf("token validation failed: %v", err)
 		if tokenCaching && errors.Is(err, errTokenExpired) {
-			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: "token expired", expiresAt: time.Now().Add(negativeCacheTtl)})
+			p.putVerdict(ctx, cacheKey, cachedVerdict{ok: false, reason: failureReason, expiresAt: time.Now().Add(negativeCacheTtl)})
 		}
-		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, fmt.Sprintf("token validation failed: %v", err))
+		return p.handleAuthFailureHeaders(reqCtx.SharedContext, onFailureStatusCode, errorMessageFormat, errorMessage, failureReason)
 	}
 
 	slog.Debug("JWT Auth Policy: Token signature validated successfully")

--- a/policies/jwt-auth/jwtauth_hardening_test.go
+++ b/policies/jwt-auth/jwtauth_hardening_test.go
@@ -489,6 +489,10 @@ func TestJWTAuthPolicy_Edge_JWKSCacheExpiry_Refetches(t *testing.T) {
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
 	params["jwksCacheTtl"] = "15ms"
+	// Disable the token verdict cache so the second identical request re-verifies the
+	// signature (and therefore re-fetches JWKS) instead of being served from cache — this
+	// test is specifically exercising JWKS-level cache expiry, not token-verdict caching.
+	params["tokenCaching"] = false
 
 	token := createTestToken(t, privateKey, map[string]interface{}{
 		"sub": "user-123",
@@ -908,12 +912,14 @@ func resetJWTAuthSingletonCache(t *testing.T) {
 	ins.cacheStore = make(map[string]*CachedJWKS)
 	ins.cacheTTLs = make(map[string]time.Time)
 	ins.cacheMutex.Unlock()
+	_ = ins.currentTokenCache().Clear(context.Background())
 
 	t.Cleanup(func() {
 		ins.cacheMutex.Lock()
 		ins.cacheStore = make(map[string]*CachedJWKS)
 		ins.cacheTTLs = make(map[string]time.Time)
 		ins.cacheMutex.Unlock()
+		_ = ins.currentTokenCache().Clear(context.Background())
 	})
 }
 

--- a/policies/jwt-auth/jwtauth_tokencache_test.go
+++ b/policies/jwt-auth/jwtauth_tokencache_test.go
@@ -1,0 +1,475 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package jwtauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// createMockRequestHeaderContextWithAPI is like createMockRequestHeaderContext but sets an API
+// identity, needed to prove the verdict cache is isolated per API.
+func createMockRequestHeaderContextWithAPI(headers map[string][]string, apiId, apiName string) *policy.RequestHeaderContext {
+	return &policy.RequestHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "test-request-id",
+			Metadata:  make(map[string]interface{}),
+			APIId:     apiId,
+			APIName:   apiName,
+		},
+		Headers: policy.NewHeaders(headers),
+		Path:    "/api/test",
+		Method:  "GET",
+	}
+}
+
+// expectedCacheKey reconstructs the cache key OnRequestHeaders would compute for the default
+// mock request context (empty APIId/APIName), so tests can inspect the cache directly.
+func expectedCacheKey(params map[string]interface{}, token string, validateIssuer bool, issuers []string, leeway time.Duration) string {
+	fingerprint := tokenConfigFingerprint("", "", params["keyManagers"], validateIssuer, issuers, leeway)
+	return buildTokenCacheKey(fingerprint, token)
+}
+
+// clearJWKSFetchCache wipes the unrelated, pre-existing JWKS-fetch cache (cacheStore/cacheTTLs)
+// without touching the token verdict cache. Tests that prove the verdict cache is what's being
+// exercised must clear this too — otherwise a token-verdict-cache miss can still "succeed"
+// because the JWKS keys for that URI are separately warm from an earlier request.
+func clearJWKSFetchCache() {
+	ins.cacheMutex.Lock()
+	defer ins.cacheMutex.Unlock()
+	ins.cacheStore = make(map[string]*CachedJWKS)
+	ins.cacheTTLs = make(map[string]time.Time)
+}
+
+func TestTokenCache_PositiveHit_SkipsVerification(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	var fetchCount int32
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jwks.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(&fetchCount, 1)
+		writeJWKSResponse(t, w, publicKey, "test-kid")
+	}))
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-cache-1",
+		"iss": "https://issuer.example.com",
+	})
+
+	p := mustGetPolicy(t, params)
+
+	ctx1 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action1 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx1, params)
+	assertAuthSuccess(t, ctx1, action1)
+	if got := atomic.LoadInt32(&fetchCount); got != 1 {
+		t.Fatalf("expected exactly 1 JWKS fetch after the first request, got %d", got)
+	}
+
+	// Clear the unrelated JWKS-fetch cache and take down the endpoint, so that anything which
+	// falls through to full re-verification is forced to hit the (now-dead) network.
+	clearJWKSFetchCache()
+	jwksServer.Close()
+
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx2, params)
+	assertAuthSuccess(t, ctx2, action2)
+
+	// A different API identity must miss the verdict cache and attempt full re-verification,
+	// which now fails because the JWKS endpoint is down and its fetch cache was cleared.
+	ctx3 := createMockRequestHeaderContextWithAPI(authHeader("Authorization", "Bearer", token), "api-2", "OtherAPI")
+	action3 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx3, params)
+	assertAuthFailure(t, ctx3, action3, 401)
+}
+
+func TestTokenCache_NegativeHit_Expired(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	expiredToken := createTestTokenWithExpiry(t, privateKey, map[string]interface{}{
+		"sub": "user-expired",
+		"iss": "https://issuer.example.com",
+	}, time.Now().Add(-time.Hour))
+
+	p := mustGetPolicy(t, params)
+
+	ctx1 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", expiredToken))
+	action1 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx1, params)
+	assertAuthFailure(t, ctx1, action1, 401)
+
+	key := expectedCacheKey(params, expiredToken, true, []string{}, 30*time.Second)
+	verdict, hit := ins.getCachedVerdict(context.Background(), key)
+	if !hit {
+		t.Fatalf("expected a cached verdict for the expired token")
+	}
+	if verdict.ok {
+		t.Fatalf("expected a negative verdict, got a positive one")
+	}
+	if verdict.reason != "token expired" {
+		t.Fatalf("expected reason %q, got %q", "token expired", verdict.reason)
+	}
+
+	// Second identical request must be served from the negative cache.
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", expiredToken))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx2, params)
+	assertAuthFailure(t, ctx2, action2, 401)
+}
+
+func TestTokenCache_NegativeHit_Malformed(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	_, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	malformedToken := "not-a-jwt-token"
+
+	p := mustGetPolicy(t, params)
+
+	ctx1 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", malformedToken))
+	action1 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx1, params)
+	assertAuthFailure(t, ctx1, action1, 401)
+
+	key := expectedCacheKey(params, malformedToken, true, []string{}, 30*time.Second)
+	verdict, hit := ins.getCachedVerdict(context.Background(), key)
+	if !hit || verdict.ok || verdict.reason != "invalid token format" {
+		t.Fatalf("expected cached negative verdict with reason %q, got hit=%v verdict=%+v", "invalid token format", hit, verdict)
+	}
+
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", malformedToken))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx2, params)
+	assertAuthFailure(t, ctx2, action2, 401)
+}
+
+func TestTokenCache_SignatureMismatch_NotCached(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	_, publicKey := generateTestKeys(t)
+	wrongPrivateKey, _ := generateTestKeys(t)
+
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	token := createTestToken(t, wrongPrivateKey, map[string]interface{}{
+		"sub": "user-bad-sig",
+		"iss": "https://issuer.example.com",
+	})
+
+	p := mustGetPolicy(t, params)
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthFailure(t, ctx, action, 401)
+
+	key := expectedCacheKey(params, token, true, []string{}, 30*time.Second)
+	if _, hit := ins.getCachedVerdict(context.Background(), key); hit {
+		t.Fatalf("signature-mismatch failures must not be negatively cached")
+	}
+}
+
+func TestTokenCache_JWKSFetchFailure_NotCached(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, _ := generateTestKeys(t)
+
+	params := newRemoteParams("http://127.0.0.1:1/jwks.json") // reserved port, connection refused
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-fetch-fail",
+		"iss": "https://issuer.example.com",
+	})
+
+	p := mustGetPolicy(t, params)
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthFailure(t, ctx, action, 401)
+
+	key := expectedCacheKey(params, token, true, []string{}, 30*time.Second)
+	if _, hit := ins.getCachedVerdict(context.Background(), key); hit {
+		t.Fatalf("JWKS fetch failures must not be negatively cached")
+	}
+}
+
+func TestTokenCache_NotYetValid_NotCached(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-nbf",
+		"iss": "https://issuer.example.com",
+		"nbf": time.Now().Add(time.Hour).Unix(),
+	})
+
+	p := mustGetPolicy(t, params)
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthFailure(t, ctx, action, 401)
+
+	key := expectedCacheKey(params, token, true, []string{}, 30*time.Second)
+	if _, hit := ins.getCachedVerdict(context.Background(), key); hit {
+		t.Fatalf("not-yet-valid (nbf) failures must not be negatively cached")
+	}
+}
+
+func TestTokenCache_Disabled_NoCacheEntries(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["tokenCaching"] = false
+
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-disabled",
+		"iss": "https://issuer.example.com",
+	})
+
+	p := mustGetPolicy(t, params)
+	for i := 0; i < 2; i++ {
+		ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+		action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+		assertAuthSuccess(t, ctx, action)
+	}
+
+	if got := ins.currentTokenCache().GetStats().Size; got != 0 {
+		t.Fatalf("expected no cache entries when tokenCaching=false, got %d", got)
+	}
+}
+
+func TestTokenCache_PositiveTTL_CappedByTokenCacheTtl(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["tokenCacheTtl"] = "50ms"
+
+	// Token exp is far in the future, so the cap must come from tokenCacheTtl, not the token.
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-ttl-cap",
+		"iss": "https://issuer.example.com",
+	})
+
+	p := mustGetPolicy(t, params)
+
+	before := time.Now()
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthSuccess(t, ctx, action)
+
+	key := expectedCacheKey(params, token, true, []string{}, 30*time.Second)
+	verdict, hit := ins.getCachedVerdict(context.Background(), key)
+	if !hit || !verdict.ok {
+		t.Fatalf("expected a cached positive verdict")
+	}
+	if verdict.expiresAt.After(before.Add(200 * time.Millisecond)) {
+		t.Fatalf("expected cache expiry capped near tokenCacheTtl (50ms), got expiresAt=%v (now=%v)", verdict.expiresAt, before)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	// Clear the unrelated JWKS-fetch cache and take down the endpoint: if the verdict-cache
+	// entry had survived, the second call would still succeed regardless of these two lines.
+	clearJWKSFetchCache()
+	jwksServer.Close()
+
+	ctx2 := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action2 := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx2, params)
+	assertAuthFailure(t, ctx2, action2, 401)
+}
+
+func TestTokenCache_PositiveTTL_NeverExceedsTokenExpiry(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	// tokenCacheTtl stays at its 5m default; the token itself expires in 3s, so the cache
+	// entry's expiry must be bounded by the token's exp, not the far larger 5m cap.
+	params["leeway"] = "0s"
+	token := createTestToken(t, privateKey, map[string]interface{}{
+		"sub": "user-short-exp",
+		"iss": "https://issuer.example.com",
+		"exp": time.Now().Add(3 * time.Second).Unix(),
+	})
+
+	p := mustGetPolicy(t, params)
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthSuccess(t, ctx, action)
+
+	key := expectedCacheKey(params, token, true, []string{}, 0)
+	verdict, hit := ins.getCachedVerdict(context.Background(), key)
+	if !hit || !verdict.ok {
+		t.Fatalf("expected a cached positive verdict")
+	}
+	if verdict.expiresAt.After(time.Now().Add(4 * time.Second)) {
+		t.Fatalf("expected cache expiry bounded by the token's short exp, not the 5m tokenCacheTtl default; got %v", verdict.expiresAt)
+	}
+}
+
+func TestTokenCache_NegativeTTL_ExpiresAfterWindow(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["negativeCacheTtl"] = "30ms"
+
+	expiredToken := createTestTokenWithExpiry(t, privateKey, map[string]interface{}{
+		"sub": "user-neg-ttl",
+		"iss": "https://issuer.example.com",
+	}, time.Now().Add(-time.Hour))
+
+	p := mustGetPolicy(t, params)
+	ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", expiredToken))
+	action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+	assertAuthFailure(t, ctx, action, 401)
+
+	key := expectedCacheKey(params, expiredToken, true, []string{}, 30*time.Second)
+	if _, hit := ins.getCachedVerdict(context.Background(), key); !hit {
+		t.Fatalf("expected a negative cache entry immediately after the failed request")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, hit := ins.getCachedVerdict(context.Background(), key); hit {
+		t.Fatalf("expected the negative cache entry to have expired after negativeCacheTtl")
+	}
+}
+
+func TestTokenConfigFingerprint_ChangesInvalidateCache(t *testing.T) {
+	km := []interface{}{
+		map[string]interface{}{
+			"name":   "km-primary",
+			"issuer": "https://issuer.example.com",
+			"jwks": map[string]interface{}{
+				"remote": map[string]interface{}{"uri": "https://idp.example/jwks.json"},
+			},
+		},
+	}
+	base := tokenConfigFingerprint("api-1", "PetStore", km, true, []string{"km-primary"}, 30*time.Second)
+
+	cases := []struct {
+		name string
+		fp   string
+	}{
+		{"different apiId", tokenConfigFingerprint("api-2", "PetStore", km, true, []string{"km-primary"}, 30*time.Second)},
+		{"different apiName", tokenConfigFingerprint("api-1", "Other", km, true, []string{"km-primary"}, 30*time.Second)},
+		{"different validateIssuer", tokenConfigFingerprint("api-1", "PetStore", km, false, []string{"km-primary"}, 30*time.Second)},
+		{"different issuers", tokenConfigFingerprint("api-1", "PetStore", km, true, []string{"other"}, 30*time.Second)},
+		{"different leeway", tokenConfigFingerprint("api-1", "PetStore", km, true, []string{"km-primary"}, time.Minute)},
+	}
+	for _, tc := range cases {
+		if tc.fp == base {
+			t.Errorf("%s: expected a different fingerprint, got the same value", tc.name)
+		}
+	}
+
+	kmChanged := []interface{}{
+		map[string]interface{}{
+			"name":   "km-primary",
+			"issuer": "https://issuer.example.com",
+			"jwks": map[string]interface{}{
+				"remote": map[string]interface{}{"uri": "https://idp.example/OTHER.json"},
+			},
+		},
+	}
+	if fp := tokenConfigFingerprint("api-1", "PetStore", kmChanged, true, []string{"km-primary"}, 30*time.Second); fp == base {
+		t.Errorf("different key manager config: expected a different fingerprint, got the same value")
+	}
+
+	if again := tokenConfigFingerprint("api-1", "PetStore", km, true, []string{"km-primary"}, 30*time.Second); again != base {
+		t.Errorf("expected tokenConfigFingerprint to be deterministic for identical inputs")
+	}
+}
+
+func TestGetPolicy_TokenCacheMaxSizeApplied(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+	t.Cleanup(func() {
+		ins.ensureTokenCache(defaultTokenCacheMaxSize)
+	})
+
+	params := newRemoteParams("http://127.0.0.1:1/jwks.json")
+	params["cacheMaxSize"] = 5
+
+	mustGetPolicy(t, params)
+
+	if got := ins.currentTokenCache().GetStats().MaxSize; got != 5 {
+		t.Fatalf("expected token cache MaxSize=5, got %d", got)
+	}
+}
+
+func TestCacheMaxSize_GloballyBounded_TokenCache(t *testing.T) {
+	resetJWTAuthSingletonCache(t)
+	t.Cleanup(func() {
+		ins.ensureTokenCache(defaultTokenCacheMaxSize)
+	})
+
+	privateKey, publicKey := generateTestKeys(t)
+	jwksServer := createJWKSServer(t, publicKey, "test-kid")
+	defer jwksServer.Close()
+
+	params := newRemoteParams(jwksServer.URL + "/jwks.json")
+	params["cacheMaxSize"] = 2
+
+	p := mustGetPolicy(t, params)
+
+	for i := 0; i < 5; i++ {
+		token := createTestToken(t, privateKey, map[string]interface{}{
+			"sub": fmt.Sprintf("user-bound-%d", i),
+			"iss": "https://issuer.example.com",
+		})
+		ctx := createMockRequestHeaderContext(authHeader("Authorization", "Bearer", token))
+		action := p.(*JwtAuthPolicy).OnRequestHeaders(context.Background(), ctx, params)
+		assertAuthSuccess(t, ctx, action)
+	}
+
+	stats := ins.currentTokenCache().GetStats()
+	if stats.Size > 2 {
+		t.Fatalf("expected cache size bounded at 2, got %d", stats.Size)
+	}
+	if stats.EvictCount == 0 {
+		t.Fatalf("expected at least one eviction once 5 distinct tokens exceeded the size-2 bound")
+	}
+}

--- a/policies/jwt-auth/jwtauth_tokencache_test.go
+++ b/policies/jwt-auth/jwtauth_tokencache_test.go
@@ -135,8 +135,9 @@ func TestTokenCache_NegativeHit_Expired(t *testing.T) {
 	if verdict.ok {
 		t.Fatalf("expected a negative verdict, got a positive one")
 	}
-	if verdict.reason != "token expired" {
-		t.Fatalf("expected reason %q, got %q", "token expired", verdict.reason)
+	const wantReason = "token validation failed: token expired"
+	if verdict.reason != wantReason {
+		t.Fatalf("expected reason %q, got %q", wantReason, verdict.reason)
 	}
 
 	// Second identical request must be served from the negative cache.
@@ -279,7 +280,7 @@ func TestTokenCache_PositiveTTL_CappedByTokenCacheTtl(t *testing.T) {
 	jwksServer := createJWKSServer(t, publicKey, "test-kid")
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	params["tokenCacheTtl"] = "50ms"
+	params["tokenCacheTtl"] = "300ms"
 
 	// Token exp is far in the future, so the cap must come from tokenCacheTtl, not the token.
 	token := createTestToken(t, privateKey, map[string]interface{}{
@@ -299,11 +300,11 @@ func TestTokenCache_PositiveTTL_CappedByTokenCacheTtl(t *testing.T) {
 	if !hit || !verdict.ok {
 		t.Fatalf("expected a cached positive verdict")
 	}
-	if verdict.expiresAt.After(before.Add(200 * time.Millisecond)) {
-		t.Fatalf("expected cache expiry capped near tokenCacheTtl (50ms), got expiresAt=%v (now=%v)", verdict.expiresAt, before)
+	if verdict.expiresAt.After(before.Add(1 * time.Second)) {
+		t.Fatalf("expected cache expiry capped near tokenCacheTtl (300ms), got expiresAt=%v (now=%v)", verdict.expiresAt, before)
 	}
 
-	time.Sleep(80 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	// Clear the unrelated JWKS-fetch cache and take down the endpoint: if the verdict-cache
 	// entry had survived, the second call would still succeed regardless of these two lines.
 	clearJWKSFetchCache()
@@ -354,7 +355,7 @@ func TestTokenCache_NegativeTTL_ExpiresAfterWindow(t *testing.T) {
 	defer jwksServer.Close()
 
 	params := newRemoteParams(jwksServer.URL + "/jwks.json")
-	params["negativeCacheTtl"] = "30ms"
+	params["negativeCacheTtl"] = "300ms"
 
 	expiredToken := createTestTokenWithExpiry(t, privateKey, map[string]interface{}{
 		"sub": "user-neg-ttl",
@@ -371,7 +372,7 @@ func TestTokenCache_NegativeTTL_ExpiresAfterWindow(t *testing.T) {
 		t.Fatalf("expected a negative cache entry immediately after the failed request")
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	if _, hit := ins.getCachedVerdict(context.Background(), key); hit {
 		t.Fatalf("expected the negative cache entry to have expired after negativeCacheTtl")

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.2.0
+version: v1.2.1
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.
@@ -181,6 +181,51 @@ systemParameters:
       description: Duration string for JWKS caching (e.g., "5m"). If omitted a default is used.
       default: "5m"
       "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.jwkscachettl}"
+
+    tokenCaching:
+      type: boolean
+      description: >-
+        Whether to cache token verification verdicts. When true (default), a signature-verified
+        token skips re-verification (unverified parsing, key manager/certificate parsing, and
+        signature checking) on repeat presentation, and a deterministically invalid token
+        (expired or malformed) is also cached so repeated bad tokens are rejected without
+        re-verification. Caching a successful verdict means a revoked token may still be
+        accepted for up to tokenCacheTtl after it was last verified; set to false to force full
+        verification on every request.
+      default: true
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.tokencaching}"
+
+    tokenCacheTtl:
+      type: string
+      description: >-
+        Maximum duration a successfully verified token is trusted from cache (e.g., "5m"). The
+        actual cache expiry is the sooner of this value and the token's own exp claim (minus
+        leeway), so this bounds how long a revoked token may still be accepted after its last
+        verification.
+      default: "5m"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.tokencachettl}"
+
+    negativeCacheTtl:
+      type: string
+      description: >-
+        Duration a deterministically invalid verification verdict (expired or malformed token
+        only) is cached before re-verification is attempted again (e.g., "30s"). Kept short
+        since this is purely a DoS/retry-absorption optimization; transient failures (e.g. JWKS
+        fetch errors) and not-yet-valid (nbf) tokens are never cached, since they may resolve on
+        a later attempt.
+      default: "30s"
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.negativecachettl}"
+
+    cacheMaxSize:
+      type: integer
+      description: >-
+        Maximum total number of cached verification verdicts (successful and failed, combined)
+        to hold across all APIs (a single global bound, not per-API). When the limit is reached,
+        the cache evicts the least-recently-used existing entries to make room. Changing this
+        value rebuilds the shared cache, which flushes all currently cached verdicts.
+      default: 100000
+      minimum: 1
+      "wso2/defaultValue": "${config.policy_configurations.jwtauth_v1.cachemaxsize}"
 
     jwksFetchTimeout:
       type: string


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2605

This pull request introduces version 1.2 of the `jwt-auth` policy, adding comprehensive documentation, metadata, and enhanced token verification caching to improve performance and flexibility. It also updates the SDK core dependency and refines the policy listing to reference the new version.

**Documentation and Metadata**

* Added a complete, user-focused documentation file for `jwt-auth` v1.2, covering features, configuration, and usage examples, including new options for token verification caching and JWT forwarding controls.
* Added a `metadata.json` file describing the `jwt-auth` v1.2 policy for cataloging and discovery.
* Updated the main policy listing in `docs/README.md` to reference the new v1.2 documentation and clarify the policy description.

**Token Verification Caching and Performance Improvements**

* Introduced a shared, bounded in-memory cache for JWT verification results (`cachedVerdict`), with configurable size and TTL, negative caching for expired/malformed tokens, and concurrency-safe cache management. This reduces repeated signature verifications and mitigates DoS from repeated bad tokens. [[1]](diffhunk://#diff-fdee622e269ef28ee19d8a1204de3cab11f0ae18629dabe8dec4ccad778dceebR21-R74) [[2]](diffhunk://#diff-fdee622e269ef28ee19d8a1204de3cab11f0ae18629dabe8dec4ccad778dceebR113-R140)

**Dependency Update**

* Updated the SDK core dependency to version `v0.2.16` for compatibility and feature support.