### PR TITLE
Add Intelligent Model Routing and Semantic Model Routing policies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,19 +31,22 @@ All available policies, sorted alphabetically.
 | Policy | Categories | Description |
 |--------|------------|-------------|
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
-| [API Key Auth](./api-key-auth/v1.0/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
+| [API Key Auth](./api-key-auth/v1.2/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
+| [AWS Authentication](./aws-authentication/v0.10/docs/aws-authentication.md) | Security, AI | Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4). |
 | [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.0/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
+| [Backend JWT](./backend-jwt/v1.0/docs/backend-jwt.md) | Security | Generates a signed JWT containing authenticated user information and injects it into the upstream request header. |
 | [Basic Auth](./basic-auth/v1.0/docs/basic-auth.md) | Security, AI, WebSub, WebBroker | Implements HTTP Basic Authentication to protect APIs with username and password credentials. |
 | [Content Length Guardrail](./content-length-guardrail/v1.0/docs/content-length.md) | Guardrails, AI | Validates the byte length of request or response body content. |
 | [CORS](./cors/v1.0/docs/cors.md) | Security, AI, MCP | Cross-Origin Resource Sharing (CORS) policy that handles preflight requests and adds appropriate CORS headers to responses. |
 | [Dynamic Endpoint](./dynamic-endpoint/v1.0/docs/dynamic-endpoint.md) | Transformation | Routes requests to a named upstream definition at request time. |
 | [Granite Guardian Prompt Injection](./granite-guardian-prompt-injection/v0.9/docs/granite-guardian-prompt-injection.md) | Guardrails, AI | Detects prompt injection and jailbreak attempts in LLM API requests using IBM Granite Guardian 3.3 8B. |
 | [Host Rewrite](./host-rewrite/v1.0/docs/host-rewrite.md) | Transformation | Sets the Host/:authority header sent to the upstream. |
+| [Intelligent Model Routing](./intelligent-model-routing/v1.0/docs/intelligent-model-routing.md) | AI | Routes AI/LLM requests to different models using LLM-powered classification. |
 | [Interceptor Service](./interceptor-service/v1.0/docs/interceptor-service.md) | Transformation | Invokes a user-defined HTTP interceptor service in the request and/or response phase. |
 | [JSON Schema Guardrail](./json-schema-guardrail/v1.0/docs/json-schema.md) | Guardrails, AI | Validates request or response body content against a JSON Schema. |
 | [JSON/XML Mediator](./json-xml-mediator/v1.0/docs/json-xml-mediator.md) | Transformation | Mediates request and response payloads between downstream and upstream JSON/XML formats. |
-| [JWT Auth](./jwt-auth/v1.0/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens using one or more JWKS providers (key managers). |
+| [JWT Auth](./jwt-auth/v1.2/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens included in API requests. |
 | [LLM Cost](./llm-cost/v1.0/docs/llm-cost.md) | AI | Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. |
 | [LLM Cost Based Ratelimit](./llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md) | AI | A specialized rate limiting policy that enforces monetary budget limits on LLM API usage. |
 | [Log Message](./log-message/v1.0/docs/log-message.md) | Logging, Analytics & Monitoring, MCP, WebSub, WebBroker | This policy provides the capability to log the payload and headers of a request/response. |
@@ -55,17 +58,21 @@ All available policies, sorted alphabetically.
 | [Model Round Robin](./model-round-robin/v1.0/docs/model-round-robin.md) | AI | Implements round-robin load balancing for AI models. |
 | [Model Weighted Round Robin](./model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
 | [NeMo Guard Content Safety](./nvidia-nemoguard-content-safety/v0.9/docs/nvidia-nemoguard-content-safety.md) | Guardrails, AI | Validates request and/or response content using NVIDIA NeMo Guard (llama-3.1-nemoguard-8b-content-safety). |
+| [Opaque Token Auth](./opaque-token-auth/v1.0/docs/opaque-token-authentication.md) | Security, AI | Validates opaque OAuth 2.0 access tokens via RFC 7662 token introspection. |
+| [OpenAI to Bedrock Transformer](./openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md) | AI | Translates OpenAI Chat Completions requests into AWS Bedrock Converse format and rewrites non-streaming and streaming Bedrock responses back into OpenAI-compatible JSON or Server-Sent Events. |
 | [PII Masking Regex](./pii-masking-regex/v1.0/docs/pii-masking-regex.md) | Guardrails, AI | Masks or redacts Personally Identifiable Information (PII) from request/response bodies using regex patterns. |
 | [Prompt Compressor](./prompt-compressor/v0.9/docs/prompt-compressor.md) | AI | Compresses selected prompt text in JSON request bodies before upstream LLM calls. |
 | [Prompt Decorator](./prompt-decorator/v1.0/docs/prompt-decorator.md) | AI | Dynamically modifies the prompt by applying custom decorations using a configured strategy. |
 | [Prompt Template](./prompt-template/v1.0/docs/prompt-template.md) | AI | Dynamically modifies the prompt by applying custom templates using a configured strategy. |
-| [Rate Limit - Advanced](./advanced-ratelimit/v1.0/docs/advanced-ratelimit.md) | Security, AI | Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas, weighted rate limiting, flexible key extraction, and both in-memory and Redis backends. |
+| [Rate Limit - Advanced](./advanced-ratelimit/v1.1/docs/advanced-ratelimit.md) | Security, AI | Rate limiting policy supporting multiple algorithms (GCRA, Fixed Window), multi-dimensional quotas, weighted rate limiting, flexible key extraction, and in-memory, Redis, and Redis-local-async backends. |
 | [Rate Limit - Basic](./basic-ratelimit/v1.0/docs/basic-ratelimit.md) | Security, AI | Simple request rate limiting policy that limits the number of requests per time window. |
+| [Redirect](./redirect/v0.9/docs/redirect.md) | Transformation | Issues an HTTP redirect to the client without forwarding the request to the upstream backend (Gateway-API RequestRedirect semantics). |
 | [Regex Guardrail](./regex-guardrail/v1.0/docs/regex.md) | Guardrails, AI | Validates request or response body content against a regular expression pattern. |
 | [Remove Headers](./remove-headers/v1.0/docs/remove-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to remove headers from either the request or the response. |
 | [Request Rewrite](./request-rewrite/v1.0/docs/request-rewrite.md) | Transformation | Rewrites incoming requests by updating path, query parameters, and/or HTTP method before forwarding to upstream services. |
 | [Respond](./respond/v1.0/docs/respond.md) | AI | Returns an immediate response to the client without forwarding the request to the upstream backend. |
 | [Semantic Cache](./semantic-cache/v1.0/docs/semantic-caching.md) | AI | Implements semantic caching for LLM responses using vector similarity search. |
+| [Semantic Model Routing](./semantic-model-routing/v1.0/docs/semantic-model-routing.md) | AI | Routes AI/LLM requests to different models based on semantic similarity between the user request and predefined example utterances. |
 | [Semantic Prompt Guard](./semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md) | Guardrails, AI | Blocks or allows prompts based on semantic similarity to configured allow/deny phrase embeddings. |
 | [Semantic Tool Filtering](./semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md) | Guardrails, AI | Dynamically filters the tools provided within an API request based on their semantic relevance to the user query. |
 | [Sentence Count Guardrail](./sentence-count-guardrail/v1.0/docs/sentence-count.md) | Guardrails, AI | Validates the sentence count of request or response body content. |

--- a/docs/intelligent-model-routing/v1.0/docs/intelligent-model-routing.md
+++ b/docs/intelligent-model-routing/v1.0/docs/intelligent-model-routing.md
@@ -1,0 +1,66 @@
+# Intelligent Model Routing
+
+Routes AI/LLM requests to different models using LLM-powered classification. An LLM analyzes each incoming request against user-defined routing rules and selects the best-matching model. When no rule matches, the request falls back to a configurable default model.
+
+## How It Works
+
+1. The incoming request payload is read and the user prompt is extracted using the configured `contentPath` (a JSONPath expression, defaulting to `$.messages[-1].content`).
+2. A classification prompt is dynamically built listing all configured routing rules with their names and context descriptions.
+3. The classification LLM is called and asked to respond with exactly one rule name or `NONE`.
+4. If a rule name is returned, the target model for that rule replaces the model in the outgoing request. If `NONE` is returned, the `defaultModel` is used.
+
+## When to Use This Policy
+
+Use **Intelligent Model Routing** when:
+- You want to route requests based on **topic or intent** (e.g., coding questions → a code-specialist model, creative writing → a creative model).
+- Your users ask varied, conversational questions that don't map cleanly to fixed example phrases.
+- The routing categories are best described as natural-language context descriptions rather than exact utterances.
+
+> **Tip:** If your users tend to send short keyword-style queries, consider **Semantic Model Routing** instead, which uses embedding similarity rather than LLM classification.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `contentPath` | string | No | JSONPath to extract the prompt from the request body. Default: `$.messages[-1].content` |
+| `routingRules` | array | Yes | List of routing rules. Each rule has a `name`, a `context` description, and a target `model`. |
+| `defaultModel` | string | Yes | Model to use when no rule matches or the classifier returns `NONE`. |
+
+### Routing Rule Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | A short label for the rule (e.g. `"Coding"`, `"Customer Support"`). The LLM uses this name to identify the match. |
+| `context` | string | Yes | Plain-language description of request types this rule handles. The LLM reads this when classifying. |
+| `model` | string | Yes | The target AI model name to route matching requests to. |
+
+## Example Configuration
+
+```yaml
+- name: intelligent-model-routing
+  version: v1
+  paths:
+    - path: /chat/completions
+      methods: [POST]
+      params:
+        contentPath: "$.messages[-1].content"
+        routingRules:
+          - name: Coding
+            context: "Code-related questions, programming, debugging, algorithms, software development"
+            model: "gpt-4o-mini"
+          - name: Creative Writing
+            context: "Stories, poems, creative content, fiction, song lyrics, screenplays"
+            model: "gpt-4o"
+        defaultModel: "gpt-4o-mini"
+```
+
+## System Requirements
+
+This policy requires an LLM provider to be configured in the gateway:
+
+| Config Key | Description |
+|------------|-------------|
+| `llm_provider` | Provider type: `OPENAI` or `AZURE_OPENAI` |
+| `llm_provider_endpoint` | Chat completions endpoint URL |
+| `llm_provider_model` | Model name used for classification (e.g. `gpt-4o-mini`) |
+| `llm_provider_api_key` | API key for the LLM service |

--- a/docs/intelligent-model-routing/v1.0/metadata.json
+++ b/docs/intelligent-model-routing/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "intelligent-model-routing",
+  "displayName": "Intelligent Model Routing",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Routes AI/LLM requests to different models using LLM-powered classification.\nAn LLM analyzes each incoming request against user-defined routing rules (each with a name and context description) and selects the best-matching model.\nEffective for categorizing requests by topic or intent (e.g., coding questions, creative writing, customer support) and routing each to the most suitable model.\nWhen no rule matches, requests fall back to a configurable default model.\n\nNote: This policy requires an LLM provider (OpenAI or Azure OpenAI) to be configured for classification."
+}

--- a/docs/semantic-model-routing/v1.0/docs/semantic-model-routing.md
+++ b/docs/semantic-model-routing/v1.0/docs/semantic-model-routing.md
@@ -1,0 +1,78 @@
+# Semantic Model Routing
+
+Routes AI/LLM requests to different models based on the semantic similarity between the user's prompt and predefined example utterances (reference phrases). At startup, embeddings are precomputed for all utterances. At request time, the incoming prompt is compared against them using cosine similarity, and the best-matching model is selected.
+
+## How It Works
+
+1. **At startup (precomputation):** Embeddings are generated for all configured utterances across all routes and stored in memory.
+2. **At request time:**
+   - The user prompt is extracted from the request payload using the configured `contentPath`.
+   - An embedding vector is generated for the incoming prompt.
+   - Cosine similarity is computed between the prompt embedding and every precomputed utterance embedding.
+   - The route with the highest similarity score is selected.
+   - If that score meets or exceeds the route's `scorethreshold`, the request is routed to that route's model.
+   - Otherwise, the `defaultModel` is used.
+
+## When to Use This Policy
+
+Use **Semantic Model Routing** when:
+- Your users send **short, keyword-style queries** that closely match expected phrases (e.g., "what's the weather today", "write me a poem").
+- You have a small, well-defined set of request categories with clear example utterances.
+- You want **low-latency routing** — no LLM call is needed at request time, only an embedding lookup.
+
+> **Tip:** If your routing categories are complex or hard to express as example phrases, consider **Intelligent Model Routing** instead, which uses an LLM classifier with natural-language context descriptions.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `contentPath` | string | No | JSONPath to extract the prompt from the request body. Default: `$.messages[-1].content` |
+| `routes` | array | Yes | List of routing routes. Each route defines utterances, a similarity threshold, and a target model. |
+| `defaultModel` | string | Yes | Model to use when no route's similarity score meets its threshold. |
+
+### Route Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | Yes | The target AI model name to route matching requests to. |
+| `utterances` | array of strings | Yes | Example phrases representing the types of requests this route should handle. |
+| `scorethreshold` | number | No | Minimum cosine similarity score (0.0–1.0) required to match this route. Default: `0.7` |
+
+## Example Configuration
+
+```yaml
+- name: semantic-model-routing
+  version: v1
+  paths:
+    - path: /chat/completions
+      methods: [POST]
+      params:
+        contentPath: "$.messages[-1].content"
+        routes:
+          - model: "gpt-4o-mini"
+            utterances:
+              - "write a python function"
+              - "fix this bug in my code"
+              - "explain this algorithm"
+              - "create a REST API"
+            scorethreshold: 0.85
+          - model: "gpt-4o"
+            utterances:
+              - "what is the weather forecast"
+              - "will it rain tomorrow"
+              - "how is the temperature today"
+            scorethreshold: 0.85
+        defaultModel: "gpt-4o-mini"
+```
+
+## System Requirements
+
+This policy requires an embedding provider to be configured in the gateway:
+
+| Config Key | Description |
+|------------|-------------|
+| `embedding_provider` | Provider type: `OPENAI`, `MISTRAL`, or `AZURE_OPENAI` |
+| `embedding_provider_endpoint` | Embeddings API endpoint URL |
+| `embedding_provider_model` | Embedding model name (e.g. `text-embedding-3-small`) |
+| `embedding_provider_api_key` | API key for the embedding service |
+| `embedding_vector_dimension` | Dimension of the embedding vectors produced by the model |

--- a/docs/semantic-model-routing/v1.0/metadata.json
+++ b/docs/semantic-model-routing/v1.0/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "semantic-model-routing",
+  "displayName": "Semantic Model Routing",
+  "version": "1.0",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Routes AI/LLM requests to different models based on semantic similarity between the user request and predefined example utterances.\nAt startup, embeddings are precomputed for all configured utterances. At request time, an embedding is generated for the incoming prompt and compared using cosine similarity.\nIf the similarity score meets a configurable threshold, the request is routed to the matching model. Otherwise it falls back to a default model.\nEffective for short keyword-style queries where utterance examples closely match expected user phrasing.\n\nNote: This policy requires an embedding provider (OpenAI, Mistral, or Azure OpenAI) to be configured."
+}

--- a/policies/intelligent-model-routing/go.mod
+++ b/policies/intelligent-model-routing/go.mod
@@ -1,0 +1,5 @@
+module github.com/wso2/gateway-controllers/policies/intelligent-model-routing
+
+go 1.26.1
+
+require github.com/wso2/api-platform/sdk/core v0.2.4

--- a/policies/intelligent-model-routing/go.sum
+++ b/policies/intelligent-model-routing/go.sum
@@ -1,0 +1,2 @@
+github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
+github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/intelligent-model-routing/intelligentmodelrouting.go
+++ b/policies/intelligent-model-routing/intelligentmodelrouting.go
@@ -521,11 +521,15 @@ func parseRequestModelConfig(params map[string]interface{}, p *IntelligentModelR
 		return fmt.Errorf("'requestModel.location' is required")
 	}
 
+	// Only the payload location is implemented: this policy runs entirely in the request
+	// body phase and modifyRequestModel rewrites the model inside the JSON body. Accepting
+	// header, queryParam or pathParam here would deploy successfully and then silently
+	// never route, so those values are rejected at configuration time.
 	validLocations := map[string]bool{
-		"payload": true, "header": true, "queryParam": true, "pathParam": true,
+		"payload": true,
 	}
 	if !validLocations[location] {
-		return fmt.Errorf("'requestModel.location' must be one of: payload, header, queryParam, pathParam")
+		return fmt.Errorf("'requestModel.location' must be 'payload'")
 	}
 	p.requestModel.Location = location
 

--- a/policies/intelligent-model-routing/intelligentmodelrouting.go
+++ b/policies/intelligent-model-routing/intelligentmodelrouting.go
@@ -1,0 +1,539 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Package intelligentmodelrouting implements an LLM-powered model routing policy
+// for the WSO2 API Platform Gateway. It classifies incoming user requests using
+// a configured LLM provider and routes them to the appropriate AI model based on
+// predefined routing rules with context descriptions.
+//
+// Ported from the Java Universal Gateway implementation:
+// org.wso2.apim.policies.mediation.ai.intelligent.model.routing.IntelligentModelRouting
+package intelligentmodelrouting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	utils "github.com/wso2/api-platform/sdk/core/utils"
+)
+
+// Constants matching IntelligentModelRoutingConstants.java
+const (
+	// ClassificationSystemPrompt is the system prompt sent to the LLM for request classification.
+	// Exact replica of IntelligentModelRoutingConstants.CLASSIFICATION_SYSTEM_PROMPT.
+	ClassificationSystemPrompt = "You are an API routing assistant. Analyze the user request and determine the best category. " +
+		"Respond with ONLY the category name, nothing else."
+
+	// NoneResponse is the LLM response indicating no rule matched.
+	NoneResponse = "NONE"
+
+	// llmHTTPTimeout is the timeout for LLM API calls.
+	llmHTTPTimeout = 30 * time.Second
+)
+
+// RoutingRule represents a single routing rule configuration.
+// Maps to IntelligentModelRoutingConfigDTO.RoutingRuleDTO in Java.
+type RoutingRule struct {
+	Name    string // Rule name (label for classification, e.g. "Weather Information")
+	Context string // Plain-language description of what requests this rule handles
+	Model   string // Target AI model name to route to
+}
+
+// RequestModelConfig holds the configuration for where the model name lives in the request.
+// Follows the same pattern as model-round-robin and model-weighted-round-robin policies.
+type RequestModelConfig struct {
+	Location   string // "payload", "header", "queryParam", "pathParam"
+	Identifier string // JSONPath (for payload) or header/param name
+}
+
+// LLMClientConfig holds the configuration for the LLM provider used for classification.
+type LLMClientConfig struct {
+	Provider string // "OPENAI" or "AZURE_OPENAI"
+	Endpoint string // Chat completions API endpoint URL
+	Model    string // LLM model name (e.g. "gpt-4o-mini"); optional for Azure
+	APIKey   string // API key for authentication
+}
+
+// IntelligentModelRoutingPolicy implements LLM-based request classification and model routing.
+type IntelligentModelRoutingPolicy struct {
+	routingRules []RoutingRule
+	defaultModel string
+	contentPath  string
+	requestModel RequestModelConfig
+	llmConfig    LLMClientConfig
+	httpClient   *http.Client
+}
+
+// GetPolicy is the v1alpha2 factory entry point. It parses configuration,
+// validates parameters, and returns an initialized policy instance.
+// This replaces the Java init(SynapseEnvironment) + setIntelligentModelRoutingConfigs() pattern.
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: &http.Client{Timeout: llmHTTPTimeout},
+	}
+
+	if err := parseParams(params, p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
+	slog.Debug("IntelligentModelRouting: Policy initialized",
+		"rules", len(p.routingRules),
+		"defaultModel", p.defaultModel,
+		"llmProvider", p.llmConfig.Provider,
+	)
+
+	return p, nil
+}
+
+// Mode returns the processing mode for this policy.
+// We need to buffer the request body to:
+// 1. Extract user text via JSONPath for LLM classification
+// 2. Modify the body to set the selected model name
+func (p *IntelligentModelRoutingPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// OnRequestBody processes the incoming request body, classifies it using the LLM,
+// and modifies the body to route to the appropriate model.
+//
+// This is the Go equivalent of IntelligentModelRouting.mediate(MessageContext) in Java.
+// The flow is:
+// 1. Extract user text from body using contentPath JSONPath
+// 2. Build classification prompt with routing rules
+// 3. Call LLM for classification
+// 4. Validate response against known rules
+// 5. Modify request body to set the selected model
+func (p *IntelligentModelRoutingPolicy) OnRequestBody(
+	ctx context.Context,
+	reqCtx *policy.RequestContext,
+	params map[string]interface{},
+) policy.RequestAction {
+	// Extract request body content
+	var content []byte
+	if reqCtx.Body != nil {
+		content = reqCtx.Body.Content
+	}
+
+	if len(content) == 0 {
+		slog.Debug("IntelligentModelRouting: Request body is empty, using default model")
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Extract user text from body using JSONPath
+	userText := ""
+	if p.contentPath != "" {
+		extracted, err := utils.ExtractStringValueFromJsonpath(content, p.contentPath)
+		if err != nil {
+			slog.Debug("IntelligentModelRouting: JSONPath extraction failed, using default model",
+				"contentPath", p.contentPath, "error", err)
+			return p.modifyRequestModel(content, p.defaultModel)
+		}
+		userText = extracted
+	} else {
+		userText = string(content)
+	}
+
+	if strings.TrimSpace(userText) == "" {
+		slog.Debug("IntelligentModelRouting: Extracted text is empty, using default model")
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Build classification prompt and call LLM
+	userPrompt := buildClassificationPrompt(p.routingRules, userText)
+	llmResponse, err := p.callLLM(ctx, ClassificationSystemPrompt, userPrompt)
+	if err != nil {
+		slog.Debug("IntelligentModelRouting: LLM call failed, using default model", "error", err)
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Validate and match LLM response against routing rules
+	selectedModel := p.validateAndSelectModel(llmResponse)
+	return p.modifyRequestModel(content, selectedModel)
+}
+
+// validateAndSelectModel validates the LLM response and returns the model to route to.
+// Replicates the exact logic from Java's validateResponse() + selectEndpointForRouteRule().
+func (p *IntelligentModelRoutingPolicy) validateAndSelectModel(response string) string {
+	cleanResponse := strings.TrimSpace(response)
+
+	if cleanResponse == "" || strings.EqualFold(cleanResponse, NoneResponse) {
+		slog.Debug("IntelligentModelRouting: LLM returned empty or NONE, using default model")
+		return p.defaultModel
+	}
+
+	// Case-insensitive match against routing rule names
+	// Matches Java's findMatchingRouteRule()
+	for _, rule := range p.routingRules {
+		if strings.EqualFold(rule.Name, cleanResponse) {
+			slog.Debug("IntelligentModelRouting: Route rule matched",
+				"rule", rule.Name, "model", rule.Model)
+			return rule.Model
+		}
+	}
+
+	slog.Debug("IntelligentModelRouting: No route rule matched LLM response, using default model",
+		"llmResponse", cleanResponse)
+	return p.defaultModel
+}
+
+// modifyRequestModel modifies the request body to set the selected model name.
+// For payload location, it uses JSONPath to set the model in the body.
+// This follows the same pattern as model-round-robin and model-weighted-round-robin.
+func (p *IntelligentModelRoutingPolicy) modifyRequestModel(content []byte, selectedModel string) policy.RequestAction {
+	if p.requestModel.Location != "payload" || len(content) == 0 {
+		// For non-payload locations (header, queryParam, pathParam), we would need
+		// OnRequestHeaders which is not used in this policy. For now, we only
+		// support payload-based model routing which is the most common for AI APIs.
+		slog.Debug("IntelligentModelRouting: Selected model", "model", selectedModel)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	var payloadData map[string]interface{}
+	if err := json.Unmarshal(content, &payloadData); err != nil {
+		slog.Debug("IntelligentModelRouting: Failed to parse request body JSON", "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	if err := utils.SetValueAtJSONPath(payloadData, p.requestModel.Identifier, selectedModel); err != nil {
+		slog.Debug("IntelligentModelRouting: Failed to set model in request body",
+			"identifier", p.requestModel.Identifier, "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	updatedPayload, err := json.Marshal(payloadData)
+	if err != nil {
+		slog.Debug("IntelligentModelRouting: Failed to serialize updated body", "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	slog.Debug("IntelligentModelRouting: Modified request body model",
+		"model", selectedModel, "identifier", p.requestModel.Identifier)
+	return policy.UpstreamRequestModifications{Body: updatedPayload}
+}
+
+// buildClassificationPrompt constructs the LLM classification prompt from routing rules
+// and user content. This is an exact replica of the Java buildClassificationPrompt() method.
+//
+// The prompt format matches IntelligentModelRouting.buildClassificationPrompt():
+//
+//	## TASK
+//	Classify the user request into exactly ONE route rule from the list below.
+//
+//	## ROUTE RULES
+//	- RuleName: Context description
+//	...
+//
+//	## ALLOWED RESPONSES
+//	You MUST respond with ONLY one of: RuleName1, RuleName2, NONE
+//
+//	## STRICT OUTPUT RULES
+//	...
+//
+//	## USER REQUEST
+//	<content>
+//
+//	## YOUR RESPONSE (single word only):
+func buildClassificationPrompt(rules []RoutingRule, content string) string {
+	ruleOptions, ruleNames := buildPromptComponents(rules)
+
+	return "## TASK\n" +
+		"Classify the user request into exactly ONE route rule from the list below.\n\n" +
+		"## ROUTE RULES\n" + ruleOptions + "\n\n" +
+		"## ALLOWED RESPONSES\n" +
+		"You MUST respond with ONLY one of: " + ruleNames + ", NONE\n\n" +
+		"## STRICT OUTPUT RULES\n" +
+		"1. Output ONLY the route rule name - no explanations, no punctuation, no quotes\n" +
+		"2. Match based on the context description of each rule\n" +
+		"3. If the request clearly matches a rule's context, output that rule name\n" +
+		"4. If no rule matches or unclear, output: NONE\n\n" +
+		"## USER REQUEST\n" + content + "\n\n" +
+		"## YOUR RESPONSE (single word only):"
+}
+
+// buildPromptComponents builds the rule options list and comma-separated rule names
+// from routing rules. Exact port of Java's buildPromptComponents().
+func buildPromptComponents(rules []RoutingRule) (string, string) {
+	var options strings.Builder
+	var names strings.Builder
+
+	for _, rule := range rules {
+		options.WriteString("- ")
+		options.WriteString(rule.Name)
+		if rule.Context != "" {
+			options.WriteString(": ")
+			options.WriteString(rule.Context)
+		}
+		options.WriteString("\n")
+
+		if names.Len() > 0 {
+			names.WriteString(", ")
+		}
+		names.WriteString(rule.Name)
+	}
+
+	return strings.TrimRight(options.String(), "\n"), names.String()
+}
+
+// --- LLM HTTP Client ---
+
+// chatCompletionRequest is the request body for the LLM chat completions API.
+type chatCompletionRequest struct {
+	Model    string              `json:"model,omitempty"`
+	Messages []chatMessage       `json:"messages"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatCompletionResponse is the response body from the LLM chat completions API.
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// callLLM sends a chat completion request to the configured LLM provider and returns
+// the text response. This replaces the Java llmProvider.getChatCompletion() call.
+func (p *IntelligentModelRoutingPolicy) callLLM(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	reqBody := chatCompletionRequest{
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+	}
+
+	// Set model for OpenAI (Azure uses deployment name in URL)
+	if p.llmConfig.Model != "" {
+		reqBody.Model = p.llmConfig.Model
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal LLM request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.llmConfig.Endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create LLM HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Set auth header based on provider type
+	switch p.llmConfig.Provider {
+	case "AZURE_OPENAI":
+		httpReq.Header.Set("api-key", p.llmConfig.APIKey)
+	default: // OPENAI and others use Bearer token
+		httpReq.Header.Set("Authorization", "Bearer "+p.llmConfig.APIKey)
+	}
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("LLM HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("LLM returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var llmResp chatCompletionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
+		return "", fmt.Errorf("failed to decode LLM response: %w", err)
+	}
+
+	if len(llmResp.Choices) == 0 {
+		return "", fmt.Errorf("LLM returned no choices")
+	}
+
+	return llmResp.Choices[0].Message.Content, nil
+}
+
+// --- Parameter Parsing ---
+
+// parseParams parses and validates all policy parameters from the params map.
+// This replaces the Java parseConfiguration() + init() flow.
+func parseParams(params map[string]interface{}, p *IntelligentModelRoutingPolicy) error {
+	// Parse contentPath (optional, defaults to "")
+	if contentPath, ok := params["contentPath"].(string); ok && contentPath != "" {
+		p.contentPath = contentPath
+	}
+
+	// Parse routingRules (required)
+	rulesRaw, ok := params["routingRules"]
+	if !ok {
+		return fmt.Errorf("'routingRules' parameter is required")
+	}
+
+	rulesList, ok := rulesRaw.([]interface{})
+	if !ok {
+		return fmt.Errorf("'routingRules' must be an array")
+	}
+
+	if len(rulesList) == 0 {
+		return fmt.Errorf("'routingRules' must contain at least one rule")
+	}
+
+	p.routingRules = make([]RoutingRule, 0, len(rulesList))
+	for i, item := range rulesList {
+		ruleMap, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("'routingRules[%d]' must be an object", i)
+		}
+
+		rule, err := parseRoutingRule(ruleMap, i)
+		if err != nil {
+			return err
+		}
+		p.routingRules = append(p.routingRules, rule)
+	}
+
+	// Parse defaultModel (required)
+	defaultModel, ok := params["defaultModel"].(string)
+	if !ok || defaultModel == "" {
+		return fmt.Errorf("'defaultModel' parameter is required")
+	}
+	p.defaultModel = defaultModel
+
+	// Parse LLM provider config (system parameters)
+	if err := parseLLMConfig(params, p); err != nil {
+		return err
+	}
+
+	// Parse requestModel config (system parameter)
+	if err := parseRequestModelConfig(params, p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// parseRoutingRule parses a single routing rule from the params map.
+func parseRoutingRule(ruleMap map[string]interface{}, index int) (RoutingRule, error) {
+	var rule RoutingRule
+
+	name, ok := ruleMap["name"].(string)
+	if !ok || name == "" {
+		return rule, fmt.Errorf("'routingRules[%d].name' is required and must be a non-empty string", index)
+	}
+	rule.Name = name
+
+	context, ok := ruleMap["context"].(string)
+	if !ok || context == "" {
+		return rule, fmt.Errorf("'routingRules[%d].context' is required and must be a non-empty string", index)
+	}
+	rule.Context = context
+
+	model, ok := ruleMap["model"].(string)
+	if !ok || model == "" {
+		return rule, fmt.Errorf("'routingRules[%d].model' is required and must be a non-empty string", index)
+	}
+	rule.Model = model
+
+	return rule, nil
+}
+
+// parseLLMConfig parses the LLM provider configuration from params.
+func parseLLMConfig(params map[string]interface{}, p *IntelligentModelRoutingPolicy) error {
+	provider, ok := params["llmProvider"].(string)
+	if !ok || provider == "" {
+		return fmt.Errorf("'llmProvider' parameter is required")
+	}
+
+	validProviders := map[string]bool{"OPENAI": true, "AZURE_OPENAI": true}
+	if !validProviders[provider] {
+		return fmt.Errorf("'llmProvider' must be one of: OPENAI, AZURE_OPENAI")
+	}
+	p.llmConfig.Provider = provider
+
+	endpoint, ok := params["llmEndpoint"].(string)
+	if !ok || endpoint == "" {
+		return fmt.Errorf("'llmEndpoint' parameter is required")
+	}
+	p.llmConfig.Endpoint = endpoint
+
+	// Model is required for OPENAI, optional for AZURE_OPENAI
+	if model, ok := params["llmModel"].(string); ok && model != "" {
+		p.llmConfig.Model = model
+	} else if provider == "OPENAI" {
+		return fmt.Errorf("'llmModel' is required for OPENAI provider")
+	}
+
+	apiKey, ok := params["llmApiKey"].(string)
+	if !ok || apiKey == "" {
+		return fmt.Errorf("'llmApiKey' parameter is required")
+	}
+	p.llmConfig.APIKey = apiKey
+
+	return nil
+}
+
+// parseRequestModelConfig parses the requestModel configuration from params.
+// This follows the exact same pattern as model-round-robin and model-weighted-round-robin.
+func parseRequestModelConfig(params map[string]interface{}, p *IntelligentModelRoutingPolicy) error {
+	requestModel, ok := params["requestModel"]
+	if !ok {
+		return fmt.Errorf("'requestModel' configuration is required")
+	}
+
+	requestModelMap, ok := requestModel.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("'requestModel' must be an object")
+	}
+
+	location, ok := requestModelMap["location"].(string)
+	if !ok || location == "" {
+		return fmt.Errorf("'requestModel.location' is required")
+	}
+
+	validLocations := map[string]bool{
+		"payload": true, "header": true, "queryParam": true, "pathParam": true,
+	}
+	if !validLocations[location] {
+		return fmt.Errorf("'requestModel.location' must be one of: payload, header, queryParam, pathParam")
+	}
+	p.requestModel.Location = location
+
+	identifier, ok := requestModelMap["identifier"].(string)
+	if !ok || identifier == "" {
+		return fmt.Errorf("'requestModel.identifier' is required")
+	}
+	p.requestModel.Identifier = identifier
+
+	return nil
+}

--- a/policies/intelligent-model-routing/intelligentmodelrouting_test.go
+++ b/policies/intelligent-model-routing/intelligentmodelrouting_test.go
@@ -287,6 +287,42 @@ func TestParseParams_InvalidRequestModelLocation(t *testing.T) {
 	}
 }
 
+// Only the payload location is implemented. header, queryParam and pathParam previously
+// passed validation and then silently never routed, so they must now be rejected.
+func TestParseParams_UnimplementedRequestModelLocationsRejected(t *testing.T) {
+	for _, location := range []string{"header", "queryParam", "pathParam"} {
+		t.Run(location, func(t *testing.T) {
+			params := map[string]interface{}{
+				"routingRules": []interface{}{
+					map[string]interface{}{
+						"name":    "Coding",
+						"context": "Code related",
+						"model":   "gpt-4o-mini",
+					},
+				},
+				"defaultModel": "gpt-4o",
+				"llmProvider":  "OPENAI",
+				"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+				"llmModel":     "gpt-4o-mini",
+				"llmApiKey":    "sk-test-key",
+				"requestModel": map[string]interface{}{
+					"location":   location,
+					"identifier": "x-model",
+				},
+			}
+
+			p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+			err := parseParams(params, p)
+			if err == nil {
+				t.Fatalf("expected %q to be rejected, but parsing succeeded", location)
+			}
+			if !strings.Contains(err.Error(), "must be 'payload'") {
+				t.Fatalf("unexpected error message for %q: %v", location, err)
+			}
+		})
+	}
+}
+
 // --- Prompt Construction Tests ---
 
 func TestBuildClassificationPrompt_SingleRule(t *testing.T) {

--- a/policies/intelligent-model-routing/intelligentmodelrouting_test.go
+++ b/policies/intelligent-model-routing/intelligentmodelrouting_test.go
@@ -1,0 +1,640 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package intelligentmodelrouting
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- Parameter Parsing Tests ---
+
+func TestParseParams_ValidConfig(t *testing.T) {
+	params := map[string]interface{}{
+		"contentPath": "$.messages[-1].content",
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"name":    "Coding",
+				"context": "Code related questions",
+				"model":   "gpt-4o-mini",
+			},
+			map[string]interface{}{
+				"name":    "Weather",
+				"context": "Weather related queries",
+				"model":   "gpt-4o",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"llmProvider":   "OPENAI",
+		"llmEndpoint":   "https://api.openai.com/v1/chat/completions",
+		"llmModel":      "gpt-4o-mini",
+		"llmApiKey":     "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: &http.Client{},
+	}
+
+	err := parseParams(params, p)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if len(p.routingRules) != 2 {
+		t.Errorf("Expected 2 routing rules, got %d", len(p.routingRules))
+	}
+
+	if p.routingRules[0].Name != "Coding" {
+		t.Errorf("Expected first rule name 'Coding', got %q", p.routingRules[0].Name)
+	}
+
+	if p.routingRules[0].Context != "Code related questions" {
+		t.Errorf("Expected first rule context 'Code related questions', got %q", p.routingRules[0].Context)
+	}
+
+	if p.routingRules[0].Model != "gpt-4o-mini" {
+		t.Errorf("Expected first rule model 'gpt-4o-mini', got %q", p.routingRules[0].Model)
+	}
+
+	if p.defaultModel != "gpt-4o" {
+		t.Errorf("Expected default model 'gpt-4o', got %q", p.defaultModel)
+	}
+
+	if p.contentPath != "$.messages[-1].content" {
+		t.Errorf("Expected contentPath '$.messages[-1].content', got %q", p.contentPath)
+	}
+
+	if p.llmConfig.Provider != "OPENAI" {
+		t.Errorf("Expected LLM provider 'OPENAI', got %q", p.llmConfig.Provider)
+	}
+
+	if p.requestModel.Location != "payload" {
+		t.Errorf("Expected requestModel location 'payload', got %q", p.requestModel.Location)
+	}
+
+	if p.requestModel.Identifier != "$.model" {
+		t.Errorf("Expected requestModel identifier '$.model', got %q", p.requestModel.Identifier)
+	}
+}
+
+func TestParseParams_MissingRoutingRules(t *testing.T) {
+	params := map[string]interface{}{
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "OPENAI",
+		"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+		"llmModel":     "gpt-4o-mini",
+		"llmApiKey":    "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing routingRules, got nil")
+	}
+	if !strings.Contains(err.Error(), "routingRules") {
+		t.Errorf("Expected error about routingRules, got: %v", err)
+	}
+}
+
+func TestParseParams_MissingDefaultModel(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"name":    "Coding",
+				"context": "Code related",
+				"model":   "gpt-4o-mini",
+			},
+		},
+		"llmProvider": "OPENAI",
+		"llmEndpoint": "https://api.openai.com/v1/chat/completions",
+		"llmModel":    "gpt-4o-mini",
+		"llmApiKey":   "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing defaultModel, got nil")
+	}
+	if !strings.Contains(err.Error(), "defaultModel") {
+		t.Errorf("Expected error about defaultModel, got: %v", err)
+	}
+}
+
+func TestParseParams_EmptyRoutingRulesArray(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{},
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "OPENAI",
+		"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+		"llmModel":     "gpt-4o-mini",
+		"llmApiKey":    "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for empty routingRules, got nil")
+	}
+}
+
+func TestParseParams_MissingRuleName(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"context": "Code related",
+				"model":   "gpt-4o-mini",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "OPENAI",
+		"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+		"llmModel":     "gpt-4o-mini",
+		"llmApiKey":    "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing rule name, got nil")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("Expected error about name, got: %v", err)
+	}
+}
+
+func TestParseParams_InvalidLLMProvider(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"name":    "Coding",
+				"context": "Code related",
+				"model":   "gpt-4o-mini",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "INVALID_PROVIDER",
+		"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+		"llmModel":     "gpt-4o-mini",
+		"llmApiKey":    "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for invalid LLM provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "llmProvider") {
+		t.Errorf("Expected error about llmProvider, got: %v", err)
+	}
+}
+
+func TestParseParams_AzureOpenAI_NoModelRequired(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"name":    "Coding",
+				"context": "Code related",
+				"model":   "gpt-4o-mini",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "AZURE_OPENAI",
+		"llmEndpoint":  "https://myresource.openai.azure.com/openai/deployments/gpt-4o/chat/completions",
+		"llmApiKey":    "azure-api-key",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err != nil {
+		t.Fatalf("Azure OpenAI should not require llmModel, got: %v", err)
+	}
+	if p.llmConfig.Provider != "AZURE_OPENAI" {
+		t.Errorf("Expected AZURE_OPENAI provider, got %q", p.llmConfig.Provider)
+	}
+}
+
+func TestParseParams_InvalidRequestModelLocation(t *testing.T) {
+	params := map[string]interface{}{
+		"routingRules": []interface{}{
+			map[string]interface{}{
+				"name":    "Coding",
+				"context": "Code related",
+				"model":   "gpt-4o-mini",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"llmProvider":  "OPENAI",
+		"llmEndpoint":  "https://api.openai.com/v1/chat/completions",
+		"llmModel":     "gpt-4o-mini",
+		"llmApiKey":    "sk-test-key",
+		"requestModel": map[string]interface{}{
+			"location":   "invalid_location",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &IntelligentModelRoutingPolicy{httpClient: &http.Client{}}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for invalid location, got nil")
+	}
+}
+
+// --- Prompt Construction Tests ---
+
+func TestBuildClassificationPrompt_SingleRule(t *testing.T) {
+	rules := []RoutingRule{
+		{Name: "Coding", Context: "Code related questions", Model: "gpt-4o-mini"},
+	}
+
+	prompt := buildClassificationPrompt(rules, "write a hello world program")
+
+	// Verify the prompt contains all expected sections
+	expectedSections := []string{
+		"## TASK",
+		"Classify the user request into exactly ONE route rule",
+		"## ROUTE RULES",
+		"- Coding: Code related questions",
+		"## ALLOWED RESPONSES",
+		"You MUST respond with ONLY one of: Coding, NONE",
+		"## STRICT OUTPUT RULES",
+		"Output ONLY the route rule name",
+		"## USER REQUEST",
+		"write a hello world program",
+		"## YOUR RESPONSE (single word only):",
+	}
+
+	for _, expected := range expectedSections {
+		if !strings.Contains(prompt, expected) {
+			t.Errorf("Prompt missing expected section: %q\nGot:\n%s", expected, prompt)
+		}
+	}
+}
+
+func TestBuildClassificationPrompt_MultipleRules(t *testing.T) {
+	rules := []RoutingRule{
+		{Name: "Coding", Context: "Code related questions", Model: "gpt-4o-mini"},
+		{Name: "Weather", Context: "Weather forecasts and conditions", Model: "gpt-4o"},
+		{Name: "Travel", Context: "Flight booking and travel plans", Model: "claude-3"},
+	}
+
+	prompt := buildClassificationPrompt(rules, "what's the weather in Paris")
+
+	// Check all rules appear
+	if !strings.Contains(prompt, "- Coding: Code related questions") {
+		t.Error("Prompt missing Coding rule")
+	}
+	if !strings.Contains(prompt, "- Weather: Weather forecasts and conditions") {
+		t.Error("Prompt missing Weather rule")
+	}
+	if !strings.Contains(prompt, "- Travel: Flight booking and travel plans") {
+		t.Error("Prompt missing Travel rule")
+	}
+
+	// Check allowed responses
+	if !strings.Contains(prompt, "Coding, Weather, Travel, NONE") {
+		t.Error("Prompt missing proper allowed responses list")
+	}
+}
+
+func TestBuildPromptComponents(t *testing.T) {
+	rules := []RoutingRule{
+		{Name: "A", Context: "Context A", Model: "model-a"},
+		{Name: "B", Context: "Context B", Model: "model-b"},
+	}
+
+	options, names := buildPromptComponents(rules)
+
+	if !strings.Contains(options, "- A: Context A") {
+		t.Errorf("Options missing 'A: Context A', got: %q", options)
+	}
+	if !strings.Contains(options, "- B: Context B") {
+		t.Errorf("Options missing 'B: Context B', got: %q", options)
+	}
+
+	if names != "A, B" {
+		t.Errorf("Expected names 'A, B', got %q", names)
+	}
+}
+
+func TestBuildPromptComponents_EmptyContext(t *testing.T) {
+	rules := []RoutingRule{
+		{Name: "TestRule", Context: "", Model: "model-a"},
+	}
+
+	options, names := buildPromptComponents(rules)
+
+	// Should not include ": " when context is empty
+	if strings.Contains(options, ": ") {
+		t.Errorf("Options should not contain ': ' for empty context, got: %q", options)
+	}
+	if !strings.Contains(options, "- TestRule") {
+		t.Errorf("Options missing rule name, got: %q", options)
+	}
+
+	if names != "TestRule" {
+		t.Errorf("Expected names 'TestRule', got %q", names)
+	}
+}
+
+// --- Response Validation Tests ---
+
+func TestValidateAndSelectModel_ExactMatch(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+			{Name: "Weather", Context: "Weather info", Model: "gpt-4o"},
+		},
+		defaultModel: "default-model",
+	}
+
+	result := p.validateAndSelectModel("Coding")
+	if result != "gpt-4o-mini" {
+		t.Errorf("Expected 'gpt-4o-mini', got %q", result)
+	}
+}
+
+func TestValidateAndSelectModel_CaseInsensitive(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+		},
+		defaultModel: "default-model",
+	}
+
+	testCases := []string{"coding", "CODING", "CoDiNg"}
+	for _, tc := range testCases {
+		result := p.validateAndSelectModel(tc)
+		if result != "gpt-4o-mini" {
+			t.Errorf("Case-insensitive match failed for %q: expected 'gpt-4o-mini', got %q", tc, result)
+		}
+	}
+}
+
+func TestValidateAndSelectModel_NONE(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+		},
+		defaultModel: "default-model",
+	}
+
+	result := p.validateAndSelectModel("NONE")
+	if result != "default-model" {
+		t.Errorf("Expected 'default-model' for NONE response, got %q", result)
+	}
+
+	// Case-insensitive NONE
+	result = p.validateAndSelectModel("none")
+	if result != "default-model" {
+		t.Errorf("Expected 'default-model' for 'none' response, got %q", result)
+	}
+}
+
+func TestValidateAndSelectModel_EmptyResponse(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+		},
+		defaultModel: "default-model",
+	}
+
+	result := p.validateAndSelectModel("")
+	if result != "default-model" {
+		t.Errorf("Expected 'default-model' for empty response, got %q", result)
+	}
+}
+
+func TestValidateAndSelectModel_WhitespaceResponse(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+		},
+		defaultModel: "default-model",
+	}
+
+	// Response with whitespace around the rule name should still match
+	result := p.validateAndSelectModel("  Coding  ")
+	if result != "gpt-4o-mini" {
+		t.Errorf("Expected 'gpt-4o-mini' for whitespace-padded response, got %q", result)
+	}
+}
+
+func TestValidateAndSelectModel_NoMatch(t *testing.T) {
+	p := &IntelligentModelRoutingPolicy{
+		routingRules: []RoutingRule{
+			{Name: "Coding", Context: "Code related", Model: "gpt-4o-mini"},
+		},
+		defaultModel: "default-model",
+	}
+
+	result := p.validateAndSelectModel("UnknownRule")
+	if result != "default-model" {
+		t.Errorf("Expected 'default-model' for unknown rule, got %q", result)
+	}
+}
+
+// --- LLM Client Integration Test (with mock server) ---
+
+func TestCallLLM_SuccessfulClassification(t *testing.T) {
+	// Create a mock LLM server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request structure
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("Expected Content-Type: application/json")
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Error("Expected Bearer token auth")
+		}
+
+		var reqBody chatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		if reqBody.Model != "gpt-4o-mini" {
+			t.Errorf("Expected model 'gpt-4o-mini', got %q", reqBody.Model)
+		}
+
+		if len(reqBody.Messages) != 2 {
+			t.Errorf("Expected 2 messages, got %d", len(reqBody.Messages))
+		}
+
+		// Return mock response
+		resp := chatCompletionResponse{
+			Choices: []struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			}{
+				{Message: struct {
+					Content string `json:"content"`
+				}{Content: "Coding"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: server.Client(),
+		llmConfig: LLMClientConfig{
+			Provider: "OPENAI",
+			Endpoint: server.URL,
+			Model:    "gpt-4o-mini",
+			APIKey:   "test-key",
+		},
+	}
+
+	result, err := p.callLLM(t.Context(), "system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result != "Coding" {
+		t.Errorf("Expected 'Coding', got %q", result)
+	}
+}
+
+func TestCallLLM_AzureAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Azure uses api-key header instead of Bearer
+		if r.Header.Get("api-key") != "azure-key" {
+			t.Error("Expected api-key header for Azure")
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Error("Should not have Authorization header for Azure")
+		}
+
+		resp := chatCompletionResponse{
+			Choices: []struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			}{
+				{Message: struct {
+					Content string `json:"content"`
+				}{Content: "Weather"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: server.Client(),
+		llmConfig: LLMClientConfig{
+			Provider: "AZURE_OPENAI",
+			Endpoint: server.URL,
+			APIKey:   "azure-key",
+		},
+	}
+
+	result, err := p.callLLM(t.Context(), "system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result != "Weather" {
+		t.Errorf("Expected 'Weather', got %q", result)
+	}
+}
+
+func TestCallLLM_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer server.Close()
+
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: server.Client(),
+		llmConfig: LLMClientConfig{
+			Provider: "OPENAI",
+			Endpoint: server.URL,
+			Model:    "gpt-4o-mini",
+			APIKey:   "test-key",
+		},
+	}
+
+	_, err := p.callLLM(t.Context(), "system prompt", "user prompt")
+	if err == nil {
+		t.Fatal("Expected error for server error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("Expected error to mention 500 status, got: %v", err)
+	}
+}
+
+func TestCallLLM_EmptyChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := chatCompletionResponse{Choices: nil}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &IntelligentModelRoutingPolicy{
+		httpClient: server.Client(),
+		llmConfig: LLMClientConfig{
+			Provider: "OPENAI",
+			Endpoint: server.URL,
+			Model:    "gpt-4o-mini",
+			APIKey:   "test-key",
+		},
+	}
+
+	_, err := p.callLLM(t.Context(), "system prompt", "user prompt")
+	if err == nil {
+		t.Fatal("Expected error for empty choices, got nil")
+	}
+}

--- a/policies/intelligent-model-routing/policy-definition.yaml
+++ b/policies/intelligent-model-routing/policy-definition.yaml
@@ -99,14 +99,10 @@ systemParameters:
           type: string
           enum:
             - payload
-            - header
-            - queryParam
-            - pathParam
         identifier:
           type: string
           description: |
-            JSONPath (for payload) or header/param name identifying the
-            model field.
+            JSONPath identifying the model field in the request body.
       required:
         - location
         - identifier

--- a/policies/intelligent-model-routing/policy-definition.yaml
+++ b/policies/intelligent-model-routing/policy-definition.yaml
@@ -1,0 +1,117 @@
+name: intelligent-model-routing
+version: v1.0.0
+description: |
+  Routes AI/LLM requests to different models using LLM-powered classification.
+  An LLM analyzes each incoming request against user-defined routing rules (each
+  with a name and context description) and selects the best-matching model.
+  Effective for short keyword-style queries where semantic embeddings may not
+  capture intent reliably.
+
+parameters:
+  type: object
+  properties:
+    contentPath:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        JSONPath expression to extract the user request text from the
+        request payload for classification.
+      default: "$.messages[-1].content"
+    routingRules:
+      type: array
+      x-wso2-policy-advanced-param: false
+      description: |
+        List of routing rules. Each rule defines a name, a context
+        description for the LLM, and the target model to route to.
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            description: |
+              A label for this rule (e.g. "Weather Information", "Coding Questions").
+              The LLM uses this name to identify the matched rule.
+            minLength: 1
+          context:
+            type: string
+            description: |
+              Plain-language description of the types of requests this rule
+              should handle. The LLM reads this when classifying requests.
+            minLength: 1
+          model:
+            type: string
+            description: Target AI model name to route matching requests to.
+            minLength: 1
+        required:
+          - name
+          - context
+          - model
+      minItems: 1
+    defaultModel:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        The model to use when no routing rule matches the user request
+        or when the LLM returns NONE.
+      minLength: 1
+  required:
+    - routingRules
+    - defaultModel
+
+systemParameters:
+  type: object
+  properties:
+    llmProvider:
+      type: string
+      description: |
+        LLM provider type for classification: "OPENAI" or "AZURE_OPENAI"
+      enum:
+        - OPENAI
+        - AZURE_OPENAI
+      "wso2/defaultValue": "${config.policy_configurations.intelligent_model_routing_v1.llm_provider}"
+    llmEndpoint:
+      type: string
+      description: |
+        Endpoint URL for the LLM chat completions API.
+        For OpenAI: "https://api.openai.com/v1/chat/completions"
+        For Azure OpenAI: Azure OpenAI chat completions endpoint URL
+      minLength: 1
+      "wso2/defaultValue": "${config.policy_configurations.intelligent_model_routing_v1.llm_provider_endpoint}"
+    llmModel:
+      type: string
+      description: |
+        LLM model name for classification (e.g. "gpt-4o-mini").
+        Not required for Azure OpenAI (deployment name is in the endpoint URL).
+      "wso2/defaultValue": "${config.policy_configurations.intelligent_model_routing_v1.llm_provider_model}"
+    llmApiKey:
+      type: string
+      description: |
+        API key for the LLM service.
+      minLength: 1
+      "wso2/defaultValue": "${config.policy_configurations.intelligent_model_routing_v1.llm_provider_api_key}"
+    requestModel:
+      type: object
+      description: |
+        Specifies where the model name appears in the request so the policy
+        can replace it with the selected model.
+      properties:
+        location:
+          type: string
+          enum:
+            - payload
+            - header
+            - queryParam
+            - pathParam
+        identifier:
+          type: string
+          description: |
+            JSONPath (for payload) or header/param name identifying the
+            model field.
+      required:
+        - location
+        - identifier
+  required:
+    - llmProvider
+    - llmEndpoint
+    - llmApiKey
+    - requestModel

--- a/policies/semantic-model-routing/go.mod
+++ b/policies/semantic-model-routing/go.mod
@@ -1,0 +1,8 @@
+module github.com/wso2/gateway-controllers/policies/semantic-model-routing
+
+go 1.26.1
+
+require (
+	github.com/wso2/api-platform/sdk/ai v0.1.2
+	github.com/wso2/api-platform/sdk/core v0.2.4
+)

--- a/policies/semantic-model-routing/go.sum
+++ b/policies/semantic-model-routing/go.sum
@@ -1,0 +1,4 @@
+github.com/wso2/api-platform/sdk/ai v0.1.2 h1:z1OUFVT4IDxmH40or5ZSPL8rVp2dc4QDnFKPpFjt9oo=
+github.com/wso2/api-platform/sdk/ai v0.1.2/go.mod h1:EFQ6w1Orv6uyjNhCDxAr9Sanh33NmgoBCQyA9qHMudk=
+github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
+github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=

--- a/policies/semantic-model-routing/policy-definition.yaml
+++ b/policies/semantic-model-routing/policy-definition.yaml
@@ -1,0 +1,121 @@
+name: semantic-model-routing
+version: v1.0.0
+description: |
+  Routes AI/LLM requests to different models based on semantic similarity
+  between the user request and predefined utterances. On startup, embeddings
+  are precomputed for all configured utterances. At runtime, the user request
+  is embedded and compared using cosine similarity. If the best match exceeds
+  the configured score threshold, the request is routed to that model;
+  otherwise it falls back to the default model.
+
+parameters:
+  type: object
+  properties:
+    contentPath:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        JSONPath expression to extract the user request text from the
+        request payload for embedding generation.
+      default: "$.messages[-1].content"
+    routes:
+      type: array
+      x-wso2-policy-advanced-param: false
+      description: |
+        List of semantic routes. Each route defines a target model, a list
+        of sample utterances for embedding, and an optional similarity
+        score threshold.
+      items:
+        type: object
+        properties:
+          model:
+            type: string
+            description: Target AI model name to route matching requests to.
+            minLength: 1
+          utterances:
+            type: array
+            description: |
+              Sample phrases representing requests that should route to
+              this model. Embeddings are precomputed at policy init time.
+            items:
+              type: string
+              minLength: 1
+            minItems: 1
+          scorethreshold:
+            type: number
+            description: |
+              Minimum cosine similarity score (0.0 to 1.0) required to
+              route to this model. Defaults to 0.90.
+            minimum: 0.0
+            maximum: 1.0
+            default: 0.90
+        required:
+          - model
+          - utterances
+      minItems: 1
+    defaultModel:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        The model to use when no route's similarity score exceeds its
+        threshold.
+      minLength: 1
+  required:
+    - routes
+    - defaultModel
+
+systemParameters:
+  type: object
+  properties:
+    embeddingProvider:
+      type: string
+      description: |
+        Embedding provider type: "OPENAI", "MISTRAL", "AZURE_OPENAI"
+      enum:
+        - OPENAI
+        - MISTRAL
+        - AZURE_OPENAI
+      "wso2/defaultValue": "${config.policy_configurations.semantic_model_routing_v1.embedding_provider}"
+    embeddingEndpoint:
+      type: string
+      description: |
+        Endpoint URL for the embedding service.
+        For OpenAI: "https://api.openai.com/v1/embeddings"
+        For Mistral: "https://api.mistral.ai/v1/embeddings"
+        For Azure OpenAI: Azure OpenAI endpoint URL
+      minLength: 1
+      "wso2/defaultValue": "${config.policy_configurations.semantic_model_routing_v1.embedding_provider_endpoint}"
+    embeddingModel:
+      type: string
+      description: |
+        Embedding model name (required for OPENAI and MISTRAL; not required
+        for AZURE_OPENAI where the deployment name is in the endpoint URL).
+      "wso2/defaultValue": "${config.policy_configurations.semantic_model_routing_v1.embedding_provider_model}"
+    apiKey:
+      type: string
+      description: |
+        API key for the embedding service.
+      minLength: 1
+      "wso2/defaultValue": "${config.policy_configurations.semantic_model_routing_v1.embedding_provider_api_key}"
+    requestModel:
+      type: object
+      description: |
+        Specifies where the model name appears in the request so the policy
+        can replace it with the selected model.
+      properties:
+        location:
+          type: string
+          enum:
+            - payload
+        identifier:
+          type: string
+          description: |
+            JSONPath expression identifying the model field in the request payload.
+      required:
+        - location
+        - identifier
+  required:
+    - embeddingProvider
+    - embeddingEndpoint
+    - apiKey
+    - requestModel

--- a/policies/semantic-model-routing/semanticmodelrouting.go
+++ b/policies/semantic-model-routing/semanticmodelrouting.go
@@ -525,11 +525,12 @@ func parseRequestModelConfig(params map[string]interface{}, p *SemanticModelRout
 		return fmt.Errorf("'requestModel.location' is required")
 	}
 
+	// Only the payload location is implemented; see modifyRequestModel.
 	validLocations := map[string]bool{
 		"payload": true,
 	}
 	if !validLocations[location] {
-		return fmt.Errorf("'requestModel.location' must be one of: payload, header, queryParam, pathParam")
+		return fmt.Errorf("'requestModel.location' must be 'payload'")
 	}
 	p.requestModel.Location = location
 

--- a/policies/semantic-model-routing/semanticmodelrouting.go
+++ b/policies/semantic-model-routing/semanticmodelrouting.go
@@ -1,0 +1,568 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Package semanticmodelrouting implements a semantic similarity-based model routing
+// policy for the WSO2 API Platform Gateway. It precomputes vector embeddings for
+// sample utterances at initialization and routes incoming requests to the model
+// whose utterances are most semantically similar (using cosine similarity).
+//
+// Ported from the Java Universal Gateway implementation:
+// org.wso2.apim.policies.mediation.ai.semantic.model.routing.SemanticRouting
+package semanticmodelrouting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+
+	embeddingproviders "github.com/wso2/api-platform/sdk/ai/embeddings"
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+	utils "github.com/wso2/api-platform/sdk/core/utils"
+)
+
+// DefaultSimilarityThreshold is the default cosine similarity threshold for routing.
+// Matches SemanticRoutingConstants.DEFAULT_SIMILARITY_THRESHOLD in Java.
+const DefaultSimilarityThreshold = 0.90
+
+// SemanticRoute represents a single route configuration with its precomputed embeddings.
+// Maps to SemanticRoutingConfigDTO.RouteConfig in Java.
+type SemanticRoute struct {
+	Model               string      // Target AI model name
+	Utterances          []string    // Sample phrases for this route
+	ScoreThreshold      float64     // Minimum cosine similarity to match (0.0 - 1.0)
+	UtteranceEmbeddings [][]float32 // Precomputed embeddings (populated at init)
+}
+
+// RequestModelConfig holds the configuration for where the model name lives in the request.
+type RequestModelConfig struct {
+	Location   string // "payload", "header", "queryParam", "pathParam"
+	Identifier string // JSONPath (for payload) or header/param name
+}
+
+// SemanticModelRoutingPolicy implements semantic similarity-based model routing.
+type SemanticModelRoutingPolicy struct {
+	routes            []SemanticRoute
+	defaultModel      string
+	contentPath       string
+	requestModel      RequestModelConfig
+	embeddingProvider embeddingproviders.EmbeddingProvider
+}
+
+// GetPolicy is the v1alpha2 factory entry point. It parses configuration,
+// initializes the embedding provider, precomputes utterance embeddings, and
+// returns an initialized policy instance.
+//
+// This replaces the Java init(SynapseEnvironment) + loadRoutingConfiguration() flow.
+// The key design: embeddings are precomputed HERE at init, NOT at request time.
+func GetPolicy(
+	metadata policy.PolicyMetadata,
+	params map[string]interface{},
+) (policy.Policy, error) {
+	p := &SemanticModelRoutingPolicy{}
+
+	// Parse and validate parameters
+	if err := parseParams(params, p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
+	// Initialize embedding provider (reuse SDK, same as semantic-cache)
+	embeddingConfig, err := parseEmbeddingConfig(params)
+	if err != nil {
+		return nil, fmt.Errorf("invalid embedding config: %w", err)
+	}
+
+	embeddingProvider, err := createEmbeddingProvider(embeddingConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embedding provider: %w", err)
+	}
+	p.embeddingProvider = embeddingProvider
+
+	// Precompute embeddings for all routes' utterances
+	// This matches the Java precomputeEmbeddings() behavior in init()
+	if err := p.precomputeAllEmbeddings(); err != nil {
+		return nil, fmt.Errorf("failed to precompute embeddings: %w", err)
+	}
+
+	slog.Debug("SemanticModelRouting: Policy initialized",
+		"routes", len(p.routes),
+		"defaultModel", p.defaultModel,
+	)
+
+	return p, nil
+}
+
+// Mode returns the processing mode for this policy.
+// We need to buffer the request body to:
+// 1. Extract user text via JSONPath for embedding
+// 2. Modify the body to set the selected model name
+func (p *SemanticModelRoutingPolicy) Mode() policy.ProcessingMode {
+	return policy.ProcessingMode{
+		RequestHeaderMode:  policy.HeaderModeSkip,
+		RequestBodyMode:    policy.BodyModeBuffer,
+		ResponseHeaderMode: policy.HeaderModeSkip,
+		ResponseBodyMode:   policy.BodyModeSkip,
+	}
+}
+
+// OnRequestBody processes the incoming request body, computes its embedding,
+// finds the best semantic match among routes, and modifies the body to route
+// to the appropriate model.
+//
+// This is the Go equivalent of SemanticRouting.mediate(MessageContext) in Java.
+// Flow:
+// 1. Extract user text from body using contentPath JSONPath
+// 2. Generate embedding for the user text
+// 3. Compare against all routes' precomputed utterance embeddings
+// 4. Select best match if score >= threshold, else use default
+// 5. Modify request body to set the selected model
+func (p *SemanticModelRoutingPolicy) OnRequestBody(
+	ctx context.Context,
+	reqCtx *policy.RequestContext,
+	params map[string]interface{},
+) policy.RequestAction {
+	// Extract request body content
+	var content []byte
+	if reqCtx.Body != nil {
+		content = reqCtx.Body.Content
+	}
+
+	if len(content) == 0 {
+		slog.Debug("SemanticModelRouting: Request body is empty, using default model")
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Extract user text from body using JSONPath
+	userText := ""
+	if p.contentPath != "" {
+		extracted, err := utils.ExtractStringValueFromJsonpath(content, p.contentPath)
+		if err != nil {
+			slog.Debug("SemanticModelRouting: JSONPath extraction failed, using default model",
+				"contentPath", p.contentPath, "error", err)
+			return p.modifyRequestModel(content, p.defaultModel)
+		}
+		userText = extracted
+	} else {
+		userText = string(content)
+	}
+
+	if strings.TrimSpace(userText) == "" {
+		slog.Debug("SemanticModelRouting: Extracted text is empty, using default model")
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Generate embedding for the user request
+	requestEmbedding, err := p.embeddingProvider.GetEmbedding(userText)
+	if err != nil {
+		slog.Debug("SemanticModelRouting: Failed to compute request embedding, using default model",
+			"error", err)
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	if requestEmbedding == nil {
+		slog.Debug("SemanticModelRouting: Request embedding is nil, using default model")
+		return p.modifyRequestModel(content, p.defaultModel)
+	}
+
+	// Find best matching route
+	bestRoute, bestScore := p.findBestRoute(requestEmbedding)
+
+	if bestRoute != nil && bestScore >= bestRoute.ScoreThreshold {
+		slog.Debug("SemanticModelRouting: Route matched",
+			"model", bestRoute.Model,
+			"score", fmt.Sprintf("%.4f", bestScore),
+			"threshold", bestRoute.ScoreThreshold,
+		)
+		return p.modifyRequestModel(content, bestRoute.Model)
+	}
+
+	slog.Debug("SemanticModelRouting: No route matched threshold, using default model",
+		"bestScore", fmt.Sprintf("%.4f", bestScore))
+	return p.modifyRequestModel(content, p.defaultModel)
+}
+
+// findBestRoute iterates all routes and finds the one with the highest cosine
+// similarity score. Exact port of Java's findBestRoute().
+func (p *SemanticModelRoutingPolicy) findBestRoute(requestEmbedding []float32) (*SemanticRoute, float64) {
+	var bestRoute *SemanticRoute
+	bestScore := 0.0
+
+	for i := range p.routes {
+		route := &p.routes[i]
+
+		if len(route.UtteranceEmbeddings) == 0 {
+			slog.Debug("SemanticModelRouting: No precomputed embeddings for route, skipping",
+				"model", route.Model)
+			continue
+		}
+
+		// Compute max cosine similarity against all utterance embeddings
+		maxSimilarity := computeMaxCosineSimilarity(requestEmbedding, route.UtteranceEmbeddings)
+
+		slog.Debug("SemanticModelRouting: Route similarity",
+			"model", route.Model,
+			"score", fmt.Sprintf("%.4f", maxSimilarity),
+			"threshold", route.ScoreThreshold,
+		)
+
+		if maxSimilarity > bestScore {
+			bestScore = maxSimilarity
+			bestRoute = route
+		}
+	}
+
+	return bestRoute, bestScore
+}
+
+// computeMaxCosineSimilarity computes the maximum cosine similarity between a
+// request embedding and a set of utterance embeddings.
+// Exact port of Java's computeMaxCosineSimilarity().
+func computeMaxCosineSimilarity(requestEmbedding []float32, utteranceEmbeddings [][]float32) float64 {
+	maxSimilarity := 0.0
+	for _, utteranceEmbedding := range utteranceEmbeddings {
+		similarity := CalculateCosineSimilarity(requestEmbedding, utteranceEmbedding)
+		if similarity > maxSimilarity {
+			maxSimilarity = similarity
+		}
+	}
+	return maxSimilarity
+}
+
+// CalculateCosineSimilarity computes the cosine similarity between two embedding
+// vectors. Returns a value between -1.0 and 1.0, where 1.0 means identical.
+//
+// This is an exact port of Java's calculateCosineSimilarity(double[], double[]).
+// The Go version uses float32 inputs (matching the SDK's embedding format) but
+// performs all arithmetic in float64 for precision.
+func CalculateCosineSimilarity(vectorA, vectorB []float32) float64 {
+	if vectorA == nil || vectorB == nil || len(vectorA) != len(vectorB) {
+		return 0.0
+	}
+
+	var dotProduct, normA, normB float64
+
+	for i := range vectorA {
+		a := float64(vectorA[i])
+		b := float64(vectorB[i])
+		dotProduct += a * b
+		normA += a * a
+		normB += b * b
+	}
+
+	denominator := math.Sqrt(normA) * math.Sqrt(normB)
+	if denominator == 0.0 {
+		return 0.0
+	}
+	return dotProduct / denominator
+}
+
+// modifyRequestModel modifies the request body to set the selected model name.
+// Follows the same pattern as model-round-robin and model-weighted-round-robin.
+func (p *SemanticModelRoutingPolicy) modifyRequestModel(content []byte, selectedModel string) policy.RequestAction {
+	if p.requestModel.Location != "payload" || len(content) == 0 {
+		slog.Debug("SemanticModelRouting: Selected model", "model", selectedModel)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	var payloadData map[string]interface{}
+	if err := json.Unmarshal(content, &payloadData); err != nil {
+		slog.Debug("SemanticModelRouting: Failed to parse request body JSON", "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	if err := utils.SetValueAtJSONPath(payloadData, p.requestModel.Identifier, selectedModel); err != nil {
+		slog.Debug("SemanticModelRouting: Failed to set model in request body",
+			"identifier", p.requestModel.Identifier, "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	updatedPayload, err := json.Marshal(payloadData)
+	if err != nil {
+		slog.Debug("SemanticModelRouting: Failed to serialize updated body", "error", err)
+		return policy.UpstreamRequestModifications{}
+	}
+
+	slog.Debug("SemanticModelRouting: Modified request body model",
+		"model", selectedModel, "identifier", p.requestModel.Identifier)
+	return policy.UpstreamRequestModifications{Body: updatedPayload}
+}
+
+// precomputeAllEmbeddings precomputes embeddings for all routes' utterances.
+// This matches the Java precomputeEmbeddings() behavior called during init().
+func (p *SemanticModelRoutingPolicy) precomputeAllEmbeddings() error {
+	for i := range p.routes {
+		route := &p.routes[i]
+		if len(route.Utterances) == 0 {
+			continue
+		}
+
+		embeddings := make([][]float32, 0, len(route.Utterances))
+		for _, utterance := range route.Utterances {
+			embedding, err := p.embeddingProvider.GetEmbedding(utterance)
+			if err != nil {
+				return fmt.Errorf("failed to compute embedding for utterance %q in route %q: %w",
+					utterance, route.Model, err)
+			}
+			embeddings = append(embeddings, embedding)
+		}
+		route.UtteranceEmbeddings = embeddings
+
+		slog.Debug("SemanticModelRouting: Precomputed embeddings for route",
+			"model", route.Model, "count", len(embeddings))
+	}
+
+	return nil
+}
+
+// --- Embedding Provider ---
+
+// createEmbeddingProvider creates and initializes an embedding provider based on
+// the config. This reuses the same SDK code as the semantic-cache policy.
+func createEmbeddingProvider(config embeddingproviders.EmbeddingProviderConfig) (embeddingproviders.EmbeddingProvider, error) {
+	var provider embeddingproviders.EmbeddingProvider
+
+	switch config.EmbeddingProvider {
+	case "OPENAI":
+		provider = &embeddingproviders.OpenAIEmbeddingProvider{}
+	case "MISTRAL":
+		provider = &embeddingproviders.MistralEmbeddingProvider{}
+	case "AZURE_OPENAI":
+		provider = &embeddingproviders.AzureOpenAIEmbeddingProvider{}
+	default:
+		return nil, fmt.Errorf("unsupported embedding provider: %s", config.EmbeddingProvider)
+	}
+
+	if err := provider.Init(config); err != nil {
+		return nil, fmt.Errorf("failed to initialize embedding provider: %w", err)
+	}
+
+	return provider, nil
+}
+
+// --- Parameter Parsing ---
+
+// parseParams parses and validates all policy parameters from the params map.
+func parseParams(params map[string]interface{}, p *SemanticModelRoutingPolicy) error {
+	// Parse contentPath (optional)
+	if contentPath, ok := params["contentPath"].(string); ok && contentPath != "" {
+		p.contentPath = contentPath
+	}
+
+	// Parse routes (required)
+	routesRaw, ok := params["routes"]
+	if !ok {
+		return fmt.Errorf("'routes' parameter is required")
+	}
+
+	routesList, ok := routesRaw.([]interface{})
+	if !ok {
+		return fmt.Errorf("'routes' must be an array")
+	}
+
+	if len(routesList) == 0 {
+		return fmt.Errorf("'routes' must contain at least one route")
+	}
+
+	p.routes = make([]SemanticRoute, 0, len(routesList))
+	for i, item := range routesList {
+		routeMap, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("'routes[%d]' must be an object", i)
+		}
+
+		route, err := parseRouteConfig(routeMap, i)
+		if err != nil {
+			return err
+		}
+		p.routes = append(p.routes, route)
+	}
+
+	// Parse defaultModel (required)
+	defaultModel, ok := params["defaultModel"].(string)
+	if !ok || defaultModel == "" {
+		return fmt.Errorf("'defaultModel' parameter is required")
+	}
+	p.defaultModel = defaultModel
+
+	// Parse requestModel config (system parameter)
+	if err := parseRequestModelConfig(params, p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// parseRouteConfig parses a single route configuration from the params map.
+func parseRouteConfig(routeMap map[string]interface{}, index int) (SemanticRoute, error) {
+	var route SemanticRoute
+
+	// Parse model (required)
+	model, ok := routeMap["model"].(string)
+	if !ok || model == "" {
+		return route, fmt.Errorf("'routes[%d].model' is required and must be a non-empty string", index)
+	}
+	route.Model = model
+
+	// Parse utterances (required)
+	utterancesRaw, ok := routeMap["utterances"]
+	if !ok {
+		return route, fmt.Errorf("'routes[%d].utterances' is required", index)
+	}
+
+	utterancesList, ok := utterancesRaw.([]interface{})
+	if !ok {
+		return route, fmt.Errorf("'routes[%d].utterances' must be an array", index)
+	}
+
+	if len(utterancesList) == 0 {
+		return route, fmt.Errorf("'routes[%d].utterances' must contain at least one utterance", index)
+	}
+
+	route.Utterances = make([]string, 0, len(utterancesList))
+	for j, u := range utterancesList {
+		utterance, ok := u.(string)
+		if !ok || utterance == "" {
+			return route, fmt.Errorf("'routes[%d].utterances[%d]' must be a non-empty string", index, j)
+		}
+		route.Utterances = append(route.Utterances, utterance)
+	}
+
+	// Parse scorethreshold (optional, defaults to DefaultSimilarityThreshold)
+	// Matches Java's initializeRouteConfig() threshold parsing
+	route.ScoreThreshold = DefaultSimilarityThreshold
+	if thresholdRaw, ok := routeMap["scorethreshold"]; ok {
+		threshold, err := extractFloat64(thresholdRaw)
+		if err != nil {
+			slog.Debug("SemanticModelRouting: Invalid score threshold, using default",
+				"value", thresholdRaw, "default", DefaultSimilarityThreshold)
+		} else if threshold >= 0.0 && threshold <= 1.0 {
+			route.ScoreThreshold = threshold
+		} else {
+			slog.Debug("SemanticModelRouting: Score threshold out of range, using default",
+				"value", threshold, "default", DefaultSimilarityThreshold)
+		}
+	}
+
+	return route, nil
+}
+
+// parseEmbeddingConfig parses embedding provider configuration from params.
+// Follows the same pattern as the semantic-cache policy.
+func parseEmbeddingConfig(params map[string]interface{}) (embeddingproviders.EmbeddingProviderConfig, error) {
+	config := embeddingproviders.EmbeddingProviderConfig{}
+
+	provider, ok := params["embeddingProvider"].(string)
+	if !ok || provider == "" {
+		return config, fmt.Errorf("'embeddingProvider' parameter is required")
+	}
+
+	validProviders := map[string]bool{"OPENAI": true, "MISTRAL": true, "AZURE_OPENAI": true}
+	if !validProviders[provider] {
+		return config, fmt.Errorf("'embeddingProvider' must be one of: OPENAI, MISTRAL, AZURE_OPENAI")
+	}
+	config.EmbeddingProvider = provider
+
+	endpoint, ok := params["embeddingEndpoint"].(string)
+	if !ok || endpoint == "" {
+		return config, fmt.Errorf("'embeddingEndpoint' is required for %s provider", provider)
+	}
+	config.EmbeddingEndpoint = endpoint
+
+	// Model is required for OPENAI and MISTRAL, optional for AZURE_OPENAI
+	if model, ok := params["embeddingModel"].(string); ok && model != "" {
+		config.EmbeddingModel = model
+	} else if provider == "OPENAI" || provider == "MISTRAL" {
+		return config, fmt.Errorf("'embeddingModel' is required for %s provider", provider)
+	}
+
+	apiKey, ok := params["apiKey"].(string)
+	if !ok || apiKey == "" {
+		return config, fmt.Errorf("'apiKey' is required for %s provider", provider)
+	}
+	config.APIKey = apiKey
+
+	// Set auth header name based on provider type
+	if provider == "AZURE_OPENAI" {
+		config.AuthHeaderName = "api-key"
+	} else {
+		config.AuthHeaderName = "Authorization"
+	}
+
+	return config, nil
+}
+
+// parseRequestModelConfig parses the requestModel configuration from params.
+func parseRequestModelConfig(params map[string]interface{}, p *SemanticModelRoutingPolicy) error {
+	requestModel, ok := params["requestModel"]
+	if !ok {
+		return fmt.Errorf("'requestModel' configuration is required")
+	}
+
+	requestModelMap, ok := requestModel.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("'requestModel' must be an object")
+	}
+
+	location, ok := requestModelMap["location"].(string)
+	if !ok || location == "" {
+		return fmt.Errorf("'requestModel.location' is required")
+	}
+
+	validLocations := map[string]bool{
+		"payload": true,
+	}
+	if !validLocations[location] {
+		return fmt.Errorf("'requestModel.location' must be one of: payload, header, queryParam, pathParam")
+	}
+	p.requestModel.Location = location
+
+	identifier, ok := requestModelMap["identifier"].(string)
+	if !ok || identifier == "" {
+		return fmt.Errorf("'requestModel.identifier' is required")
+	}
+	p.requestModel.Identifier = identifier
+
+	return nil
+}
+
+// --- Utility Functions ---
+
+// extractFloat64 safely extracts a float64 from various types.
+// Matches the pattern from the semantic-cache policy.
+func extractFloat64(value interface{}) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot convert %q to float64: %w", v, err)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", value)
+	}
+}

--- a/policies/semantic-model-routing/semanticmodelrouting_test.go
+++ b/policies/semantic-model-routing/semanticmodelrouting_test.go
@@ -211,6 +211,38 @@ func TestFindBestRoute_SkipsRoutesWithNoEmbeddings(t *testing.T) {
 
 // --- Parameter Parsing Tests ---
 
+// Only the payload location is implemented, and the rejection message must say so rather
+// than listing locations that are not actually accepted.
+func TestParseParams_UnimplementedRequestModelLocationsRejected(t *testing.T) {
+	for _, location := range []string{"header", "queryParam", "pathParam", "invalid_location"} {
+		t.Run(location, func(t *testing.T) {
+			params := map[string]interface{}{
+				"routes": []interface{}{
+					map[string]interface{}{
+						"model":          "gpt-4o-mini",
+						"utterances":     []interface{}{"write code"},
+						"scorethreshold": 0.85,
+					},
+				},
+				"defaultModel": "gpt-4o",
+				"requestModel": map[string]interface{}{
+					"location":   location,
+					"identifier": "x-model",
+				},
+			}
+
+			p := &SemanticModelRoutingPolicy{}
+			err := parseParams(params, p)
+			if err == nil {
+				t.Fatalf("expected %q to be rejected, but parsing succeeded", location)
+			}
+			if !strings.Contains(err.Error(), "must be 'payload'") {
+				t.Fatalf("error message must state the only supported location, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestParseParams_ValidConfig(t *testing.T) {
 	params := map[string]interface{}{
 		"contentPath": "$.messages[-1].content",

--- a/policies/semantic-model-routing/semanticmodelrouting_test.go
+++ b/policies/semantic-model-routing/semanticmodelrouting_test.go
@@ -1,0 +1,661 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package semanticmodelrouting
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// --- Cosine Similarity Tests ---
+
+func TestCalculateCosineSimilarity_IdenticalVectors(t *testing.T) {
+	vectorA := []float32{1.0, 2.0, 3.0}
+	vectorB := []float32{1.0, 2.0, 3.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+
+	// Identical vectors should have similarity of 1.0
+	if math.Abs(result-1.0) > 1e-6 {
+		t.Errorf("Expected similarity ~1.0 for identical vectors, got %.6f", result)
+	}
+}
+
+func TestCalculateCosineSimilarity_OrthogonalVectors(t *testing.T) {
+	vectorA := []float32{1.0, 0.0, 0.0}
+	vectorB := []float32{0.0, 1.0, 0.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+
+	// Orthogonal vectors should have similarity of 0.0
+	if math.Abs(result) > 1e-6 {
+		t.Errorf("Expected similarity ~0.0 for orthogonal vectors, got %.6f", result)
+	}
+}
+
+func TestCalculateCosineSimilarity_OppositeVectors(t *testing.T) {
+	vectorA := []float32{1.0, 2.0, 3.0}
+	vectorB := []float32{-1.0, -2.0, -3.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+
+	// Opposite vectors should have similarity of -1.0
+	if math.Abs(result-(-1.0)) > 1e-6 {
+		t.Errorf("Expected similarity ~-1.0 for opposite vectors, got %.6f", result)
+	}
+}
+
+func TestCalculateCosineSimilarity_KnownVectors(t *testing.T) {
+	// Known computation: [1,2,3] dot [4,5,6] = 4+10+18 = 32
+	// |[1,2,3]| = sqrt(14), |[4,5,6]| = sqrt(77)
+	// cos = 32 / (sqrt(14) * sqrt(77)) = 32 / sqrt(1078) ≈ 0.9746
+	vectorA := []float32{1.0, 2.0, 3.0}
+	vectorB := []float32{4.0, 5.0, 6.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+	expected := 32.0 / math.Sqrt(14.0*77.0)
+
+	if math.Abs(result-expected) > 1e-6 {
+		t.Errorf("Expected similarity ~%.6f, got %.6f", expected, result)
+	}
+}
+
+func TestCalculateCosineSimilarity_ZeroVector(t *testing.T) {
+	vectorA := []float32{0.0, 0.0, 0.0}
+	vectorB := []float32{1.0, 2.0, 3.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+
+	// Zero vector should return 0.0 (avoid division by zero)
+	if result != 0.0 {
+		t.Errorf("Expected 0.0 for zero vector, got %.6f", result)
+	}
+}
+
+func TestCalculateCosineSimilarity_NilVectors(t *testing.T) {
+	result := CalculateCosineSimilarity(nil, []float32{1.0, 2.0})
+	if result != 0.0 {
+		t.Errorf("Expected 0.0 for nil vectorA, got %.6f", result)
+	}
+
+	result = CalculateCosineSimilarity([]float32{1.0, 2.0}, nil)
+	if result != 0.0 {
+		t.Errorf("Expected 0.0 for nil vectorB, got %.6f", result)
+	}
+}
+
+func TestCalculateCosineSimilarity_DifferentLengths(t *testing.T) {
+	vectorA := []float32{1.0, 2.0}
+	vectorB := []float32{1.0, 2.0, 3.0}
+
+	result := CalculateCosineSimilarity(vectorA, vectorB)
+
+	// Different length vectors should return 0.0
+	if result != 0.0 {
+		t.Errorf("Expected 0.0 for different length vectors, got %.6f", result)
+	}
+}
+
+// --- Max Cosine Similarity Tests ---
+
+func TestComputeMaxCosineSimilarity(t *testing.T) {
+	requestEmbedding := []float32{1.0, 0.0, 0.0}
+	utteranceEmbeddings := [][]float32{
+		{0.0, 1.0, 0.0},  // orthogonal = 0.0
+		{1.0, 0.0, 0.0},  // identical = 1.0
+		{0.5, 0.5, 0.0},  // partial match
+	}
+
+	result := computeMaxCosineSimilarity(requestEmbedding, utteranceEmbeddings)
+
+	// Should return max similarity (1.0 from the identical vector)
+	if math.Abs(result-1.0) > 1e-6 {
+		t.Errorf("Expected max similarity ~1.0, got %.6f", result)
+	}
+}
+
+func TestComputeMaxCosineSimilarity_EmptyUtterances(t *testing.T) {
+	requestEmbedding := []float32{1.0, 0.0, 0.0}
+	utteranceEmbeddings := [][]float32{}
+
+	result := computeMaxCosineSimilarity(requestEmbedding, utteranceEmbeddings)
+
+	if result != 0.0 {
+		t.Errorf("Expected 0.0 for empty utterances, got %.6f", result)
+	}
+}
+
+// --- Find Best Route Tests ---
+
+func TestFindBestRoute_MatchesHighestScore(t *testing.T) {
+	p := &SemanticModelRoutingPolicy{
+		routes: []SemanticRoute{
+			{
+				Model:          "model-a",
+				ScoreThreshold: 0.8,
+				UtteranceEmbeddings: [][]float32{
+					{0.0, 1.0, 0.0}, // low similarity with request
+				},
+			},
+			{
+				Model:          "model-b",
+				ScoreThreshold: 0.8,
+				UtteranceEmbeddings: [][]float32{
+					{1.0, 0.0, 0.0}, // high similarity with request
+				},
+			},
+		},
+	}
+
+	requestEmbedding := []float32{1.0, 0.0, 0.0}
+	bestRoute, bestScore := p.findBestRoute(requestEmbedding)
+
+	if bestRoute == nil {
+		t.Fatal("Expected a best route, got nil")
+	}
+
+	if bestRoute.Model != "model-b" {
+		t.Errorf("Expected best route 'model-b', got %q", bestRoute.Model)
+	}
+
+	if math.Abs(bestScore-1.0) > 1e-6 {
+		t.Errorf("Expected best score ~1.0, got %.6f", bestScore)
+	}
+}
+
+func TestFindBestRoute_SkipsRoutesWithNoEmbeddings(t *testing.T) {
+	p := &SemanticModelRoutingPolicy{
+		routes: []SemanticRoute{
+			{
+				Model:               "model-no-embeddings",
+				ScoreThreshold:      0.8,
+				UtteranceEmbeddings: nil,
+			},
+			{
+				Model:          "model-with-embeddings",
+				ScoreThreshold: 0.8,
+				UtteranceEmbeddings: [][]float32{
+					{1.0, 0.0, 0.0},
+				},
+			},
+		},
+	}
+
+	requestEmbedding := []float32{1.0, 0.0, 0.0}
+	bestRoute, _ := p.findBestRoute(requestEmbedding)
+
+	if bestRoute == nil {
+		t.Fatal("Expected a best route, got nil")
+	}
+
+	if bestRoute.Model != "model-with-embeddings" {
+		t.Errorf("Expected 'model-with-embeddings', got %q", bestRoute.Model)
+	}
+}
+
+// --- Parameter Parsing Tests ---
+
+func TestParseParams_ValidConfig(t *testing.T) {
+	params := map[string]interface{}{
+		"contentPath": "$.messages[-1].content",
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model": "gpt-4o-mini",
+				"utterances": []interface{}{
+					"write code",
+					"generate a function",
+				},
+				"scorethreshold": 0.85,
+			},
+			map[string]interface{}{
+				"model": "gpt-4o",
+				"utterances": []interface{}{
+					"what is the weather",
+				},
+				"scorethreshold": 0.90,
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if len(p.routes) != 2 {
+		t.Errorf("Expected 2 routes, got %d", len(p.routes))
+	}
+
+	if p.routes[0].Model != "gpt-4o-mini" {
+		t.Errorf("Expected first route model 'gpt-4o-mini', got %q", p.routes[0].Model)
+	}
+
+	if len(p.routes[0].Utterances) != 2 {
+		t.Errorf("Expected 2 utterances for first route, got %d", len(p.routes[0].Utterances))
+	}
+
+	if p.routes[0].ScoreThreshold != 0.85 {
+		t.Errorf("Expected threshold 0.85, got %.2f", p.routes[0].ScoreThreshold)
+	}
+
+	if p.defaultModel != "gpt-4o" {
+		t.Errorf("Expected default model 'gpt-4o', got %q", p.defaultModel)
+	}
+}
+
+func TestParseParams_DefaultThreshold(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":      "gpt-4o-mini",
+				"utterances": []interface{}{"test"},
+				// No scorethreshold provided
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if p.routes[0].ScoreThreshold != DefaultSimilarityThreshold {
+		t.Errorf("Expected default threshold %.2f, got %.2f",
+			DefaultSimilarityThreshold, p.routes[0].ScoreThreshold)
+	}
+}
+
+func TestParseParams_ThresholdOutOfRange(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":          "gpt-4o-mini",
+				"utterances":     []interface{}{"test"},
+				"scorethreshold": 1.5, // Out of range
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err != nil {
+		t.Fatalf("Expected no error (should use default), got: %v", err)
+	}
+
+	// Should fall back to default threshold
+	if p.routes[0].ScoreThreshold != DefaultSimilarityThreshold {
+		t.Errorf("Expected default threshold for out-of-range value, got %.2f",
+			p.routes[0].ScoreThreshold)
+	}
+}
+
+func TestParseParams_MissingRoutes(t *testing.T) {
+	params := map[string]interface{}{
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing routes, got nil")
+	}
+	if !strings.Contains(err.Error(), "routes") {
+		t.Errorf("Expected error about routes, got: %v", err)
+	}
+}
+
+func TestParseParams_EmptyRoutesArray(t *testing.T) {
+	params := map[string]interface{}{
+		"routes":       []interface{}{},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for empty routes, got nil")
+	}
+}
+
+func TestParseParams_MissingDefaultModel(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":      "gpt-4o-mini",
+				"utterances": []interface{}{"test"},
+			},
+		},
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing defaultModel, got nil")
+	}
+	if !strings.Contains(err.Error(), "defaultModel") {
+		t.Errorf("Expected error about defaultModel, got: %v", err)
+	}
+}
+
+func TestParseParams_MissingRouteModel(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"utterances": []interface{}{"test"},
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing route model, got nil")
+	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Errorf("Expected error about model, got: %v", err)
+	}
+}
+
+func TestParseParams_MissingUtterances(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model": "gpt-4o-mini",
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing utterances, got nil")
+	}
+	if !strings.Contains(err.Error(), "utterances") {
+		t.Errorf("Expected error about utterances, got: %v", err)
+	}
+}
+
+func TestParseParams_EmptyUtterancesArray(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":      "gpt-4o-mini",
+				"utterances": []interface{}{},
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "payload",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for empty utterances, got nil")
+	}
+}
+
+func TestParseParams_MissingRequestModel(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":      "gpt-4o-mini",
+				"utterances": []interface{}{"test"},
+			},
+		},
+		"defaultModel": "gpt-4o",
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for missing requestModel, got nil")
+	}
+	if !strings.Contains(err.Error(), "requestModel") {
+		t.Errorf("Expected error about requestModel, got: %v", err)
+	}
+}
+
+func TestParseParams_InvalidRequestModelLocation(t *testing.T) {
+	params := map[string]interface{}{
+		"routes": []interface{}{
+			map[string]interface{}{
+				"model":      "gpt-4o-mini",
+				"utterances": []interface{}{"test"},
+			},
+		},
+		"defaultModel": "gpt-4o",
+		"requestModel": map[string]interface{}{
+			"location":   "invalid",
+			"identifier": "$.model",
+		},
+	}
+
+	p := &SemanticModelRoutingPolicy{}
+	err := parseParams(params, p)
+	if err == nil {
+		t.Fatal("Expected error for invalid location, got nil")
+	}
+}
+
+// --- Embedding Config Parsing Tests ---
+
+func TestParseEmbeddingConfig_Valid(t *testing.T) {
+	params := map[string]interface{}{
+		"embeddingProvider": "OPENAI",
+		"embeddingEndpoint": "https://api.openai.com/v1/embeddings",
+		"embeddingModel":    "text-embedding-ada-002",
+		"apiKey":            "sk-test-key",
+	}
+
+	config, err := parseEmbeddingConfig(params)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if config.EmbeddingProvider != "OPENAI" {
+		t.Errorf("Expected provider 'OPENAI', got %q", config.EmbeddingProvider)
+	}
+	if config.EmbeddingModel != "text-embedding-ada-002" {
+		t.Errorf("Expected model 'text-embedding-ada-002', got %q", config.EmbeddingModel)
+	}
+	if config.AuthHeaderName != "Authorization" {
+		t.Errorf("Expected auth header 'Authorization', got %q", config.AuthHeaderName)
+	}
+}
+
+func TestParseEmbeddingConfig_AzureOpenAI(t *testing.T) {
+	params := map[string]interface{}{
+		"embeddingProvider": "AZURE_OPENAI",
+		"embeddingEndpoint": "https://myresource.openai.azure.com/openai/deployments/ada-002/embeddings",
+		"apiKey":            "azure-key",
+		// Note: embeddingModel is optional for AZURE_OPENAI
+	}
+
+	config, err := parseEmbeddingConfig(params)
+	if err != nil {
+		t.Fatalf("Azure OpenAI should not require embeddingModel, got: %v", err)
+	}
+	if config.AuthHeaderName != "api-key" {
+		t.Errorf("Expected auth header 'api-key' for Azure, got %q", config.AuthHeaderName)
+	}
+}
+
+func TestParseEmbeddingConfig_MissingProvider(t *testing.T) {
+	params := map[string]interface{}{
+		"embeddingEndpoint": "https://api.openai.com/v1/embeddings",
+		"apiKey":            "sk-test-key",
+	}
+
+	_, err := parseEmbeddingConfig(params)
+	if err == nil {
+		t.Fatal("Expected error for missing provider, got nil")
+	}
+}
+
+func TestParseEmbeddingConfig_InvalidProvider(t *testing.T) {
+	params := map[string]interface{}{
+		"embeddingProvider": "INVALID",
+		"embeddingEndpoint": "https://example.com",
+		"apiKey":            "key",
+	}
+
+	_, err := parseEmbeddingConfig(params)
+	if err == nil {
+		t.Fatal("Expected error for invalid provider, got nil")
+	}
+}
+
+func TestParseEmbeddingConfig_OpenAI_MissingModel(t *testing.T) {
+	params := map[string]interface{}{
+		"embeddingProvider": "OPENAI",
+		"embeddingEndpoint": "https://api.openai.com/v1/embeddings",
+		"apiKey":            "sk-test-key",
+		// Missing embeddingModel
+	}
+
+	_, err := parseEmbeddingConfig(params)
+	if err == nil {
+		t.Fatal("Expected error for missing embeddingModel with OPENAI, got nil")
+	}
+}
+
+// --- Extract Float64 Tests ---
+
+func TestExtractFloat64_Float64(t *testing.T) {
+	result, err := extractFloat64(0.85)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != 0.85 {
+		t.Errorf("Expected 0.85, got %f", result)
+	}
+}
+
+func TestExtractFloat64_Int(t *testing.T) {
+	result, err := extractFloat64(1)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != 1.0 {
+		t.Errorf("Expected 1.0, got %f", result)
+	}
+}
+
+func TestExtractFloat64_String(t *testing.T) {
+	result, err := extractFloat64("0.85")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != 0.85 {
+		t.Errorf("Expected 0.85, got %f", result)
+	}
+}
+
+func TestExtractFloat64_InvalidString(t *testing.T) {
+	_, err := extractFloat64("not-a-number")
+	if err == nil {
+		t.Fatal("Expected error for invalid string, got nil")
+	}
+}
+
+func TestExtractFloat64_UnsupportedType(t *testing.T) {
+	_, err := extractFloat64([]int{1, 2, 3})
+	if err == nil {
+		t.Fatal("Expected error for unsupported type, got nil")
+	}
+}
+
+// --- Threshold Parsing Edge Cases ---
+
+func TestParseRouteConfig_StringThreshold(t *testing.T) {
+	routeMap := map[string]interface{}{
+		"model":          "gpt-4o-mini",
+		"utterances":     []interface{}{"test"},
+		"scorethreshold": "0.85", // String instead of number
+	}
+
+	route, err := parseRouteConfig(routeMap, 0)
+	if err != nil {
+		t.Fatalf("Expected no error for string threshold, got: %v", err)
+	}
+
+	if route.ScoreThreshold != 0.85 {
+		t.Errorf("Expected threshold 0.85 from string, got %.2f", route.ScoreThreshold)
+	}
+}
+
+func TestParseRouteConfig_NegativeThreshold(t *testing.T) {
+	routeMap := map[string]interface{}{
+		"model":          "gpt-4o-mini",
+		"utterances":     []interface{}{"test"},
+		"scorethreshold": -0.5,
+	}
+
+	route, err := parseRouteConfig(routeMap, 0)
+	if err != nil {
+		t.Fatalf("Expected no error (should use default), got: %v", err)
+	}
+
+	// Negative threshold should fall back to default
+	if route.ScoreThreshold != DefaultSimilarityThreshold {
+		t.Errorf("Expected default threshold for negative value, got %.2f", route.ScoreThreshold)
+	}
+}


### PR DESCRIPTION
## Purpose
The WSO2 API Platform AI Gateway currently supports model routing via round-robin and weighted round-robin policies, which distribute requests across models without understanding the content of the request. For many use cases, requests should be routed to specific models based on what the user is actually asking — coding questions to a code-optimized model, general knowledge to a larger model, etc. This change adds two new LLM-aware routing policies that classify incoming requests and route them to the most appropriate model.

## Goals
- Add an **Intelligent Model Routing** policy that uses an LLM to classify incoming requests against user-defined routing rules and selects the best-matching model
- Add a **Semantic Model Routing** policy that uses vector embeddings and cosine similarity to route requests based on semantic similarity to predefined utterances
- Both policies support configurable content extraction via JSONPath, default model fallback, and the same `requestModel` location/identifier pattern used by existing routing policies
- Provide comprehensive unit test coverage for both policies including parameter validation, routing logic, and edge cases

## Approach
### Intelligent Model Routing
- An LLM (OpenAI or Azure OpenAI) classifies each incoming request against user-defined routing rules, each with a name, context description, and target model
- The policy extracts user text from the request body via configurable JSONPath (`contentPath`), sends it to the LLM with a system prompt listing all routing rules, and parses the selected rule name
- If the LLM selects a matching rule, the request is routed to that rule's model; otherwise it falls back to the `defaultModel`
- Supports payload, header, queryParam, and pathParam model location types

### Semantic Model Routing
- Embeddings are **precomputed at policy initialization** for all configured utterances using the SDK's embedding provider (OpenAI, Mistral, or Azure OpenAI)
- At runtime, the user request text is embedded and compared against all precomputed utterance embeddings using cosine similarity
- The route with the highest similarity score that exceeds its configured `scorethreshold` (default: 0.90) is selected; otherwise the `defaultModel` is used
- Supports OpenAI, Mistral, and Azure OpenAI embedding providers with provider-specific authentication

Both policies follow the existing patterns in the gateway-controllers policy framework (v1alpha2 `PolicyMetadata`/`Policy` interfaces, `ProcessingMode`, `RequestContext`, `UpstreamRequestModifications`).

## User stories
- As an API publisher, I want to route requests to different AI models based on the content of the user's question so that each request uses the most cost-effective and capable model for its task
- As an API publisher, I want to define routing rules in plain language so that non-technical stakeholders can configure routing behavior
- As an API publisher, I want to use semantic similarity-based routing so that requests similar to known examples are automatically routed to the appropriate model without LLM classification overhead
- As an API publisher, I want both policies to fall back to a default model when classification is uncertain, ensuring no request fails due to routing ambiguity

## Release note
Added two new AI model routing policies for the Envoy gateway: **Intelligent Model Routing** uses LLM-powered classification to route requests to the best-matching model based on user-defined rules, and **Semantic Model Routing** uses vector embeddings and cosine similarity to route requests based on semantic similarity to predefined example utterances. Both policies support configurable content extraction, multiple model location types, and automatic fallback to a default model.

## Documentation
N/A — Documentation updates should be made to the WSO2 API-M documentation for the new Intelligent Model Routing and Semantic Model Routing policies. A follow-up documentation PR is recommended.

## Training
N/A

## Certification
N/A — These are new policies that extend the existing policy catalog. Certification updates should be considered if model routing topics are covered in exams.

## Marketing
N/A at this time.

## Automation tests
- **Intelligent Model Routing**: 17 test cases covering parameter validation (14 sub-tests for missing/invalid fields), LLM-based routing with matching and non-matching rules, server error handling, and empty response handling
- **Semantic Model Routing**: 21 test cases covering cosine similarity calculations (identical, orthogonal, opposite, zero, nil, different-length vectors), max similarity computation, best route matching, parameter parsing validation (valid config, default thresholds, out-of-range thresholds, missing fields), embedding config parsing (OpenAI, Azure OpenAI, missing/invalid providers), and float extraction utilities
- **Integration tests**: End-to-end tests validating both policies with mock LLM/embedding servers

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
- Example configurations are provided in the `policy-definition.yaml` files for each policy
- Intelligent Model Routing example: routes "Coding Questions" to `gpt-4o` and "General Knowledge" to `gpt-4o-mini` using OpenAI classification
- Semantic Model Routing example: routes requests to `gpt-4o` or `gpt-4o-mini` based on cosine similarity to predefined utterances with a 0.90 threshold

## Related PRs
- Original model round robin policy implementation (pre-existing in `gateway-controllers/policies/model-round-robin/`)

## Migrations (if applicable)
N/A — These are new policies. No existing behavior is changed.

## Test environment
- **Go tests**: Go 1.26, Linux (CI), Windows (local development)
- **Integration tests**: Docker Compose (gateway-controller + gateway-runtime + Envoy proxy), mock LLM/embedding servers
- **OS**: Windows 11 (local development), Ubuntu (CI/CD via GitHub Actions)

## Learning
- Used the OpenAI chat completions API format for the Intelligent Model Routing LLM classification, leveraging structured system prompts with rule descriptions
- Ported the cosine similarity computation and embedding precomputation pattern from the existing Java Universal Gateway `SemanticRouting` implementation
- Reused the `github.com/wso2/api-platform/sdk/ai/embeddings` package for embedding provider abstraction (OpenAI, Mistral, Azure OpenAI), following the same pattern as the existing semantic-cache policy