### PR TITLE
[Transformer] add Bedrock transformer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ All available policies, sorted alphabetically.
 | [Model Weighted Round Robin](./model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
 | [NeMo Guard Content Safety](./nvidia-nemoguard-content-safety/v0.9/docs/nvidia-nemoguard-content-safety.md) | Guardrails, AI | Validates request and/or response content using NVIDIA NeMo Guard (llama-3.1-nemoguard-8b-content-safety). |
 | [Opaque Token Auth](./opaque-token-auth/v1.0/docs/opaque-token-authentication.md) | Security, AI | Validates opaque OAuth 2.0 access tokens via RFC 7662 token introspection. |
+| [OpenAI to Bedrock Transformer](./openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md) | AI | Translates OpenAI Chat Completions requests into AWS Bedrock Converse format and rewrites non-streaming and streaming Bedrock responses back into OpenAI-compatible JSON or Server-Sent Events. |
 | [PII Masking Regex](./pii-masking-regex/v1.0/docs/pii-masking-regex.md) | Guardrails, AI | Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns. |
 | [Prompt Compressor](./prompt-compressor/v0.9/docs/prompt-compressor.md) | AI | Compresses selected prompt text in JSON request bodies before upstream LLM calls. |
 | [Prompt Decorator](./prompt-decorator/v1.0/docs/prompt-decorator.md) | AI | Dynamically modifies the prompt by applying custom decorations using a configured strategy. |

--- a/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
+++ b/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
@@ -9,8 +9,8 @@ The OpenAI to Bedrock Transformer policy lets OpenAI Chat Completions clients us
 
 The policy supports two modes:
 
-- **Single-provider mode** — attach the transformer directly to a proxy. When no provider is selected in request metadata, it always runs.
-- **Multi-provider mode** — attach the transformer to an additional Bedrock provider. It runs only when `SharedContext.Metadata["selected_provider"]` matches its provider `id`.
+- **Single-provider mode** — attach the transformer directly to a proxy that uses Bedrock as its upstream provider.
+- **Multi-provider mode** — attach the transformer to a Bedrock provider in a proxy with multiple providers. The transformer applies to requests routed to that provider.
 
 ## Features
 
@@ -26,7 +26,7 @@ The policy supports two modes:
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `model` | Yes | — | Bedrock model or inference-profile ID placed in the Converse request path. |
-| `id` | No | — | Target provider ID. It is also used as the upstream name and matched against the selected provider in multi-provider mode. |
+| `id` | No | — | Bedrock provider ID used in multi-provider configurations. |
 | `maxTokens` | No | `4096` | Fallback `inferenceConfig.maxTokens` when the OpenAI request omits both `max_completion_tokens` and `max_tokens`. |
 
 ## Example

--- a/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
+++ b/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
@@ -25,7 +25,7 @@ The policy supports two modes:
 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
-| `model` | Yes | — | Bedrock model or inference-profile ID placed in the Converse request path. |
+| `model` | No | Request `model` | Optional Bedrock model or inference-profile ID override placed in the Converse request path. |
 | `provider-id` | No | — | Bedrock provider ID used in multi-provider configurations. |
 | `maxTokens` | No | `4096` | Fallback `inferenceConfig.maxTokens` when the OpenAI request omits both `max_completion_tokens` and `max_tokens`. |
 
@@ -64,5 +64,6 @@ policies:
 ## Notes
 
 - The policy translates payloads and paths only. Configure Bedrock authentication on the upstream provider.
+- When `model` is omitted from the policy configuration, the OpenAI request's `model` field must contain a valid Bedrock model or inference-profile ID.
 - Remote image URLs are not fetched; use base64 data URIs for image input.
 - Streaming translation expects Bedrock's `application/vnd.amazon.eventstream` framing.

--- a/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
+++ b/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
@@ -26,12 +26,11 @@ The policy supports two modes:
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `model` | No | Request `model` | Optional Bedrock model or inference-profile ID override placed in the Converse request path. |
-| `provider-id` | No | — | Bedrock provider ID used in multi-provider configurations. |
-| `maxTokens` | No | `4096` | Fallback `inferenceConfig.maxTokens` when the OpenAI request omits both `max_completion_tokens` and `max_tokens`. |
+| `providerId` | No | — | Bedrock provider ID used in multi-provider configurations. |
 
 ## Example
 
-For a multi-provider LLM proxy, attach the transformer to the Bedrock provider. The provider `id` (or its `as` alias) is supplied by the gateway as `provider-id`, so it is not repeated in `params`:
+For a multi-provider LLM proxy, attach the transformer to the Bedrock provider. The provider `id` (or its `as` alias) is supplied by the gateway as `providerId`, so it is not repeated in `params`:
 
 ```yaml
 additionalProviders:
@@ -45,7 +44,6 @@ additionalProviders:
       version: v1
       params:
         model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
-        maxTokens: 4096
 ```
 
 For a single-provider proxy, attach the policy directly:

--- a/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
+++ b/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
@@ -26,12 +26,12 @@ The policy supports two modes:
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `model` | Yes | — | Bedrock model or inference-profile ID placed in the Converse request path. |
-| `id` | No | — | Bedrock provider ID used in multi-provider configurations. |
+| `provider-id` | No | — | Bedrock provider ID used in multi-provider configurations. |
 | `maxTokens` | No | `4096` | Fallback `inferenceConfig.maxTokens` when the OpenAI request omits both `max_completion_tokens` and `max_tokens`. |
 
 ## Example
 
-For a multi-provider LLM proxy, attach the transformer to the Bedrock provider. The provider `id` is supplied by the gateway, so it is not repeated in `params`:
+For a multi-provider LLM proxy, attach the transformer to the Bedrock provider. The provider `id` (or its `as` alias) is supplied by the gateway as `provider-id`, so it is not repeated in `params`:
 
 ```yaml
 additionalProviders:

--- a/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
+++ b/docs/openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md
@@ -1,0 +1,68 @@
+---
+title: "Overview"
+---
+# OpenAI to Bedrock Transformer
+
+## Overview
+
+The OpenAI to Bedrock Transformer policy lets OpenAI Chat Completions clients use the AWS Bedrock Converse API without changing their request or response handling. It rewrites requests to Bedrock's `/model/{modelId}/converse` or `/model/{modelId}/converse-stream` endpoint and translates Bedrock responses back to the OpenAI format.
+
+The policy supports two modes:
+
+- **Single-provider mode** — attach the transformer directly to a proxy. When no provider is selected in request metadata, it always runs.
+- **Multi-provider mode** — attach the transformer to an additional Bedrock provider. It runs only when `SharedContext.Metadata["selected_provider"]` matches its provider `id`.
+
+## Features
+
+- Converts OpenAI messages, system/developer prompts, inference settings, stop sequences, and tools to Bedrock Converse format.
+- Maps OpenAI assistant tool calls and tool results to Bedrock `toolUse` and `toolResult` content blocks.
+- Supports base64 data-URI images in OpenAI `image_url` blocks.
+- Rewrites non-streaming Converse responses, usage, tool calls, finish reasons, and errors to OpenAI ChatCompletion JSON.
+- Decodes Bedrock's binary Amazon event-stream responses and emits OpenAI-compatible Server-Sent Events, including usage and the final `[DONE]` marker.
+- Supports Bedrock model IDs and inference-profile IDs in the upstream path.
+
+## Parameters
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `model` | Yes | — | Bedrock model or inference-profile ID placed in the Converse request path. |
+| `id` | No | — | Target provider ID. It is also used as the upstream name and matched against the selected provider in multi-provider mode. |
+| `maxTokens` | No | `4096` | Fallback `inferenceConfig.maxTokens` when the OpenAI request omits both `max_completion_tokens` and `max_tokens`. |
+
+## Example
+
+For a multi-provider LLM proxy, attach the transformer to the Bedrock provider. The provider `id` is supplied by the gateway, so it is not repeated in `params`:
+
+```yaml
+additionalProviders:
+  - id: bedrock-provider
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer REPLACE_WITH_BEDROCK_API_KEY
+    transformer:
+      type: openai-to-bedrock-transformer
+      version: v1
+      params:
+        model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+        maxTokens: 4096
+```
+
+For a single-provider proxy, attach the policy directly:
+
+```yaml
+policies:
+  - name: openai-to-bedrock-transformer
+    version: v1
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          model: us.amazon.nova-lite-v1:0
+```
+
+## Notes
+
+- The policy translates payloads and paths only. Configure Bedrock authentication on the upstream provider.
+- Remote image URLs are not fetched; use base64 data URIs for image input.
+- Streaming translation expects Bedrock's `application/vnd.amazon.eventstream` framing.

--- a/docs/openai-to-bedrock-transformer/v0.9/metadata.json
+++ b/docs/openai-to-bedrock-transformer/v0.9/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "openai-to-bedrock-transformer",
+  "displayName": "OpenAI to Bedrock Transformer",
+  "version": "0.9",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Translates OpenAI Chat Completions requests into AWS Bedrock Converse format and rewrites non-streaming and streaming Bedrock responses back into OpenAI-compatible JSON or Server-Sent Events."
+}

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -153,6 +153,46 @@ func encodeStringHeader(name, value string) []byte {
 	return out
 }
 
+func encodeTypedHeader(name string, valueType byte, encodedValue []byte) []byte {
+	out := []byte{byte(len(name))}
+	out = append(out, name...)
+	out = append(out, valueType)
+	out = append(out, encodedValue...)
+	return out
+}
+
+func TestParseHeaders_SkipsNonStringHeaders(t *testing.T) {
+	byteArrayValue := binary.BigEndian.AppendUint16(nil, 2)
+	byteArrayValue = append(byteArrayValue, 0xaa, 0xbb)
+
+	tests := []struct {
+		name         string
+		valueType    byte
+		encodedValue []byte
+	}{
+		{"true", headerTypeTrue, nil},
+		{"false", headerTypeFalse, nil},
+		{"byte", headerTypeByte, make([]byte, 1)},
+		{"short", headerTypeShort, make([]byte, 2)},
+		{"integer", headerTypeInteger, make([]byte, 4)},
+		{"long", headerTypeLong, make([]byte, 8)},
+		{"byte array", headerTypeByteArray, byteArrayValue},
+		{"timestamp", headerTypeTimestamp, make([]byte, 8)},
+		{"UUID", headerTypeUUID, make([]byte, 16)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headerBytes := encodeTypedHeader("ignored", tt.valueType, tt.encodedValue)
+			headerBytes = append(headerBytes, encodeStringHeader(":event-type", "messageStart")...)
+
+			if got := parseHeaders(headerBytes)[":event-type"]; got != "messageStart" {
+				t.Fatalf("event type after %s header = %q, want messageStart", tt.name, got)
+			}
+		})
+	}
+}
+
 func bedrockStream() []byte {
 	var stream []byte
 	stream = append(stream, encodeFrame("messageStart", `{"role":"assistant"}`)...)
@@ -181,6 +221,19 @@ func TestEventStreamToSSE_TextStream(t *testing.T) {
 	// Every non-terminal event must be framed as an SSE data line.
 	if !strings.HasPrefix(out, "data: ") {
 		t.Errorf("SSE output must start with a data line, got:\n%s", out)
+	}
+}
+
+func TestEventStreamToSSE_PreservesNonEventStreamData(t *testing.T) {
+	data := []byte(`{"message":"upstream error"}`)
+
+	if got := eventStreamToSSE(data, false, "id", "claude"); string(got) != string(data) {
+		t.Fatalf("non-event-stream data = %q, want %q", got, data)
+	}
+
+	wantAtEnd := append(append([]byte{}, data...), sseDonePayload...)
+	if got := eventStreamToSSE(data, true, "id", "claude"); string(got) != string(wantAtEnd) {
+		t.Fatalf("final non-event-stream data = %q, want %q", got, wantAtEnd)
 	}
 }
 

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package openaitobedrock
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+func TestGetPolicy_ValidatesParams(t *testing.T) {
+	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{}); err == nil {
+		t.Fatal("expected an error when model is missing")
+	}
+	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		"model":     "us.amazon.nova-lite-v1:0",
+		"id":        "bedrock-provider",
+		"maxTokens": float64(2048),
+	}); err != nil {
+		t.Fatalf("unexpected error for valid params: %v", err)
+	}
+	for _, params := range []map[string]interface{}{
+		{"model": 42},
+		{"model": "nova", "id": true},
+		{"model": "nova", "maxTokens": 0},
+		{"model": "nova", "maxTokens": 1.5},
+	} {
+		if _, err := GetPolicy(policy.PolicyMetadata{}, params); err == nil {
+			t.Errorf("expected invalid params to fail: %#v", params)
+		}
+	}
+}
+
+func TestOnRequestBody_RewritesAndRoutes(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{
+		Model:     "us.amazon.nova-lite-v1:0",
+		Id:        "bedrock-provider",
+		MaxTokens: DefaultMaxTokens,
+	}}
+	req := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},
+		Body: &policy.Body{Present: true, Content: []byte(
+			`{"messages":[{"role":"user","content":"hello"}],"stream":true}`)},
+	}
+	action := p.OnRequestBody(context.Background(), req, nil)
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	if mods.Path == nil || *mods.Path != "/model/us.amazon.nova-lite-v1:0/converse-stream" {
+		t.Fatalf("unexpected path: %v", mods.Path)
+	}
+	if mods.UpstreamName == nil || *mods.UpstreamName != "bedrock-provider" {
+		t.Fatalf("unexpected upstream: %v", mods.UpstreamName)
+	}
+
+	req.SharedContext.Metadata[MetadataKeySelectedProvider] = "gemini-provider"
+	action = p.OnRequestBody(context.Background(), req, nil)
+	if skipped, ok := action.(policy.UpstreamRequestModifications); !ok || skipped.Body != nil {
+		t.Fatalf("non-matching provider should be skipped, got %#v", action)
+	}
+
+	req.SharedContext.Metadata[MetadataKeySelectedProvider] = "BEDROCK-PROVIDER"
+	if _, ok := p.OnRequestBody(context.Background(), req, nil).(policy.UpstreamRequestModifications); !ok {
+		t.Fatal("provider selection should be case-insensitive")
+	}
+}
+
+func TestOnRequestBody_RejectsBadBodies(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens}}
+	for _, body := range []*policy.Body{
+		nil,
+		{Present: true},
+		{Present: true, Content: []byte(`{"messages":`)},
+	} {
+		action := p.OnRequestBody(context.Background(), &policy.RequestContext{
+			SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},
+			Body:          body,
+		}, nil)
+		resp, ok := action.(policy.ImmediateResponse)
+		if !ok || resp.StatusCode != 400 {
+			t.Errorf("expected a 400 ImmediateResponse, got %#v", action)
+		}
+	}
+}
+
+func TestPolicyPhases_HandleNilSharedContext(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens}}
+
+	requestAction := p.OnRequestBody(context.Background(), &policy.RequestContext{
+		Body: &policy.Body{Present: true, Content: []byte(`{"messages":[]}`)},
+	}, nil)
+	if _, ok := requestAction.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("request phase with nil SharedContext returned %T", requestAction)
+	}
+
+	if _, ok := p.OnResponseHeaders(context.Background(), &policy.ResponseHeaderContext{}, nil).(policy.DownstreamResponseHeaderModifications); !ok {
+		t.Fatal("response-header phase must handle nil SharedContext")
+	}
+	if _, ok := p.OnResponseBody(context.Background(), &policy.ResponseContext{}, nil).(policy.DownstreamResponseModifications); !ok {
+		t.Fatal("response phase must handle nil SharedContext")
+	}
+	if _, ok := p.OnResponseBodyChunk(context.Background(), &policy.ResponseStreamContext{},
+		&policy.StreamBody{EndOfStream: true}, nil).(policy.ForwardResponseChunk); !ok {
+		t.Fatal("streaming response phase must handle nil SharedContext")
+	}
+}
+
+// encodeFrame builds a synthetic Amazon event-stream frame the way Bedrock does:
+// a :message-type=event and :event-type=<eventType> string header pair followed
+// by the JSON payload. CRCs are zeroed — the decoder does not validate them.
+func encodeFrame(eventType string, payload string) []byte {
+	headers := encodeStringHeader(":event-type", eventType)
+	headers = append(headers, encodeStringHeader(":message-type", "event")...)
+
+	totalLen := 16 + len(headers) + len(payload)
+	frame := make([]byte, 0, totalLen)
+	frame = binary.BigEndian.AppendUint32(frame, uint32(totalLen))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(len(headers)))
+	frame = binary.BigEndian.AppendUint32(frame, 0) // prelude CRC (ignored)
+	frame = append(frame, headers...)
+	frame = append(frame, payload...)
+	frame = binary.BigEndian.AppendUint32(frame, 0) // message CRC (ignored)
+	return frame
+}
+
+func encodeStringHeader(name, value string) []byte {
+	out := []byte{byte(len(name))}
+	out = append(out, name...)
+	out = append(out, headerTypeString)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+	out = append(out, value...)
+	return out
+}
+
+func bedrockStream() []byte {
+	var stream []byte
+	stream = append(stream, encodeFrame("messageStart", `{"role":"assistant"}`)...)
+	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":"Hello"}}`)...)
+	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":" world"}}`)...)
+	stream = append(stream, encodeFrame("messageStop", `{"stopReason":"end_turn"}`)...)
+	stream = append(stream, encodeFrame("metadata", `{"usage":{"inputTokens":10,"outputTokens":2,"totalTokens":12}}`)...)
+	return stream
+}
+
+func TestEventStreamToSSE_TextStream(t *testing.T) {
+	out := string(eventStreamToSSE(bedrockStream(), true, "chatcmpl-test", "claude"))
+
+	for _, want := range []string{
+		`"delta":{"role":"assistant"}`,
+		`"content":"Hello"`,
+		`"content":" world"`,
+		`"finish_reason":"stop"`,
+		`"total_tokens":12`,
+		"data: [DONE]\n\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SSE output missing %q\n---\n%s", want, out)
+		}
+	}
+	// Every non-terminal event must be framed as an SSE data line.
+	if !strings.HasPrefix(out, "data: ") {
+		t.Errorf("SSE output must start with a data line, got:\n%s", out)
+	}
+}
+
+// TestEventStreamToSSE_SplitFrames verifies that feeding the stream in
+// arbitrarily split pieces, using eventStreamBoundary to only decode whole
+// frames per flush (as the kernel does), reproduces the same SSE stream.
+func TestEventStreamToSSE_SplitFrames(t *testing.T) {
+	full := bedrockStream()
+	whole := string(eventStreamToSSE(full, true, "id", "claude"))
+
+	var assembled strings.Builder
+	var acc []byte
+	for i := 0; i < len(full); i++ {
+		acc = append(acc, full[i])
+		completeLen, hasPartial, ok := eventStreamBoundary(acc)
+		if !ok {
+			t.Fatalf("boundary check reported non-event-stream data at byte %d", i)
+		}
+		last := i == len(full)-1
+		// Flush only on a clean boundary (mirrors NeedsMoreResponseData==false)
+		// or at end of stream.
+		if (!hasPartial && completeLen == len(acc) && completeLen > 0) || last {
+			assembled.Write(eventStreamToSSE(acc, last, "id", "claude"))
+			acc = nil
+		}
+	}
+
+	if assembled.String() != whole {
+		t.Errorf("split-frame SSE differs from whole-stream SSE\nsplit:\n%s\nwhole:\n%s", assembled.String(), whole)
+	}
+}
+
+func TestNeedsMoreResponseData_Boundaries(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{Model: "claude"}}
+	frame := encodeFrame("messageStop", `{"stopReason":"end_turn"}`)
+
+	if p.NeedsMoreResponseData(frame) {
+		t.Error("a complete frame should not request more data")
+	}
+	if !p.NeedsMoreResponseData(frame[:len(frame)-3]) {
+		t.Error("a truncated frame should request more data")
+	}
+	if p.NeedsMoreResponseData(nil) {
+		t.Error("empty accumulator should not request more data")
+	}
+}
+
+func TestTranslateRequest_ConverseShape(t *testing.T) {
+	payload := map[string]interface{}{
+		"model": "gpt-4o",
+		"messages": []interface{}{
+			map[string]interface{}{"role": "system", "content": "be brief"},
+			map[string]interface{}{"role": "user", "content": "hi"},
+		},
+		"max_tokens":  100,
+		"temperature": 0.5,
+	}
+	mods := translateRequest(payload, PolicyParams{Model: "claude", MaxTokens: 4096})
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if _, hasModel := body["model"]; hasModel {
+		t.Error("Converse body must not contain 'model' (it lives in the path)")
+	}
+	system, ok := body["system"].([]interface{})
+	if !ok || len(system) != 1 {
+		t.Fatalf("expected 1 system block, got %v", body["system"])
+	}
+	inference, ok := body["inferenceConfig"].(map[string]interface{})
+	if !ok || inference["maxTokens"] == nil {
+		t.Fatalf("expected inferenceConfig.maxTokens, got %v", body["inferenceConfig"])
+	}
+	if p := bedrockConversePath("claude", true); p != "/model/claude/converse-stream" {
+		t.Errorf("unexpected streaming path: %s", p)
+	}
+}
+
+func TestTranslateRequest_ToolsImagesAndResults(t *testing.T) {
+	payload := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "describe"},
+				map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{
+					"url": "data:image/png;base64,aGVsbG8=",
+				}},
+			}},
+			map[string]interface{}{"role": "assistant", "tool_calls": []interface{}{
+				map[string]interface{}{"id": "call-1", "function": map[string]interface{}{
+					"name": "weather", "arguments": `{"city":"Colombo"}`,
+				}},
+			}},
+			map[string]interface{}{"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+		},
+		"tools": []interface{}{map[string]interface{}{
+			"type": "function",
+			"function": map[string]interface{}{
+				"name": "weather", "parameters": map[string]interface{}{"type": "object"},
+			},
+		}},
+		"tool_choice": map[string]interface{}{
+			"type": "function", "function": map[string]interface{}{"name": "weather"},
+		},
+	}
+	mods := translateRequest(payload, PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens})
+	var body map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &body); err != nil {
+		t.Fatalf("translated body is invalid: %v", err)
+	}
+	messages, _ := body["messages"].([]interface{})
+	if len(messages) != 3 {
+		t.Fatalf("expected user, assistant, and grouped tool-result messages, got %v", body["messages"])
+	}
+	toolConfig, _ := body["toolConfig"].(map[string]interface{})
+	if toolConfig == nil || toolConfig["toolChoice"] == nil {
+		t.Fatalf("expected translated tool configuration, got %v", body["toolConfig"])
+	}
+}
+
+func TestTranslateRequest_ToolChoiceNoneDropsTools(t *testing.T) {
+	payload := map[string]interface{}{
+		"tools": []interface{}{map[string]interface{}{
+			"function": map[string]interface{}{"name": "weather"},
+		}},
+		"tool_choice": "none",
+	}
+	mods := translateRequest(payload, PolicyParams{MaxTokens: DefaultMaxTokens})
+	var body map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := body["toolConfig"]; ok {
+		t.Fatalf("tool_choice=none must omit toolConfig: %v", body)
+	}
+}
+
+func TestTranslateConverseResponse_JSON(t *testing.T) {
+	converse := `{"output":{"message":{"role":"assistant","content":[{"text":"Hi there"}]}},` +
+		`"stopReason":"end_turn","usage":{"inputTokens":5,"outputTokens":3,"totalTokens":8}}`
+	action := translateConverseResponse([]byte(converse), 200, "claude", "chatcmpl-x")
+
+	mods, ok := action.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", action)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &out); err != nil {
+		t.Fatalf("translated body not JSON: %v", err)
+	}
+	if out["object"] != objectChatCompletion {
+		t.Errorf("expected object=chat.completion, got %v", out["object"])
+	}
+	choices, _ := out["choices"].([]interface{})
+	if len(choices) != 1 {
+		t.Fatalf("expected 1 choice, got %v", out["choices"])
+	}
+	choice := choices[0].(map[string]interface{})
+	msg := choice["message"].(map[string]interface{})
+	if msg["content"] != "Hi there" {
+		t.Errorf("unexpected content: %v", msg["content"])
+	}
+	if choice["finish_reason"] != "stop" {
+		t.Errorf("unexpected finish_reason: %v", choice["finish_reason"])
+	}
+}
+
+func TestTranslateConverseResponse_ToolCallAndError(t *testing.T) {
+	converse := `{"output":{"message":{"role":"assistant","content":[` +
+		`{"toolUse":{"toolUseId":"call-1","name":"weather","input":{"city":"Colombo"}}}` +
+		`]}},"stopReason":"tool_use","usage":{"inputTokens":5,"outputTokens":3}}`
+	action := translateConverseResponse([]byte(converse), 200, "nova", "chatcmpl-x")
+	mods := action.(policy.DownstreamResponseModifications)
+	var out map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &out); err != nil {
+		t.Fatal(err)
+	}
+	choice := out["choices"].([]interface{})[0].(map[string]interface{})
+	if choice["finish_reason"] != "tool_calls" {
+		t.Fatalf("unexpected finish reason: %v", choice["finish_reason"])
+	}
+	message := choice["message"].(map[string]interface{})
+	if len(message["tool_calls"].([]interface{})) != 1 {
+		t.Fatalf("expected one tool call: %v", message)
+	}
+	usage := out["usage"].(map[string]interface{})
+	if usage["total_tokens"] != float64(8) {
+		t.Fatalf("expected computed total tokens, got %v", usage)
+	}
+
+	errorAction := translateConverseResponse([]byte(`{"message":"quota exceeded"}`), 429, "nova", "id")
+	errorMods := errorAction.(policy.DownstreamResponseModifications)
+	var errorBody map[string]interface{}
+	if err := json.Unmarshal(errorMods.Body, &errorBody); err != nil {
+		t.Fatal(err)
+	}
+	errValue := errorBody["error"].(map[string]interface{})
+	if errValue["type"] != "rate_limit_error" || errValue["message"] != "quota exceeded" {
+		t.Fatalf("unexpected translated error: %v", errValue)
+	}
+}
+
+func TestStopReasonToFinish_KnownReasonsPrecedeToolFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		stopReason   string
+		hasToolCalls bool
+		want         string
+	}{
+		{name: "truncated tool call", stopReason: "max_tokens", hasToolCalls: true, want: "length"},
+		{name: "filtered tool call", stopReason: "content_filtered", hasToolCalls: true, want: "content_filter"},
+		{name: "guardrail tool call", stopReason: "guardrail_intervened", hasToolCalls: true, want: "content_filter"},
+		{name: "explicit tool use", stopReason: "tool_use", hasToolCalls: true, want: "tool_calls"},
+		{name: "unknown reason with tools", stopReason: "", hasToolCalls: true, want: "tool_calls"},
+		{name: "unknown reason without tools", stopReason: "", hasToolCalls: false, want: "stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stopReasonToFinish(tt.stopReason, tt.hasToolCalls); got != tt.want {
+				t.Fatalf("stopReasonToFinish(%q, %v) = %q, want %q",
+					tt.stopReason, tt.hasToolCalls, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEventStreamToSSE_ToolCall(t *testing.T) {
+	stream := encodeFrame("contentBlockStart", `{"contentBlockIndex":1,"start":{"toolUse":{"toolUseId":"call-1","name":"weather"}}}`)
+	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":1,"delta":{"toolUse":{"input":"{\"city\":\"Colombo\"}"}}}`)...)
+	out := string(eventStreamToSSE(stream, true, "chatcmpl-x", "nova"))
+	for _, want := range []string{`"id":"call-1"`, `"name":"weather"`, `"arguments":"{\"city\":\"Colombo\"}"`, "data: [DONE]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tool-call stream missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestDecodeEventStreamFrames_MalformedInput(t *testing.T) {
+	if _, _, ok := decodeEventStreamFrames([]byte("not an event stream")); ok {
+		t.Fatal("plain text must not be accepted as event-stream framing")
+	}
+	malformed := make([]byte, preludeWithCRCLen)
+	binary.BigEndian.PutUint32(malformed[:4], uint32(maxFrameLen+1))
+	if _, _, ok := decodeEventStreamFrames(malformed); ok {
+		t.Fatal("oversized frames must be rejected")
+	}
+}

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -33,15 +33,15 @@ func TestGetPolicy_ValidatesParams(t *testing.T) {
 		t.Fatal("expected an error when model is missing")
 	}
 	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
-		"model":     "us.amazon.nova-lite-v1:0",
-		"id":        "bedrock-provider",
-		"maxTokens": float64(2048),
+		"model":       "us.amazon.nova-lite-v1:0",
+		"provider-id": "bedrock-provider",
+		"maxTokens":   float64(2048),
 	}); err != nil {
 		t.Fatalf("unexpected error for valid params: %v", err)
 	}
 	for _, params := range []map[string]interface{}{
 		{"model": 42},
-		{"model": "nova", "id": true},
+		{"model": "nova", "provider-id": true},
 		{"model": "nova", "maxTokens": 0},
 		{"model": "nova", "maxTokens": 1.5},
 	} {
@@ -53,9 +53,9 @@ func TestGetPolicy_ValidatesParams(t *testing.T) {
 
 func TestOnRequestBody_RewritesAndRoutes(t *testing.T) {
 	p := &TranslatorPolicy{params: PolicyParams{
-		Model:     "us.amazon.nova-lite-v1:0",
-		Id:        "bedrock-provider",
-		MaxTokens: DefaultMaxTokens,
+		Model:      "us.amazon.nova-lite-v1:0",
+		ProviderID: "bedrock-provider",
+		MaxTokens:  DefaultMaxTokens,
 	}}
 	req := &policy.RequestContext{
 		SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestGetPolicy_ValidatesParams(t *testing.T) {
-	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{}); err == nil {
-		t.Fatal("expected an error when model is missing")
+	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{}); err != nil {
+		t.Fatalf("model override should be optional: %v", err)
 	}
 	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
 		"model":       "us.amazon.nova-lite-v1:0",
@@ -47,6 +47,64 @@ func TestGetPolicy_ValidatesParams(t *testing.T) {
 	} {
 		if _, err := GetPolicy(policy.PolicyMetadata{}, params); err == nil {
 			t.Errorf("expected invalid params to fail: %#v", params)
+		}
+	}
+}
+
+func TestOnRequestBody_FallsBackToRequestModel(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{MaxTokens: DefaultMaxTokens}}
+	shared := &policy.SharedContext{Metadata: map[string]interface{}{}}
+	req := &policy.RequestContext{
+		SharedContext: shared,
+		Body: &policy.Body{Present: true, Content: []byte(
+			`{"model":"us.amazon.nova-lite-v1:0","messages":[{"role":"user","content":"hello"}]}`)},
+	}
+
+	action := p.OnRequestBody(context.Background(), req, nil)
+	mods, ok := action.(policy.UpstreamRequestModifications)
+	if !ok {
+		t.Fatalf("expected UpstreamRequestModifications, got %T", action)
+	}
+	if mods.Path == nil || *mods.Path != "/model/us.amazon.nova-lite-v1:0/converse" {
+		t.Fatalf("unexpected fallback path: %v", mods.Path)
+	}
+	if got := shared.Metadata[MetadataKeyEffectiveModel]; got != "us.amazon.nova-lite-v1:0" {
+		t.Fatalf("effective model was not stored in request metadata: %v", got)
+	}
+
+	response := &policy.ResponseContext{
+		SharedContext:  shared,
+		ResponseStatus: 200,
+		ResponseBody: &policy.Body{Present: true, Content: []byte(
+			`{"output":{"message":{"role":"assistant","content":[{"text":"hello"}]}},"stopReason":"end_turn"}`)},
+	}
+	responseAction := p.OnResponseBody(context.Background(), response, nil)
+	responseMods, ok := responseAction.(policy.DownstreamResponseModifications)
+	if !ok {
+		t.Fatalf("expected DownstreamResponseModifications, got %T", responseAction)
+	}
+	var translated map[string]interface{}
+	if err := json.Unmarshal(responseMods.Body, &translated); err != nil {
+		t.Fatalf("translated response is not valid JSON: %v", err)
+	}
+	if translated["model"] != "us.amazon.nova-lite-v1:0" {
+		t.Fatalf("response did not use the effective request model: %v", translated["model"])
+	}
+}
+
+func TestOnRequestBody_RejectsMissingFallbackModel(t *testing.T) {
+	p := &TranslatorPolicy{params: PolicyParams{MaxTokens: DefaultMaxTokens}}
+	for _, body := range []string{
+		`{"messages":[]}`,
+		`{"model":"","messages":[]}`,
+		`{"model":42,"messages":[]}`,
+	} {
+		action := p.OnRequestBody(context.Background(), &policy.RequestContext{
+			SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},
+			Body:          &policy.Body{Present: true, Content: []byte(body)},
+		}, nil)
+		if response, ok := action.(policy.ImmediateResponse); !ok || response.StatusCode != 400 {
+			t.Errorf("expected a 400 response for body %s, got %#v", body, action)
 		}
 	}
 }

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -33,17 +33,14 @@ func TestGetPolicy_ValidatesParams(t *testing.T) {
 		t.Fatalf("model override should be optional: %v", err)
 	}
 	if _, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
-		"model":       "us.amazon.nova-lite-v1:0",
-		"provider-id": "bedrock-provider",
-		"maxTokens":   float64(2048),
+		"model":      "us.amazon.nova-lite-v1:0",
+		"providerId": "bedrock-provider",
 	}); err != nil {
 		t.Fatalf("unexpected error for valid params: %v", err)
 	}
 	for _, params := range []map[string]interface{}{
 		{"model": 42},
-		{"model": "nova", "provider-id": true},
-		{"model": "nova", "maxTokens": 0},
-		{"model": "nova", "maxTokens": 1.5},
+		{"model": "nova", "providerId": true},
 	} {
 		if _, err := GetPolicy(policy.PolicyMetadata{}, params); err == nil {
 			t.Errorf("expected invalid params to fail: %#v", params)
@@ -52,7 +49,7 @@ func TestGetPolicy_ValidatesParams(t *testing.T) {
 }
 
 func TestOnRequestBody_FallsBackToRequestModel(t *testing.T) {
-	p := &TranslatorPolicy{params: PolicyParams{MaxTokens: DefaultMaxTokens}}
+	p := &TranslatorPolicy{params: PolicyParams{}}
 	shared := &policy.SharedContext{Metadata: map[string]interface{}{}}
 	req := &policy.RequestContext{
 		SharedContext: shared,
@@ -93,7 +90,7 @@ func TestOnRequestBody_FallsBackToRequestModel(t *testing.T) {
 }
 
 func TestOnRequestBody_RejectsMissingFallbackModel(t *testing.T) {
-	p := &TranslatorPolicy{params: PolicyParams{MaxTokens: DefaultMaxTokens}}
+	p := &TranslatorPolicy{params: PolicyParams{}}
 	for _, body := range []string{
 		`{"messages":[]}`,
 		`{"model":"","messages":[]}`,
@@ -113,7 +110,6 @@ func TestOnRequestBody_RewritesAndRoutes(t *testing.T) {
 	p := &TranslatorPolicy{params: PolicyParams{
 		Model:      "us.amazon.nova-lite-v1:0",
 		ProviderID: "bedrock-provider",
-		MaxTokens:  DefaultMaxTokens,
 	}}
 	req := &policy.RequestContext{
 		SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},
@@ -145,7 +141,7 @@ func TestOnRequestBody_RewritesAndRoutes(t *testing.T) {
 }
 
 func TestOnRequestBody_RejectsBadBodies(t *testing.T) {
-	p := &TranslatorPolicy{params: PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens}}
+	p := &TranslatorPolicy{params: PolicyParams{Model: "nova"}}
 	for _, body := range []*policy.Body{
 		nil,
 		{Present: true},
@@ -163,7 +159,7 @@ func TestOnRequestBody_RejectsBadBodies(t *testing.T) {
 }
 
 func TestPolicyPhases_HandleNilSharedContext(t *testing.T) {
-	p := &TranslatorPolicy{params: PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens}}
+	p := &TranslatorPolicy{params: PolicyParams{Model: "nova"}}
 
 	requestAction := p.OnRequestBody(context.Background(), &policy.RequestContext{
 		Body: &policy.Body{Present: true, Content: []byte(`{"messages":[]}`)},
@@ -349,7 +345,7 @@ func TestTranslateRequest_ConverseShape(t *testing.T) {
 		"max_tokens":  100,
 		"temperature": 0.5,
 	}
-	mods := translateRequest(payload, PolicyParams{Model: "claude", MaxTokens: 4096})
+	mods := translateRequest(payload)
 
 	var body map[string]interface{}
 	if err := json.Unmarshal(mods.Body, &body); err != nil {
@@ -368,6 +364,23 @@ func TestTranslateRequest_ConverseShape(t *testing.T) {
 	}
 	if p := bedrockConversePath("claude", true); p != "/model/claude/converse-stream" {
 		t.Errorf("unexpected streaming path: %s", p)
+	}
+}
+
+func TestTranslateRequest_OmitsMaxTokensWhenNotSupplied(t *testing.T) {
+	payload := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hi"},
+		},
+	}
+	mods := translateRequest(payload)
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(mods.Body, &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if _, ok := body["inferenceConfig"]; ok {
+		t.Fatalf("inferenceConfig must be omitted when the OpenAI payload has no inference settings: %v", body)
 	}
 }
 
@@ -397,7 +410,7 @@ func TestTranslateRequest_ToolsImagesAndResults(t *testing.T) {
 			"type": "function", "function": map[string]interface{}{"name": "weather"},
 		},
 	}
-	mods := translateRequest(payload, PolicyParams{Model: "nova", MaxTokens: DefaultMaxTokens})
+	mods := translateRequest(payload)
 	var body map[string]interface{}
 	if err := json.Unmarshal(mods.Body, &body); err != nil {
 		t.Fatalf("translated body is invalid: %v", err)
@@ -419,7 +432,7 @@ func TestTranslateRequest_ToolChoiceNoneDropsTools(t *testing.T) {
 		}},
 		"tool_choice": "none",
 	}
-	mods := translateRequest(payload, PolicyParams{MaxTokens: DefaultMaxTokens})
+	mods := translateRequest(payload)
 	var body map[string]interface{}
 	if err := json.Unmarshal(mods.Body, &body); err != nil {
 		t.Fatal(err)

--- a/policies/openai-to-bedrock-transformer/eventstream.go
+++ b/policies/openai-to-bedrock-transformer/eventstream.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package openaitobedrock
+
+import "encoding/binary"
+
+// AWS event-stream ("application/vnd.amazon.eventstream") binary framing.
+//
+// Each message on the wire is laid out as:
+//
+//	 0      4          8            12                12+H            N-4     N
+//	+------+----------+------------+----------------+---------------+-------+
+//	|total | headers  | prelude    |  headers (H)   |  payload      |  msg  |
+//	|length| length   | CRC32      |                |               |  CRC32|
+//	+------+----------+------------+----------------+---------------+-------+
+//	  u32      u32         u32          H bytes         P bytes        u32
+//
+// All integers are big-endian. total length counts every byte of the frame,
+// so payload length = total - headersLen - 16 (4 prelude ints of 4 bytes +
+// the trailing message CRC). CRCs are not validated here because the gateway
+// transport already guarantees byte integrity of the upstream stream.
+//
+// Headers are a packed sequence of:
+//
+//	nameLen u8 | name (nameLen bytes) | valueType u8 | value...
+//
+// Bedrock only uses string headers (valueType 7): valueLen u16 | value bytes.
+// The headers we care about are ":event-type" (messageStart, contentBlockDelta,
+// …), ":message-type" ("event" or "exception"), and ":exception-type".
+
+const (
+	preludeLen        = 8  // totalLen(4) + headersLen(4)
+	preludeWithCRCLen = 12 // prelude(8) + preludeCRC(4)
+	frameOverhead     = 16 // prelude(8) + preludeCRC(4) + messageCRC(4)
+	minFrameLen       = frameOverhead
+	// maxFrameLen guards against treating non-event-stream bytes as a frame with
+	// an absurd advertised length. Matches the kernel's stream accumulator cap.
+	maxFrameLen = 16 * 1024 * 1024
+
+	headerTypeString = 7
+)
+
+// eventStreamFrame is one decoded message: its wire headers plus the raw
+// (usually JSON) payload bytes.
+type eventStreamFrame struct {
+	EventType     string
+	MessageType   string
+	ExceptionType string
+	Payload       []byte
+}
+
+// decodeEventStreamFrames parses every complete frame at the start of data and
+// returns them together with the number of bytes consumed. Trailing bytes that
+// form only a partial frame are left unconsumed so the caller can prepend them
+// to the next chunk. Returns ok=false when the leading bytes are not a
+// plausible event-stream frame (advertised length out of range).
+func decodeEventStreamFrames(data []byte) (frames []eventStreamFrame, consumed int, ok bool) {
+	offset := 0
+	for {
+		frame, frameLen, status := decodeOneFrame(data[offset:])
+		switch status {
+		case frameOK:
+			frames = append(frames, frame)
+			offset += frameLen
+		case frameIncomplete:
+			return frames, offset, true
+		case frameInvalid:
+			// Only signal "not event-stream" when we haven't decoded anything;
+			// otherwise report progress and stop on the garbage boundary.
+			return frames, offset, offset > 0
+		}
+	}
+}
+
+// eventStreamBoundary reports the number of leading bytes of data that form
+// whole frames and whether a partial (incomplete) frame trails them. It is the
+// cheap check used by NeedsMoreResponseData to align kernel flushes to frame
+// boundaries without decoding payloads.
+func eventStreamBoundary(data []byte) (completeLen int, hasPartial bool, ok bool) {
+	offset := 0
+	for {
+		if len(data)-offset == 0 {
+			return offset, false, true
+		}
+		_, frameLen, status := decodeOneFrame(data[offset:])
+		switch status {
+		case frameOK:
+			offset += frameLen
+		case frameIncomplete:
+			return offset, true, true
+		default: // frameInvalid
+			return offset, false, offset > 0
+		}
+	}
+}
+
+type frameStatus int
+
+const (
+	frameOK frameStatus = iota
+	frameIncomplete
+	frameInvalid
+)
+
+func decodeOneFrame(data []byte) (eventStreamFrame, int, frameStatus) {
+	if len(data) < preludeWithCRCLen {
+		return eventStreamFrame{}, 0, frameIncomplete
+	}
+	totalLen := int(binary.BigEndian.Uint32(data[0:4]))
+	headersLen := int(binary.BigEndian.Uint32(data[4:8]))
+	if totalLen < minFrameLen || totalLen > maxFrameLen ||
+		headersLen < 0 || headersLen > totalLen-frameOverhead {
+		return eventStreamFrame{}, 0, frameInvalid
+	}
+	if len(data) < totalLen {
+		return eventStreamFrame{}, 0, frameIncomplete
+	}
+
+	headerBytes := data[preludeWithCRCLen : preludeWithCRCLen+headersLen]
+	payload := data[preludeWithCRCLen+headersLen : totalLen-4]
+
+	frame := eventStreamFrame{Payload: payload}
+	for name, value := range parseHeaders(headerBytes) {
+		switch name {
+		case ":event-type":
+			frame.EventType = value
+		case ":message-type":
+			frame.MessageType = value
+		case ":exception-type":
+			frame.ExceptionType = value
+		}
+	}
+	return frame, totalLen, frameOK
+}
+
+// parseHeaders decodes the packed header block into a name→value map, keeping
+// only string-typed (type 7) headers, which is all Bedrock emits. Malformed
+// trailing bytes stop parsing rather than panic.
+func parseHeaders(data []byte) map[string]string {
+	headers := make(map[string]string)
+	offset := 0
+	for offset < len(data) {
+		nameLen := int(data[offset])
+		offset++
+		if offset+nameLen > len(data) {
+			break
+		}
+		name := string(data[offset : offset+nameLen])
+		offset += nameLen
+		if offset >= len(data) {
+			break
+		}
+		valueType := data[offset]
+		offset++
+		if valueType != headerTypeString {
+			// Non-string headers are unused by Bedrock's stream; without a length
+			// prefix we cannot safely skip them, so stop here.
+			break
+		}
+		if offset+2 > len(data) {
+			break
+		}
+		valueLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
+		offset += 2
+		if offset+valueLen > len(data) {
+			break
+		}
+		headers[name] = string(data[offset : offset+valueLen])
+		offset += valueLen
+	}
+	return headers
+}

--- a/policies/openai-to-bedrock-transformer/eventstream.go
+++ b/policies/openai-to-bedrock-transformer/eventstream.go
@@ -40,9 +40,10 @@ import "encoding/binary"
 //
 //	nameLen u8 | name (nameLen bytes) | valueType u8 | value...
 //
-// Bedrock only uses string headers (valueType 7): valueLen u16 | value bytes.
-// The headers we care about are ":event-type" (messageStart, contentBlockDelta,
-// …), ":message-type" ("event" or "exception"), and ":exception-type".
+// The headers we care about are string headers (valueType 7): ":event-type"
+// (messageStart, contentBlockDelta, …), ":message-type" ("event" or
+// "exception"), and ":exception-type". Other AWS event-stream header types
+// are skipped according to their defined widths.
 
 const (
 	preludeLen        = 8  // totalLen(4) + headersLen(4)
@@ -53,7 +54,16 @@ const (
 	// an absurd advertised length. Matches the kernel's stream accumulator cap.
 	maxFrameLen = 16 * 1024 * 1024
 
-	headerTypeString = 7
+	headerTypeTrue      = 0
+	headerTypeFalse     = 1
+	headerTypeByte      = 2
+	headerTypeShort     = 3
+	headerTypeInteger   = 4
+	headerTypeLong      = 5
+	headerTypeByteArray = 6
+	headerTypeString    = 7
+	headerTypeTimestamp = 8
+	headerTypeUUID      = 9
 )
 
 // eventStreamFrame is one decoded message: its wire headers plus the raw
@@ -150,8 +160,8 @@ func decodeOneFrame(data []byte) (eventStreamFrame, int, frameStatus) {
 }
 
 // parseHeaders decodes the packed header block into a name→value map, keeping
-// only string-typed (type 7) headers, which is all Bedrock emits. Malformed
-// trailing bytes stop parsing rather than panic.
+// only string-typed (type 7) headers. Malformed trailing bytes stop parsing
+// rather than panic.
 func parseHeaders(data []byte) map[string]string {
 	headers := make(map[string]string)
 	offset := 0
@@ -168,21 +178,36 @@ func parseHeaders(data []byte) map[string]string {
 		}
 		valueType := data[offset]
 		offset++
-		if valueType != headerTypeString {
-			// Non-string headers are unused by Bedrock's stream; without a length
-			// prefix we cannot safely skip them, so stop here.
-			break
+
+		var encodedLen int
+		switch valueType {
+		case headerTypeTrue, headerTypeFalse:
+			encodedLen = 0
+		case headerTypeByte:
+			encodedLen = 1
+		case headerTypeShort:
+			encodedLen = 2
+		case headerTypeInteger:
+			encodedLen = 4
+		case headerTypeLong, headerTypeTimestamp:
+			encodedLen = 8
+		case headerTypeUUID:
+			encodedLen = 16
+		case headerTypeByteArray, headerTypeString:
+			if offset+2 > len(data) {
+				return headers
+			}
+			encodedLen = 2 + int(binary.BigEndian.Uint16(data[offset:offset+2]))
+		default:
+			return headers
 		}
-		if offset+2 > len(data) {
-			break
+		if offset+encodedLen > len(data) {
+			return headers
 		}
-		valueLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
-		offset += 2
-		if offset+valueLen > len(data) {
-			break
+		if valueType == headerTypeString {
+			headers[name] = string(data[offset+2 : offset+encodedLen])
 		}
-		headers[name] = string(data[offset : offset+valueLen])
-		offset += valueLen
+		offset += encodedLen
 	}
 	return headers
 }

--- a/policies/openai-to-bedrock-transformer/go.mod
+++ b/policies/openai-to-bedrock-transformer/go.mod
@@ -1,0 +1,5 @@
+module github.com/wso2/gateway-controllers/policies/openai-to-bedrock-transformer
+
+go 1.26.2
+
+require github.com/wso2/api-platform/sdk/core v0.2.14

--- a/policies/openai-to-bedrock-transformer/go.sum
+++ b/policies/openai-to-bedrock-transformer/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=

--- a/policies/openai-to-bedrock-transformer/openaitobedrock.go
+++ b/policies/openai-to-bedrock-transformer/openaitobedrock.go
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package openaitobedrock translates OpenAI Chat Completions traffic to and
+// from the AWS Bedrock Converse API. Requests are rewritten to the Converse
+// wire format (path + body); responses are rewritten back to OpenAI shape.
+// Bedrock streams responses with the binary Amazon event-stream framing, which
+// this policy decodes and re-emits as OpenAI-style Server-Sent Events.
+package openaitobedrock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+const (
+	PolicyName                  = "openai-to-bedrock-transformer"
+	DefaultMaxTokens            = 4096
+	MetadataKeySelectedProvider = "selected_provider"
+)
+
+// Compile-time proof that this policy participates in every phase it declares
+// in Mode(), including chunk-by-chunk response streaming.
+var (
+	_ policy.Policy                  = (*TranslatorPolicy)(nil)
+	_ policy.RequestPolicy           = (*TranslatorPolicy)(nil)
+	_ policy.ResponseHeaderPolicy    = (*TranslatorPolicy)(nil)
+	_ policy.ResponsePolicy          = (*TranslatorPolicy)(nil)
+	_ policy.StreamingResponsePolicy = (*TranslatorPolicy)(nil)
+)
+
+type PolicyParams struct {
+	Model     string
+	Id        string
+	MaxTokens int
+}
+
+type TranslatorPolicy struct {
+	params PolicyParams
+}
+
+// GetPolicy is the exported factory the gateway calls to instantiate the policy.
+func GetPolicy(_ policy.PolicyMetadata, rawParams map[string]interface{}) (policy.Policy, error) {
+	parsed, err := parseParams(rawParams)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid params: %w", PolicyName, err)
+	}
+	return &TranslatorPolicy{params: parsed}, nil
+}
+
+// Mode buffers the (small) request body for translation, processes response
+// headers so streaming content-type can be corrected, and asks for STREAM mode
+// on the response body so Bedrock's event stream can be decoded chunk-by-chunk.
+// The kernel falls back to the buffered OnResponseBody path automatically when
+// the upstream response is not a stream.
+func (p *TranslatorPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeProcess,
+		ResponseBodyMode:   policy.BodyModeStream,
+	}
+}
+
+// ─── Request phase ────────────────────────────────────────────────────────────
+
+func (p *TranslatorPolicy) OnRequestBody(
+	_ context.Context,
+	reqCtx *policy.RequestContext,
+	_ map[string]interface{},
+) policy.RequestAction {
+	if !p.shouldRun(selectedProvider(reqCtx.SharedContext)) {
+		return policy.UpstreamRequestModifications{}
+	}
+
+	if reqCtx.Body == nil || !reqCtx.Body.Present || len(reqCtx.Body.Content) == 0 {
+		return errResponse(400, "Request body is empty.")
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(reqCtx.Body.Content, &payload); err != nil {
+		return errResponse(400, fmt.Sprintf("Invalid JSON in request body: %s", err.Error()))
+	}
+
+	if p.params.Model == "" {
+		return errResponse(400, "'model' policy parameter is required for Bedrock translation.")
+	}
+
+	streaming := boolValue(payload["stream"])
+	path := bedrockConversePath(p.params.Model, streaming)
+	slog.Debug(PolicyName+": translating request",
+		"id", p.params.Id, "model", p.params.Model, "streaming", streaming, "path", path)
+
+	mods := translateRequest(payload, p.params)
+	mods.Path = &path
+	if p.params.Id != "" && mods.UpstreamName == nil {
+		upstream := p.params.Id
+		mods.UpstreamName = &upstream
+	}
+	return mods
+}
+
+// bedrockConversePath builds the Converse endpoint path. The model id carries
+// the model selection (the awsbedrock provider template extracts it from the
+// path), so it is never placed in the body.
+func bedrockConversePath(model string, streaming bool) string {
+	if streaming {
+		return "/model/" + model + "/converse-stream"
+	}
+	return "/model/" + model + "/converse"
+}
+
+// ─── Response phase ───────────────────────────────────────────────────────────
+
+// OnResponseHeaders rewrites the upstream content-type for translated event
+// streams (application/vnd.amazon.eventstream) to text/event-stream so
+// downstream OpenAI clients recognise the Server-Sent Events we emit. JSON
+// responses are left untouched.
+func (p *TranslatorPolicy) OnResponseHeaders(
+	_ context.Context,
+	respCtx *policy.ResponseHeaderContext,
+	_ map[string]interface{},
+) policy.ResponseHeaderAction {
+	if !p.shouldRun(selectedProvider(respCtx.SharedContext)) {
+		return policy.DownstreamResponseHeaderModifications{}
+	}
+	if !isEventStreamContentType(headerValue(respCtx.ResponseHeaders, "content-type")) {
+		return policy.DownstreamResponseHeaderModifications{}
+	}
+	return policy.DownstreamResponseHeaderModifications{
+		HeadersToSet:    map[string]string{"content-type": "text/event-stream"},
+		HeadersToRemove: []string{"content-length"},
+	}
+}
+
+// OnResponseBody is the buffered fallback used when the upstream response is not
+// detected as a stream (no chunked / text-event-stream headers). It handles both
+// a Converse JSON response and a fully buffered Amazon event stream.
+func (p *TranslatorPolicy) OnResponseBody(
+	_ context.Context,
+	respCtx *policy.ResponseContext,
+	_ map[string]interface{},
+) policy.ResponseAction {
+	if !p.shouldRun(selectedProvider(respCtx.SharedContext)) {
+		return policy.DownstreamResponseModifications{}
+	}
+	if respCtx.ResponseBody == nil || !respCtx.ResponseBody.Present || len(respCtx.ResponseBody.Content) == 0 {
+		return policy.DownstreamResponseModifications{}
+	}
+
+	body := respCtx.ResponseBody.Content
+	contentType := headerValue(respCtx.ResponseHeaders, "content-type")
+
+	if isEventStreamContentType(contentType) || looksLikeEventStream(body) {
+		sse := eventStreamToSSE(body, true, p.completionID(requestID(respCtx.SharedContext)), p.params.Model)
+		return policy.DownstreamResponseModifications{
+			Body: sse,
+			HeadersToSet: map[string]string{
+				"content-type": "text/event-stream",
+			},
+			HeadersToRemove: []string{"content-length"},
+		}
+	}
+
+	slog.Debug(PolicyName+": translating buffered JSON response", "status", respCtx.ResponseStatus)
+	return translateConverseResponse(body, respCtx.ResponseStatus, p.params.Model,
+		p.completionID(requestID(respCtx.SharedContext)))
+}
+
+// ─── Streaming response phase ─────────────────────────────────────────────────
+
+// NeedsMoreResponseData keeps the kernel accumulating until its buffer ends on a
+// clean event-stream frame boundary. That guarantees OnResponseBodyChunk always
+// receives a whole number of complete frames and never a split one, so no
+// cross-chunk carry buffer (which would be unsafe on a shared policy instance)
+// is required.
+func (p *TranslatorPolicy) NeedsMoreResponseData(accumulated []byte) bool {
+	if len(accumulated) == 0 {
+		return false
+	}
+	_, hasPartial, ok := eventStreamBoundary(accumulated)
+	if !ok {
+		// Not event-stream framing (e.g. a JSON error body streamed through) —
+		// don't stall the stream waiting for a boundary that will never come.
+		return false
+	}
+	return hasPartial
+}
+
+// OnResponseBodyChunk decodes the complete frames delivered in this flush and
+// re-emits them as OpenAI SSE events, replacing the raw binary bytes. On the
+// final chunk it appends the terminating `data: [DONE]` event.
+func (p *TranslatorPolicy) OnResponseBodyChunk(
+	_ context.Context,
+	respCtx *policy.ResponseStreamContext,
+	chunk *policy.StreamBody,
+	_ map[string]interface{},
+) policy.StreamingResponseAction {
+	if !p.shouldRun(selectedProvider(respCtx.SharedContext)) {
+		return policy.ForwardResponseChunk{}
+	}
+
+	sse := eventStreamToSSE(chunk.Chunk, chunk.EndOfStream,
+		p.completionID(requestID(respCtx.SharedContext)), p.params.Model)
+	// Always return a non-nil body so the raw Amazon event-stream bytes are
+	// replaced (nil would pass them through untranslated). An empty slice emits
+	// nothing for this flush, which is correct when a frame carried no delta.
+	if sse == nil {
+		sse = []byte{}
+	}
+	return policy.ForwardResponseChunk{Body: sse}
+}
+
+// ─── Routing / selection ──────────────────────────────────────────────────────
+
+func (p *TranslatorPolicy) shouldRun(selected string) bool {
+	if selected == "" {
+		// Single-provider mode: no router selected a provider, so run.
+		return true
+	}
+	return strings.EqualFold(selected, p.params.Id)
+}
+
+func selectedProvider(shared *policy.SharedContext) string {
+	if shared == nil || shared.Metadata == nil {
+		return ""
+	}
+	raw, ok := shared.Metadata[MetadataKeySelectedProvider]
+	if !ok {
+		return ""
+	}
+	value, isString := raw.(string)
+	if !isString {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func requestID(shared *policy.SharedContext) string {
+	if shared == nil {
+		return ""
+	}
+	return shared.RequestID
+}
+
+// completionID derives a stable OpenAI completion id from the per-request id so
+// every SSE chunk of one response shares it, without holding per-request state
+// on the shared policy instance. Falls back to a random id when unavailable.
+func (p *TranslatorPolicy) completionID(requestID string) string {
+	if requestID != "" {
+		return "chatcmpl-" + strings.ReplaceAll(requestID, "-", "")
+	}
+	return newChatCompletionID()
+}
+
+// ─── Param parsing ────────────────────────────────────────────────────────────
+
+func parseParams(params map[string]interface{}) (PolicyParams, error) {
+	result := PolicyParams{MaxTokens: DefaultMaxTokens}
+
+	model, err := optionalString(params, "model")
+	if err != nil {
+		return result, err
+	}
+	if model == "" {
+		return result, fmt.Errorf("'model' is required")
+	}
+	result.Model = model
+
+	if id, err := optionalString(params, "id"); err != nil {
+		return result, err
+	} else {
+		result.Id = id
+	}
+
+	if maxTokens, ok := params["maxTokens"]; ok && maxTokens != nil {
+		if n, ok := toInt(maxTokens); ok && n > 0 {
+			result.MaxTokens = n
+		} else {
+			return result, fmt.Errorf("'maxTokens' must be a positive integer")
+		}
+	}
+
+	return result, nil
+}
+
+func optionalString(params map[string]interface{}, key string) (string, error) {
+	raw, ok := params[key]
+	if !ok || raw == nil {
+		return "", nil
+	}
+	value, isString := raw.(string)
+	if !isString {
+		return "", fmt.Errorf("'%s' must be a string", key)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func toInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		if math.IsNaN(n) || math.IsInf(n, 0) || n != math.Trunc(n) {
+			return 0, false
+		}
+		return int(n), true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return int(i), true
+		}
+	}
+	return 0, false
+}
+
+func boolValue(v interface{}) bool {
+	b, ok := v.(bool)
+	return ok && b
+}
+
+func headerValue(headers *policy.Headers, name string) string {
+	if headers == nil {
+		return ""
+	}
+	values := headers.Get(name)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func isEventStreamContentType(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	return strings.Contains(ct, "vnd.amazon.eventstream") || strings.Contains(ct, "application/octet-stream")
+}
+
+// looksLikeEventStream sniffs a buffered body for Amazon event-stream framing:
+// binary (not starting with a JSON delimiter) whose leading 4 bytes advertise a
+// plausible frame length.
+func looksLikeEventStream(body []byte) bool {
+	if len(body) < preludeWithCRCLen {
+		return false
+	}
+	trimmed := strings.TrimLeft(string(body[:1]), " \r\n\t")
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return false
+	}
+	_, _, ok := eventStreamBoundary(body)
+	return ok
+}
+
+func errResponse(statusCode int, message string) policy.ImmediateResponse {
+	body, _ := json.Marshal(map[string]interface{}{
+		"error": map[string]string{"message": message, "type": "invalid_request_error"},
+	})
+	return policy.ImmediateResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       body,
+	}
+}

--- a/policies/openai-to-bedrock-transformer/openaitobedrock.go
+++ b/policies/openai-to-bedrock-transformer/openaitobedrock.go
@@ -38,6 +38,7 @@ const (
 	PolicyName                  = "openai-to-bedrock-transformer"
 	DefaultMaxTokens            = 4096
 	MetadataKeySelectedProvider = "selected_provider"
+	MetadataKeyEffectiveModel   = "openai_to_bedrock_effective_model"
 )
 
 // Compile-time proof that this policy participates in every phase it declares
@@ -103,14 +104,16 @@ func (p *TranslatorPolicy) OnRequestBody(
 		return errResponse(400, fmt.Sprintf("Invalid JSON in request body: %s", err.Error()))
 	}
 
-	if p.params.Model == "" {
-		return errResponse(400, "'model' policy parameter is required for Bedrock translation.")
+	model, err := p.resolveModel(payload)
+	if err != nil {
+		return errResponse(400, err.Error())
 	}
+	storeEffectiveModel(reqCtx.SharedContext, model)
 
 	streaming := boolValue(payload["stream"])
-	path := bedrockConversePath(p.params.Model, streaming)
+	path := bedrockConversePath(model, streaming)
 	slog.Debug(PolicyName+": translating request",
-		"provider-id", p.params.ProviderID, "model", p.params.Model, "streaming", streaming, "path", path)
+		"provider-id", p.params.ProviderID, "model", model, "streaming", streaming, "path", path)
 
 	mods := translateRequest(payload, p.params)
 	mods.Path = &path
@@ -171,9 +174,10 @@ func (p *TranslatorPolicy) OnResponseBody(
 
 	body := respCtx.ResponseBody.Content
 	contentType := headerValue(respCtx.ResponseHeaders, "content-type")
+	model := effectiveModel(respCtx.SharedContext, p.params.Model)
 
 	if isEventStreamContentType(contentType) || looksLikeEventStream(body) {
-		sse := eventStreamToSSE(body, true, p.completionID(requestID(respCtx.SharedContext)), p.params.Model)
+		sse := eventStreamToSSE(body, true, p.completionID(requestID(respCtx.SharedContext)), model)
 		return policy.DownstreamResponseModifications{
 			Body: sse,
 			HeadersToSet: map[string]string{
@@ -184,7 +188,7 @@ func (p *TranslatorPolicy) OnResponseBody(
 	}
 
 	slog.Debug(PolicyName+": translating buffered JSON response", "status", respCtx.ResponseStatus)
-	return translateConverseResponse(body, respCtx.ResponseStatus, p.params.Model,
+	return translateConverseResponse(body, respCtx.ResponseStatus, model,
 		p.completionID(requestID(respCtx.SharedContext)))
 }
 
@@ -221,8 +225,9 @@ func (p *TranslatorPolicy) OnResponseBodyChunk(
 		return policy.ForwardResponseChunk{}
 	}
 
+	model := effectiveModel(respCtx.SharedContext, p.params.Model)
 	sse := eventStreamToSSE(chunk.Chunk, chunk.EndOfStream,
-		p.completionID(requestID(respCtx.SharedContext)), p.params.Model)
+		p.completionID(requestID(respCtx.SharedContext)), model)
 	// Always return a non-nil body so the raw Amazon event-stream bytes are
 	// replaced (nil would pass them through untranslated). An empty slice emits
 	// nothing for this flush, which is correct when a frame carried no delta.
@@ -257,6 +262,45 @@ func selectedProvider(shared *policy.SharedContext) string {
 	return strings.TrimSpace(value)
 }
 
+func (p *TranslatorPolicy) resolveModel(payload map[string]interface{}) (string, error) {
+	if p.params.Model != "" {
+		return p.params.Model, nil
+	}
+
+	raw, ok := payload["model"]
+	if !ok || raw == nil {
+		return "", fmt.Errorf("a Bedrock model must be provided in either the policy configuration or request body")
+	}
+	model, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("request field 'model' must be a string")
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "", fmt.Errorf("a Bedrock model must be provided in either the policy configuration or request body")
+	}
+	return model, nil
+}
+
+func storeEffectiveModel(shared *policy.SharedContext, model string) {
+	if shared == nil {
+		return
+	}
+	if shared.Metadata == nil {
+		shared.Metadata = map[string]interface{}{}
+	}
+	shared.Metadata[MetadataKeyEffectiveModel] = model
+}
+
+func effectiveModel(shared *policy.SharedContext, configured string) string {
+	if shared != nil && shared.Metadata != nil {
+		if model, ok := shared.Metadata[MetadataKeyEffectiveModel].(string); ok && model != "" {
+			return model
+		}
+	}
+	return configured
+}
+
 func requestID(shared *policy.SharedContext) string {
 	if shared == nil {
 		return ""
@@ -282,9 +326,6 @@ func parseParams(params map[string]interface{}) (PolicyParams, error) {
 	model, err := optionalString(params, "model")
 	if err != nil {
 		return result, err
-	}
-	if model == "" {
-		return result, fmt.Errorf("'model' is required")
 	}
 	result.Model = model
 

--- a/policies/openai-to-bedrock-transformer/openaitobedrock.go
+++ b/policies/openai-to-bedrock-transformer/openaitobedrock.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	PolicyName                  = "openai-to-bedrock-transformer"
-	DefaultMaxTokens            = 4096
 	MetadataKeySelectedProvider = "selected_provider"
 	MetadataKeyEffectiveModel   = "openai_to_bedrock_effective_model"
 )
@@ -54,7 +53,6 @@ var (
 type PolicyParams struct {
 	Model      string
 	ProviderID string
-	MaxTokens  int
 }
 
 type TranslatorPolicy struct {
@@ -113,9 +111,9 @@ func (p *TranslatorPolicy) OnRequestBody(
 	streaming := boolValue(payload["stream"])
 	path := bedrockConversePath(model, streaming)
 	slog.Debug(PolicyName+": translating request",
-		"provider-id", p.params.ProviderID, "model", model, "streaming", streaming, "path", path)
+		"providerId", p.params.ProviderID, "model", model, "streaming", streaming, "path", path)
 
-	mods := translateRequest(payload, p.params)
+	mods := translateRequest(payload)
 	mods.Path = &path
 	if p.params.ProviderID != "" && mods.UpstreamName == nil {
 		upstream := p.params.ProviderID
@@ -321,7 +319,7 @@ func (p *TranslatorPolicy) completionID(requestID string) string {
 // ─── Param parsing ────────────────────────────────────────────────────────────
 
 func parseParams(params map[string]interface{}) (PolicyParams, error) {
-	result := PolicyParams{MaxTokens: DefaultMaxTokens}
+	result := PolicyParams{}
 
 	model, err := optionalString(params, "model")
 	if err != nil {
@@ -329,18 +327,10 @@ func parseParams(params map[string]interface{}) (PolicyParams, error) {
 	}
 	result.Model = model
 
-	if providerID, err := optionalString(params, "provider-id"); err != nil {
+	if providerID, err := optionalString(params, "providerId"); err != nil {
 		return result, err
 	} else {
 		result.ProviderID = providerID
-	}
-
-	if maxTokens, ok := params["maxTokens"]; ok && maxTokens != nil {
-		if n, ok := toInt(maxTokens); ok && n > 0 {
-			result.MaxTokens = n
-		} else {
-			return result, fmt.Errorf("'maxTokens' must be a positive integer")
-		}
 	}
 
 	return result, nil

--- a/policies/openai-to-bedrock-transformer/openaitobedrock.go
+++ b/policies/openai-to-bedrock-transformer/openaitobedrock.go
@@ -51,9 +51,9 @@ var (
 )
 
 type PolicyParams struct {
-	Model     string
-	Id        string
-	MaxTokens int
+	Model      string
+	ProviderID string
+	MaxTokens  int
 }
 
 type TranslatorPolicy struct {
@@ -110,12 +110,12 @@ func (p *TranslatorPolicy) OnRequestBody(
 	streaming := boolValue(payload["stream"])
 	path := bedrockConversePath(p.params.Model, streaming)
 	slog.Debug(PolicyName+": translating request",
-		"id", p.params.Id, "model", p.params.Model, "streaming", streaming, "path", path)
+		"provider-id", p.params.ProviderID, "model", p.params.Model, "streaming", streaming, "path", path)
 
 	mods := translateRequest(payload, p.params)
 	mods.Path = &path
-	if p.params.Id != "" && mods.UpstreamName == nil {
-		upstream := p.params.Id
+	if p.params.ProviderID != "" && mods.UpstreamName == nil {
+		upstream := p.params.ProviderID
 		mods.UpstreamName = &upstream
 	}
 	return mods
@@ -239,7 +239,7 @@ func (p *TranslatorPolicy) shouldRun(selected string) bool {
 		// Single-provider mode: no router selected a provider, so run.
 		return true
 	}
-	return strings.EqualFold(selected, p.params.Id)
+	return strings.EqualFold(selected, p.params.ProviderID)
 }
 
 func selectedProvider(shared *policy.SharedContext) string {
@@ -288,10 +288,10 @@ func parseParams(params map[string]interface{}) (PolicyParams, error) {
 	}
 	result.Model = model
 
-	if id, err := optionalString(params, "id"); err != nil {
+	if providerID, err := optionalString(params, "provider-id"); err != nil {
 		return result, err
 	} else {
-		result.Id = id
+		result.ProviderID = providerID
 	}
 
 	if maxTokens, ok := params["maxTokens"]; ok && maxTokens != nil {

--- a/policies/openai-to-bedrock-transformer/policy-definition.yaml
+++ b/policies/openai-to-bedrock-transformer/policy-definition.yaml
@@ -25,18 +25,18 @@ parameters:
         us.anthropic.claude-sonnet-4-5-20250929-v1:0). Overrides the OpenAI
         "model" field.
       minLength: 1
-    id:
+    provider-id:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
         Provider this translator targets. Used as the upstream cluster name
-        (matching an id/as in the LlmProxy additionalProviders list) and, in
+        (matching an id or as alias in the LlmProxy additionalProviders list) and, in
         multi-provider mode, as the key matched (case-insensitive) against
         SharedContext.Metadata["selected_provider"]. When no provider has been
         selected upstream (single-provider proxy), the translator always runs;
         when a provider has been selected, it runs only if the selection
-        matches this id. When omitted, routing is left to the route's default
-        upstream.
+        matches this provider id. When omitted, routing is left to the route's
+        default upstream.
       minLength: 1
     maxTokens:
       type: integer

--- a/policies/openai-to-bedrock-transformer/policy-definition.yaml
+++ b/policies/openai-to-bedrock-transformer/policy-definition.yaml
@@ -22,8 +22,9 @@ parameters:
       description: |
         Bedrock model or inference-profile id placed in the request path
         (for example anthropic.claude-3-5-sonnet-20241022-v2:0 or
-        us.anthropic.claude-sonnet-4-5-20250929-v1:0). Overrides the OpenAI
-        "model" field.
+        us.anthropic.claude-sonnet-4-5-20250929-v1:0). When configured, it
+        overrides the OpenAI "model" field; when omitted, the request's model
+        field is used.
       minLength: 1
     provider-id:
       type: string
@@ -47,9 +48,6 @@ parameters:
         requires this field for many models.
       default: 4096
       minimum: 1
-  required:
-    - model
-
 systemParameters:
   type: object
   properties: {}

--- a/policies/openai-to-bedrock-transformer/policy-definition.yaml
+++ b/policies/openai-to-bedrock-transformer/policy-definition.yaml
@@ -26,7 +26,7 @@ parameters:
         overrides the OpenAI "model" field; when omitted, the request's model
         field is used.
       minLength: 1
-    provider-id:
+    providerId:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
@@ -39,15 +39,6 @@ parameters:
         matches this provider id. When omitted, routing is left to the route's
         default upstream.
       minLength: 1
-    maxTokens:
-      type: integer
-      x-wso2-policy-advanced-param: true
-      description: |
-        Fallback value for Bedrock inferenceConfig.maxTokens when the OpenAI
-        request supplies neither max_completion_tokens nor max_tokens. Bedrock
-        requires this field for many models.
-      default: 4096
-      minimum: 1
 systemParameters:
   type: object
   properties: {}

--- a/policies/openai-to-bedrock-transformer/policy-definition.yaml
+++ b/policies/openai-to-bedrock-transformer/policy-definition.yaml
@@ -1,0 +1,55 @@
+name: openai-to-bedrock-transformer
+version: v0.9.0
+description: |
+  Translates OpenAI Chat Completions requests to the AWS Bedrock Converse API
+  (/model/{modelId}/converse and /converse-stream) and rewrites Bedrock
+  responses back to the OpenAI response shape.
+
+  Non-streaming Converse JSON responses become OpenAI ChatCompletion JSON.
+  Streaming responses use Bedrock's binary Amazon event-stream framing
+  (application/vnd.amazon.eventstream); this policy decodes those frames and
+  re-emits them as OpenAI-style Server-Sent Events (data: {chunk}\n\n ...
+  data: [DONE]). It handles the event stream in both buffered and chunk-by-chunk
+  (true streaming) modes. Supports routed and unconditional execution modes.
+
+parameters:
+  type: object
+  additionalProperties: false
+  properties:
+    model:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        Bedrock model or inference-profile id placed in the request path
+        (for example anthropic.claude-3-5-sonnet-20241022-v2:0 or
+        us.anthropic.claude-sonnet-4-5-20250929-v1:0). Overrides the OpenAI
+        "model" field.
+      minLength: 1
+    id:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        Provider this translator targets. Used as the upstream cluster name
+        (matching an id/as in the LlmProxy additionalProviders list) and, in
+        multi-provider mode, as the key matched (case-insensitive) against
+        SharedContext.Metadata["selected_provider"]. When no provider has been
+        selected upstream (single-provider proxy), the translator always runs;
+        when a provider has been selected, it runs only if the selection
+        matches this id. When omitted, routing is left to the route's default
+        upstream.
+      minLength: 1
+    maxTokens:
+      type: integer
+      x-wso2-policy-advanced-param: true
+      description: |
+        Fallback value for Bedrock inferenceConfig.maxTokens when the OpenAI
+        request supplies neither max_completion_tokens nor max_tokens. Bedrock
+        requires this field for many models.
+      default: 4096
+      minimum: 1
+  required:
+    - model
+
+systemParameters:
+  type: object
+  properties: {}

--- a/policies/openai-to-bedrock-transformer/request.go
+++ b/policies/openai-to-bedrock-transformer/request.go
@@ -29,7 +29,7 @@ import (
 // translateRequest converts an OpenAI Chat Completions payload into a Bedrock
 // Converse request body. The model lives in the URL path, not the body, so it
 // is deliberately omitted here.
-func translateRequest(payload map[string]interface{}, params PolicyParams) policy.UpstreamRequestModifications {
+func translateRequest(payload map[string]interface{}) policy.UpstreamRequestModifications {
 	converse := map[string]interface{}{}
 
 	if messages, ok := payload["messages"].([]interface{}); ok {
@@ -42,7 +42,7 @@ func translateRequest(payload map[string]interface{}, params PolicyParams) polic
 		}
 	}
 
-	if inference := buildInferenceConfig(payload, params); len(inference) > 0 {
+	if inference := buildInferenceConfig(payload); len(inference) > 0 {
 		converse["inferenceConfig"] = inference
 	}
 
@@ -243,15 +243,13 @@ func convertImage(block map[string]interface{}) map[string]interface{} {
 	}
 }
 
-func buildInferenceConfig(payload map[string]interface{}, params PolicyParams) map[string]interface{} {
+func buildInferenceConfig(payload map[string]interface{}) map[string]interface{} {
 	inference := map[string]interface{}{}
 
 	if v, ok := payload["max_completion_tokens"]; ok {
 		inference["maxTokens"] = v
 	} else if v, ok := payload["max_tokens"]; ok {
 		inference["maxTokens"] = v
-	} else {
-		inference["maxTokens"] = params.MaxTokens
 	}
 
 	if v, ok := payload["temperature"]; ok {

--- a/policies/openai-to-bedrock-transformer/request.go
+++ b/policies/openai-to-bedrock-transformer/request.go
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package openaitobedrock
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// translateRequest converts an OpenAI Chat Completions payload into a Bedrock
+// Converse request body. The model lives in the URL path, not the body, so it
+// is deliberately omitted here.
+func translateRequest(payload map[string]interface{}, params PolicyParams) policy.UpstreamRequestModifications {
+	converse := map[string]interface{}{}
+
+	if messages, ok := payload["messages"].([]interface{}); ok {
+		system, converseMessages := convertMessages(messages)
+		if len(system) > 0 {
+			converse["system"] = system
+		}
+		if len(converseMessages) > 0 {
+			converse["messages"] = converseMessages
+		}
+	}
+
+	if inference := buildInferenceConfig(payload, params); len(inference) > 0 {
+		converse["inferenceConfig"] = inference
+	}
+
+	if toolConfig := buildToolConfig(payload); toolConfig != nil {
+		converse["toolConfig"] = toolConfig
+	}
+
+	newBody, err := json.Marshal(converse)
+	if err != nil {
+		return policy.UpstreamRequestModifications{
+			Body: []byte(fmt.Sprintf(`{"error":{"message":"failed to marshal Bedrock body: %s"}}`, err.Error())),
+		}
+	}
+
+	return policy.UpstreamRequestModifications{
+		Body:            newBody,
+		HeadersToSet:    map[string]string{"content-type": "application/json"},
+		HeadersToRemove: []string{"content-length"},
+	}
+}
+
+// convertMessages splits OpenAI messages into Converse system blocks and the
+// role/content message list. Consecutive tool messages collapse into a single
+// user message of toolResult blocks, matching how Converse groups tool output.
+func convertMessages(messages []interface{}) ([]map[string]interface{}, []map[string]interface{}) {
+	var system []map[string]interface{}
+	var converseMessages []map[string]interface{}
+
+	for i := 0; i < len(messages); i++ {
+		message, ok := messages[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := message["role"].(string)
+
+		switch role {
+		case "system", "developer":
+			if text := extractText(message["content"]); text != "" {
+				system = append(system, map[string]interface{}{"text": text})
+			}
+		case "user":
+			converseMessages = append(converseMessages, map[string]interface{}{
+				"role":    "user",
+				"content": convertUserContent(message["content"]),
+			})
+		case "assistant":
+			converseMessages = append(converseMessages, map[string]interface{}{
+				"role":    "assistant",
+				"content": convertAssistantContent(message),
+			})
+		case "tool":
+			var toolResults []interface{}
+			for i < len(messages) {
+				toolMessage, ok := messages[i].(map[string]interface{})
+				if !ok {
+					break
+				}
+				if r, _ := toolMessage["role"].(string); r != "tool" {
+					break
+				}
+				toolCallID, _ := toolMessage["tool_call_id"].(string)
+				toolResults = append(toolResults, map[string]interface{}{
+					"toolResult": map[string]interface{}{
+						"toolUseId": toolCallID,
+						"content":   []interface{}{map[string]interface{}{"text": extractText(toolMessage["content"])}},
+					},
+				})
+				i++
+			}
+			i-- // outer loop will re-increment
+			converseMessages = append(converseMessages, map[string]interface{}{
+				"role":    "user",
+				"content": toolResults,
+			})
+		}
+	}
+
+	return system, converseMessages
+}
+
+func extractText(content interface{}) string {
+	switch typed := content.(type) {
+	case string:
+		return typed
+	case []interface{}:
+		var parts []string
+		for _, part := range typed {
+			block, ok := part.(map[string]interface{})
+			if !ok || block["type"] != "text" {
+				continue
+			}
+			if text, ok := block["text"].(string); ok {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "")
+	}
+	return ""
+}
+
+func convertUserContent(content interface{}) []interface{} {
+	switch typed := content.(type) {
+	case string:
+		return []interface{}{map[string]interface{}{"text": typed}}
+	case []interface{}:
+		var blocks []interface{}
+		for _, part := range typed {
+			block, ok := part.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch block["type"] {
+			case "text":
+				if text, ok := block["text"].(string); ok {
+					blocks = append(blocks, map[string]interface{}{"text": text})
+				}
+			case "image_url":
+				if image := convertImage(block); image != nil {
+					blocks = append(blocks, image)
+				}
+			}
+		}
+		if len(blocks) > 0 {
+			return blocks
+		}
+	}
+	return []interface{}{map[string]interface{}{"text": ""}}
+}
+
+func convertAssistantContent(message map[string]interface{}) []interface{} {
+	var blocks []interface{}
+	if text := extractText(message["content"]); text != "" {
+		blocks = append(blocks, map[string]interface{}{"text": text})
+	}
+
+	toolCalls, _ := message["tool_calls"].([]interface{})
+	for _, raw := range toolCalls {
+		toolCall, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := toolCall["id"].(string)
+		fn, _ := toolCall["function"].(map[string]interface{})
+		if fn == nil {
+			continue
+		}
+		name, _ := fn["name"].(string)
+		argsString, _ := fn["arguments"].(string)
+
+		var input interface{} = map[string]interface{}{}
+		if argsString != "" {
+			if err := json.Unmarshal([]byte(argsString), &input); err != nil {
+				input = map[string]interface{}{}
+			}
+		}
+		blocks = append(blocks, map[string]interface{}{
+			"toolUse": map[string]interface{}{
+				"toolUseId": id,
+				"name":      name,
+				"input":     input,
+			},
+		})
+	}
+
+	if len(blocks) == 0 {
+		blocks = append(blocks, map[string]interface{}{"text": ""})
+	}
+	return blocks
+}
+
+// convertImage maps an OpenAI image_url block to a Converse image block. Only
+// base64 data URIs are supported; remote URLs are dropped since the Converse
+// image source expects inline bytes.
+func convertImage(block map[string]interface{}) map[string]interface{} {
+	imageObject, ok := block["image_url"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	url, ok := imageObject["url"].(string)
+	if !ok || !strings.HasPrefix(url, "data:") {
+		return nil
+	}
+	parts := strings.SplitN(url, ",", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	meta := strings.TrimPrefix(parts[0], "data:")
+	mediaType := strings.SplitN(meta, ";", 2)[0]
+	format := strings.TrimPrefix(mediaType, "image/")
+	if format == "" {
+		return nil
+	}
+	return map[string]interface{}{
+		"image": map[string]interface{}{
+			"format": format,
+			"source": map[string]interface{}{"bytes": parts[1]},
+		},
+	}
+}
+
+func buildInferenceConfig(payload map[string]interface{}, params PolicyParams) map[string]interface{} {
+	inference := map[string]interface{}{}
+
+	if v, ok := payload["max_completion_tokens"]; ok {
+		inference["maxTokens"] = v
+	} else if v, ok := payload["max_tokens"]; ok {
+		inference["maxTokens"] = v
+	} else {
+		inference["maxTokens"] = params.MaxTokens
+	}
+
+	if v, ok := payload["temperature"]; ok {
+		inference["temperature"] = v
+	}
+	if v, ok := payload["top_p"]; ok {
+		inference["topP"] = v
+	}
+	if stop, ok := payload["stop"]; ok && stop != nil {
+		switch s := stop.(type) {
+		case string:
+			inference["stopSequences"] = []string{s}
+		case []interface{}:
+			inference["stopSequences"] = s
+		}
+	}
+	return inference
+}
+
+// buildToolConfig maps OpenAI tools/tool_choice to a Converse toolConfig.
+// Returns nil when no tools apply (or tool_choice is "none"), in which case the
+// caller omits toolConfig entirely.
+func buildToolConfig(payload map[string]interface{}) map[string]interface{} {
+	tools, ok := payload["tools"].([]interface{})
+	if !ok || len(tools) == 0 {
+		return nil
+	}
+
+	// "none" means the model may not call tools — drop the whole toolConfig.
+	if choice, ok := payload["tool_choice"].(string); ok && choice == "none" {
+		return nil
+	}
+
+	var converseTools []interface{}
+	for _, raw := range tools {
+		tool, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fn, ok := tool["function"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		spec := map[string]interface{}{"name": fn["name"]}
+		if description, ok := fn["description"]; ok {
+			spec["description"] = description
+		}
+		schema := fn["parameters"]
+		if schema == nil {
+			schema = map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+		}
+		spec["inputSchema"] = map[string]interface{}{"json": schema}
+		converseTools = append(converseTools, map[string]interface{}{"toolSpec": spec})
+	}
+	if len(converseTools) == 0 {
+		return nil
+	}
+
+	toolConfig := map[string]interface{}{"tools": converseTools}
+	if toolChoice := convertToolChoice(payload["tool_choice"]); toolChoice != nil {
+		toolConfig["toolChoice"] = toolChoice
+	}
+	return toolConfig
+}
+
+func convertToolChoice(toolChoice interface{}) map[string]interface{} {
+	switch choice := toolChoice.(type) {
+	case string:
+		switch choice {
+		case "required":
+			return map[string]interface{}{"any": map[string]interface{}{}}
+		case "auto":
+			return map[string]interface{}{"auto": map[string]interface{}{}}
+		}
+	case map[string]interface{}:
+		if fn, ok := choice["function"].(map[string]interface{}); ok {
+			if name, ok := fn["name"].(string); ok {
+				return map[string]interface{}{"tool": map[string]interface{}{"name": name}}
+			}
+		}
+	}
+	return nil
+}

--- a/policies/openai-to-bedrock-transformer/response.go
+++ b/policies/openai-to-bedrock-transformer/response.go
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package openaitobedrock
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+const (
+	objectChatCompletion      = "chat.completion"
+	objectChatCompletionChunk = "chat.completion.chunk"
+	sseDonePayload            = "data: [DONE]\n\n"
+)
+
+// ─── Non-streaming (Converse JSON → OpenAI ChatCompletion) ────────────────────
+
+type converseResponse struct {
+	Output struct {
+		Message struct {
+			Role    string                 `json:"role"`
+			Content []converseContentBlock `json:"content"`
+		} `json:"message"`
+	} `json:"output"`
+	StopReason string        `json:"stopReason"`
+	Usage      converseUsage `json:"usage"`
+}
+
+type converseContentBlock struct {
+	Text    string `json:"text,omitempty"`
+	ToolUse *struct {
+		ToolUseID string          `json:"toolUseId"`
+		Name      string          `json:"name"`
+		Input     json.RawMessage `json:"input"`
+	} `json:"toolUse,omitempty"`
+}
+
+type converseUsage struct {
+	InputTokens  int `json:"inputTokens"`
+	OutputTokens int `json:"outputTokens"`
+	TotalTokens  int `json:"totalTokens"`
+}
+
+func translateConverseResponse(body []byte, status int, model, id string) policy.ResponseAction {
+	if status < 200 || status >= 300 {
+		return translateErrorResponse(body, status)
+	}
+
+	var resp converseResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		// 2xx but not Converse JSON — forward unchanged rather than masking it.
+		return policy.DownstreamResponseModifications{}
+	}
+
+	var textParts []string
+	var toolCalls []map[string]interface{}
+	for i := range resp.Output.Message.Content {
+		block := &resp.Output.Message.Content[i]
+		if block.Text != "" {
+			textParts = append(textParts, block.Text)
+		}
+		if block.ToolUse != nil {
+			toolCalls = append(toolCalls, map[string]interface{}{
+				"id":   block.ToolUse.ToolUseID,
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":      block.ToolUse.Name,
+					"arguments": rawInputToArguments(block.ToolUse.Input),
+				},
+			})
+		}
+	}
+
+	message := map[string]interface{}{
+		"role":    "assistant",
+		"content": strings.Join(textParts, ""),
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	}
+
+	openAIResp := map[string]interface{}{
+		"id":      id,
+		"object":  objectChatCompletion,
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]interface{}{{
+			"index":         0,
+			"message":       message,
+			"finish_reason": stopReasonToFinish(resp.StopReason, len(toolCalls) > 0),
+		}},
+		"usage": map[string]interface{}{
+			"prompt_tokens":     resp.Usage.InputTokens,
+			"completion_tokens": resp.Usage.OutputTokens,
+			"total_tokens":      totalTokens(resp.Usage),
+		},
+	}
+
+	newBody, err := json.Marshal(openAIResp)
+	if err != nil {
+		return errResponse(500, "failed to translate Bedrock response: "+err.Error())
+	}
+	return policy.DownstreamResponseModifications{
+		Body: newBody,
+		HeadersToSet: map[string]string{
+			"content-type":   "application/json",
+			"content-length": fmt.Sprintf("%d", len(newBody)),
+		},
+	}
+}
+
+func translateErrorResponse(body []byte, status int) policy.ResponseAction {
+	message := string(body)
+	var bedrockErr struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &bedrockErr); err == nil && bedrockErr.Message != "" {
+		message = bedrockErr.Message
+	}
+
+	openaiErr := map[string]interface{}{
+		"error": map[string]interface{}{
+			"type":    mapStatusToOpenAIErrorType(status),
+			"message": message,
+			"code":    fmt.Sprintf("%d", status),
+		},
+	}
+	newBody, err := json.Marshal(openaiErr)
+	if err != nil {
+		return errResponse(500, "failed to translate Bedrock error: "+err.Error())
+	}
+	return policy.DownstreamResponseModifications{
+		Body: newBody,
+		HeadersToSet: map[string]string{
+			"content-type":   "application/json",
+			"content-length": fmt.Sprintf("%d", len(newBody)),
+		},
+	}
+}
+
+// ─── Streaming (Amazon event stream → OpenAI SSE) ─────────────────────────────
+
+// eventStreamToSSE decodes every complete event-stream frame in data and renders
+// the OpenAI Server-Sent Events for them. When endOfStream is true it appends the
+// terminating `data: [DONE]` marker. Bytes that form only a partial trailing
+// frame are ignored (the kernel re-delivers them with the next flush).
+func eventStreamToSSE(data []byte, endOfStream bool, id, model string) []byte {
+	created := time.Now().Unix()
+	var out []byte
+
+	frames, _, ok := decodeEventStreamFrames(data)
+	if ok {
+		for i := range frames {
+			out = append(out, streamFrameToSSE(&frames[i], id, model, created)...)
+		}
+	}
+
+	if endOfStream {
+		out = append(out, sseDonePayload...)
+	}
+	return out
+}
+
+// streamFrameToSSE maps a single Converse stream event to zero or more OpenAI
+// SSE events.
+func streamFrameToSSE(frame *eventStreamFrame, id, model string, created int64) []byte {
+	if frame.MessageType == "exception" || frame.ExceptionType != "" {
+		return sseData(map[string]interface{}{
+			"error": map[string]interface{}{
+				"type":    "server_error",
+				"message": exceptionMessage(frame),
+			},
+		})
+	}
+
+	var event map[string]interface{}
+	if len(frame.Payload) > 0 {
+		_ = json.Unmarshal(frame.Payload, &event)
+	}
+
+	switch frame.EventType {
+	case "messageStart":
+		return sseData(streamChunk(id, model, created, map[string]interface{}{"role": "assistant"}, nil))
+
+	case "contentBlockStart":
+		start, _ := event["start"].(map[string]interface{})
+		toolUse, _ := start["toolUse"].(map[string]interface{})
+		if toolUse == nil {
+			return nil
+		}
+		delta := map[string]interface{}{
+			"tool_calls": []interface{}{map[string]interface{}{
+				"index": blockIndex(event),
+				"id":    toolUse["toolUseId"],
+				"type":  "function",
+				"function": map[string]interface{}{
+					"name":      toolUse["name"],
+					"arguments": "",
+				},
+			}},
+		}
+		return sseData(streamChunk(id, model, created, delta, nil))
+
+	case "contentBlockDelta":
+		delta, _ := event["delta"].(map[string]interface{})
+		if text, ok := delta["text"].(string); ok {
+			return sseData(streamChunk(id, model, created, map[string]interface{}{"content": text}, nil))
+		}
+		if toolUse, ok := delta["toolUse"].(map[string]interface{}); ok {
+			input, _ := toolUse["input"].(string)
+			toolDelta := map[string]interface{}{
+				"tool_calls": []interface{}{map[string]interface{}{
+					"index":    blockIndex(event),
+					"function": map[string]interface{}{"arguments": input},
+				}},
+			}
+			return sseData(streamChunk(id, model, created, toolDelta, nil))
+		}
+		return nil
+
+	case "messageStop":
+		stopReason, _ := event["stopReason"].(string)
+		return sseData(streamChunk(id, model, created, map[string]interface{}{},
+			stopReasonToFinish(stopReason, false)))
+
+	case "metadata":
+		usage, ok := event["usage"].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		chunk := streamChunk(id, model, created, nil, nil)
+		chunk["choices"] = []interface{}{}
+		chunk["usage"] = map[string]interface{}{
+			"prompt_tokens":     numberField(usage, "inputTokens"),
+			"completion_tokens": numberField(usage, "outputTokens"),
+			"total_tokens":      numberField(usage, "totalTokens"),
+		}
+		return sseData(chunk)
+	}
+	return nil
+}
+
+func streamChunk(id, model string, created int64, delta map[string]interface{}, finishReason interface{}) map[string]interface{} {
+	chunk := map[string]interface{}{
+		"id":      id,
+		"object":  objectChatCompletionChunk,
+		"created": created,
+		"model":   model,
+	}
+	if delta != nil {
+		chunk["choices"] = []interface{}{map[string]interface{}{
+			"index":         0,
+			"delta":         delta,
+			"finish_reason": finishReason,
+		}}
+	}
+	return chunk
+}
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+// sseData renders one OpenAI SSE event: `data: <json>\n\n`.
+func sseData(payload map[string]interface{}) []byte {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, 0, len(encoded)+8)
+	out = append(out, "data: "...)
+	out = append(out, encoded...)
+	out = append(out, "\n\n"...)
+	return out
+}
+
+func rawInputToArguments(input json.RawMessage) string {
+	if len(input) == 0 {
+		return "{}"
+	}
+	return string(input)
+}
+
+func totalTokens(usage converseUsage) int {
+	if usage.TotalTokens > 0 {
+		return usage.TotalTokens
+	}
+	return usage.InputTokens + usage.OutputTokens
+}
+
+func blockIndex(event map[string]interface{}) int {
+	if n, ok := toInt(event["contentBlockIndex"]); ok {
+		return n
+	}
+	return 0
+}
+
+func numberField(m map[string]interface{}, key string) int {
+	if n, ok := toInt(m[key]); ok {
+		return n
+	}
+	return 0
+}
+
+func exceptionMessage(frame *eventStreamFrame) string {
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(frame.Payload, &payload); err == nil && payload.Message != "" {
+		return payload.Message
+	}
+	if frame.ExceptionType != "" {
+		return frame.ExceptionType
+	}
+	return "bedrock stream error"
+}
+
+func stopReasonToFinish(stopReason string, hasToolCalls bool) string {
+	switch stopReason {
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	case "end_turn", "stop_sequence":
+		return "stop"
+	case "content_filtered", "guardrail_intervened":
+		return "content_filter"
+	default:
+		if hasToolCalls {
+			return "tool_calls"
+		}
+		return "stop"
+	}
+}
+
+func mapStatusToOpenAIErrorType(status int) string {
+	switch {
+	case status == 400:
+		return "invalid_request_error"
+	case status == 401:
+		return "authentication_error"
+	case status == 403:
+		return "permission_error"
+	case status == 404:
+		return "not_found_error"
+	case status == 413:
+		return "request_too_large"
+	case status == 429:
+		return "rate_limit_error"
+	case status >= 500:
+		return "server_error"
+	default:
+		return "api_error"
+	}
+}
+
+func newChatCompletionID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano())
+	}
+	return "chatcmpl-" + hex.EncodeToString(b[:])
+}

--- a/policies/openai-to-bedrock-transformer/response.go
+++ b/policies/openai-to-bedrock-transformer/response.go
@@ -175,6 +175,8 @@ func eventStreamToSSE(data []byte, endOfStream bool, id, model string) []byte {
 		for i := range frames {
 			out = append(out, streamFrameToSSE(&frames[i], id, model, created)...)
 		}
+	} else {
+		out = append(out, data...)
 	}
 
 	if endOfStream {


### PR DESCRIPTION

## Purpose

Add AWS Bedrock as a supported target for OpenAI-compatible LLM proxies. Clients should be able to send OpenAI Chat Completions requests while the gateway communicates with AWS Bedrock using the Converse API.

This also enables AWS Bedrock to participate in the existing multi-provider routing flow.

No linked issue.

## Goals

- Introduce the `openai-to-bedrock-transformer` policy.
- Translate OpenAI Chat Completions requests into AWS Bedrock Converse requests.
- Translate Bedrock responses into OpenAI-compatible responses.
- Support both non-streaming and streaming responses.
- Support single-provider and multi-provider proxy configurations.
- Support system prompts, multimodal input, tool calls, tool results, inference settings, usage information, and error responses.

## Approach

The policy implements request, response-header, buffered-response, and streaming-response processing.

The implementation:

- Rewrites requests to `/model/{modelId}/converse` or `/model/{modelId}/converse-stream`.
- Converts OpenAI messages into Bedrock Converse message and content-block structures.
- Maps system and developer messages to Bedrock system blocks.
- Maps OpenAI tool definitions, tool choices, tool calls, and tool results to their Bedrock equivalents.
- Converts supported base64 `image_url` content into Bedrock image blocks.
- Maps OpenAI inference settings to Bedrock `inferenceConfig`.
- Converts non-streaming Converse responses into OpenAI ChatCompletion responses.
- Decodes binary Amazon event-stream frames and emits OpenAI-compatible Server-Sent Events.
- Uses `selected_provider` metadata to participate in multi-provider routing.
- Runs unconditionally when no provider was selected, supporting single-provider proxies.

This change does not affect the UI.

## User stories

- As an OpenAI API client, I can use an AWS Bedrock model without changing my request format.
- As a gateway administrator, I can expose AWS Bedrock through an OpenAI-compatible endpoint.
- As a gateway administrator, I can include AWS Bedrock in a multi-provider LLM proxy.
- As a client, I can receive both non-streaming and streaming responses in OpenAI-compatible formats.
- As a client, I can use supported tool calling and multimodal inputs with Bedrock models.

## Release note

Added an OpenAI-to-AWS-Bedrock transformer policy that converts OpenAI Chat Completions traffic to the AWS Bedrock Converse API, including support for streaming responses, tool calling, multimodal input, and multi-provider routing.

## Documentation

Documentation is included in this PR:

- `docs/openai-to-bedrock/v0.9/docs/openai-to-bedrock.md`
- `docs/openai-to-bedrock/v0.9/metadata.json`
- Updated `docs/README.md` policy catalog

## Training

N/A — no training-content changes are required for this policy addition.

## Certification

N/A — this policy addition does not currently require changes to certification exams.

## Marketing

N/A — no marketing-content changes are included in this PR.

## Automation tests

- Unit tests
  - Added tests for policy parameter validation.
  - Added tests for request translation and path rewriting.
  - Added tests for single-provider and multi-provider routing.
  - Added tests for system prompts, tools, images, and tool results.
  - Added tests for non-streaming response and error translation.
  - Added tests for Amazon event-stream decoding and OpenAI SSE generation.
  - Added malformed event-stream and split-frame boundary tests.
  - Statement coverage for the new policy: **71.8%**.
  - `go test -race ./...` passed.
  - `go vet ./...` passed.
  - Existing OpenAI transformer regression suites passed.

- Integration tests
  - No new end-to-end integration tests are included in this PR.
  - Request, response, routing, and streaming behavior are covered through unit tests using representative OpenAI, Bedrock Converse, and Amazon event-stream payloads.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **N/A — this is a Go module; FindSecurityBugs is a Java-specific plugin**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

The policy documentation includes configuration examples for:

- Attaching `openai-to-bedrock-transformer` to an additional provider in a multi-provider LLM proxy.
- Attaching the transformer directly to a single-provider proxy.
- Configuring Bedrock model or inference-profile IDs.
- Configuring the fallback maximum-token value.

No credentials or functional API keys are included in the samples.

## Related PRs

N/A.

This branch is based on `multi-provider-transformers`, which introduces the common multi-provider transformer functionality used by this policy.

## Migrations (if applicable)

N/A — this is a new policy and does not change existing policy configurations or stored data.

Existing users can opt in by adding `openai-to-bedrock-transformer` to a single-provider proxy or to an AWS Bedrock entry under `additionalProviders`.

## Test environment

- Operating system: macOS
- Go version: Go 1.26.2
- SDK dependency: `github.com/wso2/api-platform/sdk/core v0.2.14`
- JDK: N/A
- Databases: N/A
- Browsers: N/A
- UI testing: N/A

## Learning

The implementation was informed by:

- The existing OpenAI transformer policies in this repository.
- The AWS Bedrock provider and OpenAI-to-Bedrock development implementation under `api-platform-main/gateway`.
- AWS Bedrock Converse request and response structures.
- Amazon event-stream binary framing.
- OpenAI Chat Completions response and streaming SSE structures.
- The existing `selected_provider` multi-provider routing convention.
