### PR TITLE
Add AI category to AWS Authentication policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ All available policies, sorted alphabetically.
 |--------|------------|-------------|
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
 | [API Key Auth](./api-key-auth/v1.1/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
-| [AWS Authentication](./aws-authentication/v0.9/docs/aws-authentication.md) | Security | Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4). |
+| [AWS Authentication](./aws-authentication/v0.9/docs/aws-authentication.md) | Security, AI | Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4). |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
 | [Backend JWT](./backend-jwt/v1.0/docs/backend-jwt.md) | Security | Generates a signed JWT containing authenticated user information and injects it into the upstream request header. |

--- a/docs/aws-authentication/v0.9/metadata.json
+++ b/docs/aws-authentication/v0.9/metadata.json
@@ -4,7 +4,8 @@
   "version": "1.0",
   "provider": "WSO2",
   "categories": [
-    "Security"
+    "Security",
+    "AI"
   ],
   "description": "Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4).\nSupports two credential-acquisition modes: AWS STS AssumeRole for temporary credentials,\nor a static IAM user access key/secret pair. Intended for backends such as API Gateway with\nIAM auth, Lambda Function URLs, OpenSearch, and S3 that require SigV4-signed requests."
 }


### PR DESCRIPTION
This pull request updates the categorization of the AWS Authentication policy to include the "AI" category in addition to "Security". The change ensures that the policy is more discoverable for AI-related use cases in both the documentation table and the policy metadata.

**Documentation and metadata updates:**

* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L35-R35): Added "AI" to the categories column for the AWS Authentication policy in the policies table.
* [`docs/aws-authentication/v0.9/metadata.json`](diffhunk://#diff-368d46dd77b3162624005fba9c807e9bdfcfaeb2ecb44bb92d75e4aa6f51ea93L7-R8): Updated the `categories` array to include "AI" alongside "Security" for the AWS Authentication policy.