### PR TITLE
[ LLM COST ] Add AWS Bedrock cost calculation support

### DIFF
--- a/policies/llm-cost/bedrock_eventstream.go
+++ b/policies/llm-cost/bedrock_eventstream.go
@@ -27,15 +27,91 @@ const (
 	bedrockEventStreamMaxFrame   = 16 * 1024 * 1024
 )
 
+type bedrockEventStreamFrame struct {
+	eventType string
+	payload   []byte
+}
+
 // bedrockConverseStreamMetadata extracts the JSON payload from the metadata
 // event in a complete Amazon event-stream response. The trailing and prelude
 // CRC fields are framing bytes here; integrity is already handled by the
 // upstream transport.
 func bedrockConverseStreamMetadata(data []byte) ([]byte, bool) {
 	var metadata []byte
-	offset := 0
+	frames, ok := bedrockEventStreamFrames(data)
+	if !ok {
+		return nil, false
+	}
+	for _, frame := range frames {
+		if frame.eventType == "metadata" {
+			if !json.Valid(frame.payload) {
+				return nil, false
+			}
+			metadata = append(metadata[:0], frame.payload...)
+		}
+	}
 
-	for offset < len(data) {
+	return metadata, metadata != nil
+}
+
+// bedrockInvokeStreamResponse extracts and merges the model-native JSON objects
+// carried by chunk events in an InvokeModelWithResponseStream response.
+//
+// On the Amazon event-stream wire, a PayloadPart is normally the raw model JSON
+// payload. Some intermediaries serialize the SDK union member instead, producing
+// either {"bytes":"<base64>"} or {"chunk":{"bytes":"<base64>"}}. Accept all
+// three forms so normalization works for direct and serialized Bedrock streams.
+func bedrockInvokeStreamResponse(data []byte) ([]byte, bool) {
+	frames, ok := bedrockEventStreamFrames(data)
+	if !ok {
+		return nil, false
+	}
+
+	payloads := make([][]byte, 0, len(frames))
+	for _, frame := range frames {
+		if frame.eventType != "chunk" {
+			continue
+		}
+		payload, ok := bedrockInvokeChunkPayload(frame.payload)
+		if !ok {
+			return nil, false
+		}
+		payloads = append(payloads, payload)
+	}
+	if len(payloads) == 0 {
+		return nil, false
+	}
+
+	merged, err := mergeJSONEvents(payloads)
+	return merged, err == nil
+}
+
+func bedrockInvokeChunkPayload(payload []byte) ([]byte, bool) {
+	if !json.Valid(payload) {
+		return nil, false
+	}
+
+	var envelope struct {
+		Bytes []byte `json:"bytes"`
+		Chunk *struct {
+			Bytes []byte `json:"bytes"`
+		} `json:"chunk"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, false
+	}
+	switch {
+	case len(envelope.Bytes) != 0:
+		payload = envelope.Bytes
+	case envelope.Chunk != nil && len(envelope.Chunk.Bytes) != 0:
+		payload = envelope.Chunk.Bytes
+	}
+	return payload, json.Valid(payload)
+}
+
+func bedrockEventStreamFrames(data []byte) ([]bedrockEventStreamFrame, bool) {
+	var frames []bedrockEventStreamFrame
+	for offset := 0; offset < len(data); {
 		remaining := data[offset:]
 		if len(remaining) < bedrockEventStreamPreludeLen {
 			return nil, false
@@ -55,17 +131,13 @@ func bedrockConverseStreamMetadata(data []byte) ([]byte, bool) {
 		if !ok {
 			return nil, false
 		}
-		if eventType == "metadata" {
-			payload := remaining[headersEnd : totalLen-4]
-			if !json.Valid(payload) {
-				return nil, false
-			}
-			metadata = append(metadata[:0], payload...)
-		}
+		frames = append(frames, bedrockEventStreamFrame{
+			eventType: eventType,
+			payload:   remaining[headersEnd : totalLen-4],
+		})
 		offset += totalLen
 	}
-
-	return metadata, metadata != nil
+	return frames, len(frames) != 0
 }
 
 // bedrockEventStreamEventType walks the packed Amazon event-stream headers and

--- a/policies/llm-cost/bedrock_eventstream.go
+++ b/policies/llm-cost/bedrock_eventstream.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package llmcost
+
+import (
+	"encoding/binary"
+	"encoding/json"
+)
+
+const (
+	bedrockEventStreamPreludeLen = 12
+	bedrockEventStreamOverhead   = 16
+	bedrockEventStreamMaxFrame   = 16 * 1024 * 1024
+)
+
+// bedrockConverseStreamMetadata extracts the JSON payload from the metadata
+// event in a complete Amazon event-stream response. The trailing and prelude
+// CRC fields are framing bytes here; integrity is already handled by the
+// upstream transport.
+func bedrockConverseStreamMetadata(data []byte) ([]byte, bool) {
+	var metadata []byte
+	offset := 0
+
+	for offset < len(data) {
+		remaining := data[offset:]
+		if len(remaining) < bedrockEventStreamPreludeLen {
+			return nil, false
+		}
+
+		totalLen := int(binary.BigEndian.Uint32(remaining[0:4]))
+		headersLen := int(binary.BigEndian.Uint32(remaining[4:8]))
+		if totalLen < bedrockEventStreamOverhead ||
+			totalLen > bedrockEventStreamMaxFrame ||
+			headersLen > totalLen-bedrockEventStreamOverhead ||
+			totalLen > len(remaining) {
+			return nil, false
+		}
+
+		headersEnd := bedrockEventStreamPreludeLen + headersLen
+		eventType, ok := bedrockEventStreamEventType(remaining[bedrockEventStreamPreludeLen:headersEnd])
+		if !ok {
+			return nil, false
+		}
+		if eventType == "metadata" {
+			payload := remaining[headersEnd : totalLen-4]
+			if !json.Valid(payload) {
+				return nil, false
+			}
+			metadata = append(metadata[:0], payload...)
+		}
+		offset += totalLen
+	}
+
+	return metadata, metadata != nil
+}
+
+// bedrockEventStreamEventType walks the packed Amazon event-stream headers and
+// returns the :event-type string. Unknown or truncated header encodings make
+// the frame invalid rather than risking an out-of-bounds read.
+func bedrockEventStreamEventType(data []byte) (string, bool) {
+	var eventType string
+	for offset := 0; offset < len(data); {
+		nameLen := int(data[offset])
+		offset++
+		if offset+nameLen >= len(data) {
+			return "", false
+		}
+		name := string(data[offset : offset+nameLen])
+		offset += nameLen
+		valueType := data[offset]
+		offset++
+
+		var valueLen int
+		var valueOffset int
+		switch valueType {
+		case 0, 1: // true, false
+		case 2: // byte
+			valueLen = 1
+		case 3: // short
+			valueLen = 2
+		case 4: // integer
+			valueLen = 4
+		case 5, 8: // long, timestamp
+			valueLen = 8
+		case 9: // UUID
+			valueLen = 16
+		case 6, 7: // byte array, string
+			if offset+2 > len(data) {
+				return "", false
+			}
+			valueLen = int(binary.BigEndian.Uint16(data[offset : offset+2]))
+			valueOffset = 2
+		default:
+			return "", false
+		}
+		if offset+valueOffset+valueLen > len(data) {
+			return "", false
+		}
+		if name == ":event-type" && valueType == 7 {
+			eventType = string(data[offset+valueOffset : offset+valueOffset+valueLen])
+		}
+		offset += valueOffset + valueLen
+	}
+	return eventType, true
+}

--- a/policies/llm-cost/calculator_anthropic.go
+++ b/policies/llm-cost/calculator_anthropic.go
@@ -175,26 +175,12 @@ func (c *AnthropicCalculator) Adjust(baseCost float64, usage Usage, pricing Mode
 	}
 
 	// Resolve the cache rates that genericCalculateCost used (tier-aware).
-	cacheReadRate := pricing.CacheReadInputTokenCost
-	cacheWrite5mRate := pricing.CacheCreationInputTokenCost
-	cacheWrite1hrRate := pricing.CacheCreationInputTokenCostAbove1hr
-	if cacheWrite1hrRate == 0 {
-		cacheWrite1hrRate = cacheWrite5mRate
-	}
-	if usage.InputTokensForTiering > 200_000 && pricing.InputCostPerTokenAbove200k > 0 {
-		if pricing.CacheReadInputTokenCostAbove200k > 0 {
-			cacheReadRate = pricing.CacheReadInputTokenCostAbove200k
-		}
-		if pricing.CacheCreationInputTokenCostAbove200k > 0 {
-			cacheWrite5mRate = pricing.CacheCreationInputTokenCostAbove200k
-			cacheWrite1hrRate = pricing.CacheCreationInputTokenCostAbove200k
-		}
-	}
+	rates := resolveRates(usage, pricing)
 
 	// Carve out cache costs before applying multiplier.
-	cacheCost := float64(usage.CachedReadTokens)*cacheReadRate +
-		float64(usage.CacheWriteTokens)*cacheWrite5mRate +
-		float64(usage.CacheWrite1hrTokens)*cacheWrite1hrRate
+	cacheCost := float64(usage.CachedReadTokens)*rates.cacheRead +
+		float64(usage.CacheWriteTokens)*rates.cacheWrite5m +
+		float64(usage.CacheWrite1hrTokens)*rates.cacheWrite1h
 
 	// Carve out web search cost — flat fee, not subject to geo/speed multiplier.
 	var webSearchCost float64

--- a/policies/llm-cost/calculator_bedrock.go
+++ b/policies/llm-cost/calculator_bedrock.go
@@ -88,15 +88,50 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 		} `json:"usage"`
 
 		// Amazon Titan InvokeModel.
-		InputTextTokenCount int64 `json:"inputTextTokenCount"`
-		Results             []struct {
+		InputTextTokenCount       int64 `json:"inputTextTokenCount"`
+		TotalOutputTextTokenCount int64 `json:"totalOutputTextTokenCount"`
+		Results                   []struct {
 			TokenCount int64 `json:"tokenCount"`
 		} `json:"results"`
+
+		// Bedrock adds these metrics to the final model-native streaming chunk
+		// for providers that do not expose a regular usage object.
+		InvocationMetrics struct {
+			InputTokenCount       int64 `json:"inputTokenCount"`
+			OutputTokenCount      int64 `json:"outputTokenCount"`
+			CacheReadInputTokens  int64 `json:"cacheReadInputTokenCount"`
+			CacheWriteInputTokens int64 `json:"cacheWriteInputTokenCount"`
+		} `json:"amazon-bedrock-invocationMetrics"`
+
+		// Nova InvokeModelWithResponseStream emits a final metadata event whose
+		// usage object is nested under the event name.
+		Metadata struct {
+			Usage struct {
+				InputTokens           int64                `json:"inputTokens"`
+				OutputTokens          int64                `json:"outputTokens"`
+				TotalTokens           int64                `json:"totalTokens"`
+				CacheReadInputTokens  int64                `json:"cacheReadInputTokens"`
+				CacheWriteInputTokens int64                `json:"cacheWriteInputTokens"`
+				CacheDetails          []bedrockCacheDetail `json:"cacheDetails"`
+			} `json:"usage"`
+		} `json:"metadata"`
 	}
 	if err := json.Unmarshal(responseBody, &resp); err != nil {
 		return Usage{}, err
 	}
 	u := resp.Usage
+
+	// Hoist Nova's named metadata event into the native usage shape used below.
+	if metadataUsage := resp.Metadata.Usage; metadataUsage.InputTokens != 0 ||
+		metadataUsage.OutputTokens != 0 || metadataUsage.CacheReadInputTokens != 0 ||
+		metadataUsage.CacheWriteInputTokens != 0 || len(metadataUsage.CacheDetails) != 0 {
+		u.InputTokens = metadataUsage.InputTokens
+		u.OutputTokens = metadataUsage.OutputTokens
+		u.TotalTokens = metadataUsage.TotalTokens
+		u.CacheReadInputTokens = metadataUsage.CacheReadInputTokens
+		u.CacheWriteInputTokens = metadataUsage.CacheWriteInputTokens
+		u.CacheDetails = metadataUsage.CacheDetails
+	}
 
 	// Native Converse (and Nova InvokeModel) token usage.
 	if u.InputTokens != 0 || u.OutputTokens != 0 ||
@@ -135,11 +170,31 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 		return usage, nil
 	}
 
+	// Some model-native streams (including older Anthropic completion streams)
+	// report token counts only in Bedrock's final invocation-metrics object.
+	metrics := resp.InvocationMetrics
+	if metrics.InputTokenCount != 0 || metrics.OutputTokenCount != 0 ||
+		metrics.CacheReadInputTokens != 0 || metrics.CacheWriteInputTokens != 0 {
+		promptTokens := metrics.InputTokenCount +
+			metrics.CacheReadInputTokens + metrics.CacheWriteInputTokens
+		return Usage{
+			PromptTokens:          promptTokens,
+			CompletionTokens:      metrics.OutputTokenCount,
+			TotalTokens:           promptTokens + metrics.OutputTokenCount,
+			InputTokensForTiering: promptTokens,
+			CachedReadTokens:      metrics.CacheReadInputTokens,
+			CacheWriteTokens:      metrics.CacheWriteInputTokens,
+		}, nil
+	}
+
 	// Titan InvokeModel reports input usage at the top level and output usage per
-	// result. Sum all result token counts because every generated candidate is billed.
-	var titanOutputTokens int64
-	for _, result := range resp.Results {
-		titanOutputTokens += result.TokenCount
+	// result. Its streaming shape instead reports the cumulative output count at
+	// the top level, so use whichever representation is present.
+	titanOutputTokens := resp.TotalOutputTextTokenCount
+	if titanOutputTokens == 0 {
+		for _, result := range resp.Results {
+			titanOutputTokens += result.TokenCount
+		}
 	}
 	if resp.InputTextTokenCount != 0 || titanOutputTokens != 0 {
 		return Usage{

--- a/policies/llm-cost/calculator_bedrock.go
+++ b/policies/llm-cost/calculator_bedrock.go
@@ -28,17 +28,47 @@ type BedrockCalculator struct {
 	OpenAICalculator
 }
 
+type bedrockCacheDetail struct {
+	TTL         string `json:"ttl"`
+	InputTokens int64  `json:"inputTokens"`
+}
+
+func bedrockCacheWritesByTTL(details []bedrockCacheDetail, aggregate int64) (int64, int64) {
+	if len(details) == 0 {
+		return aggregate, 0
+	}
+
+	var cacheWrite5m, cacheWrite1h int64
+	for _, detail := range details {
+		switch detail.TTL {
+		case "5m":
+			cacheWrite5m += detail.InputTokens
+		case "1h":
+			cacheWrite1h += detail.InputTokens
+		}
+	}
+
+	// Preserve any aggregate tokens not represented by a recognized TTL as
+	// default (5-minute) writes. This also keeps older Bedrock responses, which
+	// expose only cacheWriteInputTokens, backward compatible.
+	if classified := cacheWrite5m + cacheWrite1h; aggregate > classified {
+		cacheWrite5m += aggregate - classified
+	}
+	return cacheWrite5m, cacheWrite1h
+}
+
 // Normalize accepts native Bedrock Converse and InvokeModel usage shapes, plus
 // the OpenAI usage shape emitted by openai-to-bedrock-transformer.
 func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (Usage, error) {
 	var resp struct {
 		Usage struct {
 			// Converse / Nova InvokeModel.
-			InputTokens           int64 `json:"inputTokens"`
-			OutputTokens          int64 `json:"outputTokens"`
-			TotalTokens           int64 `json:"totalTokens"`
-			CacheReadInputTokens  int64 `json:"cacheReadInputTokens"`
-			CacheWriteInputTokens int64 `json:"cacheWriteInputTokens"`
+			InputTokens           int64                `json:"inputTokens"`
+			OutputTokens          int64                `json:"outputTokens"`
+			TotalTokens           int64                `json:"totalTokens"`
+			CacheReadInputTokens  int64                `json:"cacheReadInputTokens"`
+			CacheWriteInputTokens int64                `json:"cacheWriteInputTokens"`
+			CacheDetails          []bedrockCacheDetail `json:"cacheDetails"`
 
 			// Anthropic InvokeModel.
 			AnthropicInputTokens              int64 `json:"input_tokens"`
@@ -50,8 +80,10 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 			PromptTokens     int64 `json:"prompt_tokens"`
 			CompletionTokens int64 `json:"completion_tokens"`
 			PromptDetails    struct {
-				CachedTokens     int64 `json:"cached_tokens"`
-				CacheWriteTokens int64 `json:"cache_write_tokens"`
+				CachedTokens       int64 `json:"cached_tokens"`
+				CacheWriteTokens   int64 `json:"cache_write_tokens"`
+				CacheWrite5mTokens int64 `json:"cache_write_5m_tokens"`
+				CacheWrite1hTokens int64 `json:"cache_write_1h_tokens"`
 			} `json:"prompt_tokens_details"`
 		} `json:"usage"`
 
@@ -68,8 +100,13 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 
 	// Native Converse (and Nova InvokeModel) token usage.
 	if u.InputTokens != 0 || u.OutputTokens != 0 ||
-		u.CacheReadInputTokens != 0 || u.CacheWriteInputTokens != 0 {
-		promptTokens := u.InputTokens + u.CacheReadInputTokens + u.CacheWriteInputTokens
+		u.CacheReadInputTokens != 0 || u.CacheWriteInputTokens != 0 ||
+		len(u.CacheDetails) != 0 {
+		cacheWrite5m, cacheWrite1h := bedrockCacheWritesByTTL(
+			u.CacheDetails, u.CacheWriteInputTokens,
+		)
+		cacheWriteTokens := cacheWrite5m + cacheWrite1h
+		promptTokens := u.InputTokens + u.CacheReadInputTokens + cacheWriteTokens
 		totalTokens := u.TotalTokens
 		inclusiveTotal := promptTokens + u.OutputTokens
 		if totalTokens < inclusiveTotal {
@@ -81,7 +118,8 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 			TotalTokens:           totalTokens,
 			InputTokensForTiering: promptTokens,
 			CachedReadTokens:      u.CacheReadInputTokens,
-			CacheWriteTokens:      u.CacheWriteInputTokens,
+			CacheWriteTokens:      cacheWrite5m,
+			CacheWrite1hrTokens:   cacheWrite1h,
 		}, nil
 	}
 
@@ -115,12 +153,20 @@ func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (
 	// preserves Bedrock cache writes in a non-standard detail field so they can
 	// still be billed at the model's cache-creation rate.
 	if u.PromptTokens != 0 || u.CompletionTokens != 0 ||
-		u.PromptDetails.CachedTokens != 0 || u.PromptDetails.CacheWriteTokens != 0 {
+		u.PromptDetails.CachedTokens != 0 || u.PromptDetails.CacheWriteTokens != 0 ||
+		u.PromptDetails.CacheWrite5mTokens != 0 || u.PromptDetails.CacheWrite1hTokens != 0 {
 		usage, err := c.OpenAICalculator.Normalize(responseBody, requestBody)
 		if err != nil {
 			return Usage{}, err
 		}
-		usage.CacheWriteTokens = u.PromptDetails.CacheWriteTokens
+		if u.PromptDetails.CacheWrite5mTokens != 0 || u.PromptDetails.CacheWrite1hTokens != 0 {
+			usage.CacheWriteTokens = u.PromptDetails.CacheWrite5mTokens
+			usage.CacheWrite1hrTokens = u.PromptDetails.CacheWrite1hTokens
+		} else {
+			// Backward-compatible fallback for transformed responses that only
+			// preserve the aggregate cache-write count.
+			usage.CacheWriteTokens = u.PromptDetails.CacheWriteTokens
+		}
 		if usage.TotalTokens < usage.PromptTokens+usage.CompletionTokens {
 			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 		}

--- a/policies/llm-cost/calculator_bedrock.go
+++ b/policies/llm-cost/calculator_bedrock.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package llmcost
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// BedrockCalculator handles native AWS Bedrock Converse and InvokeModel usage,
+// as well as Converse responses converted to the OpenAI Chat Completions shape
+// by openai-to-bedrock-transformer.
+type BedrockCalculator struct {
+	OpenAICalculator
+}
+
+// Normalize accepts native Bedrock Converse and InvokeModel usage shapes, plus
+// the OpenAI usage shape emitted by openai-to-bedrock-transformer.
+func (c *BedrockCalculator) Normalize(responseBody []byte, requestBody []byte) (Usage, error) {
+	var resp struct {
+		Usage struct {
+			// Converse / Nova InvokeModel.
+			InputTokens           int64 `json:"inputTokens"`
+			OutputTokens          int64 `json:"outputTokens"`
+			TotalTokens           int64 `json:"totalTokens"`
+			CacheReadInputTokens  int64 `json:"cacheReadInputTokens"`
+			CacheWriteInputTokens int64 `json:"cacheWriteInputTokens"`
+
+			// Anthropic InvokeModel.
+			AnthropicInputTokens              int64 `json:"input_tokens"`
+			AnthropicOutputTokens             int64 `json:"output_tokens"`
+			AnthropicCacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+			AnthropicCacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+
+			// OpenAI shape emitted by openai-to-bedrock-transformer.
+			PromptTokens     int64 `json:"prompt_tokens"`
+			CompletionTokens int64 `json:"completion_tokens"`
+			PromptDetails    struct {
+				CachedTokens     int64 `json:"cached_tokens"`
+				CacheWriteTokens int64 `json:"cache_write_tokens"`
+			} `json:"prompt_tokens_details"`
+		} `json:"usage"`
+
+		// Amazon Titan InvokeModel.
+		InputTextTokenCount int64 `json:"inputTextTokenCount"`
+		Results             []struct {
+			TokenCount int64 `json:"tokenCount"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(responseBody, &resp); err != nil {
+		return Usage{}, err
+	}
+	u := resp.Usage
+
+	// Native Converse (and Nova InvokeModel) token usage.
+	if u.InputTokens != 0 || u.OutputTokens != 0 ||
+		u.CacheReadInputTokens != 0 || u.CacheWriteInputTokens != 0 {
+		promptTokens := u.InputTokens + u.CacheReadInputTokens + u.CacheWriteInputTokens
+		totalTokens := u.TotalTokens
+		inclusiveTotal := promptTokens + u.OutputTokens
+		if totalTokens < inclusiveTotal {
+			totalTokens = inclusiveTotal
+		}
+		return Usage{
+			PromptTokens:          promptTokens,
+			CompletionTokens:      u.OutputTokens,
+			TotalTokens:           totalTokens,
+			InputTokensForTiering: promptTokens,
+			CachedReadTokens:      u.CacheReadInputTokens,
+			CacheWriteTokens:      u.CacheWriteInputTokens,
+		}, nil
+	}
+
+	// Anthropic InvokeModel uses its native snake_case usage object. Reuse the
+	// Anthropic normalizer so cache-write TTL details remain accurate.
+	if u.AnthropicInputTokens != 0 || u.AnthropicOutputTokens != 0 ||
+		u.AnthropicCacheReadInputTokens != 0 || u.AnthropicCacheCreationInputTokens != 0 {
+		usage, err := (&AnthropicCalculator{}).Normalize(responseBody, requestBody)
+		if err != nil {
+			return Usage{}, err
+		}
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		return usage, nil
+	}
+
+	// Titan InvokeModel reports input usage at the top level and output usage per
+	// result. Sum all result token counts because every generated candidate is billed.
+	var titanOutputTokens int64
+	for _, result := range resp.Results {
+		titanOutputTokens += result.TokenCount
+	}
+	if resp.InputTextTokenCount != 0 || titanOutputTokens != 0 {
+		return Usage{
+			PromptTokens:     resp.InputTextTokenCount,
+			CompletionTokens: titanOutputTokens,
+			TotalTokens:      resp.InputTextTokenCount + titanOutputTokens,
+		}, nil
+	}
+
+	// Transformed Converse responses use OpenAI token names. The transformer
+	// preserves Bedrock cache writes in a non-standard detail field so they can
+	// still be billed at the model's cache-creation rate.
+	if u.PromptTokens != 0 || u.CompletionTokens != 0 ||
+		u.PromptDetails.CachedTokens != 0 || u.PromptDetails.CacheWriteTokens != 0 {
+		usage, err := c.OpenAICalculator.Normalize(responseBody, requestBody)
+		if err != nil {
+			return Usage{}, err
+		}
+		usage.CacheWriteTokens = u.PromptDetails.CacheWriteTokens
+		if usage.TotalTokens < usage.PromptTokens+usage.CompletionTokens {
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
+		return usage, nil
+	}
+
+	return Usage{}, fmt.Errorf("bedrock response does not contain supported token usage")
+}

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -131,18 +131,10 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 		return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
 	}
 
-	responseBody := respCtx.ResponseBody.Content
-
-	// If the response body is buffered SSE events rather than a single JSON
-	// object, merge all events into one JSON blob so the downstream calculators
-	// can parse it with a regular json.Unmarshal.
-	if isSSEContent(responseBody) {
-		merged, err := mergeSSEEvents(responseBody)
-		if err != nil {
-			slog.Warn("llm-cost: failed to merge SSE events", "error", err)
-			return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
-		}
-		responseBody = merged
+	responseBody, err := responseBodyForNormalization(respCtx.ResponseBody.Content, respCtx.RequestPath)
+	if err != nil {
+		slog.Warn("llm-cost: failed to prepare response body", "error", err)
+		return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
 	}
 
 	// Extract model name from response body.
@@ -299,15 +291,11 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 		return streamingCostResult{}
 	}
 
-	responseBody := body
-	if isSSEContent(body) {
-		merged, err := mergeSSEEvents(body)
-		if err != nil {
-			slog.Warn("llm-cost: failed to merge SSE events in streaming mode", "error", err)
-			setMeta(0.0, costStatusNotCalculated)
-			return streamingCostResult{}
-		}
-		responseBody = merged
+	responseBody, err := responseBodyForNormalization(body, requestPath)
+	if err != nil {
+		slog.Warn("llm-cost: failed to prepare streaming response body", "error", err)
+		setMeta(0.0, costStatusNotCalculated)
+		return streamingCostResult{}
 	}
 
 	var probe struct {
@@ -389,6 +377,26 @@ func isSSEContent(b []byte) bool {
 		}
 	}
 	return false
+}
+
+// responseBodyForNormalization converts streaming wire formats into the JSON
+// object expected by the provider calculators. Transformed Bedrock responses
+// are SSE and take the existing path; native ConverseStream responses are
+// Amazon event-stream frames whose metadata event carries usage.
+func responseBodyForNormalization(body []byte, requestPath string) ([]byte, error) {
+	path := requestPath
+	if end := strings.IndexByte(path, '?'); end >= 0 {
+		path = path[:end]
+	}
+	if strings.HasSuffix(path, "/converse-stream") {
+		if metadata, ok := bedrockConverseStreamMetadata(body); ok {
+			return metadata, nil
+		}
+	}
+	if isSSEContent(body) {
+		return mergeSSEEvents(body)
+	}
+	return body, nil
 }
 
 // mergeSSEEvents parses every SSE data/event line as JSON and shallow-merges all

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -381,16 +381,22 @@ func isSSEContent(b []byte) bool {
 
 // responseBodyForNormalization converts streaming wire formats into the JSON
 // object expected by the provider calculators. Transformed Bedrock responses
-// are SSE and take the existing path; native ConverseStream responses are
-// Amazon event-stream frames whose metadata event carries usage.
+// are SSE and take the existing path. Native Bedrock streaming responses are
+// Amazon event-stream frames: ConverseStream exposes usage in a metadata event,
+// while InvokeModelWithResponseStream carries model-native JSON in chunk events.
 func responseBodyForNormalization(body []byte, requestPath string) ([]byte, error) {
 	path := requestPath
 	if end := strings.IndexByte(path, '?'); end >= 0 {
 		path = path[:end]
 	}
-	if strings.HasSuffix(path, "/converse-stream") {
+	switch {
+	case strings.HasSuffix(path, "/converse-stream"):
 		if metadata, ok := bedrockConverseStreamMetadata(body); ok {
 			return metadata, nil
+		}
+	case strings.HasSuffix(path, "/invoke-with-response-stream"):
+		if response, ok := bedrockInvokeStreamResponse(body); ok {
+			return response, nil
 		}
 	}
 	if isSSEContent(body) {
@@ -408,7 +414,7 @@ func responseBodyForNormalization(body []byte, requestPath string) ([]byte, erro
 // from earlier events (e.g. input_tokens) survive when a later event
 // only carries output_tokens.
 func mergeSSEEvents(body []byte) ([]byte, error) {
-	merged := make(map[string]interface{})
+	var events [][]byte
 
 	for _, line := range strings.Split(string(body), "\n") {
 		line = strings.TrimRight(line, "\r")
@@ -425,11 +431,26 @@ func mergeSSEEvents(body []byte) ([]byte, error) {
 			continue
 		}
 
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(value), &event); err != nil {
+		event := []byte(value)
+		if !json.Valid(event) {
 			continue // skip non-JSON lines
 		}
+		events = append(events, event)
+	}
 
+	return mergeJSONEvents(events)
+}
+
+// mergeJSONEvents shallow-merges model streaming events into one object. Usage
+// maps are deep-merged because providers commonly split input and output token
+// counts across different events.
+func mergeJSONEvents(events [][]byte) ([]byte, error) {
+	merged := make(map[string]interface{})
+	for _, data := range events {
+		var event map[string]interface{}
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
 		for k, v := range event {
 			// Deep-merge "usage" and "usageMetadata" maps so that fields
 			// from earlier events (e.g. input_tokens) survive when a later
@@ -447,9 +468,8 @@ func mergeSSEEvents(body []byte) ([]byte, error) {
 			merged[k] = v
 		}
 	}
-
 	if len(merged) == 0 {
-		return nil, fmt.Errorf("no valid SSE events found")
+		return nil, fmt.Errorf("no valid JSON events found")
 	}
 
 	return json.Marshal(merged)

--- a/policies/llm-cost/llm_cost.go
+++ b/policies/llm-cost/llm_cost.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -48,6 +50,14 @@ const (
 	// This disambiguates x-llm-cost: 0 (which could mean zero cost or a failed calculation).
 	MetadataLLMCostStatus = "x-llm-cost-status"
 
+	// Analytics metadata keys consumed by the gateway analytics publisher.
+	// LLM Cost emits these from the same normalized usage used for billing so
+	// transformed streams (for example Bedrock -> OpenAI SSE) retain telemetry.
+	metadataPromptTokenCount     = "aitoken:prompttokencount"
+	metadataCompletionTokenCount = "aitoken:completiontokencount"
+	metadataTotalTokenCount      = "aitoken:totaltokencount"
+	metadataModelID              = "aitoken:modelid"
+
 	costStatusCalculated    = "calculated"
 	costStatusNotCalculated = "not_calculated"
 )
@@ -56,6 +66,13 @@ const (
 // and stores the result in SharedContext.Metadata under "x-llm-cost" (USD float).
 type LLMCostPolicy struct {
 	pricingMap map[string]ModelPricing
+}
+
+type streamingCostResult struct {
+	cost       float64
+	model      string
+	usage      Usage
+	calculated bool
 }
 
 var (
@@ -165,7 +182,7 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 	}
 
 	// Look up pricing entry.
-	pricing, found := lookupPricing(p.pricingMap, modelName)
+	pricing, pricingModelName, found := lookupPricingWithKey(p.pricingMap, modelName)
 	if !found {
 		slog.Warn("llm-cost: no pricing entry for model, setting cost to 0", "model", modelName)
 		return setCostMetadata(respCtx, 0.0, costStatusNotCalculated)
@@ -198,7 +215,8 @@ func (p *LLMCostPolicy) OnResponseBody(ctx context.Context, respCtx *policy.Resp
 	finalCost := calc.Adjust(baseCost, usage, pricing)
 
 	slog.Debug("llm-cost: calculated cost",
-		"model", modelName,
+		"model", pricingModelName,
+		"requested_model", modelName,
 		"provider", pricing.Provider,
 		"prompt_tokens", usage.PromptTokens,
 		"completion_tokens", usage.CompletionTokens,
@@ -243,21 +261,28 @@ func (p *LLMCostPolicy) OnResponseBodyChunk(
 		requestBody = respCtx.RequestBody.Content
 	}
 
-	cost := p.computeAndSetStreamingCost(respCtx.SharedContext, accumulated, requestBody, respCtx.RequestPath)
+	result := p.computeAndSetStreamingCost(respCtx.SharedContext, accumulated, requestBody, respCtx.RequestPath)
+	analyticsMetadata := map[string]any{
+		MetadataLLMCost: result.cost,
+	}
+	if result.calculated {
+		analyticsMetadata[metadataModelID] = result.model
+		analyticsMetadata[metadataPromptTokenCount] = strconv.FormatInt(result.usage.PromptTokens, 10)
+		analyticsMetadata[metadataCompletionTokenCount] = strconv.FormatInt(result.usage.CompletionTokens, 10)
+		analyticsMetadata[metadataTotalTokenCount] = strconv.FormatInt(result.usage.TotalTokens, 10)
+	}
 	return policy.ForwardResponseChunk{
-		AnalyticsMetadata: map[string]any{
-			MetadataLLMCost: cost,
-		},
+		AnalyticsMetadata: analyticsMetadata,
 	}
 }
 
 // computeAndSetStreamingCost parses the accumulated response bytes, calculates the
 // LLM cost, writes x-llm-cost / x-llm-cost-status into SharedContext.Metadata, and
-// returns the calculated cost in USD (0.0 on any error).
-func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedContext, body, requestBody []byte, requestPath string) float64 {
+// returns the normalized billing result (zero-valued on any error).
+func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedContext, body, requestBody []byte, requestPath string) streamingCostResult {
 	if sharedCtx == nil {
 		slog.Warn("llm-cost: SharedContext is nil in streaming mode, cannot set cost metadata")
-		return 0.0
+		return streamingCostResult{}
 	}
 	if sharedCtx.Metadata == nil {
 		sharedCtx.Metadata = make(map[string]interface{})
@@ -271,7 +296,7 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 	if len(body) == 0 {
 		slog.Warn("llm-cost: empty accumulated stream body, skipping cost calculation")
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 
 	responseBody := body
@@ -280,7 +305,7 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 		if err != nil {
 			slog.Warn("llm-cost: failed to merge SSE events in streaming mode", "error", err)
 			setMeta(0.0, costStatusNotCalculated)
-			return 0.0
+			return streamingCostResult{}
 		}
 		responseBody = merged
 	}
@@ -295,7 +320,7 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 	if err := json.Unmarshal(responseBody, &probe); err != nil {
 		slog.Warn("llm-cost: could not parse streaming response body", "error", err)
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 	modelName := probe.Model
 	if modelName == "" {
@@ -310,35 +335,36 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 	if modelName == "" {
 		slog.Warn("llm-cost: no model name found in streaming response body or request context")
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 
-	pricing, found := lookupPricing(p.pricingMap, modelName)
+	pricing, pricingModelName, found := lookupPricingWithKey(p.pricingMap, modelName)
 	if !found {
 		slog.Warn("llm-cost: no pricing entry for model, setting cost to 0", "model", modelName)
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 
 	calc := selectCalculator(pricing.Provider)
 	if calc == nil {
 		slog.Warn("llm-cost: unsupported provider in streaming mode", "provider", pricing.Provider, "model", modelName)
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 
 	usage, err := calc.Normalize(responseBody, requestBody)
 	if err != nil {
 		slog.Warn("llm-cost: failed to normalize streaming usage", "model", modelName, "error", err)
 		setMeta(0.0, costStatusNotCalculated)
-		return 0.0
+		return streamingCostResult{}
 	}
 
 	baseCost := genericCalculateCost(usage, pricing)
 	finalCost := calc.Adjust(baseCost, usage, pricing)
 
 	slog.Debug("llm-cost: calculated streaming cost",
-		"model", modelName,
+		"model", pricingModelName,
+		"requested_model", modelName,
 		"provider", pricing.Provider,
 		"prompt_tokens", usage.PromptTokens,
 		"completion_tokens", usage.CompletionTokens,
@@ -346,7 +372,12 @@ func (p *LLMCostPolicy) computeAndSetStreamingCost(sharedCtx *policy.SharedConte
 	)
 
 	setMeta(finalCost, costStatusCalculated)
-	return finalCost
+	return streamingCostResult{
+		cost:       finalCost,
+		model:      pricingModelName,
+		usage:      usage,
+		calculated: true,
+	}
 }
 
 // isSSEContent reports whether the body looks like buffered SSE data (has at
@@ -434,8 +465,9 @@ func setStreamCostMetadata(respCtx *policy.ResponseStreamContext, costUSD float6
 // modelNameFromRequest tries to extract the model name from the request context
 // when the response body does not include one. It checks the request body's
 // "model" JSON field first (OpenAI, Anthropic, Mistral convention), then falls
-// back to parsing a "/models/{name}" path segment from the request path (Gemini,
-// Vertex AI). Returns empty string if no model name can be determined.
+// back to parsing the provider-specific request path. Gemini and Vertex AI use
+// "/models/{name}" while Bedrock uses "/model/{modelId}/{operation}". Returns
+// empty string if no model name can be determined.
 func modelNameFromRequest(requestBody []byte, requestPath string) string {
 	if len(requestBody) > 0 {
 		var req struct {
@@ -443,6 +475,34 @@ func modelNameFromRequest(requestBody []byte, requestPath string) string {
 		}
 		if err := json.Unmarshal(requestBody, &req); err == nil && req.Model != "" {
 			return req.Model
+		}
+	}
+	// Bedrock Runtime: the model ID is a path parameter and is absent from both
+	// the Converse request body and response. Extract the complete segment first
+	// so ':' remains part of IDs such as "...-v1:0". AWS SDKs URL-encode ARN model
+	// IDs because their resource component can itself contain '/'.
+	if i := strings.Index(requestPath, "/model/"); i >= 0 {
+		rest := requestPath[i+len("/model/"):]
+		if end := strings.IndexByte(rest, '?'); end >= 0 {
+			rest = rest[:end]
+		}
+		for _, suffix := range []string{
+			"/invoke-with-bidirectional-stream",
+			"/invoke-with-response-stream",
+			"/converse-stream",
+			"/converse",
+			"/invoke",
+		} {
+			if strings.HasSuffix(rest, suffix) {
+				rest = strings.TrimSuffix(rest, suffix)
+				break
+			}
+		}
+		if rest != "" {
+			if decoded, err := url.PathUnescape(rest); err == nil {
+				return decoded
+			}
+			return rest
 		}
 	}
 	// Gemini/Vertex AI: model name is embedded in the path, e.g.

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -18,6 +18,7 @@ package llmcost
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"math"
 	"os"
@@ -291,6 +292,46 @@ func TestBedrockCalculator_NormalizeNativeConverseUsage(t *testing.T) {
 	}
 }
 
+func TestBedrockCalculator_NormalizeNativeConverseCacheWriteTTLs(t *testing.T) {
+	c := &BedrockCalculator{}
+	usage, err := c.Normalize([]byte(`{
+		"usage": {
+			"inputTokens": 10,
+			"outputTokens": 3,
+			"totalTokens": 13,
+			"cacheReadInputTokens": 4,
+			"cacheWriteInputTokens": 1200,
+			"cacheDetails": [
+				{"ttl": "1h", "inputTokens": 1000},
+				{"ttl": "5m", "inputTokens": 200}
+			]
+		}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 1214 || usage.CompletionTokens != 3 || usage.TotalTokens != 1217 {
+		t.Errorf("unexpected Bedrock usage: %+v", usage)
+	}
+	if usage.CachedReadTokens != 4 || usage.CacheWriteTokens != 200 ||
+		usage.CacheWrite1hrTokens != 1000 {
+		t.Errorf("unexpected Bedrock cache TTL usage: %+v", usage)
+	}
+
+	pricing, ok := lookupPricing(testPricingMap, "anthropic.claude-opus-4-6-v1")
+	if !ok {
+		t.Fatal("missing Bedrock Claude Opus 4.6 pricing")
+	}
+	want := float64(10)*pricing.InputCostPerToken +
+		float64(3)*pricing.OutputCostPerToken +
+		float64(4)*pricing.CacheReadInputTokenCost +
+		float64(200)*pricing.CacheCreationInputTokenCost +
+		float64(1000)*pricing.CacheCreationInputTokenCostAbove1hr
+	if got := genericCalculateCost(usage, pricing); !almostEqual(got, want) {
+		t.Fatalf("native cache TTL usage cost = %.10f, want %.10f", got, want)
+	}
+}
+
 func TestBedrockCalculator_NormalizeAnthropicInvokeModel(t *testing.T) {
 	c := &BedrockCalculator{}
 	usage, err := c.Normalize([]byte(`{
@@ -357,6 +398,74 @@ func TestBedrockCalculator_TransformedCacheUsageCost(t *testing.T) {
 	// cache write $7.5e-6 = $83.7e-6.
 	if got, want := genericCalculateCost(usage, pricing), 0.0000837; !almostEqual(got, want) {
 		t.Fatalf("transformed cache usage cost = %.10f, want %.10f", got, want)
+	}
+}
+
+func TestBedrockCalculator_TransformedCacheWriteTTLCost(t *testing.T) {
+	c := &BedrockCalculator{}
+	body := []byte(`{
+		"usage": {
+			"prompt_tokens": 20,
+			"completion_tokens": 3,
+			"total_tokens": 23,
+			"prompt_tokens_details": {
+				"cached_tokens": 4,
+				"cache_write_tokens": 6,
+				"cache_write_5m_tokens": 2,
+				"cache_write_1h_tokens": 4
+			}
+		}
+	}`)
+	usage, err := c.Normalize(body, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.CacheWriteTokens != 2 || usage.CacheWrite1hrTokens != 4 {
+		t.Fatalf("unexpected transformed cache TTL usage: %+v", usage)
+	}
+
+	pricing, ok := lookupPricing(testPricingMap, "anthropic.claude-opus-4-6-v1")
+	if !ok {
+		t.Fatal("missing Bedrock Claude Opus 4.6 pricing")
+	}
+	want := float64(10)*pricing.InputCostPerToken +
+		float64(3)*pricing.OutputCostPerToken +
+		float64(4)*pricing.CacheReadInputTokenCost +
+		float64(2)*pricing.CacheCreationInputTokenCost +
+		float64(4)*pricing.CacheCreationInputTokenCostAbove1hr
+	if got := genericCalculateCost(usage, pricing); !almostEqual(got, want) {
+		t.Fatalf("transformed cache TTL usage cost = %.10f, want %.10f", got, want)
+	}
+}
+
+func TestBedrockCalculator_CacheWrite1hrAbove200kCost(t *testing.T) {
+	pricing, ok := lookupPricing(testPricingMap, "anthropic.claude-sonnet-4-5-20250929-v1:0")
+	if !ok {
+		t.Fatal("missing Bedrock Claude Sonnet 4.5 pricing")
+	}
+	if got, want := pricing.CacheCreationInputTokenCostAbove1hrAbove200k, 0.000012; got != want {
+		t.Fatalf("decoded combined 1hr and >200k cache-write rate = %g, want %g", got, want)
+	}
+
+	usage := Usage{
+		PromptTokens:          200_002,
+		InputTokensForTiering: 200_002,
+		CacheWriteTokens:      1,
+		CacheWrite1hrTokens:   1,
+	}
+	rates := resolveRates(usage, pricing)
+	if got, want := rates.cacheWrite5m, 0.0000075; got != want {
+		t.Errorf(">200k 5-minute cache-write rate = %g, want %g", got, want)
+	}
+	if got, want := rates.cacheWrite1h, 0.000012; got != want {
+		t.Errorf(">200k 1-hour cache-write rate = %g, want %g", got, want)
+	}
+
+	wantCost := float64(200_000)*pricing.InputCostPerTokenAbove200k +
+		pricing.CacheCreationInputTokenCostAbove200k +
+		pricing.CacheCreationInputTokenCostAbove1hrAbove200k
+	if got := genericCalculateCost(usage, pricing); !almostEqual(got, wantCost) {
+		t.Fatalf("combined 1hr and >200k cost = %.10f, want %.10f", got, wantCost)
 	}
 }
 
@@ -455,6 +564,58 @@ func TestOnResponseBodyChunk_BedrockNative_CacheCost(t *testing.T) {
 	// Regular input $30e-6 + output $45e-6 + cache read $1.2e-6 +
 	// cache write $7.5e-6 = $83.7e-6.
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000837000")
+}
+
+func TestOnResponseBodyChunk_BedrockConverseStream_NativeEventStream(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/converse-stream"
+
+	messageStart := encodeBedrockEventStreamFrame("messageStart", `{"role":"assistant"}`)
+	metadata := encodeBedrockEventStreamFrame("metadata",
+		`{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}`)
+
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: messageStart,
+		Index: 0,
+	}, nil)
+	if _, ok := ctx.Metadata[MetadataLLMCostStatus]; ok {
+		t.Fatal("cost status set before the native stream reached end-of-stream")
+	}
+	if forward, ok := action.(policy.ForwardResponseChunk); ok && len(forward.AnalyticsMetadata) != 0 {
+		t.Fatal("analytics metadata set before the native stream reached end-of-stream")
+	}
+
+	action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk:       metadata,
+		EndOfStream: true,
+		Index:       1,
+	}, nil)
+	// Claude 3.7 Sonnet on Bedrock: 10 * $3/M + 3 * $15/M = $0.000075.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
+func encodeBedrockEventStreamFrame(eventType, payload string) []byte {
+	headers := encodeBedrockEventStreamStringHeader(":event-type", eventType)
+	headers = append(headers, encodeBedrockEventStreamStringHeader(":message-type", "event")...)
+
+	totalLen := bedrockEventStreamOverhead + len(headers) + len(payload)
+	frame := make([]byte, 0, totalLen)
+	frame = binary.BigEndian.AppendUint32(frame, uint32(totalLen))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(len(headers)))
+	frame = binary.BigEndian.AppendUint32(frame, 0)
+	frame = append(frame, headers...)
+	frame = append(frame, payload...)
+	frame = binary.BigEndian.AppendUint32(frame, 0)
+	return frame
+}
+
+func encodeBedrockEventStreamStringHeader(name, value string) []byte {
+	header := []byte{byte(len(name))}
+	header = append(header, name...)
+	header = append(header, 7)
+	header = binary.BigEndian.AppendUint16(header, uint16(len(value)))
+	return append(header, value...)
 }
 
 func TestOnResponseBodyChunk_BedrockAnthropicInvokeModel(t *testing.T) {

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -18,6 +18,7 @@ package llmcost
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"math"
@@ -593,6 +594,116 @@ func TestOnResponseBodyChunk_BedrockConverseStream_NativeEventStream(t *testing.
 	}, nil)
 	// Claude 3.7 Sonnet on Bedrock: 10 * $3/M + 3 * $15/M = $0.000075.
 	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
+func TestOnResponseBodyChunk_BedrockAnthropicInvokeModelWithResponseStream(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/invoke-with-response-stream"
+
+	messageStart := encodeBedrockEventStreamFrame("chunk",
+		`{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}`)
+	messageDelta := encodeBedrockEventStreamFrame("chunk",
+		`{"type":"message_delta","usage":{"output_tokens":3}}`)
+
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: messageStart,
+		Index: 0,
+	}, nil)
+	if _, ok := ctx.Metadata[MetadataLLMCostStatus]; ok {
+		t.Fatal("cost status set before the native stream reached end-of-stream")
+	}
+
+	action = p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk:       messageDelta,
+		EndOfStream: true,
+		Index:       1,
+	}, nil)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
+func TestBedrockInvokeStreamResponse_DecodesSerializedPayloadPart(t *testing.T) {
+	messageStart := base64.StdEncoding.EncodeToString([]byte(
+		`{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}`,
+	))
+	messageDelta := base64.StdEncoding.EncodeToString([]byte(
+		`{"type":"message_delta","usage":{"output_tokens":3}}`,
+	))
+	stream := append(
+		encodeBedrockEventStreamFrame("chunk", `{"bytes":"`+messageStart+`"}`),
+		encodeBedrockEventStreamFrame("chunk", `{"chunk":{"bytes":"`+messageDelta+`"}}`)...,
+	)
+
+	response, ok := bedrockInvokeStreamResponse(stream)
+	if !ok {
+		t.Fatal("expected serialized PayloadPart frames to be decoded")
+	}
+	usage, err := (&BedrockCalculator{}).Normalize(response, nil)
+	if err != nil {
+		t.Fatalf("unexpected normalization error: %v", err)
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 3 || usage.TotalTokens != 13 {
+		t.Fatalf("unexpected Anthropic streaming usage: %+v", usage)
+	}
+}
+
+func TestBedrockInvokeStreamResponse_NovaMetadata(t *testing.T) {
+	stream := append(
+		encodeBedrockEventStreamFrame("chunk",
+			`{"contentBlockDelta":{"delta":{"text":"hello"}}}`),
+		encodeBedrockEventStreamFrame("chunk",
+			`{"metadata":{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}}`)...,
+	)
+
+	response, ok := bedrockInvokeStreamResponse(stream)
+	if !ok {
+		t.Fatal("expected Nova chunk frames to be merged")
+	}
+	usage, err := (&BedrockCalculator{}).Normalize(response, nil)
+	if err != nil {
+		t.Fatalf("unexpected normalization error: %v", err)
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 3 || usage.TotalTokens != 13 {
+		t.Fatalf("unexpected Nova streaming usage: %+v", usage)
+	}
+}
+
+func TestBedrockInvokeStreamResponse_TitanUsage(t *testing.T) {
+	stream := append(
+		encodeBedrockEventStreamFrame("chunk",
+			`{"index":0,"inputTextTokenCount":10,"totalOutputTextTokenCount":1,"outputText":"hello"}`),
+		encodeBedrockEventStreamFrame("chunk",
+			`{"index":0,"inputTextTokenCount":10,"totalOutputTextTokenCount":3,"outputText":" world","completionReason":"FINISHED"}`)...,
+	)
+
+	response, ok := bedrockInvokeStreamResponse(stream)
+	if !ok {
+		t.Fatal("expected Titan chunk frames to be merged")
+	}
+	usage, err := (&BedrockCalculator{}).Normalize(response, nil)
+	if err != nil {
+		t.Fatalf("unexpected normalization error: %v", err)
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 3 || usage.TotalTokens != 13 {
+		t.Fatalf("unexpected Titan streaming usage: %+v", usage)
+	}
+}
+
+func TestBedrockInvokeStreamResponse_InvocationMetrics(t *testing.T) {
+	stream := encodeBedrockEventStreamFrame("chunk",
+		`{"completion":"done","amazon-bedrock-invocationMetrics":{"inputTokenCount":10,"outputTokenCount":3}}`)
+
+	response, ok := bedrockInvokeStreamResponse(stream)
+	if !ok {
+		t.Fatal("expected invocation metrics chunk to be extracted")
+	}
+	usage, err := (&BedrockCalculator{}).Normalize(response, nil)
+	if err != nil {
+		t.Fatalf("unexpected normalization error: %v", err)
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 3 || usage.TotalTokens != 13 {
+		t.Fatalf("unexpected invocation metrics usage: %+v", usage)
+	}
 }
 
 func encodeBedrockEventStreamFrame(eventType, payload string) []byte {

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -225,6 +225,325 @@ func TestOpenAICalculator_Adjust_PassThrough(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// AWS Bedrock calculator
+// ---------------------------------------------------------------------------
+
+func TestSelectCalculator_Bedrock(t *testing.T) {
+	if _, ok := selectCalculator("bedrock").(*BedrockCalculator); !ok {
+		t.Error("provider bedrock did not select BedrockCalculator")
+	}
+}
+
+func TestPricingFixture_BedrockModels(t *testing.T) {
+	const expectedBedrockEntries = 138
+	bedrockEntries := 0
+	for _, pricing := range testPricingMap {
+		if pricing.Provider == "bedrock" {
+			bedrockEntries++
+		}
+	}
+	if bedrockEntries != expectedBedrockEntries {
+		t.Fatalf("Bedrock pricing entries = %d, want %d", bedrockEntries, expectedBedrockEntries)
+	}
+
+	// Cover representative vendors and regional inference profiles from the
+	// pricing snapshot imported from api-platform PR #2771.
+	for _, modelID := range []string{
+		"amazon.nova-micro-v1:0",
+		"apac.amazon.nova-micro-v1:0",
+		"eu.anthropic.claude-sonnet-4-6",
+		"global.anthropic.claude-opus-4-6-v1",
+		"us.meta.llama4-scout-17b-instruct-v1:0",
+		"mistral.mistral-large-3-675b-instruct",
+		"openai.gpt-oss-120b-1:0",
+		"qwen.qwen3-32b-v1:0",
+	} {
+		pricing, ok := lookupPricing(testPricingMap, modelID)
+		if !ok {
+			t.Errorf("missing Bedrock pricing for %q", modelID)
+			continue
+		}
+		if pricing.Provider != "bedrock" {
+			t.Errorf("provider for %q = %q, want bedrock", modelID, pricing.Provider)
+		}
+	}
+}
+
+func TestBedrockCalculator_NormalizeNativeConverseUsage(t *testing.T) {
+	c := &BedrockCalculator{}
+	usage, err := c.Normalize([]byte(`{
+		"usage": {
+			"inputTokens": 10,
+			"outputTokens": 3,
+			"totalTokens": 13,
+			"cacheReadInputTokens": 4,
+			"cacheWriteInputTokens": 2
+		}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 16 || usage.CompletionTokens != 3 || usage.TotalTokens != 19 {
+		t.Errorf("unexpected Bedrock usage: %+v", usage)
+	}
+	if usage.CachedReadTokens != 4 || usage.CacheWriteTokens != 2 {
+		t.Errorf("unexpected Bedrock cache usage: %+v", usage)
+	}
+}
+
+func TestBedrockCalculator_NormalizeAnthropicInvokeModel(t *testing.T) {
+	c := &BedrockCalculator{}
+	usage, err := c.Normalize([]byte(`{
+		"usage": {
+			"input_tokens": 10,
+			"output_tokens": 3,
+			"cache_read_input_tokens": 4,
+			"cache_creation_input_tokens": 2
+		}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 16 || usage.CompletionTokens != 3 || usage.TotalTokens != 19 {
+		t.Errorf("unexpected Anthropic InvokeModel usage: %+v", usage)
+	}
+	if usage.CachedReadTokens != 4 || usage.CacheWriteTokens != 2 {
+		t.Errorf("unexpected Anthropic InvokeModel cache usage: %+v", usage)
+	}
+}
+
+func TestBedrockCalculator_NormalizeTitanInvokeModel(t *testing.T) {
+	c := &BedrockCalculator{}
+	usage, err := c.Normalize([]byte(`{
+		"inputTextTokenCount": 10,
+		"results": [{"tokenCount": 3}, {"tokenCount": 2}]
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 5 || usage.TotalTokens != 15 {
+		t.Errorf("unexpected Titan InvokeModel usage: %+v", usage)
+	}
+}
+
+func TestBedrockCalculator_RejectsMissingUsage(t *testing.T) {
+	if _, err := (&BedrockCalculator{}).Normalize([]byte(`{"completion":"hello"}`), nil); err == nil {
+		t.Fatal("expected a Bedrock response without token usage to fail normalization")
+	}
+}
+
+func TestBedrockCalculator_TransformedCacheUsageCost(t *testing.T) {
+	c := &BedrockCalculator{}
+	body := []byte(`{
+		"usage": {
+			"prompt_tokens": 16,
+			"completion_tokens": 3,
+			"total_tokens": 19,
+			"prompt_tokens_details": {
+				"cached_tokens": 4,
+				"cache_write_tokens": 2
+			}
+		}
+	}`)
+	usage, err := c.Normalize(body, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pricing, ok := lookupPricing(testPricingMap, "anthropic.claude-3-7-sonnet-20250219-v1:0")
+	if !ok {
+		t.Fatal("missing Bedrock Claude 3.7 Sonnet pricing")
+	}
+	// Regular input $30e-6 + output $45e-6 + cache read $1.2e-6 +
+	// cache write $7.5e-6 = $83.7e-6.
+	if got, want := genericCalculateCost(usage, pricing), 0.0000837; !almostEqual(got, want) {
+		t.Fatalf("transformed cache usage cost = %.10f, want %.10f", got, want)
+	}
+}
+
+func TestModelNameFromRequest_BedrockPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "converse inference profile",
+			path: "/model/us.anthropic.claude-3-haiku-20240307-v1:0/converse",
+			want: "us.anthropic.claude-3-haiku-20240307-v1:0",
+		},
+		{
+			name: "invoke model",
+			path: "/model/anthropic.claude-3-haiku-20240307-v1:0/invoke?trace=enabled",
+			want: "anthropic.claude-3-haiku-20240307-v1:0",
+		},
+		{
+			name: "URL encoded foundation model ARN",
+			path: "/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A%3Afoundation-model%2Fanthropic.claude-3-haiku-20240307-v1%3A0/converse-stream",
+			want: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0",
+		},
+		{
+			name: "decoded foundation model ARN",
+			path: "/model/arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0/converse",
+			want: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modelNameFromRequest(nil, tt.path); got != tt.want {
+				t.Fatalf("modelNameFromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupPricing_BedrockModelIDAliases(t *testing.T) {
+	for _, modelID := range []string{
+		"anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+	} {
+		pricing, ok := lookupPricing(testPricingMap, modelID)
+		if !ok {
+			t.Errorf("expected Bedrock pricing for %q", modelID)
+			continue
+		}
+		if pricing.Provider != "bedrock" {
+			t.Errorf("provider for %q = %q, want bedrock", modelID, pricing.Provider)
+		}
+	}
+}
+
+func TestLookupPricing_BedrockInferenceProfileFallbacks(t *testing.T) {
+	const model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+	pricingMap := map[string]ModelPricing{
+		model: {Provider: "bedrock", InputCostPerToken: 1},
+	}
+	for _, prefix := range []string{"us-gov.", "au.", "jp."} {
+		pricing, key, ok := lookupPricingWithKey(pricingMap, prefix+model)
+		if !ok {
+			t.Errorf("expected %s inference profile to fall back to foundation-model pricing", prefix)
+			continue
+		}
+		if key != model || pricing.Provider != "bedrock" {
+			t.Errorf("unexpected %s pricing match: key=%q pricing=%+v", prefix, key, pricing)
+		}
+	}
+}
+
+func TestOnResponseBodyChunk_BedrockNative_ModelFromURL(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/us.anthropic.claude-3-7-sonnet-20250219-v1:0/converse"
+	body := []byte(`{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}`)
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: body, EndOfStream: true,
+	}, nil)
+	// Claude 3.7 Sonnet on Bedrock: 10 * $3/M + 3 * $15/M = $0.000075.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
+func TestOnResponseBodyChunk_BedrockNative_CacheCost(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/converse"
+	body := []byte(`{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13,"cacheReadInputTokens":4,"cacheWriteInputTokens":2}}`)
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: body, EndOfStream: true,
+	}, nil)
+	// Regular input $30e-6 + output $45e-6 + cache read $1.2e-6 +
+	// cache write $7.5e-6 = $83.7e-6.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000837000")
+}
+
+func TestOnResponseBodyChunk_BedrockAnthropicInvokeModel(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/invoke"
+	body := []byte(`{"usage":{"input_tokens":10,"output_tokens":3}}`)
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: body, EndOfStream: true,
+	}, nil)
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
+func TestOnResponseBodyChunk_BedrockInvokeModelMissingUsage_NotCalculated(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/anthropic.claude-3-7-sonnet-20250219-v1:0/invoke"
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: []byte(`{"completion":"hello"}`), EndOfStream: true,
+	}, nil)
+	assertStreamCostMetadata(t, ctx, action, costStatusNotCalculated, "0.0000000000")
+}
+
+func TestOnResponseBodyChunk_BedrockARN_UsesCanonicalAnalyticsModel(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A%3Afoundation-model%2Fanthropic.claude-3-7-sonnet-20250219-v1%3A0/converse"
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: []byte(`{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}`), EndOfStream: true,
+	}, nil)
+	forward, ok := action.(policy.ForwardResponseChunk)
+	if !ok {
+		t.Fatalf("expected ForwardResponseChunk, got %T", action)
+	}
+	const wantModel = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+	if got := forward.AnalyticsMetadata[metadataModelID]; got != wantModel {
+		t.Fatalf("analytics model = %v, want %q", got, wantModel)
+	}
+}
+
+func TestOnResponseBodyChunk_BedrockNova_ModelFromURL(t *testing.T) {
+	p := &LLMCostPolicy{pricingMap: testPricingMap}
+	ctx := makeStreamResponseContext()
+	ctx.RequestPath = "/model/apac.amazon.nova-micro-v1:0/converse"
+	body := []byte(`{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}`)
+	action := p.OnResponseBodyChunk(context.Background(), ctx, &policy.StreamBody{
+		Chunk: body, EndOfStream: true,
+	}, nil)
+	// Nova Micro APAC: 10 * $0.037/M + 3 * $0.148/M = $0.000000814.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000008140")
+}
+
+func TestOnResponseBodyChunk_SSE_BedrockTransformed_Calculated(t *testing.T) {
+	const model = "anthropic.claude-3-haiku-20240307-v1:0"
+	pricingMap := map[string]ModelPricing{
+		model: {
+			Provider:           "bedrock",
+			InputCostPerToken:  2.5e-7,
+			OutputCostPerToken: 1.25e-6,
+		},
+	}
+	p := &LLMCostPolicy{pricingMap: pricingMap}
+	body := []byte(
+		"data: {\"id\":\"chatcmpl-bedrock\",\"model\":\"" + model + "\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n" +
+			"data: {\"id\":\"chatcmpl-bedrock\",\"model\":\"" + model + "\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":3,\"total_tokens\":13}}\n" +
+			"data: [DONE]\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{body})
+	// 10 * 2.5e-7 + 3 * 1.25e-6 = 6.25e-6.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000062500")
+	fwd, ok := action.(policy.ForwardResponseChunk)
+	if !ok {
+		t.Fatalf("expected ForwardResponseChunk, got %T", action)
+	}
+	wantAnalytics := map[string]any{
+		MetadataLLMCost:              6.25e-6,
+		metadataModelID:              model,
+		metadataPromptTokenCount:     "10",
+		metadataCompletionTokenCount: "3",
+		metadataTotalTokenCount:      "13",
+	}
+	for key, want := range wantAnalytics {
+		if got := fwd.AnalyticsMetadata[key]; got != want {
+			t.Errorf("analytics metadata %q = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Mistral calculator
 // ---------------------------------------------------------------------------
 

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v1.0.3
+version: v1.0.4
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").
@@ -9,7 +9,9 @@ description: |
   for Gemini native format), looks it up in the pricing database, normalises
   the usage object using a provider-specific calculator, and computes the cost.
 
-  Supported providers: OpenAI, Anthropic, Gemini (Google AI Studio + Vertex AI), Mistral.
+  Supported providers: OpenAI, Anthropic, Gemini (Google AI Studio + Vertex AI),
+  Mistral, native AWS Bedrock Converse/InvokeModel responses, and Bedrock
+  responses translated to OpenAI format by the openai-to-bedrock-transformer policy.
 
   Notes:
   - This policy runs in the response phase only.

--- a/policies/llm-cost/pricing.go
+++ b/policies/llm-cost/pricing.go
@@ -118,12 +118,13 @@ type ModelPricing struct {
 	CacheReadInputTokenCostFlex float64 `json:"cache_read_input_token_cost_flex"`
 
 	// Prompt caching
-	CacheReadInputTokenCost              float64 `json:"cache_read_input_token_cost"`
-	CacheCreationInputTokenCost          float64 `json:"cache_creation_input_token_cost"`
-	CacheCreationInputTokenCostAbove1hr  float64 `json:"cache_creation_input_token_cost_above_1hr"`
-	CacheReadInputTokenCostAbove200k     float64 `json:"cache_read_input_token_cost_above_200k_tokens"`
-	CacheCreationInputTokenCostAbove200k float64 `json:"cache_creation_input_token_cost_above_200k_tokens"`
-	CacheReadInputTokenCostAbove272k     float64 `json:"cache_read_input_token_cost_above_272k_tokens"`
+	CacheReadInputTokenCost                      float64 `json:"cache_read_input_token_cost"`
+	CacheCreationInputTokenCost                  float64 `json:"cache_creation_input_token_cost"`
+	CacheCreationInputTokenCostAbove1hr          float64 `json:"cache_creation_input_token_cost_above_1hr"`
+	CacheReadInputTokenCostAbove200k             float64 `json:"cache_read_input_token_cost_above_200k_tokens"`
+	CacheCreationInputTokenCostAbove200k         float64 `json:"cache_creation_input_token_cost_above_200k_tokens"`
+	CacheCreationInputTokenCostAbove1hrAbove200k float64 `json:"cache_creation_input_token_cost_above_1hr_above_200k_tokens"`
+	CacheReadInputTokenCostAbove272k             float64 `json:"cache_read_input_token_cost_above_272k_tokens"`
 
 	// Cached audio token read rate (Gemini models with separate audio caching cost).
 	// When set, cached audio input tokens are billed at this rate instead of
@@ -437,9 +438,12 @@ func resolveRates(usage Usage, pricing ModelPricing) effectiveRates {
 		}
 		if pricing.CacheCreationInputTokenCostAbove200k > 0 {
 			r.cacheWrite5m = pricing.CacheCreationInputTokenCostAbove200k
-			// TODO: if Anthropic ever defines cache_creation_input_token_cost_above_1hr_above_200k_tokens,
-			// select it here. For now, the >200k write rate applies to both TTLs.
+			// Preserve the previous fallback for pricing entries that define only
+			// a general >200k cache-write rate.
 			r.cacheWrite1h = pricing.CacheCreationInputTokenCostAbove200k
+		}
+		if pricing.CacheCreationInputTokenCostAbove1hrAbove200k > 0 {
+			r.cacheWrite1h = pricing.CacheCreationInputTokenCostAbove1hrAbove200k
 		}
 	case tierTokens > 128_000 && pricing.InputCostPerTokenAbove128k > 0:
 		r.input = pricing.InputCostPerTokenAbove128k

--- a/policies/llm-cost/pricing.go
+++ b/policies/llm-cost/pricing.go
@@ -266,6 +266,8 @@ func selectCalculator(provider string) providerCalculator {
 		return &GeminiCalculator{}
 	case "mistral":
 		return &MistralCalculator{}
+	case "bedrock":
+		return &BedrockCalculator{}
 	default:
 		return nil
 	}
@@ -276,40 +278,69 @@ func selectCalculator(provider string) providerCalculator {
 // knownProviderPrefixes are namespaces where the API returns bare model names
 // but the pricing key is namespaced (e.g. "mistral-large-latest" → "mistral/mistral-large-latest").
 var knownProviderPrefixes = []string{
+	"bedrock/",
 	"mistral/",
 	"vertex_ai/",
 }
 
+var bedrockInferenceProfilePrefixes = []string{
+	"us-gov.", "us.", "eu.", "apac.", "global.", "au.", "jp.",
+}
+
 func lookupPricing(pricingMap map[string]ModelPricing, modelName string) (ModelPricing, bool) {
+	pricing, _, found := lookupPricingWithKey(pricingMap, modelName)
+	return pricing, found
+}
+
+// lookupPricingWithKey returns both the pricing record and the canonical key
+// that matched it. The key is used for analytics so URL ARNs and bare model IDs
+// do not create separate model dimensions for the same pricing entry.
+func lookupPricingWithKey(pricingMap map[string]ModelPricing, modelName string) (ModelPricing, string, bool) {
 	// Canonicalize to lowercase once upfront so all comparisons are case-insensitive.
-	modelName = strings.ToLower(modelName)
+	modelName = strings.ToLower(strings.TrimSpace(modelName))
 
 	// tryMatch checks the map and also runs progressive suffix stripping on candidate.
-	tryMatch := func(candidate string) (ModelPricing, bool) {
+	tryMatch := func(candidate string) (ModelPricing, string, bool) {
 		if p, ok := pricingMap[candidate]; ok {
-			return p, true
+			return p, candidate, true
 		}
 		// Progressive suffix stripping: "gpt-4o-2024-11-20" → "gpt-4o-2024-11" → "gpt-4o-2024" → "gpt-4o"
 		parts := strings.Split(candidate, "-")
 		for i := len(parts) - 1; i >= 1; i-- {
-			if p, ok := pricingMap[strings.Join(parts[:i], "-")]; ok {
-				return p, true
+			key := strings.Join(parts[:i], "-")
+			if p, ok := pricingMap[key]; ok {
+				return p, key, true
 			}
 		}
-		return ModelPricing{}, false
+		return ModelPricing{}, "", false
 	}
 
 	// 1. Exact match (with suffix stripping).
-	if p, ok := tryMatch(modelName); ok {
-		return p, true
+	if p, key, ok := tryMatch(modelName); ok {
+		return p, key, true
+	}
+
+	// Bedrock may identify a foundation model through a cross-region inference
+	// profile (for example "us.anthropic.claude-...") or a URL-encoded ARN.
+	// Exact profile-specific pricing wins above; these aliases are fallbacks for
+	// pricing files that contain only the underlying foundation-model ID.
+	for _, alias := range bedrockModelAliases(modelName) {
+		if p, key, ok := tryMatch(alias); ok {
+			return p, key, true
+		}
+		if !strings.Contains(alias, "/") {
+			if p, key, ok := tryMatch("bedrock/" + alias); ok {
+				return p, key, true
+			}
+		}
 	}
 
 	// 2. Strip provider-prefix duplicates: some responses echo "openai/gpt-4o"
 	//    but the JSON key is "gpt-4o".
 	if idx := strings.Index(modelName, "/"); idx != -1 {
 		bare := modelName[idx+1:]
-		if p, ok := tryMatch(bare); ok {
-			return p, true
+		if p, key, ok := tryMatch(bare); ok {
+			return p, key, true
 		}
 	}
 
@@ -319,13 +350,38 @@ func lookupPricing(pricingMap map[string]ModelPricing, modelName string) (ModelP
 	//    (e.g. "mistral/mistral-large-latest").
 	if !strings.Contains(modelName, "/") {
 		for _, prefix := range knownProviderPrefixes {
-			if p, ok := tryMatch(prefix + modelName); ok {
-				return p, true
+			if p, key, ok := tryMatch(prefix + modelName); ok {
+				return p, key, true
 			}
 		}
 	}
 
-	return ModelPricing{}, false
+	return ModelPricing{}, "", false
+}
+
+// bedrockModelAliases returns canonical model IDs for Bedrock foundation-model
+// and system-defined inference-profile identifiers. Application/provisioned
+// profile IDs cannot be resolved locally because they do not encode a model ID.
+func bedrockModelAliases(modelName string) []string {
+	candidate := strings.TrimPrefix(modelName, "bedrock/")
+	for _, marker := range []string{"foundation-model/", "inference-profile/"} {
+		if i := strings.Index(candidate, marker); i >= 0 {
+			candidate = candidate[i+len(marker):]
+			break
+		}
+	}
+
+	aliases := make([]string, 0, 2)
+	if candidate != modelName {
+		aliases = append(aliases, candidate)
+	}
+	for _, prefix := range bedrockInferenceProfilePrefixes {
+		if strings.HasPrefix(candidate, prefix) {
+			aliases = append(aliases, strings.TrimPrefix(candidate, prefix))
+			break
+		}
+	}
+	return aliases
 }
 
 // effectiveRates holds the resolved per-token rates after applying context-window

--- a/policies/llm-cost/testdata/model_prices.json
+++ b/policies/llm-cost/testdata/model_prices.json
@@ -6897,5 +6897,1638 @@
     "provider": "openai",
     "input_cost_per_second": 0.0001,
     "output_cost_per_second": 0.0001
+  },
+  "amazon.nova-2-lite-v1:0": {
+    "cache_read_input_token_cost": 7.5E-8,
+    "input_cost_per_token": 3E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000025,
+    "provider": "bedrock"
+  },
+  "amazon.nova-2-pro-preview-20251202-v1:0": {
+    "cache_read_input_token_cost": 5.46875E-7,
+    "input_cost_per_token": 0.0000021875,
+    "input_cost_per_image_token": 0.0000021875,
+    "input_cost_per_audio_token": 0.0000021875,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000175,
+    "provider": "bedrock"
+  },
+  "amazon.nova-lite-v1:0": {
+    "input_cost_per_token": 6E-8,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 2.4E-7,
+    "provider": "bedrock"
+  },
+  "amazon.nova-micro-v1:0": {
+    "input_cost_per_token": 3.5E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 1.4E-7,
+    "provider": "bedrock"
+  },
+  "amazon.nova-pro-v1:0": {
+    "input_cost_per_token": 8E-7,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 0.0000032,
+    "provider": "bedrock"
+  },
+  "anthropic.claude-3-7-sonnet-20250219-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.000015,
+    "provider": "bedrock"
+  },
+  "anthropic.claude-fable-5": {
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_above_1hr": 0.00002,
+    "cache_read_input_token_cost": 0.000001,
+    "input_cost_per_token": 0.00001,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.00005,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_creation_input_token_cost_above_1hr": 0.000002,
+    "cache_read_input_token_cost": 1E-7,
+    "input_cost_per_token": 0.000001,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000005,
+    "provider": "bedrock"
+  },
+  "anthropic.claude-haiku-4-5@20251001": {
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_creation_input_token_cost_above_1hr": 0.000002,
+    "cache_read_input_token_cost": 1E-7,
+    "input_cost_per_token": 0.000001,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000005,
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-1-20250805-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-5-20251101-v1:0": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-6-v1": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-sonnet-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_1hr": 0.000006,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.000012,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_1hr": 0.000006,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_creation_input_token_cost_above_1hr": 0.000004,
+    "cache_read_input_token_cost": 2E-7,
+    "input_cost_per_token": 0.000002,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.00001,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "apac.amazon.nova-2-lite-v1:0": {
+    "cache_read_input_token_cost": 8.25E-8,
+    "input_cost_per_token": 3.3E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.00000275,
+    "provider": "bedrock"
+  },
+  "apac.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "cache_read_input_token_cost": 5.46875E-7,
+    "input_cost_per_token": 0.0000021875,
+    "input_cost_per_image_token": 0.0000021875,
+    "input_cost_per_audio_token": 0.0000021875,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000175,
+    "provider": "bedrock"
+  },
+  "apac.amazon.nova-lite-v1:0": {
+    "input_cost_per_token": 6.3E-8,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 2.52E-7,
+    "provider": "bedrock"
+  },
+  "apac.amazon.nova-micro-v1:0": {
+    "input_cost_per_token": 3.7E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 1.48E-7,
+    "provider": "bedrock"
+  },
+  "apac.amazon.nova-pro-v1:0": {
+    "input_cost_per_token": 8.4E-7,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 0.00000336,
+    "provider": "bedrock"
+  },
+  "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1E-7,
+    "input_cost_per_token": 0.0000011,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000055,
+    "provider": "bedrock"
+  },
+  "apac.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_creation_input_token_cost_above_1hr": 0.0000022,
+    "cache_read_input_token_cost": 1.1E-7,
+    "input_cost_per_token": 0.0000011,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000055,
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-opus-4-6-v1": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "input_cost_per_token_above_200k_tokens": 0.0000066,
+    "output_cost_per_token_above_200k_tokens": 0.00002475,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "au.anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_creation_input_token_cost_above_1hr": 0.0000044,
+    "cache_read_input_token_cost": 2.2E-7,
+    "input_cost_per_token": 0.0000022,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000011,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "deepseek.v3-v1:0": {
+    "input_cost_per_token": 5.8E-7,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 81920,
+    "max_tokens": 81920,
+    "output_cost_per_token": 0.00000168,
+    "provider": "bedrock"
+  },
+  "deepseek.v3.2": {
+    "input_cost_per_token": 6.2E-7,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "max_tokens": 163840,
+    "output_cost_per_token": 0.00000185,
+    "provider": "bedrock"
+  },
+  "eu.amazon.nova-2-lite-v1:0": {
+    "cache_read_input_token_cost": 8.25E-8,
+    "input_cost_per_token": 3.3E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.00000275,
+    "provider": "bedrock"
+  },
+  "eu.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "cache_read_input_token_cost": 5.46875E-7,
+    "input_cost_per_token": 0.0000021875,
+    "input_cost_per_image_token": 0.0000021875,
+    "input_cost_per_audio_token": 0.0000021875,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000175,
+    "provider": "bedrock"
+  },
+  "eu.amazon.nova-lite-v1:0": {
+    "input_cost_per_token": 7.8E-8,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 3.12E-7,
+    "provider": "bedrock"
+  },
+  "eu.amazon.nova-micro-v1:0": {
+    "input_cost_per_token": 4.6E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 1.84E-7,
+    "provider": "bedrock"
+  },
+  "eu.amazon.nova-pro-v1:0": {
+    "input_cost_per_token": 0.00000105,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 0.0000042,
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-fable-5": {
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_creation_input_token_cost_above_1hr": 0.000022,
+    "cache_read_input_token_cost": 0.0000011,
+    "input_cost_per_token": 0.000011,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000055,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_creation_input_token_cost_above_1hr": 0.0000022,
+    "cache_read_input_token_cost": 1.1E-7,
+    "input_cost_per_token": 0.0000011,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000055,
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-1-20250805-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-6-v1": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "input_cost_per_token_above_200k_tokens": 0.0000066,
+    "output_cost_per_token_above_200k_tokens": 0.00002475,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_creation_input_token_cost_above_1hr": 0.0000044,
+    "cache_read_input_token_cost": 2.2E-7,
+    "input_cost_per_token": 0.0000022,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000011,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "eu.deepseek.v3.2": {
+    "input_cost_per_token": 7.4E-7,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "max_tokens": 163840,
+    "output_cost_per_token": 0.00000222,
+    "provider": "bedrock"
+  },
+  "eu.mistral.pixtral-large-2502-v1:0": {
+    "input_cost_per_token": 0.000002,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 0.000006,
+    "provider": "bedrock"
+  },
+  "global.amazon.nova-2-lite-v1:0": {
+    "cache_read_input_token_cost": 7.5E-8,
+    "input_cost_per_token": 3E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000025,
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-fable-5": {
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_above_1hr": 0.00002,
+    "cache_read_input_token_cost": 0.000001,
+    "input_cost_per_token": 0.00001,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.00005,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_creation_input_token_cost_above_1hr": 0.000002,
+    "cache_read_input_token_cost": 1E-7,
+    "input_cost_per_token": 0.000001,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000005,
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-opus-4-6-v1": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_creation_input_token_cost_above_1hr": 0.00001,
+    "cache_read_input_token_cost": 5E-7,
+    "input_cost_per_token": 0.000005,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000025,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_1hr": 0.000006,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.000012,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_1hr": 0.000006,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "global.anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_creation_input_token_cost_above_1hr": 0.000004,
+    "cache_read_input_token_cost": 2E-7,
+    "input_cost_per_token": 0.000002,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.00001,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "google.gemma-3-12b-it": {
+    "input_cost_per_token": 9E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 2.9E-7,
+    "provider": "bedrock"
+  },
+  "google.gemma-3-27b-it": {
+    "input_cost_per_token": 2.3E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 3.8E-7,
+    "provider": "bedrock"
+  },
+  "google.gemma-3-4b-it": {
+    "input_cost_per_token": 4E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 8E-8,
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_creation_input_token_cost_above_1hr": 0.0000022,
+    "cache_read_input_token_cost": 1.1E-7,
+    "input_cost_per_token": 0.0000011,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000055,
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "input_cost_per_token_above_200k_tokens": 0.0000066,
+    "output_cost_per_token_above_200k_tokens": 0.00002475,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "jp.anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_creation_input_token_cost_above_1hr": 0.0000044,
+    "cache_read_input_token_cost": 2.2E-7,
+    "input_cost_per_token": 0.0000022,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000011,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "meta.llama3-3-70b-instruct-v1:0": {
+    "input_cost_per_token": 7.2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 7.2E-7,
+    "provider": "bedrock"
+  },
+  "meta.llama4-maverick-17b-instruct-v1:0": {
+    "input_cost_per_token": 2.4E-7,
+    "input_cost_per_token_batches": 1.2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 9.7E-7,
+    "output_cost_per_token_batches": 4.85E-7,
+    "provider": "bedrock"
+  },
+  "meta.llama4-scout-17b-instruct-v1:0": {
+    "input_cost_per_token": 1.7E-7,
+    "input_cost_per_token_batches": 8.5E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 6.6E-7,
+    "output_cost_per_token_batches": 3.3E-7,
+    "provider": "bedrock"
+  },
+  "minimax.minimax-m2": {
+    "input_cost_per_token": 3E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000012,
+    "provider": "bedrock"
+  },
+  "minimax.minimax-m2.1": {
+    "input_cost_per_token": 3E-7,
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000012,
+    "provider": "bedrock"
+  },
+  "minimax.minimax-m2.5": {
+    "input_cost_per_token": 3E-7,
+    "output_cost_per_token": 0.0000012,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "provider": "bedrock"
+  },
+  "mistral.devstral-2-123b": {
+    "input_cost_per_token": 4E-7,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.000002,
+    "provider": "bedrock"
+  },
+  "mistral.magistral-small-2509": {
+    "input_cost_per_token": 5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000015,
+    "provider": "bedrock"
+  },
+  "mistral.ministral-3-14b-instruct": {
+    "input_cost_per_token": 2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 2E-7,
+    "provider": "bedrock"
+  },
+  "mistral.ministral-3-3b-instruct": {
+    "input_cost_per_token": 1E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 1E-7,
+    "provider": "bedrock"
+  },
+  "mistral.ministral-3-8b-instruct": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 1.5E-7,
+    "provider": "bedrock"
+  },
+  "mistral.mistral-large-3-675b-instruct": {
+    "input_cost_per_token": 5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000015,
+    "provider": "bedrock"
+  },
+  "mistral.voxtral-mini-3b-2507": {
+    "input_cost_per_token": 4E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 4E-8,
+    "provider": "bedrock"
+  },
+  "mistral.voxtral-small-24b-2507": {
+    "input_cost_per_token": 1E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 3E-7,
+    "provider": "bedrock"
+  },
+  "moonshot.kimi-k2-thinking": {
+    "input_cost_per_token": 6E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000025,
+    "provider": "bedrock"
+  },
+  "moonshotai.kimi-k2.5": {
+    "input_cost_per_token": 6E-7,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "max_tokens": 262144,
+    "output_cost_per_token": 0.000003,
+    "provider": "bedrock"
+  },
+  "nvidia.nemotron-nano-12b-v2": {
+    "input_cost_per_token": 2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 6E-7,
+    "provider": "bedrock"
+  },
+  "nvidia.nemotron-nano-3-30b": {
+    "input_cost_per_token": 6E-8,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 2.4E-7,
+    "provider": "bedrock"
+  },
+  "nvidia.nemotron-nano-9b-v2": {
+    "input_cost_per_token": 6E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 2.3E-7,
+    "provider": "bedrock"
+  },
+  "nvidia.nemotron-super-3-120b": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32768,
+    "max_tokens": 32768,
+    "output_cost_per_token": 6.5E-7,
+    "provider": "bedrock"
+  },
+  "openai.gpt-oss-120b-1:0": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 6E-7,
+    "provider": "bedrock"
+  },
+  "openai.gpt-oss-20b-1:0": {
+    "input_cost_per_token": 7E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 3E-7,
+    "provider": "bedrock"
+  },
+  "openai.gpt-oss-safeguard-120b": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 6E-7,
+    "provider": "bedrock"
+  },
+  "openai.gpt-oss-safeguard-20b": {
+    "input_cost_per_token": 7E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 2E-7,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-235b-a22b-2507-v1:0": {
+    "input_cost_per_token": 2.2E-7,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "max_tokens": 131072,
+    "output_cost_per_token": 8.8E-7,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-32b-v1:0": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "max_tokens": 16384,
+    "output_cost_per_token": 6E-7,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-coder-30b-a3b-v1:0": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "max_tokens": 131072,
+    "output_cost_per_token": 6E-7,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-coder-480b-a35b-v1:0": {
+    "input_cost_per_token": 2.2E-7,
+    "max_input_tokens": 262000,
+    "max_output_tokens": 65536,
+    "max_tokens": 65536,
+    "output_cost_per_token": 0.0000018,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-coder-next": {
+    "input_cost_per_token": 5E-7,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000012,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-next-80b-a3b": {
+    "input_cost_per_token": 1.5E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.0000012,
+    "provider": "bedrock"
+  },
+  "qwen.qwen3-vl-235b-a22b": {
+    "input_cost_per_token": 5.3E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.00000266,
+    "provider": "bedrock"
+  },
+  "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_creation_input_token_cost_above_1hr": 0.0000072,
+    "cache_read_input_token_cost": 3.6E-7,
+    "input_cost_per_token": 0.0000036,
+    "input_cost_per_token_above_200k_tokens": 0.0000072,
+    "output_cost_per_token_above_200k_tokens": 0.000027,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.000009,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000144,
+    "cache_read_input_token_cost_above_200k_tokens": 7.2E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000018,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-2-lite-v1:0": {
+    "cache_read_input_token_cost": 8.25E-8,
+    "input_cost_per_token": 3.3E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.00000275,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "cache_read_input_token_cost": 5.46875E-7,
+    "input_cost_per_token": 0.0000021875,
+    "input_cost_per_image_token": 0.0000021875,
+    "input_cost_per_audio_token": 0.0000021875,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000175,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-lite-v1:0": {
+    "input_cost_per_token": 6E-8,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 2.4E-7,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-micro-v1:0": {
+    "input_cost_per_token": 3.5E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 1.4E-7,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-premier-v1:0": {
+    "input_cost_per_token": 0.0000025,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 0.0000125,
+    "provider": "bedrock"
+  },
+  "us.amazon.nova-pro-v1:0": {
+    "input_cost_per_token": 8E-7,
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "max_tokens": 10000,
+    "output_cost_per_token": 0.0000032,
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.000015,
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-fable-5": {
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_creation_input_token_cost_above_1hr": 0.000022,
+    "cache_read_input_token_cost": 0.0000011,
+    "input_cost_per_token": 0.000011,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000055,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_creation_input_token_cost_above_1hr": 0.0000022,
+    "cache_read_input_token_cost": 1.1E-7,
+    "input_cost_per_token": 0.0000011,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000055,
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "input_cost_per_token": 0.000015,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "max_tokens": 32000,
+    "output_cost_per_token": 0.000075,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-6-v1": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-7": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-opus-4-8": {
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_creation_input_token_cost_above_1hr": 0.000011,
+    "cache_read_input_token_cost": 5.5E-7,
+    "input_cost_per_token": 0.0000055,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000275,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3E-7,
+    "input_cost_per_token": 0.000003,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.000015,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "input_cost_per_token_above_200k_tokens": 0.0000066,
+    "output_cost_per_token_above_200k_tokens": 0.00002475,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
+    "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_1hr": 0.0000066,
+    "cache_read_input_token_cost": 3.3E-7,
+    "input_cost_per_token": 0.0000033,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "output_cost_per_token": 0.0000165,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.anthropic.claude-sonnet-5": {
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_creation_input_token_cost_above_1hr": 0.0000044,
+    "cache_read_input_token_cost": 2.2E-7,
+    "input_cost_per_token": 0.0000022,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.000011,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "provider": "bedrock"
+  },
+  "us.deepseek.r1-v1:0": {
+    "input_cost_per_token": 0.00000135,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 0.0000054,
+    "provider": "bedrock"
+  },
+  "us.deepseek.v3.2": {
+    "input_cost_per_token": 6.2E-7,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "max_tokens": 163840,
+    "output_cost_per_token": 0.00000185,
+    "provider": "bedrock"
+  },
+  "us.meta.llama3-3-70b-instruct-v1:0": {
+    "input_cost_per_token": 7.2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 7.2E-7,
+    "provider": "bedrock"
+  },
+  "us.meta.llama4-maverick-17b-instruct-v1:0": {
+    "input_cost_per_token": 2.4E-7,
+    "input_cost_per_token_batches": 1.2E-7,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 9.7E-7,
+    "output_cost_per_token_batches": 4.85E-7,
+    "provider": "bedrock"
+  },
+  "us.meta.llama4-scout-17b-instruct-v1:0": {
+    "input_cost_per_token": 1.7E-7,
+    "input_cost_per_token_batches": 8.5E-8,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 6.6E-7,
+    "output_cost_per_token_batches": 3.3E-7,
+    "provider": "bedrock"
+  },
+  "us.mistral.pixtral-large-2502-v1:0": {
+    "input_cost_per_token": 0.000002,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "output_cost_per_token": 0.000006,
+    "provider": "bedrock"
+  },
+  "us.writer.palmyra-x4-v1:0": {
+    "input_cost_per_token": 0.0000025,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.00001,
+    "provider": "bedrock"
+  },
+  "us.writer.palmyra-x5-v1:0": {
+    "input_cost_per_token": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.000006,
+    "provider": "bedrock"
+  },
+  "writer.palmyra-x4-v1:0": {
+    "input_cost_per_token": 0.0000025,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.00001,
+    "provider": "bedrock"
+  },
+  "writer.palmyra-x5-v1:0": {
+    "input_cost_per_token": 6E-7,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "output_cost_per_token": 0.000006,
+    "provider": "bedrock"
+  },
+  "zai.glm-4.7": {
+    "input_cost_per_token": 6E-7,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 0.0000022,
+    "provider": "bedrock"
+  },
+  "zai.glm-4.7-flash": {
+    "input_cost_per_token": 7E-8,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "output_cost_per_token": 4E-7,
+    "provider": "bedrock"
+  },
+  "zai.glm-5": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "provider": "bedrock"
   }
 }

--- a/policies/llm-cost/testdata/model_prices.json
+++ b/policies/llm-cost/testdata/model_prices.json
@@ -6899,8 +6899,8 @@
     "output_cost_per_second": 0.0001
   },
   "amazon.nova-2-lite-v1:0": {
-    "cache_read_input_token_cost": 7.5E-8,
-    "input_cost_per_token": 3E-7,
+    "cache_read_input_token_cost": 7.5e-08,
+    "input_cost_per_token": 3e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -6908,7 +6908,7 @@
     "provider": "bedrock"
   },
   "amazon.nova-2-pro-preview-20251202-v1:0": {
-    "cache_read_input_token_cost": 5.46875E-7,
+    "cache_read_input_token_cost": 5.46875e-07,
     "input_cost_per_token": 0.0000021875,
     "input_cost_per_image_token": 0.0000021875,
     "input_cost_per_audio_token": 0.0000021875,
@@ -6919,23 +6919,23 @@
     "provider": "bedrock"
   },
   "amazon.nova-lite-v1:0": {
-    "input_cost_per_token": 6E-8,
+    "input_cost_per_token": 6e-08,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 2.4E-7,
+    "output_cost_per_token": 2.4e-07,
     "provider": "bedrock"
   },
   "amazon.nova-micro-v1:0": {
-    "input_cost_per_token": 3.5E-8,
+    "input_cost_per_token": 3.5e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 1.4E-7,
+    "output_cost_per_token": 1.4e-07,
     "provider": "bedrock"
   },
   "amazon.nova-pro-v1:0": {
-    "input_cost_per_token": 8E-7,
+    "input_cost_per_token": 8e-07,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
@@ -6944,7 +6944,7 @@
   },
   "anthropic.claude-3-7-sonnet-20250219-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -6971,7 +6971,7 @@
   "anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.00000125,
     "cache_creation_input_token_cost_above_1hr": 0.000002,
-    "cache_read_input_token_cost": 1E-7,
+    "cache_read_input_token_cost": 1e-07,
     "input_cost_per_token": 0.000001,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -6982,7 +6982,7 @@
   "anthropic.claude-haiku-4-5@20251001": {
     "cache_creation_input_token_cost": 0.00000125,
     "cache_creation_input_token_cost_above_1hr": 0.000002,
-    "cache_read_input_token_cost": 1E-7,
+    "cache_read_input_token_cost": 1e-07,
     "input_cost_per_token": 0.000001,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7023,7 +7023,7 @@
   "anthropic.claude-opus-4-5-20251101-v1:0": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7039,7 +7039,7 @@
   "anthropic.claude-opus-4-6-v1": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7055,7 +7055,7 @@
   "anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7071,7 +7071,7 @@
   "anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7086,12 +7086,12 @@
   },
   "anthropic.claude-sonnet-4-20250514-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7106,13 +7106,13 @@
   "anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
     "cache_creation_input_token_cost_above_1hr": 0.000006,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.000012,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7127,7 +7127,7 @@
   "anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.00000375,
     "cache_creation_input_token_cost_above_1hr": 0.000006,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -7143,7 +7143,7 @@
   "anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.0000025,
     "cache_creation_input_token_cost_above_1hr": 0.000004,
-    "cache_read_input_token_cost": 2E-7,
+    "cache_read_input_token_cost": 2e-07,
     "input_cost_per_token": 0.000002,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7157,8 +7157,8 @@
     "provider": "bedrock"
   },
   "apac.amazon.nova-2-lite-v1:0": {
-    "cache_read_input_token_cost": 8.25E-8,
-    "input_cost_per_token": 3.3E-7,
+    "cache_read_input_token_cost": 8.25e-08,
+    "input_cost_per_token": 3.3e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7166,7 +7166,7 @@
     "provider": "bedrock"
   },
   "apac.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "cache_read_input_token_cost": 5.46875E-7,
+    "cache_read_input_token_cost": 5.46875e-07,
     "input_cost_per_token": 0.0000021875,
     "input_cost_per_image_token": 0.0000021875,
     "input_cost_per_audio_token": 0.0000021875,
@@ -7177,23 +7177,23 @@
     "provider": "bedrock"
   },
   "apac.amazon.nova-lite-v1:0": {
-    "input_cost_per_token": 6.3E-8,
+    "input_cost_per_token": 6.3e-08,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 2.52E-7,
+    "output_cost_per_token": 2.52e-07,
     "provider": "bedrock"
   },
   "apac.amazon.nova-micro-v1:0": {
-    "input_cost_per_token": 3.7E-8,
+    "input_cost_per_token": 3.7e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 1.48E-7,
+    "output_cost_per_token": 1.48e-07,
     "provider": "bedrock"
   },
   "apac.amazon.nova-pro-v1:0": {
-    "input_cost_per_token": 8.4E-7,
+    "input_cost_per_token": 8.4e-07,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
@@ -7202,7 +7202,7 @@
   },
   "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1E-7,
+    "cache_read_input_token_cost": 1.1e-07,
     "input_cost_per_token": 0.0000011,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7212,12 +7212,12 @@
   },
   "apac.anthropic.claude-sonnet-4-20250514-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7232,7 +7232,7 @@
   "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.000001375,
     "cache_creation_input_token_cost_above_1hr": 0.0000022,
-    "cache_read_input_token_cost": 1.1E-7,
+    "cache_read_input_token_cost": 1.1e-07,
     "input_cost_per_token": 0.0000011,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7243,7 +7243,7 @@
   "au.anthropic.claude-opus-4-6-v1": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7259,7 +7259,7 @@
   "au.anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7275,7 +7275,7 @@
   "au.anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7291,13 +7291,13 @@
   "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "input_cost_per_token_above_200k_tokens": 0.0000066,
     "output_cost_per_token_above_200k_tokens": 0.00002475,
     "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
-    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7312,7 +7312,7 @@
   "au.anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -7328,7 +7328,7 @@
   "au.anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.00000275,
     "cache_creation_input_token_cost_above_1hr": 0.0000044,
-    "cache_read_input_token_cost": 2.2E-7,
+    "cache_read_input_token_cost": 2.2e-07,
     "input_cost_per_token": 0.0000022,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7342,7 +7342,7 @@
     "provider": "bedrock"
   },
   "deepseek.v3-v1:0": {
-    "input_cost_per_token": 5.8E-7,
+    "input_cost_per_token": 5.8e-07,
     "max_input_tokens": 163840,
     "max_output_tokens": 81920,
     "max_tokens": 81920,
@@ -7350,7 +7350,7 @@
     "provider": "bedrock"
   },
   "deepseek.v3.2": {
-    "input_cost_per_token": 6.2E-7,
+    "input_cost_per_token": 6.2e-07,
     "max_input_tokens": 163840,
     "max_output_tokens": 163840,
     "max_tokens": 163840,
@@ -7358,8 +7358,8 @@
     "provider": "bedrock"
   },
   "eu.amazon.nova-2-lite-v1:0": {
-    "cache_read_input_token_cost": 8.25E-8,
-    "input_cost_per_token": 3.3E-7,
+    "cache_read_input_token_cost": 8.25e-08,
+    "input_cost_per_token": 3.3e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7367,7 +7367,7 @@
     "provider": "bedrock"
   },
   "eu.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "cache_read_input_token_cost": 5.46875E-7,
+    "cache_read_input_token_cost": 5.46875e-07,
     "input_cost_per_token": 0.0000021875,
     "input_cost_per_image_token": 0.0000021875,
     "input_cost_per_audio_token": 0.0000021875,
@@ -7378,19 +7378,19 @@
     "provider": "bedrock"
   },
   "eu.amazon.nova-lite-v1:0": {
-    "input_cost_per_token": 7.8E-8,
+    "input_cost_per_token": 7.8e-08,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 3.12E-7,
+    "output_cost_per_token": 3.12e-07,
     "provider": "bedrock"
   },
   "eu.amazon.nova-micro-v1:0": {
-    "input_cost_per_token": 4.6E-8,
+    "input_cost_per_token": 4.6e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 1.84E-7,
+    "output_cost_per_token": 1.84e-07,
     "provider": "bedrock"
   },
   "eu.amazon.nova-pro-v1:0": {
@@ -7420,7 +7420,7 @@
   "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.000001375,
     "cache_creation_input_token_cost_above_1hr": 0.0000022,
-    "cache_read_input_token_cost": 1.1E-7,
+    "cache_read_input_token_cost": 1.1e-07,
     "input_cost_per_token": 0.0000011,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7460,7 +7460,7 @@
   },
   "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
     "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7476,7 +7476,7 @@
   "eu.anthropic.claude-opus-4-6-v1": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7492,7 +7492,7 @@
   "eu.anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7508,7 +7508,7 @@
   "eu.anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7523,12 +7523,12 @@
   },
   "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7543,13 +7543,13 @@
   "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "input_cost_per_token_above_200k_tokens": 0.0000066,
     "output_cost_per_token_above_200k_tokens": 0.00002475,
     "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
-    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7564,7 +7564,7 @@
   "eu.anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -7580,7 +7580,7 @@
   "eu.anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.00000275,
     "cache_creation_input_token_cost_above_1hr": 0.0000044,
-    "cache_read_input_token_cost": 2.2E-7,
+    "cache_read_input_token_cost": 2.2e-07,
     "input_cost_per_token": 0.0000022,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7594,7 +7594,7 @@
     "provider": "bedrock"
   },
   "eu.deepseek.v3.2": {
-    "input_cost_per_token": 7.4E-7,
+    "input_cost_per_token": 7.4e-07,
     "max_input_tokens": 163840,
     "max_output_tokens": 163840,
     "max_tokens": 163840,
@@ -7610,8 +7610,8 @@
     "provider": "bedrock"
   },
   "global.amazon.nova-2-lite-v1:0": {
-    "cache_read_input_token_cost": 7.5E-8,
-    "input_cost_per_token": 3E-7,
+    "cache_read_input_token_cost": 7.5e-08,
+    "input_cost_per_token": 3e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7637,7 +7637,7 @@
   "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.00000125,
     "cache_creation_input_token_cost_above_1hr": 0.000002,
-    "cache_read_input_token_cost": 1E-7,
+    "cache_read_input_token_cost": 1e-07,
     "input_cost_per_token": 0.000001,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7648,7 +7648,7 @@
   "global.anthropic.claude-opus-4-5-20251101-v1:0": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7664,7 +7664,7 @@
   "global.anthropic.claude-opus-4-6-v1": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7680,7 +7680,7 @@
   "global.anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7696,7 +7696,7 @@
   "global.anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_1hr": 0.00001,
-    "cache_read_input_token_cost": 5E-7,
+    "cache_read_input_token_cost": 5e-07,
     "input_cost_per_token": 0.000005,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7711,12 +7711,12 @@
   },
   "global.anthropic.claude-sonnet-4-20250514-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7731,13 +7731,13 @@
   "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
     "cache_creation_input_token_cost_above_1hr": 0.000006,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.000012,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7752,7 +7752,7 @@
   "global.anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.00000375,
     "cache_creation_input_token_cost_above_1hr": 0.000006,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -7768,7 +7768,7 @@
   "global.anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.0000025,
     "cache_creation_input_token_cost_above_1hr": 0.000004,
-    "cache_read_input_token_cost": 2E-7,
+    "cache_read_input_token_cost": 2e-07,
     "input_cost_per_token": 0.000002,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7782,33 +7782,33 @@
     "provider": "bedrock"
   },
   "google.gemma-3-12b-it": {
-    "input_cost_per_token": 9E-8,
+    "input_cost_per_token": 9e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 2.9E-7,
+    "output_cost_per_token": 2.9e-07,
     "provider": "bedrock"
   },
   "google.gemma-3-27b-it": {
-    "input_cost_per_token": 2.3E-7,
+    "input_cost_per_token": 2.3e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 3.8E-7,
+    "output_cost_per_token": 3.8e-07,
     "provider": "bedrock"
   },
   "google.gemma-3-4b-it": {
-    "input_cost_per_token": 4E-8,
+    "input_cost_per_token": 4e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 8E-8,
+    "output_cost_per_token": 8e-08,
     "provider": "bedrock"
   },
   "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.000001375,
     "cache_creation_input_token_cost_above_1hr": 0.0000022,
-    "cache_read_input_token_cost": 1.1E-7,
+    "cache_read_input_token_cost": 1.1e-07,
     "input_cost_per_token": 0.0000011,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -7818,7 +7818,7 @@
   },
   "jp.anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7834,7 +7834,7 @@
   "jp.anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7850,13 +7850,13 @@
   "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "input_cost_per_token_above_200k_tokens": 0.0000066,
     "output_cost_per_token_above_200k_tokens": 0.00002475,
     "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
-    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -7871,7 +7871,7 @@
   "jp.anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -7887,7 +7887,7 @@
   "jp.anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.00000275,
     "cache_creation_input_token_cost_above_1hr": 0.0000044,
-    "cache_read_input_token_cost": 2.2E-7,
+    "cache_read_input_token_cost": 2.2e-07,
     "input_cost_per_token": 0.0000022,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -7901,35 +7901,35 @@
     "provider": "bedrock"
   },
   "meta.llama3-3-70b-instruct-v1:0": {
-    "input_cost_per_token": 7.2E-7,
+    "input_cost_per_token": 7.2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 7.2E-7,
+    "output_cost_per_token": 7.2e-07,
     "provider": "bedrock"
   },
   "meta.llama4-maverick-17b-instruct-v1:0": {
-    "input_cost_per_token": 2.4E-7,
-    "input_cost_per_token_batches": 1.2E-7,
+    "input_cost_per_token": 2.4e-07,
+    "input_cost_per_token_batches": 1.2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 9.7E-7,
-    "output_cost_per_token_batches": 4.85E-7,
+    "output_cost_per_token": 9.7e-07,
+    "output_cost_per_token_batches": 4.85e-07,
     "provider": "bedrock"
   },
   "meta.llama4-scout-17b-instruct-v1:0": {
-    "input_cost_per_token": 1.7E-7,
-    "input_cost_per_token_batches": 8.5E-8,
+    "input_cost_per_token": 1.7e-07,
+    "input_cost_per_token_batches": 8.5e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 6.6E-7,
-    "output_cost_per_token_batches": 3.3E-7,
+    "output_cost_per_token": 6.6e-07,
+    "output_cost_per_token_batches": 3.3e-07,
     "provider": "bedrock"
   },
   "minimax.minimax-m2": {
-    "input_cost_per_token": 3E-7,
+    "input_cost_per_token": 3e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -7937,7 +7937,7 @@
     "provider": "bedrock"
   },
   "minimax.minimax-m2.1": {
-    "input_cost_per_token": 3E-7,
+    "input_cost_per_token": 3e-07,
     "max_input_tokens": 196000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -7945,7 +7945,7 @@
     "provider": "bedrock"
   },
   "minimax.minimax-m2.5": {
-    "input_cost_per_token": 3E-7,
+    "input_cost_per_token": 3e-07,
     "output_cost_per_token": 0.0000012,
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
@@ -7953,7 +7953,7 @@
     "provider": "bedrock"
   },
   "mistral.devstral-2-123b": {
-    "input_cost_per_token": 4E-7,
+    "input_cost_per_token": 4e-07,
     "max_input_tokens": 256000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -7961,7 +7961,7 @@
     "provider": "bedrock"
   },
   "mistral.magistral-small-2509": {
-    "input_cost_per_token": 5E-7,
+    "input_cost_per_token": 5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -7969,31 +7969,31 @@
     "provider": "bedrock"
   },
   "mistral.ministral-3-14b-instruct": {
-    "input_cost_per_token": 2E-7,
+    "input_cost_per_token": 2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 2E-7,
+    "output_cost_per_token": 2e-07,
     "provider": "bedrock"
   },
   "mistral.ministral-3-3b-instruct": {
-    "input_cost_per_token": 1E-7,
+    "input_cost_per_token": 1e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 1E-7,
+    "output_cost_per_token": 1e-07,
     "provider": "bedrock"
   },
   "mistral.ministral-3-8b-instruct": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 1.5E-7,
+    "output_cost_per_token": 1.5e-07,
     "provider": "bedrock"
   },
   "mistral.mistral-large-3-675b-instruct": {
-    "input_cost_per_token": 5E-7,
+    "input_cost_per_token": 5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8001,23 +8001,23 @@
     "provider": "bedrock"
   },
   "mistral.voxtral-mini-3b-2507": {
-    "input_cost_per_token": 4E-8,
+    "input_cost_per_token": 4e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 4E-8,
+    "output_cost_per_token": 4e-08,
     "provider": "bedrock"
   },
   "mistral.voxtral-small-24b-2507": {
-    "input_cost_per_token": 1E-7,
+    "input_cost_per_token": 1e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 3E-7,
+    "output_cost_per_token": 3e-07,
     "provider": "bedrock"
   },
   "moonshot.kimi-k2-thinking": {
-    "input_cost_per_token": 6E-7,
+    "input_cost_per_token": 6e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8025,7 +8025,7 @@
     "provider": "bedrock"
   },
   "moonshotai.kimi-k2.5": {
-    "input_cost_per_token": 6E-7,
+    "input_cost_per_token": 6e-07,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "max_tokens": 262144,
@@ -8033,95 +8033,95 @@
     "provider": "bedrock"
   },
   "nvidia.nemotron-nano-12b-v2": {
-    "input_cost_per_token": 2E-7,
+    "input_cost_per_token": 2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 6E-7,
+    "output_cost_per_token": 6e-07,
     "provider": "bedrock"
   },
   "nvidia.nemotron-nano-3-30b": {
-    "input_cost_per_token": 6E-8,
+    "input_cost_per_token": 6e-08,
     "max_input_tokens": 262144,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 2.4E-7,
+    "output_cost_per_token": 2.4e-07,
     "provider": "bedrock"
   },
   "nvidia.nemotron-nano-9b-v2": {
-    "input_cost_per_token": 6E-8,
+    "input_cost_per_token": 6e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 2.3E-7,
+    "output_cost_per_token": 2.3e-07,
     "provider": "bedrock"
   },
   "nvidia.nemotron-super-3-120b": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 256000,
     "max_output_tokens": 32768,
     "max_tokens": 32768,
-    "output_cost_per_token": 6.5E-7,
+    "output_cost_per_token": 6.5e-07,
     "provider": "bedrock"
   },
   "openai.gpt-oss-120b-1:0": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
-    "output_cost_per_token": 6E-7,
+    "output_cost_per_token": 6e-07,
     "provider": "bedrock"
   },
   "openai.gpt-oss-20b-1:0": {
-    "input_cost_per_token": 7E-8,
+    "input_cost_per_token": 7e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
-    "output_cost_per_token": 3E-7,
+    "output_cost_per_token": 3e-07,
     "provider": "bedrock"
   },
   "openai.gpt-oss-safeguard-120b": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 6E-7,
+    "output_cost_per_token": 6e-07,
     "provider": "bedrock"
   },
   "openai.gpt-oss-safeguard-20b": {
-    "input_cost_per_token": 7E-8,
+    "input_cost_per_token": 7e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
-    "output_cost_per_token": 2E-7,
+    "output_cost_per_token": 2e-07,
     "provider": "bedrock"
   },
   "qwen.qwen3-235b-a22b-2507-v1:0": {
-    "input_cost_per_token": 2.2E-7,
+    "input_cost_per_token": 2.2e-07,
     "max_input_tokens": 262144,
     "max_output_tokens": 131072,
     "max_tokens": 131072,
-    "output_cost_per_token": 8.8E-7,
+    "output_cost_per_token": 8.8e-07,
     "provider": "bedrock"
   },
   "qwen.qwen3-32b-v1:0": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 131072,
     "max_output_tokens": 16384,
     "max_tokens": 16384,
-    "output_cost_per_token": 6E-7,
+    "output_cost_per_token": 6e-07,
     "provider": "bedrock"
   },
   "qwen.qwen3-coder-30b-a3b-v1:0": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 262144,
     "max_output_tokens": 131072,
     "max_tokens": 131072,
-    "output_cost_per_token": 6E-7,
+    "output_cost_per_token": 6e-07,
     "provider": "bedrock"
   },
   "qwen.qwen3-coder-480b-a35b-v1:0": {
-    "input_cost_per_token": 2.2E-7,
+    "input_cost_per_token": 2.2e-07,
     "max_input_tokens": 262000,
     "max_output_tokens": 65536,
     "max_tokens": 65536,
@@ -8129,7 +8129,7 @@
     "provider": "bedrock"
   },
   "qwen.qwen3-coder-next": {
-    "input_cost_per_token": 5E-7,
+    "input_cost_per_token": 5e-07,
     "max_input_tokens": 262144,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8137,7 +8137,7 @@
     "provider": "bedrock"
   },
   "qwen.qwen3-next-80b-a3b": {
-    "input_cost_per_token": 1.5E-7,
+    "input_cost_per_token": 1.5e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8145,7 +8145,7 @@
     "provider": "bedrock"
   },
   "qwen.qwen3-vl-235b-a22b": {
-    "input_cost_per_token": 5.3E-7,
+    "input_cost_per_token": 5.3e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8155,13 +8155,13 @@
   "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.0000045,
     "cache_creation_input_token_cost_above_1hr": 0.0000072,
-    "cache_read_input_token_cost": 3.6E-7,
+    "cache_read_input_token_cost": 3.6e-07,
     "input_cost_per_token": 0.0000036,
     "input_cost_per_token_above_200k_tokens": 0.0000072,
     "output_cost_per_token_above_200k_tokens": 0.000027,
     "cache_creation_input_token_cost_above_200k_tokens": 0.000009,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000144,
-    "cache_read_input_token_cost_above_200k_tokens": 7.2E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 7.2e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -8169,8 +8169,8 @@
     "provider": "bedrock"
   },
   "us.amazon.nova-2-lite-v1:0": {
-    "cache_read_input_token_cost": 8.25E-8,
-    "input_cost_per_token": 3.3E-7,
+    "cache_read_input_token_cost": 8.25e-08,
+    "input_cost_per_token": 3.3e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -8178,7 +8178,7 @@
     "provider": "bedrock"
   },
   "us.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "cache_read_input_token_cost": 5.46875E-7,
+    "cache_read_input_token_cost": 5.46875e-07,
     "input_cost_per_token": 0.0000021875,
     "input_cost_per_image_token": 0.0000021875,
     "input_cost_per_audio_token": 0.0000021875,
@@ -8189,19 +8189,19 @@
     "provider": "bedrock"
   },
   "us.amazon.nova-lite-v1:0": {
-    "input_cost_per_token": 6E-8,
+    "input_cost_per_token": 6e-08,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 2.4E-7,
+    "output_cost_per_token": 2.4e-07,
     "provider": "bedrock"
   },
   "us.amazon.nova-micro-v1:0": {
-    "input_cost_per_token": 3.5E-8,
+    "input_cost_per_token": 3.5e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
-    "output_cost_per_token": 1.4E-7,
+    "output_cost_per_token": 1.4e-07,
     "provider": "bedrock"
   },
   "us.amazon.nova-premier-v1:0": {
@@ -8213,7 +8213,7 @@
     "provider": "bedrock"
   },
   "us.amazon.nova-pro-v1:0": {
-    "input_cost_per_token": 8E-7,
+    "input_cost_per_token": 8e-07,
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "max_tokens": 10000,
@@ -8222,7 +8222,7 @@
   },
   "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -8249,7 +8249,7 @@
   "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "cache_creation_input_token_cost": 0.000001375,
     "cache_creation_input_token_cost_above_1hr": 0.0000022,
-    "cache_read_input_token_cost": 1.1E-7,
+    "cache_read_input_token_cost": 1.1e-07,
     "input_cost_per_token": 0.0000011,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -8290,7 +8290,7 @@
   "us.anthropic.claude-opus-4-5-20251101-v1:0": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -8306,7 +8306,7 @@
   "us.anthropic.claude-opus-4-6-v1": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -8322,7 +8322,7 @@
   "us.anthropic.claude-opus-4-7": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -8338,7 +8338,7 @@
   "us.anthropic.claude-opus-4-8": {
     "cache_creation_input_token_cost": 0.000006875,
     "cache_creation_input_token_cost_above_1hr": 0.000011,
-    "cache_read_input_token_cost": 5.5E-7,
+    "cache_read_input_token_cost": 5.5e-07,
     "input_cost_per_token": 0.0000055,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -8353,12 +8353,12 @@
   },
   "us.anthropic.claude-sonnet-4-20250514-v1:0": {
     "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3E-7,
+    "cache_read_input_token_cost": 3e-07,
     "input_cost_per_token": 0.000003,
     "input_cost_per_token_above_200k_tokens": 0.000006,
     "output_cost_per_token_above_200k_tokens": 0.0000225,
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost_above_200k_tokens": 6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -8373,13 +8373,13 @@
   "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "input_cost_per_token_above_200k_tokens": 0.0000066,
     "output_cost_per_token_above_200k_tokens": 0.00002475,
     "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
     "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.0000132,
-    "cache_read_input_token_cost_above_200k_tokens": 6.6E-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "max_tokens": 64000,
@@ -8394,7 +8394,7 @@
   "us.anthropic.claude-sonnet-4-6": {
     "cache_creation_input_token_cost": 0.000004125,
     "cache_creation_input_token_cost_above_1hr": 0.0000066,
-    "cache_read_input_token_cost": 3.3E-7,
+    "cache_read_input_token_cost": 3.3e-07,
     "input_cost_per_token": 0.0000033,
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -8410,7 +8410,7 @@
   "us.anthropic.claude-sonnet-5": {
     "cache_creation_input_token_cost": 0.00000275,
     "cache_creation_input_token_cost_above_1hr": 0.0000044,
-    "cache_read_input_token_cost": 2.2E-7,
+    "cache_read_input_token_cost": 2.2e-07,
     "input_cost_per_token": 0.0000022,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -8432,7 +8432,7 @@
     "provider": "bedrock"
   },
   "us.deepseek.v3.2": {
-    "input_cost_per_token": 6.2E-7,
+    "input_cost_per_token": 6.2e-07,
     "max_input_tokens": 163840,
     "max_output_tokens": 163840,
     "max_tokens": 163840,
@@ -8440,31 +8440,31 @@
     "provider": "bedrock"
   },
   "us.meta.llama3-3-70b-instruct-v1:0": {
-    "input_cost_per_token": 7.2E-7,
+    "input_cost_per_token": 7.2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 7.2E-7,
+    "output_cost_per_token": 7.2e-07,
     "provider": "bedrock"
   },
   "us.meta.llama4-maverick-17b-instruct-v1:0": {
-    "input_cost_per_token": 2.4E-7,
-    "input_cost_per_token_batches": 1.2E-7,
+    "input_cost_per_token": 2.4e-07,
+    "input_cost_per_token_batches": 1.2e-07,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 9.7E-7,
-    "output_cost_per_token_batches": 4.85E-7,
+    "output_cost_per_token": 9.7e-07,
+    "output_cost_per_token_batches": 4.85e-07,
     "provider": "bedrock"
   },
   "us.meta.llama4-scout-17b-instruct-v1:0": {
-    "input_cost_per_token": 1.7E-7,
-    "input_cost_per_token_batches": 8.5E-8,
+    "input_cost_per_token": 1.7e-07,
+    "input_cost_per_token_batches": 8.5e-08,
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
     "max_tokens": 4096,
-    "output_cost_per_token": 6.6E-7,
-    "output_cost_per_token_batches": 3.3E-7,
+    "output_cost_per_token": 6.6e-07,
+    "output_cost_per_token_batches": 3.3e-07,
     "provider": "bedrock"
   },
   "us.mistral.pixtral-large-2502-v1:0": {
@@ -8484,7 +8484,7 @@
     "provider": "bedrock"
   },
   "us.writer.palmyra-x5-v1:0": {
-    "input_cost_per_token": 6E-7,
+    "input_cost_per_token": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8500,7 +8500,7 @@
     "provider": "bedrock"
   },
   "writer.palmyra-x5-v1:0": {
-    "input_cost_per_token": 6E-7,
+    "input_cost_per_token": 6e-07,
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
     "max_tokens": 8192,
@@ -8508,7 +8508,7 @@
     "provider": "bedrock"
   },
   "zai.glm-4.7": {
-    "input_cost_per_token": 6E-7,
+    "input_cost_per_token": 6e-07,
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
@@ -8516,11 +8516,11 @@
     "provider": "bedrock"
   },
   "zai.glm-4.7-flash": {
-    "input_cost_per_token": 7E-8,
+    "input_cost_per_token": 7e-08,
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
-    "output_cost_per_token": 4E-7,
+    "output_cost_per_token": 4e-07,
     "provider": "bedrock"
   },
   "zai.glm-5": {

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -253,7 +253,7 @@ func bedrockStream() []byte {
 	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":"Hello"}}`)...)
 	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":" world"}}`)...)
 	stream = append(stream, encodeFrame("messageStop", `{"stopReason":"end_turn"}`)...)
-	stream = append(stream, encodeFrame("metadata", `{"usage":{"inputTokens":10,"outputTokens":2,"totalTokens":12}}`)...)
+	stream = append(stream, encodeFrame("metadata", `{"usage":{"inputTokens":10,"outputTokens":2,"totalTokens":12,"cacheReadInputTokens":4,"cacheWriteInputTokens":2}}`)...)
 	return stream
 }
 
@@ -265,7 +265,10 @@ func TestEventStreamToSSE_TextStream(t *testing.T) {
 		`"content":"Hello"`,
 		`"content":" world"`,
 		`"finish_reason":"stop"`,
-		`"total_tokens":12`,
+		`"prompt_tokens":16`,
+		`"total_tokens":18`,
+		`"cached_tokens":4`,
+		`"cache_write_tokens":2`,
 		"data: [DONE]\n\n",
 	} {
 		if !strings.Contains(out, want) {
@@ -444,7 +447,8 @@ func TestTranslateRequest_ToolChoiceNoneDropsTools(t *testing.T) {
 
 func TestTranslateConverseResponse_JSON(t *testing.T) {
 	converse := `{"output":{"message":{"role":"assistant","content":[{"text":"Hi there"}]}},` +
-		`"stopReason":"end_turn","usage":{"inputTokens":5,"outputTokens":3,"totalTokens":8}}`
+		`"stopReason":"end_turn","usage":{"inputTokens":5,"outputTokens":3,"totalTokens":8,` +
+		`"cacheReadInputTokens":4,"cacheWriteInputTokens":2}}`
 	action := translateConverseResponse([]byte(converse), 200, "claude", "chatcmpl-x")
 
 	mods, ok := action.(policy.DownstreamResponseModifications)
@@ -469,6 +473,14 @@ func TestTranslateConverseResponse_JSON(t *testing.T) {
 	}
 	if choice["finish_reason"] != "stop" {
 		t.Errorf("unexpected finish_reason: %v", choice["finish_reason"])
+	}
+	usage := out["usage"].(map[string]interface{})
+	if usage["prompt_tokens"] != float64(11) || usage["total_tokens"] != float64(14) {
+		t.Fatalf("translated usage does not include cache tokens: %v", usage)
+	}
+	details := usage["prompt_tokens_details"].(map[string]interface{})
+	if details["cached_tokens"] != float64(4) || details["cache_write_tokens"] != float64(2) {
+		t.Fatalf("translated cache token details are incomplete: %v", details)
 	}
 }
 

--- a/policies/openai-to-bedrock-transformer/bedrock_test.go
+++ b/policies/openai-to-bedrock-transformer/bedrock_test.go
@@ -253,7 +253,7 @@ func bedrockStream() []byte {
 	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":"Hello"}}`)...)
 	stream = append(stream, encodeFrame("contentBlockDelta", `{"contentBlockIndex":0,"delta":{"text":" world"}}`)...)
 	stream = append(stream, encodeFrame("messageStop", `{"stopReason":"end_turn"}`)...)
-	stream = append(stream, encodeFrame("metadata", `{"usage":{"inputTokens":10,"outputTokens":2,"totalTokens":12,"cacheReadInputTokens":4,"cacheWriteInputTokens":2}}`)...)
+	stream = append(stream, encodeFrame("metadata", `{"usage":{"inputTokens":10,"outputTokens":2,"totalTokens":12,"cacheReadInputTokens":4,"cacheWriteInputTokens":6,"cacheDetails":[{"ttl":"1h","inputTokens":4},{"ttl":"5m","inputTokens":2}]}}`)...)
 	return stream
 }
 
@@ -265,10 +265,12 @@ func TestEventStreamToSSE_TextStream(t *testing.T) {
 		`"content":"Hello"`,
 		`"content":" world"`,
 		`"finish_reason":"stop"`,
-		`"prompt_tokens":16`,
-		`"total_tokens":18`,
+		`"prompt_tokens":20`,
+		`"total_tokens":22`,
 		`"cached_tokens":4`,
-		`"cache_write_tokens":2`,
+		`"cache_write_tokens":6`,
+		`"cache_write_5m_tokens":2`,
+		`"cache_write_1h_tokens":4`,
 		"data: [DONE]\n\n",
 	} {
 		if !strings.Contains(out, want) {
@@ -448,7 +450,8 @@ func TestTranslateRequest_ToolChoiceNoneDropsTools(t *testing.T) {
 func TestTranslateConverseResponse_JSON(t *testing.T) {
 	converse := `{"output":{"message":{"role":"assistant","content":[{"text":"Hi there"}]}},` +
 		`"stopReason":"end_turn","usage":{"inputTokens":5,"outputTokens":3,"totalTokens":8,` +
-		`"cacheReadInputTokens":4,"cacheWriteInputTokens":2}}`
+		`"cacheReadInputTokens":4,"cacheWriteInputTokens":6,"cacheDetails":[` +
+		`{"ttl":"1h","inputTokens":4},{"ttl":"5m","inputTokens":2}]}}`
 	action := translateConverseResponse([]byte(converse), 200, "claude", "chatcmpl-x")
 
 	mods, ok := action.(policy.DownstreamResponseModifications)
@@ -475,11 +478,13 @@ func TestTranslateConverseResponse_JSON(t *testing.T) {
 		t.Errorf("unexpected finish_reason: %v", choice["finish_reason"])
 	}
 	usage := out["usage"].(map[string]interface{})
-	if usage["prompt_tokens"] != float64(11) || usage["total_tokens"] != float64(14) {
+	if usage["prompt_tokens"] != float64(15) || usage["total_tokens"] != float64(18) {
 		t.Fatalf("translated usage does not include cache tokens: %v", usage)
 	}
 	details := usage["prompt_tokens_details"].(map[string]interface{})
-	if details["cached_tokens"] != float64(4) || details["cache_write_tokens"] != float64(2) {
+	if details["cached_tokens"] != float64(4) || details["cache_write_tokens"] != float64(6) ||
+		details["cache_write_5m_tokens"] != float64(2) ||
+		details["cache_write_1h_tokens"] != float64(4) {
 		t.Fatalf("translated cache token details are incomplete: %v", details)
 	}
 }

--- a/policies/openai-to-bedrock-transformer/response.go
+++ b/policies/openai-to-bedrock-transformer/response.go
@@ -58,11 +58,17 @@ type converseContentBlock struct {
 }
 
 type converseUsage struct {
-	InputTokens           int `json:"inputTokens"`
-	OutputTokens          int `json:"outputTokens"`
-	TotalTokens           int `json:"totalTokens"`
-	CacheReadInputTokens  int `json:"cacheReadInputTokens"`
-	CacheWriteInputTokens int `json:"cacheWriteInputTokens"`
+	InputTokens           int           `json:"inputTokens"`
+	OutputTokens          int           `json:"outputTokens"`
+	TotalTokens           int           `json:"totalTokens"`
+	CacheReadInputTokens  int           `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens int           `json:"cacheWriteInputTokens"`
+	CacheDetails          []cacheDetail `json:"cacheDetails"`
+}
+
+type cacheDetail struct {
+	TTL         string `json:"ttl"`
+	InputTokens int    `json:"inputTokens"`
 }
 
 func translateConverseResponse(body []byte, status int, model, id string) policy.ResponseAction {
@@ -258,6 +264,7 @@ func streamFrameToSSE(frame *eventStreamFrame, id, model string, created int64) 
 			TotalTokens:           numberField(usage, "totalTokens"),
 			CacheReadInputTokens:  numberField(usage, "cacheReadInputTokens"),
 			CacheWriteInputTokens: numberField(usage, "cacheWriteInputTokens"),
+			CacheDetails:          cacheDetailsField(usage),
 		})
 		return sseData(chunk)
 	}
@@ -304,27 +311,52 @@ func rawInputToArguments(input json.RawMessage) string {
 }
 
 func totalTokens(usage converseUsage) int {
+	cacheWrite5m, cacheWrite1h := cacheWritesByTTL(usage)
 	inclusiveTotal := usage.InputTokens + usage.CacheReadInputTokens +
-		usage.CacheWriteInputTokens + usage.OutputTokens
+		cacheWrite5m + cacheWrite1h + usage.OutputTokens
 	if usage.TotalTokens > inclusiveTotal {
 		return usage.TotalTokens
 	}
 	return inclusiveTotal
 }
 
+func cacheWritesByTTL(usage converseUsage) (int, int) {
+	if len(usage.CacheDetails) == 0 {
+		return usage.CacheWriteInputTokens, 0
+	}
+
+	var cacheWrite5m, cacheWrite1h int
+	for _, detail := range usage.CacheDetails {
+		switch detail.TTL {
+		case "5m":
+			cacheWrite5m += detail.InputTokens
+		case "1h":
+			cacheWrite1h += detail.InputTokens
+		}
+	}
+	if classified := cacheWrite5m + cacheWrite1h; usage.CacheWriteInputTokens > classified {
+		cacheWrite5m += usage.CacheWriteInputTokens - classified
+	}
+	return cacheWrite5m, cacheWrite1h
+}
+
 // openAIUsage preserves Converse cache usage while translating to the OpenAI
 // shape. prompt_tokens is inclusive, cached_tokens identifies the discounted
-// cache reads, and cache_write_tokens is retained for llm-cost's Bedrock
-// calculator even though it is not part of the standard OpenAI schema.
+// cache reads, and cache-write totals plus their TTL breakdown are retained for
+// llm-cost's Bedrock calculator even though they are not standard OpenAI fields.
 func openAIUsage(usage converseUsage) map[string]interface{} {
+	cacheWrite5m, cacheWrite1h := cacheWritesByTTL(usage)
+	cacheWriteTotal := cacheWrite5m + cacheWrite1h
 	return map[string]interface{}{
 		"prompt_tokens": usage.InputTokens + usage.CacheReadInputTokens +
-			usage.CacheWriteInputTokens,
+			cacheWriteTotal,
 		"completion_tokens": usage.OutputTokens,
 		"total_tokens":      totalTokens(usage),
 		"prompt_tokens_details": map[string]interface{}{
-			"cached_tokens":      usage.CacheReadInputTokens,
-			"cache_write_tokens": usage.CacheWriteInputTokens,
+			"cached_tokens":         usage.CacheReadInputTokens,
+			"cache_write_tokens":    cacheWriteTotal,
+			"cache_write_5m_tokens": cacheWrite5m,
+			"cache_write_1h_tokens": cacheWrite1h,
 		},
 	}
 }
@@ -341,6 +373,23 @@ func numberField(m map[string]interface{}, key string) int {
 		return n
 	}
 	return 0
+}
+
+func cacheDetailsField(m map[string]interface{}) []cacheDetail {
+	rawDetails, _ := m["cacheDetails"].([]interface{})
+	details := make([]cacheDetail, 0, len(rawDetails))
+	for _, rawDetail := range rawDetails {
+		detail, _ := rawDetail.(map[string]interface{})
+		ttl, _ := detail["ttl"].(string)
+		if ttl == "" {
+			continue
+		}
+		details = append(details, cacheDetail{
+			TTL:         ttl,
+			InputTokens: numberField(detail, "inputTokens"),
+		})
+	}
+	return details
 }
 
 func exceptionMessage(frame *eventStreamFrame) string {

--- a/policies/openai-to-bedrock-transformer/response.go
+++ b/policies/openai-to-bedrock-transformer/response.go
@@ -58,9 +58,11 @@ type converseContentBlock struct {
 }
 
 type converseUsage struct {
-	InputTokens  int `json:"inputTokens"`
-	OutputTokens int `json:"outputTokens"`
-	TotalTokens  int `json:"totalTokens"`
+	InputTokens           int `json:"inputTokens"`
+	OutputTokens          int `json:"outputTokens"`
+	TotalTokens           int `json:"totalTokens"`
+	CacheReadInputTokens  int `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens int `json:"cacheWriteInputTokens"`
 }
 
 func translateConverseResponse(body []byte, status int, model, id string) policy.ResponseAction {
@@ -111,11 +113,7 @@ func translateConverseResponse(body []byte, status int, model, id string) policy
 			"message":       message,
 			"finish_reason": stopReasonToFinish(resp.StopReason, len(toolCalls) > 0),
 		}},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     resp.Usage.InputTokens,
-			"completion_tokens": resp.Usage.OutputTokens,
-			"total_tokens":      totalTokens(resp.Usage),
-		},
+		"usage": openAIUsage(resp.Usage),
 	}
 
 	newBody, err := json.Marshal(openAIResp)
@@ -254,11 +252,13 @@ func streamFrameToSSE(frame *eventStreamFrame, id, model string, created int64) 
 		}
 		chunk := streamChunk(id, model, created, nil, nil)
 		chunk["choices"] = []interface{}{}
-		chunk["usage"] = map[string]interface{}{
-			"prompt_tokens":     numberField(usage, "inputTokens"),
-			"completion_tokens": numberField(usage, "outputTokens"),
-			"total_tokens":      numberField(usage, "totalTokens"),
-		}
+		chunk["usage"] = openAIUsage(converseUsage{
+			InputTokens:           numberField(usage, "inputTokens"),
+			OutputTokens:          numberField(usage, "outputTokens"),
+			TotalTokens:           numberField(usage, "totalTokens"),
+			CacheReadInputTokens:  numberField(usage, "cacheReadInputTokens"),
+			CacheWriteInputTokens: numberField(usage, "cacheWriteInputTokens"),
+		})
 		return sseData(chunk)
 	}
 	return nil
@@ -304,10 +304,29 @@ func rawInputToArguments(input json.RawMessage) string {
 }
 
 func totalTokens(usage converseUsage) int {
-	if usage.TotalTokens > 0 {
+	inclusiveTotal := usage.InputTokens + usage.CacheReadInputTokens +
+		usage.CacheWriteInputTokens + usage.OutputTokens
+	if usage.TotalTokens > inclusiveTotal {
 		return usage.TotalTokens
 	}
-	return usage.InputTokens + usage.OutputTokens
+	return inclusiveTotal
+}
+
+// openAIUsage preserves Converse cache usage while translating to the OpenAI
+// shape. prompt_tokens is inclusive, cached_tokens identifies the discounted
+// cache reads, and cache_write_tokens is retained for llm-cost's Bedrock
+// calculator even though it is not part of the standard OpenAI schema.
+func openAIUsage(usage converseUsage) map[string]interface{} {
+	return map[string]interface{}{
+		"prompt_tokens": usage.InputTokens + usage.CacheReadInputTokens +
+			usage.CacheWriteInputTokens,
+		"completion_tokens": usage.OutputTokens,
+		"total_tokens":      totalTokens(usage),
+		"prompt_tokens_details": map[string]interface{}{
+			"cached_tokens":      usage.CacheReadInputTokens,
+			"cache_write_tokens": usage.CacheWriteInputTokens,
+		},
+	}
 }
 
 func blockIndex(event map[string]interface{}) int {


### PR DESCRIPTION

## Purpose

Add AWS Bedrock support to the `llm-cost` policy so Bedrock requests can be costed and used with cost-based rate limiting.

Previously, native Bedrock responses do not reliably include a model identifier in the request or response body. This prevented the policy from locating model pricing and calculating Bedrock request costs.

No linked issue.

## Goals

- Calculate costs for native AWS Bedrock Converse and InvokeModel responses.
- Extract the Bedrock model or inference-profile ID from the request URL.
- Normalize Bedrock usage fields into the common `llm-cost` usage model.
- Resolve Bedrock inference-profile prefixes and model ARN aliases against pricing data.
- Preserve existing cost behavior for OpenAI, Anthropic, Gemini/Vertex AI, and Mistral.
- Support Bedrock responses translated to OpenAI format by the existing OpenAI-to-Bedrock transformer.

## Approach

- Added a `BedrockCalculator` to normalize:
  - Bedrock Converse camelCase usage fields.
  - Anthropic-style InvokeModel usage fields.
  - Titan InvokeModel token usage fields.
  - OpenAI-compatible transformed Bedrock responses.
- Added Bedrock URL model extraction for `/model/{modelId}/converse`, `/converse-stream`, `invoke`, and `invoke-with-response-stream` endpoints.
- Added pricing aliases for Bedrock inference-profile prefixes and foundation model ARNs.
- Standardized Bedrock pricing entries on provider value `bedrock`.
- Added tests for calculator selection, URL extraction, ARN decoding, pricing aliases, native and transformed Bedrock responses, and cache token handling.

This change does not affect the UI.

## User stories

- As a gateway administrator, I can apply cost-based rate limiting to AWS Bedrock APIs.
- As a gateway administrator, I can use Bedrock inference-profile IDs such as `apac.amazon.nova-micro-v1:0` without manually normalizing them.
- As an API developer, I can receive accurate cost attribution for Bedrock Converse and InvokeModel requests.
- As an OpenAI-compatible client using the Bedrock transformer, I can have transformed Bedrock responses included in cost calculation.

## Release note

Added AWS Bedrock support to the `llm-cost` policy, including native Converse and InvokeModel response cost calculation, URL-based model detection, and Bedrock pricing alias resolution.

## Documentation

N/A — no new policy parameters or deployment configuration were introduced. The `llm-cost` policy definition was updated to document Bedrock support.

## Training

N/A — no training-content changes are required.

## Certification

N/A — this policy enhancement does not require certification-exam changes.

## Marketing

N/A — no marketing-content changes are required.

## Automation tests

### Unit tests

Added coverage for:

- Bedrock calculator selection.
- Native Bedrock Converse usage normalization.
- Bedrock InvokeModel and Titan usage normalization.
- URL model extraction, including encoded and decoded Bedrock ARNs.
- Inference-profile prefix and model alias pricing lookup.
- Native Bedrock response cost calculation.
- OpenAI-transformed Bedrock response cost calculation.
- Cache read/write token propagation for transformed responses.

Executed successfully:

```bash
cd policies/llm-cost
go test ./...
go test -race ./...
go vet ./...
```

Also executed transformer tests successfully:

```bash
cd policies/openai-to-bedrock-transformer
go test ./...
go test -race ./...
go vet ./...
```

### Integration tests

End-to-end coverage is included in the related API Platform PR. It validates the complete Bedrock flow:

`Bedrock URL → model extraction → pricing lookup → usage normalization → cost calculation → cost-based rate limiting`

The E2E suite passed:

- 23/23 scenarios
- 479/479 steps
- Bedrock scenario: first two requests return `200`; the third returns `429` after the configured budget is exhausted.

## Security checks

- Followed secure coding standards: **Yes**
- Ran FindSecurityBugs plugin and verified report: **N/A** — this is a Go policy module; FindSecurityBugs is Java-specific.
- Confirmed that this PR does not commit keys, passwords, tokens, usernames, or other secrets: **Yes**

## Samples

N/A — no new standalone samples are required. Bedrock behavior is covered through unit and integration tests.

## Related PRs

- [[wso2/gateway-controllers#228](https://github.com/wso2/gateway-controllers/pull/228)](https://github.com/wso2/gateway-controllers/pull/228) — OpenAI-to-Bedrock transformer, merged.
- [[wso2/api-platform#2771](https://github.com/wso2/api-platform/pull/2771)](https://github.com/wso2/api-platform/pull/2771) — Bedrock model-pricing entries and end-to-end cost-based rate-limit coverage.

## Migrations

N/A — no migration is required. Existing gateway configurations are unaffected. Bedrock cost calculation is enabled when the `llm-cost` policy is applied to a Bedrock API or proxy.

## Test environment

- Operating system: macOS
- Go: Go 1.26.x
- Container runtime: Rancher Desktop / Docker
- JDK: N/A
- Database: N/A
- Browser: N/A

## Learning

The implementation follows the existing provider-calculator design used by OpenAI, Anthropic, Gemini, and Mistral.

Bedrock response handling was based on AWS Bedrock Converse and InvokeModel usage structures, including URL model identifiers, inference-profile prefixes, foundation model ARNs, and native token-usage response fields. The implementation also builds on the merged OpenAI-to-Bedrock transformer policy for OpenAI-compatible transformed responses.
