### PR TITLE
Refactor MCP auth/authz policy error handling

### DIFF
--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -21,6 +21,7 @@ package mcpauthn
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -40,6 +41,13 @@ const (
 	AuthType               = "mcp/oauth"
 	MetadataKeyAuthSuccess = "auth.success"
 	MetadataKeyAuthMethod  = "auth.method"
+
+	// JSON-RPC 2.0 constants. MCP is JSON-RPC 2.0, so protocol-level errors
+	// (as opposed to HTTP/OAuth auth failures) must be surfaced as JSON-RPC
+	// error objects. See https://www.jsonrpc.org/specification#error_object.
+	JSONRPCVersion        = "2.0"
+	JSONRPCParseError     = -32700 // invalid JSON was received
+	JSONRPCInvalidRequest = -32600 // valid JSON that is not a valid request object
 )
 
 type McpAuthPolicy struct {
@@ -426,7 +434,7 @@ func (p *McpAuthPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Reques
 		var mcpReq MCPRequest
 		if err := json.Unmarshal(reqCtx.Body.Content, &mcpReq); err != nil {
 			slog.Debug("MCP Auth Policy: Failed to parse MCP request", "error", err)
-			return p.handleAuthFailure(reqCtx.SharedContext, p.OnFailureStatusCode, p.ErrorMessageFormat, "Invalid MCP request format")
+			return p.handleBadRequest(err)
 		}
 
 		slog.Debug("MCP Auth Policy: Extracted MCP attributes",
@@ -478,6 +486,37 @@ func (p *McpAuthPolicy) handleAuthFailure(shared *policy.SharedContext, statusCo
 		StatusCode: statusCode,
 		Headers:    headers,
 		Body:       []byte(body),
+	}
+}
+
+// handleBadRequest constructs an HTTP 400 response carrying a JSON-RPC 2.0 error
+// object, as MCP requires for protocol-level errors (unlike authentication
+// failures, which are signalled at the HTTP/OAuth layer with WWW-Authenticate).
+// A body with invalid JSON syntax is reported as -32700 (Parse error); a body
+// that is valid JSON but not a valid request object as -32600 (Invalid Request).
+// The id is null because it cannot be recovered from an unparseable request. This
+// response is not subject to errorMessageFormat, which governs auth failures only.
+func (p *McpAuthPolicy) handleBadRequest(parseErr error) policy.ImmediateResponse {
+	code, message := JSONRPCInvalidRequest, "Invalid Request"
+	var syntaxErr *json.SyntaxError
+	if errors.As(parseErr, &syntaxErr) {
+		code, message = JSONRPCParseError, "Parse error"
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": JSONRPCVersion,
+		"id":      nil,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+			"data":    "Invalid MCP request format",
+		},
+	})
+
+	return policy.ImmediateResponse{
+		StatusCode: 400,
+		Headers:    map[string]string{"content-type": "application/json"},
+		Body:       body,
 	}
 }
 

--- a/policies/mcp-auth/mcp-auth_test.go
+++ b/policies/mcp-auth/mcp-auth_test.go
@@ -361,9 +361,11 @@ func TestOnRequestBody_Delegation_Failure(t *testing.T) {
 }
 
 // jsonRPCErrorResponse mirrors the JSON-RPC 2.0 error envelope for assertions.
