### PR TITLE
Add per-environment policy registration and a new publish-policy workflow

### DIFF
--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Validate inputs and policy existence
         env:
@@ -109,6 +111,7 @@ jobs:
       - name: Validate API configuration
         env:
           POLICY_HUB_URL: ${{ vars.POLICY_HUB_URL }}
+          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
           ENVIRONMENT_INPUT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
@@ -118,11 +121,15 @@ jobs:
             {
               echo "## ❌ Configuration Error"
               echo "**Error:** Missing POLICY_HUB_URL environment variable"
-              echo ""
-              echo "**To fix this:**"
-              echo "1. Go to repository Settings → Environments"
-              echo "2. Select the \`$ENVIRONMENT_INPUT\` environment"
-              echo "3. Add a variable named \`POLICY_HUB_URL\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [[ -z "${POLICY_HUB_TOKEN:-}" ]]; then
+            echo "::error::Missing POLICY_HUB_TOKEN secret"
+            {
+              echo "## ❌ Configuration Error"
+              echo "**Error:** Missing POLICY_HUB_TOKEN secret"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
@@ -188,8 +195,9 @@ jobs:
           [[ "$name" == "$POLICY_NAME" ]] \
             || fail "Policy name mismatch: metadata.json has '$name', but workflow input is '$POLICY_NAME'"
 
-          # Validate that version matches input (remove 'v' prefix if present)
+          # Validate that version matches input (remove 'v'/'V' prefix if present)
           metadata_version=${version#v}
+          metadata_version=${metadata_version#V}
           [[ "$metadata_version" == "$MINOR_VERSION" ]] \
             || fail "Version mismatch: metadata.json has '$version', but workflow input is '$MINOR_VERSION'"
 
@@ -267,10 +275,7 @@ jobs:
             "$API_URL/policies/$METADATA_NAME/versions/$METADATA_VERSION"
           )
 
-          # Add authentication header if token is provided
-          if [[ -n "${POLICY_HUB_TOKEN:-}" ]]; then
-            curl_args+=("-H" "api-key: $POLICY_HUB_TOKEN")
-          fi
+          curl_args+=("-H" "api-key: $POLICY_HUB_TOKEN")
 
           # Add form fields
           curl_args+=("--form-string" "metadata=$METADATA_CONTENT")

--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -1,0 +1,371 @@
+# Publish Policy
+#
+# Packages a single policy version's docs/assets and publishes them to
+# Policy Hub for one selected environment. This is distinct from Release
+# Policy: this publishes documentation/metadata for an already-released
+# policy version — it does not tag or register the policy module itself.
+
+name: Publish Policy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to publish to'
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      policy_name:
+        description: 'Name of the policy to publish'
+        required: true
+        type: string
+      minor_version:
+        description: 'Minor version (e.g., 0.1, 1.2, or v0.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-policy-${{ github.event.inputs.policy_name }}-${{ github.event.inputs.minor_version }}-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Validate inputs and policy existence
+        env:
+          POLICY_NAME_INPUT: ${{ inputs.policy_name }}
+          MINOR_VERSION_INPUT: ${{ inputs.minor_version }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          # Trim whitespace from policy name
+          POLICY_NAME=$(echo "$POLICY_NAME_INPUT" | xargs)
+
+          # Trim whitespace and strip an optional leading 'v'/'V' (e.g. "v1.0" -> "1.0")
+          RAW_MINOR_VERSION=$(echo "$MINOR_VERSION_INPUT" | xargs)
+          MINOR_VERSION="${RAW_MINOR_VERSION#v}"
+          MINOR_VERSION="${MINOR_VERSION#V}"
+
+          # Validate policy name: only letters, numbers, hyphen, underscore; no slashes or traversal
+          [[ -n "$POLICY_NAME" ]] || fail "Policy name is required"
+          [[ "$POLICY_NAME" =~ ^[A-Za-z0-9_-]+$ ]] || fail "Policy name must contain only letters, numbers, hyphens, and underscores (no spaces, slashes, or special characters). Got: '$POLICY_NAME'"
+
+          # Validate minor version format
+          [[ "$MINOR_VERSION" =~ ^[0-9]+\.[0-9]+$ ]] || fail "Minor version must be in format X.Y (e.g., 0.1, 1.2). Got: '$RAW_MINOR_VERSION'"
+
+          # Check if policy directory exists in docs/
+          DOCS_POLICY_DIR="docs/$POLICY_NAME"
+          [[ -d "$DOCS_POLICY_DIR" ]] || fail "Policy directory not found in docs/: $DOCS_POLICY_DIR"
+
+          # Check if version directory exists — this one gets a richer summary
+          # (available versions) since a bare mismatch message isn't actionable here.
+          VERSION_DIR="$DOCS_POLICY_DIR/v$MINOR_VERSION"
+          if [[ ! -d "$VERSION_DIR" ]]; then
+            echo "::error::Version directory not found: $VERSION_DIR"
+            {
+              echo "## ❌ Failed"
+              echo ""
+              echo "**Error:** Version directory not found: \`$VERSION_DIR\`"
+              echo ""
+              echo "**Available versions for $POLICY_NAME:**"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            ls -1 "$DOCS_POLICY_DIR/" 2>/dev/null >> "$GITHUB_STEP_SUMMARY" || echo "No versions found" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # Check if policies directory exists
+          POLICIES_DIR="policies/$POLICY_NAME"
+          [[ -d "$POLICIES_DIR" ]] || fail "Policy directory not found in policies/: $POLICIES_DIR"
+
+          echo "✅ Policy validation passed"
+          {
+            echo "POLICY_NAME=$POLICY_NAME"
+            echo "MINOR_VERSION=$MINOR_VERSION"
+            echo "VERSION_DIR=$VERSION_DIR"
+            echo "POLICIES_DIR=$POLICIES_DIR"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate API configuration
+        env:
+          POLICY_HUB_URL: ${{ vars.POLICY_HUB_URL }}
+          ENVIRONMENT_INPUT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${POLICY_HUB_URL:-}" ]]; then
+            echo "::error::Missing POLICY_HUB_URL environment variable"
+            {
+              echo "## ❌ Configuration Error"
+              echo "**Error:** Missing POLICY_HUB_URL environment variable"
+              echo ""
+              echo "**To fix this:**"
+              echo "1. Go to repository Settings → Environments"
+              echo "2. Select the \`$ENVIRONMENT_INPUT\` environment"
+              echo "3. Add a variable named \`POLICY_HUB_URL\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "✅ API configuration validated"
+          echo "API_URL=$POLICY_HUB_URL" >> "$GITHUB_ENV"
+
+      - name: Parse and validate metadata.json
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          METADATA_FILE="$VERSION_DIR/metadata.json"
+
+          # Check if metadata.json exists
+          [[ -f "$METADATA_FILE" ]] || fail "metadata.json not found: $METADATA_FILE"
+
+          # Validate JSON syntax
+          if ! jq empty "$METADATA_FILE" 2>/dev/null; then
+            echo "::error::Invalid JSON in metadata.json"
+            {
+              echo "## ❌ Failed"
+              echo ""
+              echo "**Error:** Invalid JSON in metadata.json"
+              echo '```'
+              cat "$METADATA_FILE"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # Extract and validate required fields
+          name=$(jq -r '.name // empty' "$METADATA_FILE")
+          version=$(jq -r '.version // empty' "$METADATA_FILE")
+          displayName=$(jq -r '.displayName // empty' "$METADATA_FILE")
+          provider=$(jq -r '.provider // empty' "$METADATA_FILE")
+          categories=$(jq -r '.categories // empty' "$METADATA_FILE")
+          description=$(jq -r '.description // empty' "$METADATA_FILE")
+
+          # Check required fields
+          MISSING_FIELDS=()
+          [[ -z "$name" ]] && MISSING_FIELDS+=("name")
+          [[ -z "$version" ]] && MISSING_FIELDS+=("version")
+          [[ -z "$displayName" ]] && MISSING_FIELDS+=("displayName")
+          [[ -z "$provider" ]] && MISSING_FIELDS+=("provider")
+          [[ -z "$categories" || "$categories" == "null" ]] && MISSING_FIELDS+=("categories")
+          [[ -z "$description" ]] && MISSING_FIELDS+=("description")
+
+          if [[ ${#MISSING_FIELDS[@]} -gt 0 ]]; then
+            fail "Missing required fields in metadata.json ($METADATA_FILE): ${MISSING_FIELDS[*]}"
+          fi
+
+          # Validate that .categories is a non-empty array
+          jq -e '.categories | type=="array" and length>0' "$METADATA_FILE" >/dev/null \
+            || fail "'categories' must be a non-empty array in metadata.json ($METADATA_FILE)"
+
+          # Validate that name matches input
+          [[ "$name" == "$POLICY_NAME" ]] \
+            || fail "Policy name mismatch: metadata.json has '$name', but workflow input is '$POLICY_NAME'"
+
+          # Validate that version matches input (remove 'v' prefix if present)
+          metadata_version=${version#v}
+          [[ "$metadata_version" == "$MINOR_VERSION" ]] \
+            || fail "Version mismatch: metadata.json has '$version', but workflow input is '$MINOR_VERSION'"
+
+          echo "✅ Metadata validation passed"
+          {
+            echo "METADATA_NAME=$name"
+            echo "METADATA_VERSION=$metadata_version"
+          } >> "$GITHUB_ENV"
+
+      - name: Create policy package
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          # Create temporary directory for packaging
+          TEMP_DIR=$(mktemp -d)
+          PACKAGE_DIR="$TEMP_DIR/package"
+          mkdir -p "$PACKAGE_DIR"
+
+          # Copy docs folder if it exists
+          DOCS_SOURCE="$VERSION_DIR/docs"
+          if [[ -d "$DOCS_SOURCE" ]]; then
+            cp -r "$DOCS_SOURCE" "$PACKAGE_DIR/"
+            echo "✅ Copied docs folder"
+          else
+            fail "docs folder not found: $DOCS_SOURCE"
+          fi
+
+          # Copy assets folder if it exists
+          ASSETS_SOURCE="$VERSION_DIR/assets"
+          if [[ -d "$ASSETS_SOURCE" ]]; then
+            cp -r "$ASSETS_SOURCE" "$PACKAGE_DIR/"
+            echo "✅ Copied assets folder"
+          else
+            echo "ℹ️  No assets folder found (optional)"
+          fi
+
+          # Create zip file
+          ZIP_NAME="${METADATA_NAME}-${METADATA_VERSION}.zip"
+          ZIP_PATH="$GITHUB_WORKSPACE/$ZIP_NAME"
+
+          (cd "$PACKAGE_DIR" && zip -r "$ZIP_PATH" . -x "*.DS_Store")
+
+          # Verify zip was created
+          [[ -f "$ZIP_PATH" ]] || fail "Failed to create zip file: $ZIP_PATH"
+
+          echo "✅ Created policy package: $ZIP_NAME"
+          {
+            echo "ZIP_NAME=$ZIP_NAME"
+            echo "TEMP_DIR=$TEMP_DIR"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish policy
+        env:
+          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Read metadata.json content
+          METADATA_CONTENT=$(cat "$VERSION_DIR/metadata.json")
+
+          # Build curl args array safely
+          curl_args=(
+            "-sS"
+            "-w" "%{http_code}"
+            "-o" "response.txt"
+            "-X" "POST"
+            "--max-time" "30"
+            "--connect-timeout" "10"
+            "$API_URL/policies/$METADATA_NAME/versions/$METADATA_VERSION"
+          )
+
+          # Add authentication header if token is provided
+          if [[ -n "${POLICY_HUB_TOKEN:-}" ]]; then
+            curl_args+=("-H" "api-key: $POLICY_HUB_TOKEN")
+          fi
+
+          # Add form fields
+          curl_args+=("--form-string" "metadata=$METADATA_CONTENT")
+          curl_args+=("-F" "docs=@$GITHUB_WORKSPACE/$ZIP_NAME")
+
+          # Execute the curl command, keeping curl's own exit code separate from the HTTP status
+          if ! HTTP_STATUS=$(curl "${curl_args[@]}"); then
+            echo "::error::Request to Policy Hub failed (network error or timeout)"
+            {
+              echo "## ❌ Publishing Failed"
+              echo "**Error:** Could not reach Policy Hub (network error or timeout)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "HTTP Status: $HTTP_STATUS"
+
+          RESPONSE_BODY=""
+          if [[ -f response.txt ]]; then
+            RESPONSE_BODY=$(cat response.txt)
+          fi
+
+          # Check if request was successful
+          if [[ "$HTTP_STATUS" -ge 200 && "$HTTP_STATUS" -lt 300 ]]; then
+            echo "✅ Policy published successfully!"
+            echo "📨 API Response:"
+            echo "$RESPONSE_BODY"
+
+            # Extract status from response
+            PUBLISH_STATUS=$(echo "$RESPONSE_BODY" | jq -r '.data.status // "published"' 2>/dev/null || echo "published")
+            echo "PUBLISH_STATUS=$PUBLISH_STATUS" >> "$GITHUB_ENV"
+          elif [[ "$HTTP_STATUS" == "401" ]]; then
+            # Never echo the response body for 401s: some APIs reflect request
+            # headers/credentials back in auth-error bodies, and $GITHUB_STEP_SUMMARY
+            # is not secret-masked the way console log output is.
+            echo "::error::Policy publishing failed: Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN"
+            {
+              echo "## ❌ Publishing Failed"
+              echo "**HTTP Status:** \`401\`"
+              echo ""
+              echo "**Error:** Unauthorized — check POLICY_HUB_TOKEN"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          else
+            # Extract just the message field if present, otherwise fall back to the raw body
+            ERROR_MESSAGE=$(echo "$RESPONSE_BODY" | jq -r '.message // empty' 2>/dev/null || true)
+            if [[ -z "$ERROR_MESSAGE" ]]; then
+              ERROR_MESSAGE="${RESPONSE_BODY:-No response body}"
+            fi
+
+            echo "::error::Policy publishing failed with HTTP status $HTTP_STATUS: $ERROR_MESSAGE"
+            {
+              echo "## ❌ Publishing Failed"
+              echo "**HTTP Status:** \`$HTTP_STATUS\`"
+              echo ""
+              echo "**Error:** $ERROR_MESSAGE"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # Clean up temporary files (best-effort; do not fail the job on cleanup issues)
+          if [[ -n "${ZIP_NAME:-}" && -f "${ZIP_NAME:-}" ]]; then
+            rm -f "$ZIP_NAME"
+          fi
+          if [[ -n "${TEMP_DIR:-}" && -d "${TEMP_DIR:-}" ]]; then
+            rm -rf "$TEMP_DIR"
+          fi
+          if [[ -f "response.txt" ]]; then
+            rm -f response.txt
+          fi
+          echo "🧹 Cleanup completed"
+
+      - name: Summary
+        if: success()
+        env:
+          ENVIRONMENT_INPUT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          echo "🎉 Policy Publishing Summary"
+          echo "=========================="
+          echo "Policy Name: $METADATA_NAME"
+          echo "Version: $METADATA_VERSION"
+          echo "Status: ✅ Successfully Published"
+
+          {
+            echo "## 🎉 Policy Published Successfully"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| **Policy Name** | \`$METADATA_NAME\` |"
+            echo "| **Version** | \`$METADATA_VERSION\` |"
+            echo "| **Environment** | \`$ENVIRONMENT_INPUT\` |"
+            echo "| **Status** | \`$PUBLISH_STATUS\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -78,9 +78,9 @@ jobs:
           set -euo pipefail
 
           ENVS=()
-          [[ "$PUBLISH_DEV" == "true" ]] && ENVS+=("dev")
-          [[ "$PUBLISH_STAGING" == "true" ]] && ENVS+=("staging")
-          [[ "$PUBLISH_PRODUCTION" == "true" ]] && ENVS+=("production")
+          [[ "$PUBLISH_DEV" == "true" ]] && ENVS+=("Dev")
+          [[ "$PUBLISH_STAGING" == "true" ]] && ENVS+=("Staging")
+          [[ "$PUBLISH_PRODUCTION" == "true" ]] && ENVS+=("Production")
 
           if [[ ${#ENVS[@]} -eq 0 ]]; then
             echo "ℹ️ No environment selected — nothing will be published"

--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -1,50 +1,98 @@
 # Publish Policy
 #
 # Packages a single policy version's docs/assets and publishes them to
-# Policy Hub for one selected environment. This is distinct from Release
+# Policy Hub for each selected environment. This is distinct from Release
 # Policy: this publishes documentation/metadata for an already-released
 # policy version — it does not tag or register the policy module itself.
+#
+# Validation and packaging happen once (job: build), then the resulting
+# package is published to every selected environment in parallel
+# (job: publish), each leg gated by its own GitHub Environment protection
+# rules and secrets — matching the structure of Release Policy.
 
 name: Publish Policy
 
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Environment to publish to'
-        required: true
-        type: choice
-        options:
-          - dev
-          - staging
-          - production
       policy_name:
         description: 'Name of the policy to publish'
         required: true
         type: string
       minor_version:
-        description: 'Minor version (e.g., 0.1, 1.2, or v0.1)'
+        description: 'Minor version (e.g., 0.1, 1.2, v0.1, or 1.2.0)'
         required: true
         type: string
+      publish_dev:
+        description: 'Publish to dev'
+        required: false
+        type: boolean
+        default: true
+      publish_staging:
+        description: 'Publish to staging'
+        required: false
+        type: boolean
+        default: false
+      publish_production:
+        description: 'Publish to production'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-policy-${{ github.event.inputs.policy_name }}-${{ github.event.inputs.minor_version }}-${{ github.event.inputs.environment }}
+  group: publish-policy-${{ github.event.inputs.policy_name }}-${{ github.event.inputs.minor_version }}
   cancel-in-progress: false
 
 jobs:
-  publish:
+  # ------------------------------------------------------------
+  # Validate inputs/metadata and build the policy package once.
+  # No Policy Hub / API calls happen here at all.
+  # ------------------------------------------------------------
+  build:
+    name: Validate & Build Policy Package
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: ${{ inputs.environment }}
+    outputs:
+      metadata_name: ${{ steps.metadata.outputs.metadata_name }}
+      metadata_version: ${{ steps.metadata.outputs.metadata_version }}
+      zip_name: ${{ steps.package.outputs.zip_name }}
+      environments: ${{ steps.envs.outputs.environments }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Determine target environments
+        id: envs
+        shell: bash
+        env:
+          PUBLISH_DEV: ${{ inputs.publish_dev }}
+          PUBLISH_STAGING: ${{ inputs.publish_staging }}
+          PUBLISH_PRODUCTION: ${{ inputs.publish_production }}
+        run: |
+          set -euo pipefail
+
+          ENVS=()
+          [[ "$PUBLISH_DEV" == "true" ]] && ENVS+=("dev")
+          [[ "$PUBLISH_STAGING" == "true" ]] && ENVS+=("staging")
+          [[ "$PUBLISH_PRODUCTION" == "true" ]] && ENVS+=("production")
+
+          if [[ ${#ENVS[@]} -eq 0 ]]; then
+            echo "ℹ️ No environment selected — nothing will be published"
+            JSON="[]"
+          else
+            echo "Selected environments: ${ENVS[*]}"
+            # printf still runs its format once even with zero args, so build the
+            # JSON array only in this branch where ENVS is guaranteed non-empty.
+            JSON=$(printf '%s\n' "${ENVS[@]}" | jq -R . | jq -sc .)
+          fi
+
+          echo "environments=$JSON" >> "$GITHUB_OUTPUT"
 
       - name: Validate inputs and policy existence
         env:
@@ -67,12 +115,18 @@ jobs:
           MINOR_VERSION="${RAW_MINOR_VERSION#v}"
           MINOR_VERSION="${MINOR_VERSION#V}"
 
+          # Drop an optional patch component (e.g. "1.0.0" -> "1.0") so a full
+          # semver input still resolves to the X.Y docs/policy directories.
+          if [[ "$MINOR_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            MINOR_VERSION="${MINOR_VERSION%.*}"
+          fi
+
           # Validate policy name: only letters, numbers, hyphen, underscore; no slashes or traversal
           [[ -n "$POLICY_NAME" ]] || fail "Policy name is required"
           [[ "$POLICY_NAME" =~ ^[A-Za-z0-9_-]+$ ]] || fail "Policy name must contain only letters, numbers, hyphens, and underscores (no spaces, slashes, or special characters). Got: '$POLICY_NAME'"
 
           # Validate minor version format
-          [[ "$MINOR_VERSION" =~ ^[0-9]+\.[0-9]+$ ]] || fail "Minor version must be in format X.Y (e.g., 0.1, 1.2). Got: '$RAW_MINOR_VERSION'"
+          [[ "$MINOR_VERSION" =~ ^[0-9]+\.[0-9]+$ ]] || fail "Minor version must be in format X.Y or X.Y.Z (e.g., 0.1, 1.2, 1.2.0). Got: '$RAW_MINOR_VERSION'"
 
           # Check if policy directory exists in docs/
           DOCS_POLICY_DIR="docs/$POLICY_NAME"
@@ -108,36 +162,8 @@ jobs:
             echo "POLICIES_DIR=$POLICIES_DIR"
           } >> "$GITHUB_ENV"
 
-      - name: Validate API configuration
-        env:
-          POLICY_HUB_URL: ${{ vars.POLICY_HUB_URL }}
-          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
-          ENVIRONMENT_INPUT: ${{ inputs.environment }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${POLICY_HUB_URL:-}" ]]; then
-            echo "::error::Missing POLICY_HUB_URL environment variable"
-            {
-              echo "## ❌ Configuration Error"
-              echo "**Error:** Missing POLICY_HUB_URL environment variable"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          if [[ -z "${POLICY_HUB_TOKEN:-}" ]]; then
-            echo "::error::Missing POLICY_HUB_TOKEN secret"
-            {
-              echo "## ❌ Configuration Error"
-              echo "**Error:** Missing POLICY_HUB_TOKEN secret"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "✅ API configuration validated"
-          echo "API_URL=$POLICY_HUB_URL" >> "$GITHUB_ENV"
-
       - name: Parse and validate metadata.json
+        id: metadata
         run: |
           set -euo pipefail
 
@@ -206,8 +232,13 @@ jobs:
             echo "METADATA_NAME=$name"
             echo "METADATA_VERSION=$metadata_version"
           } >> "$GITHUB_ENV"
+          {
+            echo "metadata_name=$name"
+            echo "metadata_version=$metadata_version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create policy package
+        id: package
         run: |
           set -euo pipefail
 
@@ -237,7 +268,7 @@ jobs:
             cp -r "$ASSETS_SOURCE" "$PACKAGE_DIR/"
             echo "✅ Copied assets folder"
           else
-            echo "ℹ️  No assets folder found (optional)"
+            echo "ℹ️ No assets folder found (optional)"
           fi
 
           # Create zip file
@@ -249,20 +280,124 @@ jobs:
           # Verify zip was created
           [[ -f "$ZIP_PATH" ]] || fail "Failed to create zip file: $ZIP_PATH"
 
+          # Stage metadata.json alongside the zip so it travels in the same
+          # artifact — the publish job runs on a fresh runner with no checkout.
+          cp "$VERSION_DIR/metadata.json" "$GITHUB_WORKSPACE/metadata.json"
+
           echo "✅ Created policy package: $ZIP_NAME"
           {
             echo "ZIP_NAME=$ZIP_NAME"
             echo "TEMP_DIR=$TEMP_DIR"
           } >> "$GITHUB_ENV"
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Publish policy
+      - name: Upload policy package for publishing
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-package
+          path: |
+            ${{ env.ZIP_NAME }}
+            metadata.json
+          retention-days: 1
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # Clean up temporary files (best-effort; do not fail the job on cleanup issues)
+          if [[ -n "${TEMP_DIR:-}" && -d "${TEMP_DIR:-}" ]]; then
+            rm -rf "$TEMP_DIR"
+          fi
+          echo "🧹 Cleanup completed"
+
+      - name: Summary
+        if: success()
+        run: |
+          set -euo pipefail
+          {
+            echo "## ✅ Validation & Packaging Passed"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| **Policy Name** | \`$METADATA_NAME\` |"
+            echo "| **Version** | \`$METADATA_VERSION\` |"
+            echo "| **Package** | \`$ZIP_NAME\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ------------------------------------------------------------
+  # Publish the built package to Policy Hub, once per selected
+  # environment, in parallel. fail-fast: false so one environment's
+  # failure doesn't cancel the others. Skipped entirely when no
+  # environment was selected.
+  #
+  # Each matrix leg runs under its own `environment:`, so per-environment
+  # GitHub Environment protection rules (required reviewers, etc.) and
+  # scoped vars/secrets still apply exactly as before.
+  # ------------------------------------------------------------
+  publish:
+    name: Publish to ${{ matrix.environment }}
+    needs: build
+    if: needs.build.outputs.environments != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ matrix.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJson(needs.build.outputs.environments) }}
+
+    steps:
+      - name: Download policy package
+        uses: actions/download-artifact@v8
+        with:
+          name: policy-package
+
+      - name: Validate API configuration
         env:
+          POLICY_HUB_URL: ${{ vars.POLICY_HUB_URL }}
           POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
         run: |
           set -euo pipefail
 
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          [[ -n "${POLICY_HUB_URL:-}" ]] || fail "Missing POLICY_HUB_URL environment variable"
+          [[ -n "${POLICY_HUB_TOKEN:-}" ]] || fail "Missing POLICY_HUB_TOKEN secret"
+
+          echo "✅ API configuration validated"
+          echo "API_URL=$POLICY_HUB_URL" >> "$GITHUB_ENV"
+
+      - name: Publish policy
+        env:
+          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
+          METADATA_NAME: ${{ needs.build.outputs.metadata_name }}
+          METADATA_VERSION: ${{ needs.build.outputs.metadata_version }}
+          ZIP_NAME: ${{ needs.build.outputs.zip_name }}
+          ENV_NAME: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+
+          # Writes one "### Publish: <env>" block to the job summary per
+          # invocation — every matrix leg's outcome shows up on the run's
+          # Summary page without needing a separate aggregator job.
+          summarize() {
+            {
+              echo "### Publish: $ENV_NAME"
+              echo ""
+              echo "| Field | Value |"
+              echo "|-------|-------|"
+              echo "| Policy | \`$METADATA_NAME\` |"
+              echo "| Version | \`$METADATA_VERSION\` |"
+              echo "| Status | $1 |"
+              echo "| Message | $2 |"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
           # Read metadata.json content
-          METADATA_CONTENT=$(cat "$VERSION_DIR/metadata.json")
+          METADATA_CONTENT=$(cat "$GITHUB_WORKSPACE/metadata.json")
 
           # Build curl args array safely
           curl_args=(
@@ -283,11 +418,8 @@ jobs:
 
           # Execute the curl command, keeping curl's own exit code separate from the HTTP status
           if ! HTTP_STATUS=$(curl "${curl_args[@]}"); then
-            echo "::error::Request to Policy Hub failed (network error or timeout)"
-            {
-              echo "## ❌ Publishing Failed"
-              echo "**Error:** Could not reach Policy Hub (network error or timeout)"
-            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Request to Policy Hub failed (network error or timeout) for $ENV_NAME"
+            summarize "❌ Failed" "Could not reach Policy Hub (network error or timeout)"
             exit 1
           fi
 
@@ -300,24 +432,19 @@ jobs:
 
           # Check if request was successful
           if [[ "$HTTP_STATUS" -ge 200 && "$HTTP_STATUS" -lt 300 ]]; then
-            echo "✅ Policy published successfully!"
+            echo "✅ Policy published successfully to $ENV_NAME!"
             echo "📨 API Response:"
             echo "$RESPONSE_BODY"
 
             # Extract status from response
             PUBLISH_STATUS=$(echo "$RESPONSE_BODY" | jq -r '.data.status // "published"' 2>/dev/null || echo "published")
-            echo "PUBLISH_STATUS=$PUBLISH_STATUS" >> "$GITHUB_ENV"
+            summarize "✅ Published" "Status: \`$PUBLISH_STATUS\`"
           elif [[ "$HTTP_STATUS" == "401" ]]; then
             # Never echo the response body for 401s: some APIs reflect request
             # headers/credentials back in auth-error bodies, and $GITHUB_STEP_SUMMARY
             # is not secret-masked the way console log output is.
-            echo "::error::Policy publishing failed: Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN"
-            {
-              echo "## ❌ Publishing Failed"
-              echo "**HTTP Status:** \`401\`"
-              echo ""
-              echo "**Error:** Unauthorized — check POLICY_HUB_TOKEN"
-            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Policy publishing failed for $ENV_NAME: Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN"
+            summarize "❌ Failed" "Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN for this environment"
             exit 1
           else
             # Extract just the message field if present, otherwise fall back to the raw body
@@ -326,51 +453,14 @@ jobs:
               ERROR_MESSAGE="${RESPONSE_BODY:-No response body}"
             fi
 
-            echo "::error::Policy publishing failed with HTTP status $HTTP_STATUS: $ERROR_MESSAGE"
-            {
-              echo "## ❌ Publishing Failed"
-              echo "**HTTP Status:** \`$HTTP_STATUS\`"
-              echo ""
-              echo "**Error:** $ERROR_MESSAGE"
-            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Policy publishing failed for $ENV_NAME with HTTP status $HTTP_STATUS: $ERROR_MESSAGE"
+            summarize "❌ Failed" "HTTP \`$HTTP_STATUS\`: $ERROR_MESSAGE"
             exit 1
           fi
 
       - name: Cleanup
         if: always()
         run: |
-          # Clean up temporary files (best-effort; do not fail the job on cleanup issues)
-          if [[ -n "${ZIP_NAME:-}" && -f "${ZIP_NAME:-}" ]]; then
-            rm -f "$ZIP_NAME"
-          fi
-          if [[ -n "${TEMP_DIR:-}" && -d "${TEMP_DIR:-}" ]]; then
-            rm -rf "$TEMP_DIR"
-          fi
-          if [[ -f "response.txt" ]]; then
-            rm -f response.txt
-          fi
+          # Clean up downloaded files (best-effort; do not fail the job on cleanup issues)
+          rm -f "${{ needs.build.outputs.zip_name }}" metadata.json response.txt
           echo "🧹 Cleanup completed"
-
-      - name: Summary
-        if: success()
-        env:
-          ENVIRONMENT_INPUT: ${{ inputs.environment }}
-        run: |
-          set -euo pipefail
-
-          echo "🎉 Policy Publishing Summary"
-          echo "=========================="
-          echo "Policy Name: $METADATA_NAME"
-          echo "Version: $METADATA_VERSION"
-          echo "Status: ✅ Successfully Published"
-
-          {
-            echo "## 🎉 Policy Published Successfully"
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Policy Name** | \`$METADATA_NAME\` |"
-            echo "| **Version** | \`$METADATA_VERSION\` |"
-            echo "| **Environment** | \`$ENVIRONMENT_INPUT\` |"
-            echo "| **Status** | \`$PUBLISH_STATUS\` |"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -298,7 +298,7 @@ jobs:
           path: |
             ${{ env.ZIP_NAME }}
             metadata.json
-          retention-days: 1
+          retention-days: 7
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -348,7 +348,7 @@ jobs:
         with:
           name: policy-definition
           path: ${{ steps.meta.outputs.target_dir }}/policy-definition.yaml
-          retention-days: 1
+          retention-days: 7
 
       - name: Publish summary
         shell: bash

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -1,14 +1,17 @@
 # Release Policy
 #
-# Validates, tests, and tags a policy version (job: release), then registers
-# it with Policy Hub for each selected environment (job: register).
+# Validates and tests a policy version (job: validate), then creates its git
+# tag under GitHub Environment approval and, for each selected environment,
+# registers it with Policy Hub (jobs: release-policy-tag-only / release-and-register-policy).
 #
-# Tagging never depends on registration succeeding: a git tag only asserts
-# "this version passed validation and tests". Policy Hub registration is a
-# separate, independently retryable concern per environment — selecting zero
-# environments produces a tag-only release (no Policy Hub calls at all), and
-# releasing an already-tagged version to a new environment reuses that tag's
-# exact content rather than re-validating against whatever HEAD is now.
+# Tag creation always requires environment approval: if no environment was
+# selected, the Dev environment's approval gates a tag-only release (no
+# Policy Hub calls at all); if one or more environments were selected,
+# approval for any one of them is enough to create the tag, and each
+# environment's own approval separately gates its own Policy Hub
+# registration. Releasing an already-tagged version to a new environment
+# reuses that tag's exact content rather than re-validating against
+# whatever HEAD is now.
 
 name: Release Policy
 
@@ -48,16 +51,16 @@ concurrency:
 
 jobs:
   # ------------------------------------------------------------
-  # Validate, test, and tag the release. No Policy Hub / API calls
-  # happen here at all. Any failure writes its own summary and exits
-  # immediately — nothing downstream is needed to explain a failure.
+  # Validate and test the release. No tagging, environment approval, or
+  # Policy Hub / API calls happen here at all — tag creation is gated by
+  # environment approval in the jobs below. Any failure writes its own
+  # summary and exits immediately — nothing downstream is needed to
+  # explain a failure.
   # ------------------------------------------------------------
-  release:
-    name: Validate, Test & Release Policy
+  validate:
+    name: Validate & Test Policy
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write
     outputs:
       target_dir: ${{ steps.meta.outputs.target_dir }}
       module_path: ${{ steps.meta.outputs.module_path }}
@@ -93,7 +96,7 @@ jobs:
 
           fail() {
             echo "::error::$1"
-            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            { echo "## ❌ Validation Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
@@ -118,7 +121,7 @@ jobs:
           [[ "$RELEASE_PRODUCTION" == "true" ]] && ENVS+=("production")
 
           if [[ ${#ENVS[@]} -eq 0 ]]; then
-            echo "ℹ️  No environment selected — this will be a tag-only release (no Policy Hub registration)"
+            echo "ℹ️ No environment selected — this will be a tag-only release (no Policy Hub registration)"
             JSON="[]"
           else
             echo "Selected environments: ${ENVS[*]}"
@@ -160,13 +163,13 @@ jobs:
       - name: Check for existing release tag
         id: tag-check
         shell: bash
+        env:
+          TAG_NAME: ${{ steps.meta.outputs.tag_name }}
         run: |
           set -euo pipefail
 
-          TAG_NAME="${{ steps.meta.outputs.tag_name }}"
-
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "ℹ️  Tag already exists: $TAG_NAME"
+            echo "ℹ️ Tag already exists: $TAG_NAME"
             git show "$TAG_NAME" --no-patch --format="Tagged commit: %H (%ai) - %s"
             echo "Checking out that exact commit so every selected environment releases identical content."
             git checkout "refs/tags/$TAG_NAME"
@@ -183,16 +186,17 @@ jobs:
           POLICY_INPUT: ${{ inputs.policy }}
           VERSION_INPUT: ${{ inputs.version }}
           CANONICAL_REPOSITORY: ${{ vars.CANONICAL_REPOSITORY || github.repository }}
+          DIR: ${{ steps.meta.outputs.target_dir }}
+          EXPECTED_MODULE_PATH: ${{ steps.meta.outputs.module_path }}
         run: |
           set -euo pipefail
 
           fail() {
             echo "::error::$1"
-            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            { echo "## ❌ Validation Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
-          DIR="${{ steps.meta.outputs.target_dir }}"
           MAJOR="${VERSION_INPUT%%.*}"
 
           [[ -d "$DIR" ]] || fail "Missing directory: $DIR"
@@ -205,7 +209,7 @@ jobs:
 
           if [[ -f "$DIR/go.mod" ]]; then
             echo "RUNTIME=go" >> "$GITHUB_ENV"
-            EXPECTED="${{ steps.meta.outputs.module_path }}"
+            EXPECTED="$EXPECTED_MODULE_PATH"
             ACTUAL=$(grep '^module ' "$DIR/go.mod" | awk '{print $2}')
 
             [[ "$EXPECTED" == "$ACTUAL" ]] || fail "go.mod module mismatch. Expected: $EXPECTED, Actual: $ACTUAL"
@@ -242,16 +246,16 @@ jobs:
         shell: bash
         env:
           VERSION_INPUT: ${{ inputs.version }}
+          DIR: ${{ steps.meta.outputs.target_dir }}
         run: |
           set -euo pipefail
 
           fail() {
             echo "::error::$1"
-            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            { echo "## ❌ Validation Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
-          DIR="${{ steps.meta.outputs.target_dir }}"
           INPUT_VERSION="$VERSION_INPUT"
 
           POLICY_DEF_VERSION=$(yq eval '.version' "$DIR/policy-definition.yaml")
@@ -303,22 +307,24 @@ jobs:
       - name: Run policy tests
         working-directory: ${{ steps.meta.outputs.target_dir }}
         shell: bash
+        env:
+          POLICY_INPUT: ${{ inputs.policy }}
         run: |
           set -euo pipefail
 
           fail() {
             echo "::error::$1"
-            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            { echo "## ❌ Validation Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
           if [[ "${RUNTIME}" == "go" ]]; then
-            go test -v -race ./... || fail "Go tests failed for policy ${{ inputs.policy }}"
+            go test -v -race ./... || fail "Go tests failed for policy $POLICY_INPUT"
           elif [[ "${RUNTIME}" == "python" ]]; then
             if python -m pytest --version 2>/dev/null; then
-              PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/ -v || fail "Python tests failed for policy ${{ inputs.policy }}"
+              PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/ -v || fail "Python tests failed for policy $POLICY_INPUT"
             else
-              PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_*.py' -v || fail "Python tests failed for policy ${{ inputs.policy }}"
+              PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_*.py' -v || fail "Python tests failed for policy $POLICY_INPUT"
             fi
           fi
 
@@ -329,31 +335,12 @@ jobs:
 
           fail() {
             echo "::error::$1"
-            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            { echo "## ❌ Validation Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }
 
           git diff --exit-code || fail "Working tree has uncommitted changes after running tests"
           [[ -z "$(git status --porcelain)" ]] || fail "Working tree has untracked files after running tests"
-
-      - name: Create and push tag
-        if: steps.tag-check.outputs.tag_existed == 'false'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "${{ steps.meta.outputs.tag_name }}" \
-            -m "Release ${{ inputs.policy }} v${{ inputs.version }}"
-
-          git push "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git" \
-            "${{ steps.meta.outputs.tag_name }}"
-
-          echo "✅ Tag created and pushed: ${{ steps.meta.outputs.tag_name }}"
 
       - name: Upload policy definition for registration
         uses: actions/upload-artifact@v7
@@ -366,51 +353,187 @@ jobs:
         shell: bash
         env:
           TAG_EXISTED: ${{ steps.tag-check.outputs.tag_existed }}
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+          TAG_NAME: ${{ steps.meta.outputs.tag_name }}
+          MODULE_PATH: ${{ steps.meta.outputs.module_path }}
         run: |
           set -euo pipefail
 
-          TAG_STATUS="✅ Policy version released (tag \`${{ steps.meta.outputs.tag_name }}\` created and pushed)"
+          TAG_STATUS="⏳ Pending environment approval — this policy version will be released once approved"
           if [[ "$TAG_EXISTED" == "true" ]]; then
-            TAG_STATUS="ℹ️ This policy version was already released (tag \`${{ steps.meta.outputs.tag_name }}\`) — reused its content, no new policy module released"
+            TAG_STATUS="ℹ️ This policy version was already released (tag \`$TAG_NAME\`) — reused its content, no new policy module released"
           fi
 
           {
-            echo "## ✅ Validation, Tests & Tagging Passed"
+            echo "## ✅ Validation & Tests Passed"
             echo ""
             echo "| Item | Value |"
             echo "|------|------|"
-            echo "| Policy | \`${{ inputs.policy }}\` |"
-            echo "| Version | \`${{ inputs.version }}\` |"
-            echo "| Tag | \`${{ steps.meta.outputs.tag_name }}\` |"
-            echo "| Package Path | \`${{ steps.meta.outputs.module_path }}\` |"
+            echo "| Policy | \`$POLICY_INPUT\` |"
+            echo "| Version | \`$VERSION_INPUT\` |"
+            echo "| Tag | \`$TAG_NAME\` |"
+            echo "| Package Path | \`$MODULE_PATH\` |"
             echo ""
             echo "**Tests:** ✅ Passed"
-            echo "**Tag:** $TAG_STATUS"
+            echo ""
+            echo "## ℹ️ Release Status"
+            echo ""
+            echo "$TAG_STATUS"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ------------------------------------------------------------
-  # Register the policy in Policy Hub, once per selected environment.
-  # fail-fast: false so one environment's failure doesn't cancel the others.
-  # Skipped entirely when no environment was selected (tag-only release).
+  # Tag-only release path: when no environment was selected, tag creation
+  # still requires sign-off. Gated on the Dev GitHub Environment's required
+  # reviewers. The `release-and-register-policy` matrix below never runs in
+  # this case.
   # ------------------------------------------------------------
-  register:
-    name: Register to ${{ matrix.environment }}
-    needs: release
-    if: needs.release.outputs.environments != '[]'
+  release-policy-tag-only:
+    name: Release Policy (Tag-only)
+    needs: validate
+    if: needs.validate.outputs.environments == '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: dev
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create and push tag
+        if: needs.validate.outputs.tag_existed == 'false'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.validate.outputs.tag_name }}
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG_NAME" -m "Release $POLICY_INPUT v$VERSION_INPUT"
+
+          git push "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git" \
+            "$TAG_NAME"
+
+          echo "✅ Tag created and pushed: $TAG_NAME"
+
+      - name: Publish summary
+        shell: bash
+        env:
+          TAG_EXISTED: ${{ needs.validate.outputs.tag_existed }}
+          TAG_NAME: ${{ needs.validate.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          TAG_STATUS="✅ Policy released — tag created and pushed (not registered to any environment)"
+          if [[ "$TAG_EXISTED" == "true" ]]; then
+            TAG_STATUS="ℹ️ Policy already released — reused the existing tag, nothing new pushed"
+          fi
+
+          {
+            echo "### Tag: $TAG_NAME"
+            echo ""
+            echo "**Status:** $TAG_STATUS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ------------------------------------------------------------
+  # Create the release tag and register the policy in Policy Hub, once per
+  # selected environment. fail-fast: false so one environment's failure
+  # doesn't cancel the others. Skipped entirely when no environment was
+  # selected (tag-only release, handled instead by release-policy-tag-only
+  # above).
+  #
+  # Each environment's approval gate covers both tag creation and
+  # registration for that environment, so there is exactly one approval per
+  # environment rather than a separate gate stacked in front of this one.
+  # Because multiple environments can be approved independently and
+  # concurrently, whichever leg is approved first creates the tag; the
+  # others detect it already exists and skip creating it (see the
+  # concurrency-safe check below).
+  # ------------------------------------------------------------
+  release-and-register-policy:
+    name: Release & Register to ${{ matrix.environment }}
+    needs: validate
+    if: needs.validate.outputs.environments != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: ${{ matrix.environment }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJson(needs.release.outputs.environments) }}
+        environment: ${{ fromJson(needs.validate.outputs.environments) }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create and push tag
+        if: needs.validate.outputs.tag_existed == 'false'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.validate.outputs.tag_name }}
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Multiple environments can be approved independently and around
+          # the same time, so more than one matrix leg can reach this step.
+          # Check the remote directly right before creating — a plain `git
+          # fetch` of a single ref only updates FETCH_HEAD, not a local tag
+          # ref, so it can't be used for this check — and treat losing the
+          # race to another leg's push as success rather than failing this leg.
+          TAG_STATUS="✅ Policy released — tag created and pushed following this environment's approval"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+            echo "ℹ️ Tag already created by another environment's approval — nothing to do"
+            TAG_STATUS="ℹ️ Policy already released by another environment's approval — reusing that tag"
+          else
+            git tag -a "$TAG_NAME" -m "Release $POLICY_INPUT v$VERSION_INPUT"
+
+            if ! PUSH_OUTPUT=$(git push "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git" "$TAG_NAME" 2>&1); then
+              if echo "$PUSH_OUTPUT" | grep -qi "already exists"; then
+                echo "ℹ️ Lost the race to another environment's approval — tag already exists remotely"
+                TAG_STATUS="ℹ️ Policy already released by another environment's approval — reusing that tag"
+              else
+                echo "::error::Failed to push tag $TAG_NAME"
+                echo "$PUSH_OUTPUT"
+                {
+                  echo "## ❌ Failed"
+                  echo ""
+                  echo "**Error:** Failed to push tag \`$TAG_NAME\`"
+                  echo '```'
+                  echo "$PUSH_OUTPUT"
+                  echo '```'
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 1
+              fi
+            else
+              echo "✅ Tag created and pushed: $TAG_NAME"
+            fi
+          fi
+          echo "TAG_STATUS=$TAG_STATUS" >> "$GITHUB_ENV"
+
       - name: Download policy definition
         uses: actions/download-artifact@v8
         with:
           name: policy-definition
-          path: ${{ needs.release.outputs.target_dir }}
+          path: ${{ needs.validate.outputs.target_dir }}
 
       - name: Register policy in Policy Hub
         shell: bash
@@ -419,22 +542,24 @@ jobs:
           POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
           POLICY_INPUT: ${{ inputs.policy }}
           VERSION_INPUT: ${{ inputs.version }}
-          TARGET_DIR: ${{ needs.release.outputs.target_dir }}
+          TARGET_DIR: ${{ needs.validate.outputs.target_dir }}
           ENV_NAME: ${{ matrix.environment }}
+          TAG_STATUS: ${{ env.TAG_STATUS || 'ℹ️ This policy version was already released — reused its content' }}
         run: |
           set -euo pipefail
 
-          # Writes one "### Registration: <env>" block to the job summary per
-          # invocation — every matrix leg's outcome shows up on the run's
-          # Summary page without needing a separate aggregator job.
+          # Writes one "### Release & Registration: <env>" block to the job
+          # summary per invocation — every matrix leg's outcome shows up on
+          # the run's Summary page without needing a separate aggregator job.
           summarize() {
             {
-              echo "### Registration: $ENV_NAME"
+              echo "### Release & Registration: $ENV_NAME"
               echo ""
               echo "| Field | Value |"
               echo "|-------|-------|"
               echo "| Policy | \`$POLICY_INPUT\` |"
               echo "| Version | \`$VERSION_INPUT\` |"
+              echo "| Tag | $TAG_STATUS |"
               echo "| Status | $1 |"
               echo "| Message | $2 |"
             } >> "$GITHUB_STEP_SUMMARY"
@@ -460,7 +585,7 @@ jobs:
           elif [[ "$STATUS" == "409" ]]; then
             MESSAGE=$(echo "$BODY" | jq -r '.message // empty' 2>/dev/null || true)
             [[ -z "$MESSAGE" ]] && MESSAGE="Version already released to this environment"
-            echo "ℹ️  Already released to $ENV_NAME (HTTP 409) — treating as no-op, not a failure"
+            echo "ℹ️ Already released to $ENV_NAME (HTTP 409) — treating as no-op, not a failure"
             summarize "ℹ️ Already released" "$MESSAGE"
           elif [[ "$STATUS" == "401" ]]; then
             # Never echo the response body for 401s: some APIs reflect request

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -503,7 +503,7 @@ jobs:
           # ref, so it can't be used for this check — and treat losing the
           # race to another leg's push as success rather than failing this leg.
           TAG_STATUS="✅ Policy released — tag created and pushed following this environment's approval"
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+          if git ls-remote --exit-code --tags "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git" "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
             echo "ℹ️ Tag already created by another environment's approval — nothing to do"
             TAG_STATUS="ℹ️ Policy already released by another environment's approval — reusing that tag"
           else

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -117,9 +117,9 @@ jobs:
           set -euo pipefail
 
           ENVS=()
-          [[ "$RELEASE_DEV" == "true" ]] && ENVS+=("dev")
-          [[ "$RELEASE_STAGING" == "true" ]] && ENVS+=("staging")
-          [[ "$RELEASE_PRODUCTION" == "true" ]] && ENVS+=("production")
+          [[ "$RELEASE_DEV" == "true" ]] && ENVS+=("Dev")
+          [[ "$RELEASE_STAGING" == "true" ]] && ENVS+=("Staging")
+          [[ "$RELEASE_PRODUCTION" == "true" ]] && ENVS+=("Production")
 
           if [[ ${#ENVS[@]} -eq 0 ]]; then
             echo "ℹ️ No environment selected — this will be a tag-only release (no Policy Hub registration)"
@@ -395,7 +395,7 @@ jobs:
     if: needs.validate.outputs.environments == '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: dev
+    environment: Dev
     permissions:
       contents: write
 

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate inputs
         shell: bash
@@ -403,6 +404,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create and push tag
         if: needs.validate.outputs.tag_existed == 'false'
@@ -478,6 +480,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create and push tag
         if: needs.validate.outputs.tag_existed == 'false'
@@ -576,8 +579,8 @@ jobs:
             -H "api-key: $POLICY_HUB_TOKEN" \
             -F "definition=@$TARGET_DIR/policy-definition.yaml;type=application/yaml")
 
-          STATUS=$(echo "$RESPONSE" | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')
-          BODY=$(echo "$RESPONSE" | sed -E 's/HTTPSTATUS:[0-9]{3}$//')
+          STATUS="${RESPONSE##*HTTPSTATUS:}"
+          BODY="${RESPONSE%HTTPSTATUS:*}"
 
           if [[ "$STATUS" =~ ^(200|201)$ ]]; then
             echo "✅ Released to $ENV_NAME"

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -27,17 +27,17 @@ on:
         description: "Release to dev"
         required: false
         type: boolean
-        default: false
+        default: true
       release_staging:
         description: "Release to staging"
         required: false
         type: boolean
-        default: false
+        default: true
       release_production:
         description: "Release to production"
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -62,7 +62,7 @@ jobs:
       target_dir: ${{ steps.meta.outputs.target_dir }}
       module_path: ${{ steps.meta.outputs.module_path }}
       tag_name: ${{ steps.meta.outputs.tag_name }}
-      pip_package: ${{ steps.meta.outputs.pip_package }}
+      pip_package: ${{ steps.structure.outputs.pip_package }}
       environments: ${{ steps.envs.outputs.environments }}
       tag_existed: ${{ steps.tag-check.outputs.tag_existed }}
 
@@ -153,17 +153,9 @@ jobs:
 
           TAG_NAME="policies/$POLICY/v$VERSION"
 
-          # For Python policies, construct the shortened URL (same pattern as Go MODULE_PATH
-          # but with @vMAJOR suffix instead of /vMAJOR path segment).
-          PIP_PACKAGE=""
-          if [[ -f "$TARGET_DIR/pyproject.toml" ]]; then
-            PIP_PACKAGE="github.com/$CANONICAL_REPOSITORY/policies/$POLICY@v$MAJOR"
-          fi
-
           echo "target_dir=$TARGET_DIR" >> "$GITHUB_OUTPUT"
           echo "module_path=$MODULE_PATH" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-          echo "pip_package=$PIP_PACKAGE" >> "$GITHUB_OUTPUT"
 
       - name: Check for existing release tag
         id: tag-check
@@ -185,7 +177,12 @@ jobs:
           fi
 
       - name: Validate policy structure
+        id: structure
         shell: bash
+        env:
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+          CANONICAL_REPOSITORY: ${{ vars.CANONICAL_REPOSITORY || github.repository }}
         run: |
           set -euo pipefail
 
@@ -196,9 +193,15 @@ jobs:
           }
 
           DIR="${{ steps.meta.outputs.target_dir }}"
+          MAJOR="${VERSION_INPUT%%.*}"
 
           [[ -d "$DIR" ]] || fail "Missing directory: $DIR"
           [[ -f "$DIR/policy-definition.yaml" ]] || fail "Missing policy-definition.yaml in $DIR"
+
+          # PIP_PACKAGE is derived here (post tag-checkout) rather than in "Resolve
+          # module metadata", since that step runs before the tag-reuse checkout and
+          # would otherwise reflect HEAD's file layout instead of the released commit's.
+          PIP_PACKAGE=""
 
           if [[ -f "$DIR/go.mod" ]]; then
             echo "RUNTIME=go" >> "$GITHUB_ENV"
@@ -225,9 +228,15 @@ jobs:
             [[ -d "$DIR/tests" ]] || fail "Missing tests/ directory in $DIR"
 
             echo "✅ Python Policy structure valid (src layout)"
+
+            # For Python policies, construct the shortened URL (same pattern as Go
+            # MODULE_PATH but with @vMAJOR suffix instead of /vMAJOR path segment).
+            PIP_PACKAGE="github.com/$CANONICAL_REPOSITORY/policies/$POLICY_INPUT@v$MAJOR"
           else
             fail "Current implementation requires either go.mod or pyproject.toml"
           fi
+
+          echo "pip_package=$PIP_PACKAGE" >> "$GITHUB_OUTPUT"
 
       - name: Validate version consistency
         shell: bash

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -1,3 +1,15 @@
+# Release Policy
+#
+# Validates, tests, and tags a policy version (job: release), then registers
+# it with Policy Hub for each selected environment (job: register).
+#
+# Tagging never depends on registration succeeding: a git tag only asserts
+# "this version passed validation and tests". Policy Hub registration is a
+# separate, independently retryable concern per environment — selecting zero
+# environments produces a tag-only release (no Policy Hub calls at all), and
+# releasing an already-tagged version to a new environment reuses that tag's
+# exact content rather than re-validating against whatever HEAD is now.
+
 name: Release Policy
 
 on:
@@ -11,15 +23,48 @@ on:
         description: "Version (SemVer: X.Y.Z | X.Y.Z-dev.N | X.Y.Z-rc.N)"
         required: true
         type: string
+      release_dev:
+        description: "Release to dev"
+        required: false
+        type: boolean
+        default: false
+      release_staging:
+        description: "Release to staging"
+        required: false
+        type: boolean
+        default: false
+      release_production:
+        description: "Release to production"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-policy-${{ github.event.inputs.policy }}-${{ github.event.inputs.version }}
+  cancel-in-progress: false
 
 jobs:
-  release-policy:
+  # ------------------------------------------------------------
+  # Validate, test, and tag the release. No Policy Hub / API calls
+  # happen here at all. Any failure writes its own summary and exits
+  # immediately — nothing downstream is needed to explain a failure.
+  # ------------------------------------------------------------
+  release:
     name: Validate, Test & Release Policy
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+    outputs:
+      target_dir: ${{ steps.meta.outputs.target_dir }}
+      module_path: ${{ steps.meta.outputs.module_path }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
+      pip_package: ${{ steps.meta.outputs.pip_package }}
+      environments: ${{ steps.envs.outputs.environments }}
+      tag_existed: ${{ steps.tag-check.outputs.tag_existed }}
 
     services:
       redis:
@@ -33,66 +78,86 @@ jobs:
           --health-retries 5
 
     steps:
-      # ------------------------------------------------------------
-      # Checkout
-      # ------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      # ------------------------------------------------------------
-      # Validate inputs
-      # ------------------------------------------------------------
       - name: Validate inputs
         shell: bash
+        env:
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          POLICY="${{ github.event.inputs.policy }}"
-          VERSION="${{ github.event.inputs.version }}"
-
-          if ! [[ "$POLICY" =~ ^[a-zA-Z0-9-]+$ ]]; then
-            echo "❌ Invalid policy name: $POLICY"
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
-          fi
+          }
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc)\.[0-9]+)?$ ]]; then
-            echo "❌ Invalid version format: $VERSION"
-            exit 1
-          fi
+          [[ "$POLICY_INPUT" =~ ^[a-zA-Z0-9-]+$ ]] || fail "Invalid policy name: $POLICY_INPUT"
+          [[ "$VERSION_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc)\.[0-9]+)?$ ]] || fail "Invalid version format: $VERSION_INPUT"
 
           echo "✅ Inputs validated"
 
-      # ------------------------------------------------------------
-      # Resolve module metadata
-      # ------------------------------------------------------------
-      - name: Resolve module metadata
-        id: meta
+      - name: Determine target environments
+        id: envs
         shell: bash
+        env:
+          RELEASE_DEV: ${{ inputs.release_dev }}
+          RELEASE_STAGING: ${{ inputs.release_staging }}
+          RELEASE_PRODUCTION: ${{ inputs.release_production }}
         run: |
           set -euo pipefail
 
-          POLICY="${{ github.event.inputs.policy }}"
-          VERSION="${{ github.event.inputs.version }}"
+          ENVS=()
+          [[ "$RELEASE_DEV" == "true" ]] && ENVS+=("dev")
+          [[ "$RELEASE_STAGING" == "true" ]] && ENVS+=("staging")
+          [[ "$RELEASE_PRODUCTION" == "true" ]] && ENVS+=("production")
+
+          if [[ ${#ENVS[@]} -eq 0 ]]; then
+            echo "ℹ️  No environment selected — this will be a tag-only release (no Policy Hub registration)"
+            JSON="[]"
+          else
+            echo "Selected environments: ${ENVS[*]}"
+            # printf still runs its format once even with zero args, so build the
+            # JSON array only in this branch where ENVS is guaranteed non-empty.
+            JSON=$(printf '%s\n' "${ENVS[@]}" | jq -R . | jq -sc .)
+          fi
+
+          echo "environments=$JSON" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve module metadata
+        id: meta
+        shell: bash
+        env:
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+          CANONICAL_REPOSITORY: ${{ vars.CANONICAL_REPOSITORY || github.repository }}
+        run: |
+          set -euo pipefail
+
+          POLICY="$POLICY_INPUT"
+          VERSION="$VERSION_INPUT"
           MAJOR="${VERSION%%.*}"
 
           if [[ "$MAJOR" == "0" || "$MAJOR" == "1" ]]; then
             TARGET_DIR="policies/$POLICY"
-            MODULE_PATH="github.com/${{ github.repository }}/policies/$POLICY"
+            MODULE_PATH="github.com/$CANONICAL_REPOSITORY/policies/$POLICY"
           else
             TARGET_DIR="policies/$POLICY/v$MAJOR"
-            MODULE_PATH="github.com/${{ github.repository }}/policies/$POLICY/v$MAJOR"
+            MODULE_PATH="github.com/$CANONICAL_REPOSITORY/policies/$POLICY/v$MAJOR"
           fi
 
           TAG_NAME="policies/$POLICY/v$VERSION"
 
           # For Python policies, construct the shortened URL (same pattern as Go MODULE_PATH
           # but with @vMAJOR suffix instead of /vMAJOR path segment).
-          # Example: github.com/wso2/gateway-controllers/policies/prompt-compressor@v0
           PIP_PACKAGE=""
           if [[ -f "$TARGET_DIR/pyproject.toml" ]]; then
-            PIP_PACKAGE="github.com/${{ github.repository }}/policies/$POLICY@v$MAJOR"
+            PIP_PACKAGE="github.com/$CANONICAL_REPOSITORY/policies/$POLICY@v$MAJOR"
           fi
 
           echo "target_dir=$TARGET_DIR" >> "$GITHUB_OUTPUT"
@@ -100,121 +165,116 @@ jobs:
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "pip_package=$PIP_PACKAGE" >> "$GITHUB_OUTPUT"
 
-      # ------------------------------------------------------------
-      # Validate policy structure
-      # ------------------------------------------------------------
+      - name: Check for existing release tag
+        id: tag-check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG_NAME="${{ steps.meta.outputs.tag_name }}"
+
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "ℹ️  Tag already exists: $TAG_NAME"
+            git show "$TAG_NAME" --no-patch --format="Tagged commit: %H (%ai) - %s"
+            echo "Checking out that exact commit so every selected environment releases identical content."
+            git checkout "refs/tags/$TAG_NAME"
+            echo "tag_existed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ Tag does not exist yet — this is the first release of this version"
+            echo "tag_existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate policy structure
         shell: bash
         run: |
           set -euo pipefail
 
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
           DIR="${{ steps.meta.outputs.target_dir }}"
 
-          [[ -d "$DIR" ]] || { echo "❌ Missing directory: $DIR"; exit 1; }
-          [[ -f "$DIR/policy-definition.yaml" ]] || { echo "❌ Missing policy-definition.yaml in $DIR"; exit 1; }
+          [[ -d "$DIR" ]] || fail "Missing directory: $DIR"
+          [[ -f "$DIR/policy-definition.yaml" ]] || fail "Missing policy-definition.yaml in $DIR"
 
           if [[ -f "$DIR/go.mod" ]]; then
             echo "RUNTIME=go" >> "$GITHUB_ENV"
             EXPECTED="${{ steps.meta.outputs.module_path }}"
             ACTUAL=$(grep '^module ' "$DIR/go.mod" | awk '{print $2}')
 
-            [[ "$EXPECTED" == "$ACTUAL" ]] || {
-              echo "❌ go.mod module mismatch"
-              echo "Expected: $EXPECTED"
-              echo "Actual:   $ACTUAL"
-              exit 1
-            }
+            [[ "$EXPECTED" == "$ACTUAL" ]] || fail "go.mod module mismatch. Expected: $EXPECTED, Actual: $ACTUAL"
             echo "✅ Go Policy structure valid"
           elif [[ -f "$DIR/pyproject.toml" ]]; then
             echo "RUNTIME=python" >> "$GITHUB_ENV"
 
             # Validate src layout: src/ directory must exist
-            [[ -d "$DIR/src" ]] || { echo "❌ Missing src/ directory in $DIR (expected src layout)"; exit 1; }
+            [[ -d "$DIR/src" ]] || fail "Missing src/ directory in $DIR (expected src layout)"
 
             # Validate that at least one Python package exists under src/
             PKG_COUNT=$(find "$DIR/src" -mindepth 1 -maxdepth 1 -type d ! -name '__pycache__' | wc -l | tr -d ' ')
-            [[ "$PKG_COUNT" -ge 1 ]] || { echo "❌ No Python package found under $DIR/src/"; exit 1; }
+            [[ "$PKG_COUNT" -ge 1 ]] || fail "No Python package found under $DIR/src/"
 
             # Validate that the package contains a policy.py module
             POLICY_PY=$(find "$DIR/src" -mindepth 2 -maxdepth 2 -name 'policy.py' -type f | head -1)
-            [[ -n "$POLICY_PY" ]] || { echo "❌ Missing policy.py module in src package"; exit 1; }
+            [[ -n "$POLICY_PY" ]] || fail "Missing policy.py module in src package"
 
             # Validate that tests/ directory exists
-            [[ -d "$DIR/tests" ]] || { echo "❌ Missing tests/ directory in $DIR"; exit 1; }
+            [[ -d "$DIR/tests" ]] || fail "Missing tests/ directory in $DIR"
 
             echo "✅ Python Policy structure valid (src layout)"
           else
-            echo "❌ Current implementation requires either go.mod or pyproject.toml"
-            exit 1
+            fail "Current implementation requires either go.mod or pyproject.toml"
           fi
 
-      # ------------------------------------------------------------
-      # Validate version consistency
-      # ------------------------------------------------------------
       - name: Validate version consistency
         shell: bash
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
           DIR="${{ steps.meta.outputs.target_dir }}"
-          INPUT_VERSION="${{ github.event.inputs.version }}"
+          INPUT_VERSION="$VERSION_INPUT"
 
-          # Extract version from policy-definition.yaml
           POLICY_DEF_VERSION=$(yq eval '.version' "$DIR/policy-definition.yaml")
-
-          # Remove 'v' prefix if present in policy-definition.yaml
           POLICY_DEF_VERSION=${POLICY_DEF_VERSION#v}
 
           echo "Input version: $INPUT_VERSION"
           echo "Policy definition version: $POLICY_DEF_VERSION"
 
-          if [[ "$INPUT_VERSION" != "$POLICY_DEF_VERSION" ]]; then
-            echo "❌ Version mismatch!"
-            echo "The version specified in the workflow input ($INPUT_VERSION) does not match"
-            echo "the version in the policy-definition.yaml file ($POLICY_DEF_VERSION)."
-            echo "Please update the policy-definition.yaml version to v$INPUT_VERSION or"
-            echo "use version $POLICY_DEF_VERSION in the workflow input."
-            exit 1
-          fi
+          [[ "$INPUT_VERSION" == "$POLICY_DEF_VERSION" ]] || fail "Version mismatch: workflow input ($INPUT_VERSION) vs policy-definition.yaml ($POLICY_DEF_VERSION)"
 
-          # For Python policies, also validate pyproject.toml version
           if [[ "${RUNTIME:-}" == "python" ]]; then
             PYPROJECT_VERSION=$(yq eval '.project.version' "$DIR/pyproject.toml")
             echo "pyproject.toml version: $PYPROJECT_VERSION"
 
-            if [[ "$INPUT_VERSION" != "$PYPROJECT_VERSION" ]]; then
-              echo "❌ pyproject.toml version mismatch!"
-              echo "The version specified in the workflow input ($INPUT_VERSION) does not match"
-              echo "the version in pyproject.toml ($PYPROJECT_VERSION)."
-              echo "Please update pyproject.toml version to $INPUT_VERSION."
-              exit 1
-            fi
+            [[ "$INPUT_VERSION" == "$PYPROJECT_VERSION" ]] || fail "Version mismatch: workflow input ($INPUT_VERSION) vs pyproject.toml ($PYPROJECT_VERSION)"
           fi
 
           echo "✅ Version consistency validated"
 
-      # ------------------------------------------------------------
-      # Setup Go
-      # ------------------------------------------------------------
       - name: Setup Go
         if: env.RUNTIME == 'go'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: ${{ steps.meta.outputs.target_dir }}/go.mod
           cache: false
 
-      # ------------------------------------------------------------
-      # Setup Python
-      # ------------------------------------------------------------
       - name: Setup Python
         if: env.RUNTIME == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
 
-      # ------------------------------------------------------------
-      # Install Python policy dependencies
-      # ------------------------------------------------------------
       - name: Install Python policy dependencies
         if: env.RUNTIME == 'python'
         working-directory: ${{ steps.meta.outputs.target_dir }}
@@ -231,129 +291,44 @@ jobs:
           pip install -e . --no-deps
           echo "✅ Python policy dependencies installed"
 
-      # ------------------------------------------------------------
-      # Run tests
-      # ------------------------------------------------------------
       - name: Run policy tests
         working-directory: ${{ steps.meta.outputs.target_dir }}
         shell: bash
         run: |
           set -euo pipefail
+
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
           if [[ "${RUNTIME}" == "go" ]]; then
-            go test -v -race ./...
+            go test -v -race ./... || fail "Go tests failed for policy ${{ inputs.policy }}"
           elif [[ "${RUNTIME}" == "python" ]]; then
-            # Use pytest if available, otherwise fall back to unittest
             if python -m pytest --version 2>/dev/null; then
-              PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/ -v
+              PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/ -v || fail "Python tests failed for policy ${{ inputs.policy }}"
             else
-              PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_*.py' -v
+              PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_*.py' -v || fail "Python tests failed for policy ${{ inputs.policy }}"
             fi
           fi
 
-      # ------------------------------------------------------------
-      # Git hygiene
-      # ------------------------------------------------------------
       - name: Ensure clean working tree
         shell: bash
         run: |
           set -euo pipefail
-          git diff --exit-code
-          test -z "$(git status --porcelain)"
 
-      # ------------------------------------------------------------
-      # Ensure version uniqueness
-      # ------------------------------------------------------------
-      - name: Ensure version is new
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git rev-parse "${{ steps.meta.outputs.tag_name }}" >/dev/null 2>&1; then
-            echo "❌ Tag already exists: ${{ steps.meta.outputs.tag_name }}"
-            echo "Existing tag information:"
-            git show "${{ steps.meta.outputs.tag_name }}" --no-patch --format="%H %s (%ai)"
+          fail() {
+            echo "::error::$1"
+            { echo "## ❌ Release Failed"; echo ""; echo "**Error:** $1"; } >> "$GITHUB_STEP_SUMMARY"
             exit 1
-          else
-            echo "✅ Version is new"
-          fi
+          }
 
-      # ------------------------------------------------------------
-      # Register Policy in Policy Hub (MANDATORY, multipart)
-      # ------------------------------------------------------------
-      - name: Register policy in Policy Hub
-        if: false  # Temporarily disabled
-        id: policy-hub
-        shell: bash
-        env:
-          POLICY_HUB_URL: ${{ secrets.POLICY_HUB_URL }}
-          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
-        run: |
-          set -euo pipefail
+          git diff --exit-code || fail "Working tree has uncommitted changes after running tests"
+          [[ -z "$(git status --porcelain)" ]] || fail "Working tree has untracked files after running tests"
 
-          if [[ -z "${POLICY_HUB_URL:-}" || -z "${POLICY_HUB_TOKEN:-}" ]]; then
-            echo "registration_status=skipped" >> "$GITHUB_OUTPUT"
-            echo "registration_message=Missing POLICY_HUB_URL or POLICY_HUB_TOKEN" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          DIR="${{ steps.meta.outputs.target_dir }}"
-
-          if [[ "${RUNTIME}" == "python" ]]; then
-            PACKAGE_FIELD="-F pip_package=${{ steps.meta.outputs.pip_package }}"
-          else
-            PACKAGE_FIELD="-F module_path=${{ steps.meta.outputs.module_path }}"
-          fi
-
-          RESPONSE=$(curl -sSL -w "HTTPSTATUS:%{http_code}" \
-            -X POST "$POLICY_HUB_URL/policies/register" \
-            -H "Authorization: Bearer $POLICY_HUB_TOKEN" \
-            -F "policy=${{ github.event.inputs.policy }}" \
-            -F "version=${{ github.event.inputs.version }}" \
-            $PACKAGE_FIELD \
-            -F "repository=${{ github.repository }}" \
-            -F "policy_definition=@$DIR/policy-definition.yaml;type=application/yaml")
-
-          STATUS=$(echo "$RESPONSE" | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')
-          BODY=$(echo "$RESPONSE" | sed -E 's/HTTPSTATUS:[0-9]{3}$//')
-
-          if [[ "$STATUS" =~ ^(200|201)$ ]]; then
-            echo "registration_status=success" >> "$GITHUB_OUTPUT"
-            echo "registration_message=Policy registered successfully" >> "$GITHUB_OUTPUT"
-          else
-            echo "registration_status=failed" >> "$GITHUB_OUTPUT"
-            echo "registration_message=HTTP $STATUS: $BODY" >> "$GITHUB_OUTPUT"
-          fi
-
-      # ------------------------------------------------------------
-      # Set default Policy Hub outputs (since registration is disabled)
-      # ------------------------------------------------------------
-      - name: Set default Policy Hub outputs
-        id: policy-hub-default
-        shell: bash
-        run: |
-          echo "registration_status=skipped" >> "$GITHUB_OUTPUT"
-          echo "registration_message=Policy Hub registration disabled for testing" >> "$GITHUB_OUTPUT"
-
-      # ------------------------------------------------------------
-      # Resolve final Policy Hub status
-      # ------------------------------------------------------------
-      - name: Resolve Policy Hub status
-        id: policy-hub-final
-        shell: bash
-        run: |
-          # Use actual Policy Hub result if it ran, otherwise use default
-          if [[ "${{ steps.policy-hub.conclusion }}" == "success" || "${{ steps.policy-hub.conclusion }}" == "failure" ]]; then
-            echo "registration_status=${{ steps.policy-hub.outputs.registration_status }}" >> "$GITHUB_OUTPUT"
-            echo "registration_message=${{ steps.policy-hub.outputs.registration_message }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "registration_status=${{ steps.policy-hub-default.outputs.registration_status }}" >> "$GITHUB_OUTPUT"
-            echo "registration_message=${{ steps.policy-hub-default.outputs.registration_message }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      # ------------------------------------------------------------
-      # Create and push Git tag (only on successful registration or skipped)
-      # ------------------------------------------------------------
       - name: Create and push tag
-        if: steps.policy-hub-final.outputs.registration_status == 'success' || steps.policy-hub-final.outputs.registration_status == 'skipped'
+        if: steps.tag-check.outputs.tag_existed == 'false'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -364,102 +339,131 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git tag -a "${{ steps.meta.outputs.tag_name }}" \
-            -m "Release ${{ github.event.inputs.policy }} v${{ github.event.inputs.version }}"
+            -m "Release ${{ inputs.policy }} v${{ inputs.version }}"
 
           git push "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git" \
             "${{ steps.meta.outputs.tag_name }}"
 
-      # ------------------------------------------------------------
-      # Verify Go module resolution (only on successful registration or skipped)
-      # ------------------------------------------------------------
-      # - name: Verify Go module resolution
-      #   if: steps.policy-hub-default.outputs.registration_status == 'success' || steps.policy-hub-default.outputs.registration_status == 'skipped'
-      #   shell: bash
-      #   run: |
-      #     set -euo pipefail
+          echo "✅ Tag created and pushed: ${{ steps.meta.outputs.tag_name }}"
 
-      #     MOD="${{ steps.meta.outputs.module_path }}"
-      #     VER="v${{ github.event.inputs.version }}"
+      - name: Upload policy definition for registration
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-definition
+          path: ${{ steps.meta.outputs.target_dir }}/policy-definition.yaml
+          retention-days: 1
 
-      #     for i in 1 2 3; do
-      #       if go list -m "$MOD@$VER"; then
-      #         echo "✅ Module resolved"
-      #         exit 0
-      #       fi
-      #       sleep 15
-      #     done
-
-      #     echo "❌ Go module resolution failed"
-      #     exit 1
-
-      # ------------------------------------------------------------
-      # Publish summary (Markdown)
-      # ------------------------------------------------------------
       - name: Publish summary
-        run: |
-          case "${{ steps.policy-hub-final.outputs.registration_status }}" in
-            success)
-              TITLE=" Policy Released Successfully"
-              HUB="✅ Policy Hub registration successful"
-              ACTION=""
-              TAG_STATUS="✅ Git tag created"
-              MODULE_STATUS="✅ Package verified"
-              ;;
-            skipped)
-              TITLE="🎉 Policy Released Successfully"
-              HUB="ℹ️ Policy Hub registration skipped (not configured)"
-              ACTION=""
-              TAG_STATUS="✅ Git tag created"
-              MODULE_STATUS="✅ Package verified"
-              ;;
-            failed)
-              TITLE="❌ Policy Release Failed"
-              HUB="❌ Policy Hub registration failed"
-              ACTION="**Fix:** Review Policy Hub error details above and retry."
-              TAG_STATUS="❌ Git tag not created"
-              MODULE_STATUS="❌ Package not verified"
-              ;;
-            *)
-              TITLE="❌ Policy Release Failed"
-              HUB="❌ Unknown Policy Hub state"
-              ACTION="**Fix:** Inspect workflow logs."
-              TAG_STATUS="❌ Git tag not created"
-              MODULE_STATUS="❌ Package not verified"
-              ;;
-          esac
-
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          # $TITLE
-
-          | Item | Value |
-          |------|------|
-          | Policy | \`${{ github.event.inputs.policy }}\` |
-          | Version | \`${{ github.event.inputs.version }}\` |
-          | Tag | \`${{ steps.meta.outputs.tag_name }}\` |
-          | Package Path | \`${{ steps.meta.outputs.module_path }}\` |
-
-          ## Status
-          ✅ Tests passed  
-          $TAG_STATUS  
-          $MODULE_STATUS  
-          $HUB
-
-          $ACTION
-          EOF
-
-      # ------------------------------------------------------------
-      # Final status enforcement
-      # ------------------------------------------------------------
-      - name: Final status check
         shell: bash
+        env:
+          TAG_EXISTED: ${{ steps.tag-check.outputs.tag_existed }}
         run: |
-          case "${{ steps.policy-hub-final.outputs.registration_status }}" in
-            success|skipped)
-              echo "✅ Workflow completed successfully"
-              exit 0
-              ;;
-            *)
-              echo "❌ Workflow failed due to Policy Hub registration"
-              exit 1
-              ;;
-          esac
+          set -euo pipefail
+
+          TAG_STATUS="✅ Policy version released (tag \`${{ steps.meta.outputs.tag_name }}\` created and pushed)"
+          if [[ "$TAG_EXISTED" == "true" ]]; then
+            TAG_STATUS="ℹ️ This policy version was already released (tag \`${{ steps.meta.outputs.tag_name }}\`) — reused its content, no new policy module released"
+          fi
+
+          {
+            echo "## ✅ Validation, Tests & Tagging Passed"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|------|"
+            echo "| Policy | \`${{ inputs.policy }}\` |"
+            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Tag | \`${{ steps.meta.outputs.tag_name }}\` |"
+            echo "| Package Path | \`${{ steps.meta.outputs.module_path }}\` |"
+            echo ""
+            echo "**Tests:** ✅ Passed"
+            echo "**Tag:** $TAG_STATUS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ------------------------------------------------------------
+  # Register the policy in Policy Hub, once per selected environment.
+  # fail-fast: false so one environment's failure doesn't cancel the others.
+  # Skipped entirely when no environment was selected (tag-only release).
+  # ------------------------------------------------------------
+  register:
+    name: Register to ${{ matrix.environment }}
+    needs: release
+    if: needs.release.outputs.environments != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ${{ matrix.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJson(needs.release.outputs.environments) }}
+
+    steps:
+      - name: Download policy definition
+        uses: actions/download-artifact@v8
+        with:
+          name: policy-definition
+          path: ${{ needs.release.outputs.target_dir }}
+
+      - name: Register policy in Policy Hub
+        shell: bash
+        env:
+          POLICY_HUB_URL: ${{ vars.POLICY_HUB_URL }}
+          POLICY_HUB_TOKEN: ${{ secrets.POLICY_HUB_TOKEN }}
+          POLICY_INPUT: ${{ inputs.policy }}
+          VERSION_INPUT: ${{ inputs.version }}
+          TARGET_DIR: ${{ needs.release.outputs.target_dir }}
+          ENV_NAME: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+
+          # Writes one "### Registration: <env>" block to the job summary per
+          # invocation — every matrix leg's outcome shows up on the run's
+          # Summary page without needing a separate aggregator job.
+          summarize() {
+            {
+              echo "### Registration: $ENV_NAME"
+              echo ""
+              echo "| Field | Value |"
+              echo "|-------|-------|"
+              echo "| Policy | \`$POLICY_INPUT\` |"
+              echo "| Version | \`$VERSION_INPUT\` |"
+              echo "| Status | $1 |"
+              echo "| Message | $2 |"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          if [[ -z "${POLICY_HUB_URL:-}" || -z "${POLICY_HUB_TOKEN:-}" ]]; then
+            echo "::warning::Missing POLICY_HUB_URL or POLICY_HUB_TOKEN for environment '$ENV_NAME' — skipping registration"
+            summarize "⚠️ Skipped" "Missing POLICY_HUB_URL or POLICY_HUB_TOKEN"
+            exit 0
+          fi
+
+          RESPONSE=$(curl -sS -w "HTTPSTATUS:%{http_code}" \
+            -X POST "$POLICY_HUB_URL/policies/$POLICY_INPUT/versions/$VERSION_INPUT/release" \
+            -H "api-key: $POLICY_HUB_TOKEN" \
+            -F "definition=@$TARGET_DIR/policy-definition.yaml;type=application/yaml")
+
+          STATUS=$(echo "$RESPONSE" | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')
+          BODY=$(echo "$RESPONSE" | sed -E 's/HTTPSTATUS:[0-9]{3}$//')
+
+          if [[ "$STATUS" =~ ^(200|201)$ ]]; then
+            echo "✅ Released to $ENV_NAME"
+            summarize "✅ Released" "Policy registered successfully"
+          elif [[ "$STATUS" == "409" ]]; then
+            MESSAGE=$(echo "$BODY" | jq -r '.message // empty' 2>/dev/null || true)
+            [[ -z "$MESSAGE" ]] && MESSAGE="Version already released to this environment"
+            echo "ℹ️  Already released to $ENV_NAME (HTTP 409) — treating as no-op, not a failure"
+            summarize "ℹ️ Already released" "$MESSAGE"
+          elif [[ "$STATUS" == "401" ]]; then
+            # Never echo the response body for 401s: some APIs reflect request
+            # headers/credentials back in auth-error bodies, and $GITHUB_STEP_SUMMARY
+            # is not secret-masked the way console log output is.
+            echo "::error::Registration failed for $ENV_NAME: Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN for this environment"
+            summarize "❌ Failed" "Unauthorized (HTTP 401) — check POLICY_HUB_TOKEN for this environment"
+            exit 1
+          else
+            MESSAGE=$(echo "$BODY" | jq -r '.message // empty' 2>/dev/null || true)
+            [[ -z "$MESSAGE" ]] && MESSAGE="${BODY:-No response body} (HTTP $STATUS)"
+            echo "::error::Registration failed for $ENV_NAME: $MESSAGE"
+            summarize "❌ Failed" "$MESSAGE"
+            exit 1
+          fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow, `publish-policy.yml`, to automate the process of packaging and publishing policy documentation and metadata to the Policy Hub for a selected environment. The workflow ensures robust validation of inputs, metadata, and API configuration, and provides clear error handling and summary reporting throughout the process.

The most important changes are:

**New workflow for policy publishing:**
* Added `.github/workflows/publish-policy.yml` to package and publish a specific policy version's docs and metadata to Policy Hub for dev, staging, or production environments. This workflow is triggered manually and is distinct from the release workflow, focusing on documentation/metadata for already-released policy versions.

**Input and validation improvements:**
* Implements comprehensive validation for workflow inputs (`policy_name`, `minor_version`, and `environment`), checks for the existence of required directories and files, and validates the structure and content of `metadata.json` (including required fields and correct versioning).
* Validates API configuration by ensuring the presence of the `POLICY_HUB_URL` environment variable and provides actionable error messages if missing.

**Packaging and publishing logic:**
* Automates creation of a zip package containing the policy docs and assets, and safely uploads it to the Policy Hub API using `curl`, with support for authentication and robust error handling for network and API errors