### PR TITLE
Refactor valuePrefix param of API key auth policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ All available policies, sorted alphabetically.
 | Policy | Categories | Description |
 |--------|------------|-------------|
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
-| [API Key Auth](./api-key-auth/v1.1/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
+| [API Key Auth](./api-key-auth/v1.2/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
 | [AWS Authentication](./aws-authentication/v0.9/docs/aws-authentication.md) | Security, AI | Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4). |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |

--- a/docs/api-key-auth/v1.2/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.2/docs/apikey-authentication.md
@@ -11,7 +11,7 @@ The API Key Authentication policy validates API keys to secure APIs by verifying
 
 - Validates API keys from request headers
 - Configurable key extraction from headers (case-insensitive)
-- Optional value prefix stripping before validation (e.g., `Bearer `)
+- Optional prefix stripping from API key value before validation (e.g., `Bearer `)
 - Pre-generated key validation against gateway-managed key lists
 - Request context enrichment with authentication metadata
 - Issuer-based key validation via system configuration
@@ -25,11 +25,11 @@ The API Key Authentication policy uses a two-level configuration model. User par
 
 These parameters are configured per-API/route by the API developer:
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `key` | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters. |
-| `in` | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported. |
-| `value-prefix` | string | No | `""` | Advanced parameter. Optional prefix stripped from the header value before validation (e.g., `Bearer ` when the key is sent in an `Authorization` header). Matching and removal are case-insensitive. If the parameter is set but the header value does not start with the prefix, the request is rejected as malformed. Length: 1-64 characters. |
+| Parameter     | Type | Required | Default | Description                                                                                                                                                                                                                                                                                                                   |
+|---------------|------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `key`         | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters.                                                                                                                                                                           |
+| `in`          | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported.                                                                                                                                                                                                                                                |
+| `valuePrefix` | string | No | `""` | Optional prefix stripped from the header value before validation (e.g., `Bearer ` when the key is sent in an `Authorization` header). Matching and removal are case-insensitive. If the parameter is set but the header value does not start with the prefix, the request is rejected as malformed. Length: 1-128 characters. |
 
 ### System Parameters (config.toml)
 
@@ -213,7 +213,7 @@ spec:
       params:
         key: Authorization
         in: header
-        value-prefix: "Bearer "
+        valuePrefix: "Bearer "
   operations:
     - method: GET
       path: /{country_code}/{city}
@@ -229,7 +229,7 @@ spec:
 
 - Based on `in`, it extracts the API key from a request header (case-insensitive header lookup).
 
-- If `value-prefix` is configured, the policy strips the prefix from the extracted value (case-insensitive) before validation. If the value does not start with the configured prefix, the resulting key is empty and the request is rejected as malformed.
+- If `valuePrefix` is configured, the policy strips the prefix from the extracted value (case-insensitive) before validation. If the value does not start with the configured prefix, the resulting key is empty and the request is rejected as malformed.
 
 - If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
 

--- a/docs/api-key-auth/v1.2/docs/apikey-authentication.md
+++ b/docs/api-key-auth/v1.2/docs/apikey-authentication.md
@@ -1,0 +1,256 @@
+---
+title: "Overview"
+---
+# API Key Authentication
+
+## Overview
+
+The API Key Authentication policy validates API keys to secure APIs by verifying pre-generated keys before allowing access to protected resources. This policy is essential for API security, supporting header-based key validation.
+
+## Features
+
+- Validates API keys from request headers
+- Configurable key extraction from headers (case-insensitive)
+- Optional value prefix stripping before validation (e.g., `Bearer `)
+- Pre-generated key validation against gateway-managed key lists
+- Request context enrichment with authentication metadata
+- Issuer-based key validation via system configuration
+- Streaming-compatible request processing (header-phase only)
+
+## Configuration
+
+The API Key Authentication policy uses a two-level configuration model. User parameters are configured per-API/route in the API definition YAML, and system parameters are resolved from gateway configuration.
+
+### User Parameters (API Definition)
+
+These parameters are configured per-API/route by the API developer:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | string | Yes | `API-Key` | The name of the header that contains the API key. Case-insensitive matching is used (e.g., "X-API-Key", "Authorization"). Length: 1-128 characters. |
+| `in` | string | Yes | `header` | Specifies where to look for the API key. Currently only "header" is supported. |
+| `value-prefix` | string | No | `""` | Advanced parameter. Optional prefix stripped from the header value before validation (e.g., `Bearer ` when the key is sent in an `Authorization` header). Matching and removal are case-insensitive. If the parameter is set but the header value does not start with the prefix, the request is rejected as malformed. Length: 1-64 characters. |
+
+### System Parameters (config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `issuer` | string | No | `""` | Identifier of the portal associated with this gateway. Resolved from `config.toml` `[api_key] issuer` at startup. When set to a non-empty string, the policy rejects any API key whose issuer field is non-null and does not match this value. When empty or absent, the issuer check is skipped entirely. |
+
+#### Sample System Configuration
+
+```toml
+[api_key]
+issuer = "https://portal.example.com"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: api-key-auth
+  gomodule: github.com/wso2/gateway-controllers/policies/api-key-auth@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic API Key Authentication (Header)
+
+Apply API key authentication using a custom header
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 2: Default Header Name
+
+Use the default API-Key header name
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: API-Key
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 3: Custom Header Name
+
+Use a custom header for API key authentication
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 4: Route-Specific Authentication
+
+Apply different API key configurations to different routes
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: X-Custom-Auth
+        in: header
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+      policies:
+        - name: api-key-auth
+          version: v1
+          params:
+            key: X-API-Key
+            in: header
+    - method: GET
+      path: /alerts/active
+      policies:
+        - name: api-key-auth
+          version: v1
+          params:
+            key: Authorization
+            in: header
+    - method: POST
+      path: /alerts/active
+```
+
+### Example 5: Stripping a Value Prefix
+
+Extract the API key from an `Authorization` header that carries a `Bearer ` prefix. The prefix is removed before validation, so a request sending `Authorization: Bearer <api-key>` is validated against `<api-key>`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: RestApi
+metadata:
+  name: weather-api-v1.0
+spec:
+  displayName: Weather-API
+  version: v1.0
+  context: /weather/$version
+  upstream:
+    main:
+      url: http://sample-backend:5000/api/v2
+  policies:
+    - name: api-key-auth
+      version: v1
+      params:
+        key: Authorization
+        in: header
+        value-prefix: "Bearer "
+  operations:
+    - method: GET
+      path: /{country_code}/{city}
+    - method: GET
+      path: /alerts/active
+    - method: POST
+      path: /alerts/active
+```
+
+## How it Works
+
+- On each request, the gateway policy reads `key` and `in` from the policy configuration and validates that required parameters are present.
+
+- Based on `in`, it extracts the API key from a request header (case-insensitive header lookup).
+
+- If `value-prefix` is configured, the policy strips the prefix from the extracted value (case-insensitive) before validation. If the value does not start with the configured prefix, the resulting key is empty and the request is rejected as malformed.
+
+- If the key is missing, empty, or the required API context values are unavailable, the policy short-circuits the request and returns `401 Unauthorized` with a JSON error response.
+
+- For valid inputs, the policy calls the API key store validator using API and operation context (`apiId`, operation path, HTTP method) to determine whether the key is allowed for the target operation.
+
+- If an `issuer` is configured at the system level, the policy additionally verifies that the API key's issuer field matches the configured value. Keys with a non-null issuer that does not match are rejected.
+
+- On successful validation, the request continues upstream and authentication metadata is added to the shared context (`auth.success=true`, `auth.method=api-key`). The policy does not modify response traffic.
+
+- Key lifecycle and control-plane capabilities still apply, but are handled outside this gateway runtime policy: quota enforcement (including `remaining_api_key_quota` in key management APIs), key generation/regeneration, key format, secure hashing/storage, masking, access control, and audit logging.
+
+
+## Notes:
+
+- API keys offer a lightweight, secure authentication mechanism for internal services, partner and third-party integrations, legacy systems, development and testing environments, and service-to-service communication, providing a practical alternative to complex OAuth flows while ensuring controlled access through HTTPS-only transmission, secure hashing, masking, and constant-time validation.
+
+- Store API keys securely, never exposing them in client-side code, logs, or version control systems.
+
+- The platform enforces access control, audit logging, and quota limits to prevent abuse and support traceability. To maintain security over time, keys should be regenerated regularly, handled carefully in logs and query parameters, and revoked immediately if compromised.
+
+- Use clear, descriptive naming and maintain separate keys per environment (development, staging, production) to simplify management.
+
+- Always transmit API keys over HTTPS only and ensure logging practices do not inadvertently expose sensitive key material.
+

--- a/docs/api-key-auth/v1.2/metadata.json
+++ b/docs/api-key-auth/v1.2/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "api-key-auth",
+  "displayName": "API Key Auth",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "Security",
+    "AI",
+    "WebSub",
+    "WebBroker"
+  ],
+  "description": "Implements API Key Authentication to protect APIs with pre-shared API keys.\nValidates API keys from request headers against a configured\nlist of valid keys and sets authentication metadata in the request context."
+}

--- a/docs/api-key-auth/v1.2/metadata.json
+++ b/docs/api-key-auth/v1.2/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "api-key-auth",
   "displayName": "API Key Auth",
-  "version": "1.1",
+  "version": "1.2",
   "provider": "WSO2",
   "categories": [
     "Security",

--- a/policies/api-key-auth/apikey.go
+++ b/policies/api-key-auth/apikey.go
@@ -163,7 +163,7 @@ func (p *APIKeyPolicy) authenticate(
 	}
 
 	var valuePrefix string
-	if valuePrefixRaw, ok := params["value-prefix"]; ok {
+	if valuePrefixRaw, ok := params["valuePrefix"]; ok {
 		if vp, ok := valuePrefixRaw.(string); ok {
 			valuePrefix = vp
 		}

--- a/policies/api-key-auth/apikey_test.go
+++ b/policies/api-key-auth/apikey_test.go
@@ -206,9 +206,9 @@ func TestAPIKeyPolicy_OnRequestHeaders_SuccessWithValuePrefix(t *testing.T) {
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
 	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
-		"key":          "authorization",
-		"in":           "header",
-		"value-prefix": "Bearer ",
+		"key":         "authorization",
+		"in":          "header",
+		"valuePrefix": "Bearer ",
 	})
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
@@ -230,9 +230,9 @@ func TestAPIKeyPolicy_OnRequestHeaders_ValuePrefixIsCaseInsensitive(t *testing.T
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
 	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
-		"key":          "authorization",
-		"in":           "header",
-		"value-prefix": "bearer ",
+		"key":         "authorization",
+		"in":          "header",
+		"valuePrefix": "bearer ",
 	})
 
 	if ctx.SharedContext.AuthContext == nil || !ctx.SharedContext.AuthContext.Authenticated {
@@ -255,9 +255,9 @@ func TestAPIKeyPolicy_OnRequestHeaders_FailsWhenValuePrefixMissing(t *testing.T)
 	}, "api-1", "OrdersAPI", "v1", "/orders")
 
 	action := p.OnRequestHeaders(context.Background(), ctx, map[string]interface{}{
-		"key":          "authorization",
-		"in":           "header",
-		"value-prefix": "Bearer ",
+		"key":         "authorization",
+		"in":          "header",
+		"valuePrefix": "Bearer ",
 	})
 
 	assertUnauthorizedJSON(t, action)

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v1.1.0
+version: v1.2.0
 description: |
   Secures APIs by validating API keys in incoming requests. API keys are
   provided through a configured HTTP header.
@@ -29,7 +29,7 @@ parameters:
       enum:
         - "header"
 
-    value-prefix:
+    valuePrefix:
       type: string
       x-wso2-policy-advanced-param: true
       description: |


### PR DESCRIPTION
This pull request introduces version 1.2.0 of the API Key Authentication policy standardizing the parameter name `value-prefix` to `valuePrefix`.

**API Key Authentication Policy v1.2.0 Update**

**Configuration and Parameter Standardization**
* Changed the parameter name from `value-prefix` to `valuePrefix` in the policy definition, implementation, and tests to ensure consistency across user configuration, code, and documentation. [[1]](diffhunk://#diff-1363efa44564d1da59d09a8bf2a1f6e7769e86cae86c916886ac8f001d34791fL32-R32) [[2]](diffhunk://#diff-89ad499b6ab886792718743f066c5ad8c0194a5aac1ace42a0e2e4e7c793e4eaL166-R166) [[3]](diffhunk://#diff-eab3aebfadaf5688f536cfc532738cea36323692557fea26c892f0c88d6eea75L211-R211) [[4]](diffhunk://#diff-eab3aebfadaf5688f536cfc532738cea36323692557fea26c892f0c88d6eea75L235-R235) [[5]](diffhunk://#diff-eab3aebfadaf5688f536cfc532738cea36323692557fea26c892f0c88d6eea75L260-R260)

**Documentation and Metadata Updates**
* Added a comprehensive new overview and usage guide for API Key Authentication in `apikey-authentication.md`, including configuration options, reference scenarios, and security notes.
* Updated the policy version to `v1.2.0` in `policy-definition.yaml` and changed documentation links in `docs/README.md` to reference v1.2. [[1]](diffhunk://#diff-1363efa44564d1da59d09a8bf2a1f6e7769e86cae86c916886ac8f001d34791fL2-R2) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L32-R34)
* Added a new `metadata.json` for version 1.2, describing the policy and its categories.