+// ID is captured as RawMessage so a missing "id" field (nil) can be distinguished
+// from an explicit "id": null (the literal bytes "null").
 type jsonRPCErrorResponse struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      *int   `json:"id"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
 	Error   struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
@@ -406,8 +408,10 @@ func assertJSONRPCError(t *testing.T, resp policy.ImmediateResponse, wantCode in
 	if parsed.JSONRPC != "2.0" {
 		t.Errorf("Expected jsonrpc \"2.0\", got %q", parsed.JSONRPC)
 	}
-	if parsed.ID != nil {
-		t.Errorf("Expected id null, got %v", *parsed.ID)
+	if parsed.ID == nil {
+		t.Errorf("Expected id field to be present")
+	} else if string(parsed.ID) != "null" {
+		t.Errorf("Expected id to be null, got %s", parsed.ID)
 	}
 	if parsed.Error.Code != wantCode {
 		t.Errorf("Expected error code %d, got %d", wantCode, parsed.Error.Code)

--- a/policies/mcp-auth/mcp-auth_test.go
+++ b/policies/mcp-auth/mcp-auth_test.go
@@ -360,6 +360,79 @@ func TestOnRequestBody_Delegation_Failure(t *testing.T) {
 	}
 }
 
+// jsonRPCErrorResponse mirrors the JSON-RPC 2.0 error envelope for assertions.
+type jsonRPCErrorResponse struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      *int   `json:"id"`
+	Error   struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    string `json:"data"`
+	} `json:"error"`
+}
+
+// mcpBadRequest issues an OnRequestBody call for a POST /mcp with the given body
+// and returns the resulting ImmediateResponse.
+func mcpBadRequest(t *testing.T, body []byte) policy.ImmediateResponse {
+	t.Helper()
+	p := createTestPolicy()
+	ctx := createMockRequestBodyContext(nil)
+	ctx.Method = "POST"
+	ctx.Path = "/mcp"
+	ctx.OperationPath = "/mcp"
+	ctx.Body = &policy.Body{Content: body, Present: true}
+
+	action := p.OnRequestBody(context.Background(), ctx, map[string]any{})
+	resp, ok := action.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("Expected ImmediateResponse, got %T", action)
+	}
+	return resp
+}
+
+// assertJSONRPCError decodes the response body and validates the JSON-RPC error envelope.
+func assertJSONRPCError(t *testing.T, resp policy.ImmediateResponse, wantCode int, wantMessage string) {
+	t.Helper()
+	if resp.StatusCode != 400 {
+		t.Errorf("Expected status 400, got %d", resp.StatusCode)
+	}
+	if ct := resp.Headers["content-type"]; ct != "application/json" {
+		t.Errorf("Expected content-type application/json, got %q", ct)
+	}
+	var parsed jsonRPCErrorResponse
+	if err := json.Unmarshal(resp.Body, &parsed); err != nil {
+		t.Fatalf("Response body is not valid JSON: %v (body: %s)", err, resp.Body)
+	}
+	if parsed.JSONRPC != "2.0" {
+		t.Errorf("Expected jsonrpc \"2.0\", got %q", parsed.JSONRPC)
+	}
+	if parsed.ID != nil {
+		t.Errorf("Expected id null, got %v", *parsed.ID)
+	}
+	if parsed.Error.Code != wantCode {
+		t.Errorf("Expected error code %d, got %d", wantCode, parsed.Error.Code)
+	}
+	if parsed.Error.Message != wantMessage {
+		t.Errorf("Expected error message %q, got %q", wantMessage, parsed.Error.Message)
+	}
+}
+
+// TestOnRequestBody_InvalidJSON_ReturnsParseError verifies that a body with invalid
+// JSON syntax is reported as HTTP 400 with a JSON-RPC -32700 (Parse error) object,
+// rather than an authentication failure. Regression test for wso2/api-platform#2751.
+func TestOnRequestBody_InvalidJSON_ReturnsParseError(t *testing.T) {
+	resp := mcpBadRequest(t, []byte("not-json"))
+	assertJSONRPCError(t, resp, JSONRPCParseError, "Parse error")
+}
+
+// TestOnRequestBody_InvalidStructure_ReturnsInvalidRequest verifies that a body that
+// is valid JSON but not a valid MCP request object is reported as HTTP 400 with a
+// JSON-RPC -32600 (Invalid Request) object.
+func TestOnRequestBody_InvalidStructure_ReturnsInvalidRequest(t *testing.T) {
+	resp := mcpBadRequest(t, []byte("[]"))
+	assertJSONRPCError(t, resp, JSONRPCInvalidRequest, "Invalid Request")
+}
+
 func TestOnRequestBody_InvalidOnFailureStatusCode(t *testing.T) {
 	p := &McpAuthPolicy{}
 	ctx := createMockRequestBodyContext(nil)

--- a/policies/mcp-auth/policy-definition.yaml
+++ b/policies/mcp-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-auth
-version: v1.1.0
+version: v1.1.1
 description: |
   Secure Model Context Protocol traffic by validating bearer access tokens for MCP resources using the underlying JWT authentication runtime.
 

--- a/policies/mcp-authz/mcp-authz.go
+++ b/policies/mcp-authz/mcp-authz.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -38,6 +39,12 @@ const (
 	MetadataMcpCapabilityName = "mcp.name"
 	McpOAuthAuthType          = "mcp/oauth"
 	McpOAuthzAuthType         = "mcp/oauth+authz"
+
+	// Bearer error codes per RFC 6750 §3.1: invalid_token pairs with 401,
+	// insufficient_scope with 403, invalid_request with 400.
+	ErrorInvalidRequest    = "invalid_request"
+	ErrorInvalidToken      = "invalid_token"
+	ErrorInsufficientScope = "insufficient_scope"
 )
 
 // MCPRequest represents the JSON-RPC MCP request structure
@@ -95,7 +102,6 @@ func GetPolicy(
 
 	return p, nil
 }
-
 
 // parseRules extracts and validates rules from the 4 top-level arrays: tools, resources, prompts, methods
 func parseRules(params map[string]any) ([]Rule, error) {
@@ -238,14 +244,14 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Reque
 	authCtx := reqCtx.SharedContext.AuthContext
 	if authCtx == nil || !authCtx.Authenticated {
 		slog.Debug("MCP Authorization Policy: No authenticated context found")
-		return p.handleAuthFailure(reqCtx, "Unauthorized: scope/claim validation failed", nil)
+		return p.handleAuthFailure(reqCtx, http.StatusUnauthorized, ErrorInvalidToken, "Unauthorized: scope/claim validation failed", nil)
 	}
 
 	// Parse MCP request to extract method and name
 	var mcpReq MCPRequest
 	if err := json.Unmarshal(reqCtx.Body.Content, &mcpReq); err != nil {
 		slog.Debug("MCP Authorization Policy: Failed to parse MCP request", "error", err)
-		return p.handleAuthFailure(reqCtx, "Invalid MCP request format", nil)
+		return p.handleAuthFailure(reqCtx, http.StatusBadRequest, ErrorInvalidRequest, "Invalid MCP request format", nil)
 	}
 
 	slog.Debug("MCP Authorization Policy: Extracted MCP attributes",
@@ -277,7 +283,7 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Reque
 		slog.Debug("MCP Authorization Policy: Authorization check failed",
 			"attributeName", mcpReq.Params.Name,
 			"method", mcpReq.Method)
-		return p.handleAuthFailure(reqCtx, "Forbidden: insufficient permissions to access this MCP resource", missingScopes)
+		return p.handleAuthFailure(reqCtx, http.StatusForbidden, ErrorInsufficientScope, "Forbidden: insufficient permissions to access this MCP resource", missingScopes)
 	}
 
 	slog.Debug("MCP Authorization Policy: Authorization check passed")
@@ -288,7 +294,7 @@ func (p *McpAuthzPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.Reque
 	return nil
 }
 
-func (p *McpAuthzPolicy) handleAuthFailure(reqCtx *policy.RequestContext, errorMessage string, scopeMap map[string]struct{}) policy.RequestAction {
+func (p *McpAuthzPolicy) handleAuthFailure(reqCtx *policy.RequestContext, statusCode int, errorCode, errorMessage string, scopeMap map[string]struct{}) policy.RequestAction {
 	slog.Debug("MCP Authorization Policy: handleAuthFailure called",
 		"errorMessage", errorMessage,
 	)
@@ -298,7 +304,7 @@ func (p *McpAuthzPolicy) handleAuthFailure(reqCtx *policy.RequestContext, errorM
 		missingScopes = append(missingScopes, s)
 	}
 
-	wwwAuthHeader := generateWwwAuthenticateHeader(reqCtx.Scheme, reqCtx.Authority, reqCtx.Vhost, reqCtx.APIContext, reqCtx.Metadata, missingScopes, errorMessage)
+	wwwAuthHeader := generateWwwAuthenticateHeader(reqCtx.Scheme, reqCtx.Authority, reqCtx.Vhost, reqCtx.APIContext, reqCtx.Metadata, missingScopes, errorCode, errorMessage)
 
 	headers := map[string]string{
 		"content-type":        "application/json",
@@ -306,13 +312,13 @@ func (p *McpAuthzPolicy) handleAuthFailure(reqCtx *policy.RequestContext, errorM
 	}
 
 	errResponse := map[string]interface{}{
-		"error":   "Forbidden",
+		"error":   http.StatusText(statusCode),
 		"message": errorMessage,
 	}
 	bodyBytes, _ := json.Marshal(errResponse)
 
 	return policy.ImmediateResponse{
-		StatusCode: 403,
+		StatusCode: statusCode,
 		Headers:    headers,
 		Body:       bodyBytes,
 	}
@@ -574,7 +580,7 @@ func generateResourcePath(scheme, authority, vhost, apiContext, gatewayHost, res
 }
 
 // generateWwwAuthenticateHeader generates the WWW-Authenticate header value
-func generateWwwAuthenticateHeader(scheme, authority, vhost, apiContext string, metadata map[string]any, scopes []string, errorDesc string) string {
+func generateWwwAuthenticateHeader(scheme, authority, vhost, apiContext string, metadata map[string]any, scopes []string, errorCode, errorDesc string) string {
 	slog.Debug("MCP Authorization Policy: Generating WWW-Authenticate header")
 	gatewayHostString, _ := metadata["gatewayHost"].(string)
 	headerValue := AuthMethodBearer + "\"" + generateResourcePath(scheme, authority, vhost, apiContext, gatewayHostString, WellKnownPath) + "\""
@@ -582,9 +588,12 @@ func generateWwwAuthenticateHeader(scheme, authority, vhost, apiContext string, 
 		slog.Debug("MCP Authorization Policy: Adding scopes to WWW-Authenticate header")
 		headerValue += ", scope=\"" + strings.Join(scopes, " ") + "\""
 	}
-	if errorDesc != "" {
-		slog.Debug("MCP Authorization Policy: Adding error description to WWW-Authenticate header")
-		headerValue += ", error=\"invalid_token\", error_description=\"" + errorDesc + "\""
+	if errorCode != "" {
+		slog.Debug("MCP Authorization Policy: Adding error code to WWW-Authenticate header", "error", errorCode)
+		headerValue += ", error=\"" + errorCode + "\""
+		if errorDesc != "" {
+			headerValue += ", error_description=\"" + errorDesc + "\""
+		}
 	}
 	return headerValue
 }

--- a/policies/mcp-authz/mcp-authz_test.go
+++ b/policies/mcp-authz/mcp-authz_test.go
@@ -133,6 +133,9 @@ func TestOnRequest_NoAuthContext(t *testing.T) {
 	if resp.StatusCode != 401 {
 		t.Errorf("Expected 401, got %d", resp.StatusCode)
 	}
+	if wwwAuth := resp.Headers[WWWAuthenticateHeader]; !strings.Contains(wwwAuth, `error="invalid_token"`) {
+		t.Errorf("Expected error=\"invalid_token\" in WWW-Authenticate header, got: %s", wwwAuth)
+	}
 }
 
 func TestOnRequest_NotAuthenticated(t *testing.T) {
@@ -146,6 +149,9 @@ func TestOnRequest_NotAuthenticated(t *testing.T) {
 	}
 	if resp.StatusCode != 401 {
 		t.Errorf("Expected 401, got %d", resp.StatusCode)
+	}
+	if wwwAuth := resp.Headers[WWWAuthenticateHeader]; !strings.Contains(wwwAuth, `error="invalid_token"`) {
+		t.Errorf("Expected error=\"invalid_token\" in WWW-Authenticate header, got: %s", wwwAuth)
 	}
 }
 
@@ -162,6 +168,9 @@ func TestOnRequest_InvalidMCPBody(t *testing.T) {
 	}
 	if resp.StatusCode != 400 {
 		t.Errorf("Expected 400, got %d", resp.StatusCode)
+	}
+	if wwwAuth := resp.Headers[WWWAuthenticateHeader]; !strings.Contains(wwwAuth, `error="invalid_request"`) {
+		t.Errorf("Expected error=\"invalid_request\" in WWW-Authenticate header, got: %s", wwwAuth)
 	}
 }
 

--- a/policies/mcp-authz/mcp-authz_test.go
+++ b/policies/mcp-authz/mcp-authz_test.go
@@ -130,8 +130,8 @@ func TestOnRequest_NoAuthContext(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse, got %T", action)
 	}
-	if resp.StatusCode != 403 {
-		t.Errorf("Expected 403, got %d", resp.StatusCode)
+	if resp.StatusCode != 401 {
+		t.Errorf("Expected 401, got %d", resp.StatusCode)
 	}
 }
 
@@ -144,8 +144,8 @@ func TestOnRequest_NotAuthenticated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse, got %T", action)
 	}
-	if resp.StatusCode != 403 {
-		t.Errorf("Expected 403, got %d", resp.StatusCode)
+	if resp.StatusCode != 401 {
+		t.Errorf("Expected 401, got %d", resp.StatusCode)
 	}
 }
 
@@ -160,8 +160,8 @@ func TestOnRequest_InvalidMCPBody(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected ImmediateResponse, got %T", action)
 	}
-	if resp.StatusCode != 403 {
-		t.Errorf("Expected 403, got %d", resp.StatusCode)
+	if resp.StatusCode != 400 {
+		t.Errorf("Expected 400, got %d", resp.StatusCode)
 	}
 }
 
@@ -218,6 +218,9 @@ func TestOnRequest_ScopeCheckFails(t *testing.T) {
 	wwwAuth := resp.Headers[WWWAuthenticateHeader]
 	if !strings.Contains(wwwAuth, "mcp:tools:write") {
 		t.Errorf("Expected missing scope in WWW-Authenticate header, got: %s", wwwAuth)
+	}
+	if !strings.Contains(wwwAuth, "error=\"insufficient_scope\"") {
+		t.Errorf("Expected error=\"insufficient_scope\" in WWW-Authenticate header, got: %s", wwwAuth)
 	}
 }
 

--- a/policies/mcp-authz/policy-definition.yaml
+++ b/policies/mcp-authz/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-authz
-version: v1.0.1
+version: v1.0.2
 description: |
   Authorize MCP tools, resources, prompts, and methods using claim/scope rules after `mcp-auth`; evaluate rules by specificity, require all matching rules to pass, and allow access when no rule matches.
 


### PR DESCRIPTION
## Purpose

- $Subject
- Related Issues: https://github.com/wso2/api-platform/issues/2751

## Description

This pull request improves standards compliance and error handling in both the `mcp-auth` and `mcp-authz` policies, ensuring protocol-level errors are surfaced correctly and that OAuth2 error codes are used consistently in HTTP responses and headers. The changes also update tests and documentation to match the new behavior.

**MCP Authentication (`mcp-auth`) Improvements:**

- **JSON-RPC 2.0 Error Handling:**  
  - Protocol-level errors (invalid JSON or request structure) now return a proper JSON-RPC 2.0 error object with HTTP 400, distinguishing them from authentication failures. This includes new logic to return `-32700` (Parse error) or `-32600` (Invalid Request) codes as appropriate. [[1]](diffhunk://#diff-facda959f0e92283f0f03264d2f503aa81fee595f0371039973600eb8b865891R24) [[2]](diffhunk://#diff-facda959f0e92283f0f03264d2f503aa81fee595f0371039973600eb8b865891R44-R50) [[3]](diffhunk://#diff-facda959f0e92283f0f03264d2f503aa81fee595f0371039973600eb8b865891L429-R437)
  - Added comprehensive tests to verify correct error responses for malformed requests.

**MCP Authorization (`mcp-authz`) Improvements:**

- **OAuth2 Error Codes and Statuses:**  
  - Error responses now use the correct HTTP status codes: 401 for missing/invalid tokens, 403 for insufficient scope, and 400 for invalid requests, with matching OAuth2 error codes (`invalid_token`, `insufficient_scope`, `invalid_request`). [[1]](diffhunk://#diff-09d8e0f05ec7f7bb01bd0a200e84f1ed21a72e0e7e71894d5b56436d364b5353L241-R254) [[2]](diffhunk://#diff-09d8e0f05ec7f7bb01bd0a200e84f1ed21a72e0e7e71894d5b56436d364b5353L280-R286) [[3]](diffhunk://#diff-09d8e0f05ec7f7bb01bd0a200e84f1ed21a72e0e7e71894d5b56436d364b5353L291-R297) [[4]](diffhunk://#diff-09d8e0f05ec7f7bb01bd0a200e84f1ed21a72e0e7e71894d5b56436d364b5353R42-R47)
  - The `WWW-Authenticate` header is updated to include the appropriate `error` and `error_description` fields per RFC 6750.
- **Test Updates:**  
  - Tests are updated to expect the new status codes and error codes in responses and headers. [[1]](diffhunk://#diff-af83ff338afd92345b1babed58428723f96a885e2e05b39daffc4e9f271f0239L133-R134) [[2]](diffhunk://#diff-af83ff338afd92345b1babed58428723f96a885e2e05b39daffc4e9f271f0239L147-R148) [[3]](diffhunk://#diff-af83ff338afd92345b1babed58428723f96a885e2e05b39daffc4e9f271f0239L163-R164) [[4]](diffhunk://#diff-af83ff338afd92345b1babed58428723f96a885e2e05b39daffc4e9f271f0239R222-R224)

**Documentation:**

- **Policy Version Bumps:**  
  - Updated `policy-definition.yaml` files to reflect new patch versions for both policies. [[1]](diffhunk://#diff-77cdb9d5265f3b8c69aff77880c82410d7b2e10a3dc83c83db0e65c352bd0011L2-R2) [[2]](diffhunk://#diff-9e3f4147c9d309105509138123e8e8407c4494b696ccdbf60c47d5d50c736445L2-R2)