### PR TITLE
Add header snapshot functionality to mcp-auth policy

### DIFF
--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -1,9 +1,9 @@
 module github.com/wso2/gateway-controllers/policies/mcp-auth
 
-go 1.26.2
+go 1.26.5
 
-require github.com/wso2/api-platform/sdk/core v0.2.14
+require github.com/wso2/api-platform/sdk/core v0.3.0
 
-require github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0
+require github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.2
 
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/policies/mcp-auth/go.sum
+++ b/policies/mcp-auth/go.sum
@@ -1,6 +1,6 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
-github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0 h1:8NDu++azRvqf0rO5uYN5HlgvuQG47gAWJFuz7XGYrBQ=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.1.0/go.mod h1:wLDwZ0793wAj2eRS1zzS/yxUf33810NmbKqV/vsfmbo=
+github.com/wso2/api-platform/sdk/core v0.3.0 h1:iPUEwB1lpjQto/Gjgl1F4ZrrU4P85bXvmabxgBSHs7E=
+github.com/wso2/api-platform/sdk/core v0.3.0/go.mod h1:NZMDIQadQDpbynlCLYdZT6duiHwnf7emr7SbLHdCjaE=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.2 h1:E1zoy5xVcqpJEoleJVEj3NIsp9XDoMjyakInI6eXKyk=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.2/go.mod h1:yLGJQ2Q/8AxzeipJJChoVuxIzueR6QvIbCKYVDSyGSo=

--- a/policies/mcp-auth/header_snapshot.go
+++ b/policies/mcp-auth/header_snapshot.go
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package mcpauthn
+
+import policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+
+// getDownstreamHeaders returns the snapshot of the original client
+// request headers when the gateway provides it, falling back to the live
+// (possibly peer-mutated) request headers on older gateways that predate the
+// Downstream snapshot.
+//
+// Use this for every header read that feeds an authentication, authorization,
+// or gating decision. The kernel runs every policy's header phase before any
+// policy's body phase, mutating one shared header set in place, so a decision
+// that reads the live headers can observe a value another policy rewrote —
+// regardless of policy order. The Downstream snapshot always holds what the
+// client actually sent.
+//
+// The nil-checks are required, not optional: Downstream (and its Request) is
+// nil on gateways built before the snapshot-header-context feature, and the
+// fallback preserves the pre-feature behaviour on those runtimes.
+func getDownstreamHeaders(ds *policy.DownstreamContext, live *policy.Headers) *policy.Headers {
+	if ds != nil && ds.Request != nil && ds.Request.Headers != nil {
+		return ds.Request.Headers
+	}
+	return live
+}

--- a/policies/mcp-auth/mcp-auth.go
+++ b/policies/mcp-auth/mcp-auth.go
@@ -352,7 +352,7 @@ func (p *McpAuthPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.Req
 	// Check for GET /.well-known/oauth-protected-resource
 	if reqCtx.Method == "GET" && isWellKnownEndpointRequest(reqCtx.OperationPath) {
 		slog.Debug("MCP Auth Policy: Handling well-known protected resource metadata request")
-		sessionIds := reqCtx.Headers.Get(McpSessionHeader)
+		sessionIds := getDownstreamHeaders(reqCtx.Downstream, reqCtx.Headers).Get(McpSessionHeader)
 		sessionId := ""
 		if len(sessionIds) > 0 {
 			sessionId = sessionIds[0]
@@ -487,7 +487,7 @@ func (p *McpAuthPolicy) handleAuth(ctx context.Context, reqCtx *policy.RequestCo
 		OnRequestHeaders(context.Context, *policy.RequestHeaderContext, map[string]interface{}) policy.RequestHeaderAction
 	}
 
-	sessionIds := reqCtx.Headers.Get(McpSessionHeader)
+	sessionIds := getDownstreamHeaders(reqCtx.Downstream, reqCtx.Headers).Get(McpSessionHeader)
 	sessionId := ""
 	if len(sessionIds) > 0 {
 		sessionId = sessionIds[0]
@@ -515,6 +515,10 @@ func (p *McpAuthPolicy) handleAuth(ctx context.Context, reqCtx *policy.RequestCo
 		Authority:     reqCtx.Authority,
 		Scheme:        reqCtx.Scheme,
 		Vhost:         reqCtx.Vhost,
+		// Propagate the downstream snapshot so the delegated JWT auth
+		// policy validates the Authorization header the client actually sent,
+		// not one a peer policy rewrote during the header phase.
+		Downstream: reqCtx.Downstream,
 	}
 	headerAction := hrp.OnRequestHeaders(ctx, headerCtx, jwtParams)
 	if ir, ok := headerAction.(policy.ImmediateResponse); ok {


### PR DESCRIPTION
## Purpose

- $Subject
- Related Issues: https://github.com/wso2/api-platform/issues/2736

## Description

This pull request introduces improvements to the MCP Auth policy for more reliable and secure header handling, especially regarding authentication decisions. The main change is using a snapshot of the original client request headers (when available), which prevents issues caused by other policies mutating headers during processing. It also updates dependencies to newer versions.

**Header handling improvements:**

* Added a new helper function `getDownstreamHeaders` in `header_snapshot.go` to consistently retrieve the original client request headers from `DownstreamContext` when available, with fallback to live headers for backward compatibility. This function is now used for all reads of authentication-related headers.
* Updated all usages of `reqCtx.Headers.Get(McpSessionHeader)` in `mcp-auth.go` to use `getDownstreamHeaders`, ensuring that authentication decisions are based on the original headers sent by the client, not potentially mutated ones. [[1]](diffhunk://#diff-facda959f0e92283f0f03264d2f503aa81fee595f0371039973600eb8b865891L355-R355) [[2]](diffhunk://#diff-facda959f0e92283f0f03264d2f503aa81fee595f0371039973600eb8b865891L490-R490)
* Modified the JWT authentication delegation to propagate the `Downstream` snapshot, so delegated policies also validate against the original client headers.

**Dependency updates:**

* Updated `go.mod` to require newer versions of Go, the API platform SDK, and the JWT Auth policy, ensuring compatibility and access to the latest features and fixes.