### PR TITLE
Add support for request header snapshots and improve JWT Auth handling

### DIFF
--- a/policies/jwt-auth/go.mod
+++ b/policies/jwt-auth/go.mod
@@ -1,8 +1,8 @@
 module github.com/wso2/gateway-controllers/policies/jwt-auth
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/wso2/api-platform/sdk/core v0.2.16
+	github.com/wso2/api-platform/sdk/core v0.3.0
 )

--- a/policies/jwt-auth/go.sum
+++ b/policies/jwt-auth/go.sum
@@ -1,4 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.2.16 h1:mIUOjrfX6gJNsntddYo+J70e7BHgrGC6DT3ZOVnVKZE=
-github.com/wso2/api-platform/sdk/core v0.2.16/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/api-platform/sdk/core v0.3.0 h1:iPUEwB1lpjQto/Gjgl1F4ZrrU4P85bXvmabxgBSHs7E=
+github.com/wso2/api-platform/sdk/core v0.3.0/go.mod h1:NZMDIQadQDpbynlCLYdZT6duiHwnf7emr7SbLHdCjaE=

--- a/policies/jwt-auth/header_snapshot.go
+++ b/policies/jwt-auth/header_snapshot.go
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package jwtauth
+
+import policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+
+// getDownstreamHeaders returns the snapshot of the original client
+// request headers when the gateway provides it, falling back to the live
+// (possibly peer-mutated) request headers on older gateways that predate the
+// Downstream snapshot.
+//
+// Use this for every header read that feeds an authentication, authorization,
+// or gating decision. The kernel runs every policy's header phase before any
+// policy's body phase, mutating one shared header set in place, so a decision
+// that reads the live headers can observe a value another policy rewrote —
+// regardless of policy order. The Downstream snapshot always holds what the
+// client actually sent.
+//
+// The nil-checks are required, not optional: Downstream (and its Request) is
+// nil on gateways built before the snapshot-header-context feature, and the
+// fallback preserves the pre-feature behaviour on those runtimes.
+func getDownstreamHeaders(ds *policy.DownstreamContext, live *policy.Headers) *policy.Headers {
+	if ds != nil && ds.Request != nil && ds.Request.Headers != nil {
+		return ds.Request.Headers
+	}
+	return live
+}

--- a/policies/jwt-auth/jwtauth.go
+++ b/policies/jwt-auth/jwtauth.go
@@ -1465,7 +1465,7 @@ func (p *JwtAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 		authHeaderScheme = userAuthHeaderPrefix
 	}
 
-	authHeaders := reqCtx.Headers.Get(strings.ToLower(headerName))
+	authHeaders := getDownstreamHeaders(reqCtx.Downstream, reqCtx.Headers).Get(strings.ToLower(headerName))
 	if len(authHeaders) == 0 {
 		slog.Debug("JWT Auth Policy: Missing authorization header",
 			"headerName", headerName,

--- a/policies/jwt-auth/policy-definition.yaml
+++ b/policies/jwt-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: jwt-auth
-version: v1.2.1
+version: v1.2.2
 description: |
   Validates JWT access tokens included in API requests. The gateway verifies the
   token's signature, expiry, issuer, audience, scopes, and required claims.


### PR DESCRIPTION
## Purpose

- $Subject
- Related issues: https://github.com/wso2/api-platform/issues/2736

## Description

This pull request introduces an important bug fix to the JWT Auth policy by ensuring that authentication decisions are always made based on the original client request headers, even if other policies have mutated the headers. It also updates dependencies and adds a new helper function for header retrieval.

**Bug Fixes and Improvements:**

* Ensures that the JWT Auth policy reads the original client request headers (using the new `getDownstreamHeaders` function) instead of potentially mutated headers, which prevents authentication errors when other policies modify headers. [[1]](diffhunk://#diff-fdee622e269ef28ee19d8a1204de3cab11f0ae18629dabe8dec4ccad778dceebL1468-R1468) [[2]](diffhunk://#diff-81df0158542b2870de19fe8823365225536a1e69a43d5f476ac305fa9d1660f3R1-R42)
* Adds the `header_snapshot.go` file with the `getDownstreamHeaders` helper function, which safely retrieves the original headers when available and falls back to live headers for backward compatibility.

**Dependency Updates:**

* Updates the `go` version to 1.26.5 and `github.com/wso2/api-platform/sdk/core` to v0.3.0 in `go.mod` for compatibility and new features.