### PR TITLE
Bump advanced ratelimit policy to v1.1.1

### DIFF
--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v1.1.0
+version: v1.1.1
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.


### PR DESCRIPTION
## Purpose

This pull request makes a patch version update to the `advanced-ratelimit` policy. The version is incremented from `v1.1.0` to `v1.1.1` in the `policy-definition.yaml` file.

- Version bump related to https://github.com/wso2/gateway-controllers/pull/216