### PR TITLE
[Gateway] Add multi provider support for model/weighted round-robin routing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ All available policies, sorted alphabetically.
 | [MCP Authorization](./mcp-authz/v1.0/docs/mcp-authorization.md) | MCP, AI, Security | MCP Authorization policy validates access to MCP resources (tools, resources, prompts) and methods based on JWT claims or OAuth scopes provided by the mcp-auth policy. |
 | [MCP Rate Limit](./mcp-ratelimit/v1.0/docs/mcp-ratelimit.md) | MCP, AI, Security | Applies rate limits to MCP traffic per tool, resource, prompt, or JSON-RPC method. |
 | [MCP Rewrite](./mcp-rewrite/v1.0/docs/mcp-rewrite.md) | MCP, AI | MCP Rewrite policy defines user-facing tools, resources, and prompts and maps them to backend capability names using optional "target" fields. |
-| [Model Round Robin](./model-round-robin/v1.0/docs/model-round-robin.md) | AI | Implements round-robin load balancing for AI models. |
-| [Model Weighted Round Robin](./model-weighted-round-robin/v1.0/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
+| [Model Round Robin](./model-round-robin/v1.1/docs/model-round-robin.md) | AI | Implements round-robin load balancing for AI models. |
+| [Model Weighted Round Robin](./model-weighted-round-robin/v1.1/docs/model-weighted-round-robin.md) | AI | Implements weighted round-robin load balancing for AI models. |
 | [NeMo Guard Content Safety](./nvidia-nemoguard-content-safety/v0.9/docs/nvidia-nemoguard-content-safety.md) | Guardrails, AI | Validates request and/or response content using NVIDIA NeMo Guard (llama-3.1-nemoguard-8b-content-safety). |
 | [Opaque Token Auth](./opaque-token-auth/v1.0/docs/opaque-token-authentication.md) | Security, AI | Validates opaque OAuth 2.0 access tokens via RFC 7662 token introspection. |
 | [OpenAI to Bedrock Transformer](./openai-to-bedrock-transformer/v0.9/docs/openai-to-bedrock-transformer.md) | AI | Translates OpenAI Chat Completions requests into AWS Bedrock Converse format and rewrites non-streaming and streaming Bedrock responses back into OpenAI-compatible JSON or Server-Sent Events. |

--- a/docs/model-round-robin/v1.1/docs/model-round-robin.md
+++ b/docs/model-round-robin/v1.1/docs/model-round-robin.md
@@ -1,0 +1,280 @@
+---
+title: "Overview"
+---
+# Model Round Robin
+
+## Overview
+
+The Model Round Robin policy implements round-robin load balancing for AI models. It distributes requests evenly across multiple configured AI models in a cyclic manner, ensuring equal request allocation over time and preventing overloading of any single model. This policy is useful for distributing load across multiple models, improving availability, and managing resource utilization.
+
+## Features
+
+- Even distribution of requests across multiple models in a cyclic pattern
+- Optional per-target routing to additional LLM providers (multi-provider round robin)
+- Automatic model suspension on failures (5xx or 429 responses), scoped to the selected provider/model pair
+- Configurable suspension duration for failed models
+- Support for extracting model identifier from payload, headers, query parameters, or path parameters
+- Dynamic model selection based on availability
+
+## Configuration
+
+This policy requires configuration in both the API definition YAML and the LLM provider template.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `models` | `Model` array | Yes | - | List of models for round-robin distribution. Each model must have a `model` name. |
+| `suspendDuration` | integer | No | `30` | Suspension time in seconds for failed models. Set to `0` to disable failed-model suspension tracking. Must be >= 0. |
+
+### Model Configuration
+
+Each model in the `models` array is an object with the following properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `model` | string | Yes | The AI model name to use for load balancing. |
+| `provider` | string | No | Optionally routes this target to an additional LLM provider. Must match an `LlmProxy` `additionalProviders[].as` value, or the provider id when `as` is absent. When omitted, the request uses the `LlmProxy` primary/default provider. |
+
+#### Multi-provider routing
+
+Each round-robin target can optionally name an additional provider. When a target
+specifies `provider`, the policy:
+
+- routes the request to that provider's named upstream (Envoy dynamic cluster
+  selection) during the request **header** phase, so the selected upstream is
+  chosen before the request is forwarded, and
+- records `selected_provider` in request metadata so conditional provider
+  authentication and protocol transformers can adapt to the chosen provider.
+
+When `provider` is omitted, no upstream override is applied and `selected_provider`
+is not set, so the `LlmProxy` primary-provider fallback, authentication, and
+default cluster logic continue to apply unchanged.
+
+```yaml
+models:
+  - model: gpt-4o
+    # Omitted provider → LlmProxy primary/default provider.
+  - model: claude-sonnet-4-5-20250929
+    provider: anthropic-provider   # matches additionalProviders[].as (or provider id)
+```
+
+
+#### LLM provider template
+
+This policy depends on the `requestModel` configuration defined in the LLM provider template to identify and extract the model from incoming requests.
+
+> **Required:** The `requestModel` configuration must be provided; the policy will not function without it.
+
+### `requestModel` Parameters
+
+| Parameter                 | Type   | Required | Description                                                                                                                                                                                              |
+| ------------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requestModel.location`   | string | Yes      | Specifies where the model identifier is located in the request. Supported values: `payload`, `header`, `queryParam`, `pathParam`.                                                                        |
+| `requestModel.identifier` | string | Yes      | Extraction key used to identify the model. This can be a JSONPath expression (for `payload`), header name (for `header`), query parameter name (for `queryParam`), or a regex pattern (for `pathParam`). |
+
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: model-round-robin
+  gomodule: github.com/wso2/gateway-controllers/policies/model-round-robin@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Round Robin with Payload-based Model
+
+Deploy an LLM provider with round-robin load balancing across multiple models:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: round-robin-provider
+spec:
+  displayName: Round Robin Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: model-round-robin
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4
+              - model: gpt-3.5-turbo
+              - model: gpt-4-turbo
+            suspendDuration: 60
+```
+
+**Test the round-robin distribution:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# First request - will use gpt-4
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+
+# Second request - will use gpt-3.5-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+
+# Third request - will use gpt-4-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+```
+
+### Example 2: Multi-Provider Round Robin
+
+Route round-robin targets across a primary provider and two additional providers.
+Deploy the three `LlmProvider` resources first. The `LlmProxy` references their
+`metadata.name` values through `id`. Each `models[]` entry references an additional
+provider by its proxy-local `as` alias (or by `id` when `as` is omitted). Targets
+without a `provider` use the primary provider.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProxy
+metadata:
+  name: multi-provider-round-robin
+spec:
+  displayName: Multi Provider Round Robin
+  version: v1.0
+  provider:
+    id: openai-primary-provider
+  additionalProviders:
+    - id: anthropic-provider-resource
+      as: anthropic-provider
+    - id: bedrock-provider-resource
+      as: bedrock-provider
+      transformer:
+        type: openai-to-bedrock-transformer
+        version: v0
+  policies:
+    - name: model-round-robin
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4o                          # primary provider
+              - model: claude-sonnet-4-5-20250929
+                provider: anthropic-provider
+              - model: anthropic.claude-3-5-sonnet-20240620-v1:0
+                provider: bedrock-provider
+            suspendDuration: 60
+```
+
+With this configuration, successive requests rotate primary → anthropic-provider
+→ bedrock-provider → primary …. Requests routed to an additional provider carry
+`selected_provider` metadata so the provider's conditional authentication and any
+protocol transformer (for example, an OpenAI→Bedrock transformer) are applied.
+
+## How It Works
+
+#### Model Selection
+On each request, the policy selects the next available model in the configured list using a round-robin algorithm.
+- **Model Extraction**: The policy extracts the original model from the request (if configured) and stores it for reference.
+- **Model Modification**: The policy modifies the request to use the selected model based on the `requestModel` configuration.
+
+#### Request Model Locations
+
+The policy supports extracting the model identifier from different locations in the request:
+
+**Payload (JSONPath)**: Extract model from JSON payload using JSONPath:
+
+- **Location**: `payload`
+- **Identifier**: JSONPath expression (e.g., `$.model`, `$.messages[0].model`)
+
+**Header**: Extract model from HTTP header:
+- **Location**: `header`
+- **Identifier**: Header name (e.g., `X-Model-Name`, `X-LLM-Model`)
+
+**Query Parameter**: Extract model from URL query parameter:
+
+- **Location**: `queryParam`
+- **Identifier**: Query parameter name (e.g., `model`, `llm_model`)
+
+**Path Parameter**: Extract model from URL path using regex:
+
+- **Location**: `pathParam`
+- **Identifier**: Regex pattern to match model in path (e.g., `models/([a-zA-Z0-9.\-]+)`)
+
+#### Model Suspension
+
+When a model returns a 5xx or 429 response, the policy can automatically suspend that model for a configurable duration:
+
+- **Suspension Duration**: Configured via the `suspendDuration` parameter (in seconds)
+- **Automatic Recovery**: Suspended models are automatically re-enabled after the suspension period expires
+- **Availability Check**: Suspended models are skipped during round-robin selection until they recover
+
+#### Suspension Behavior
+
+- Suspension is tracked per **provider/model pair**, not by model name alone. The same
+  model name behind two different providers is suspended independently, so a failure
+  on one provider does not remove the model from rotation on another provider.
+- If all targets are suspended, the policy returns HTTP 503 with error: "All models are currently unavailable"
+- Suspension period starts from the time of failure
+
+
+## Notes
+- For path parameters, the regex pattern should include a capturing group to extract the model name. The policy uses the first capturing group as the model identifier.
+- This capability evenly distributes requests across multiple models to improve availability, balance load and cost, support A/B testing, and enable seamless traffic sharing across models from different providers.
+- The round-robin index is maintained per policy instance and increments for each request.
+- Model selection is deterministic and follows a strict cyclic pattern.
+- The original model from the request is stored in metadata but is replaced with the selected model for routing.
+- If `suspendDuration` is 0, failed models are not suspended and will continue to be selected in the round-robin cycle.
+- The `requestModel` configuration is required and must be provided by the LLM provider template.
+- **State locality:** Round-robin index and provider/model suspension state are held in
+  memory, local to each policy-engine instance. They are not shared across instances and
+  are reset on process restart or configuration reload. With multiple gateway replicas,
+  each replica advances its own round-robin cursor and tracks suspensions independently.

--- a/docs/model-round-robin/v1.1/metadata.json
+++ b/docs/model-round-robin/v1.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "model-round-robin",
+  "displayName": "Model Round Robin",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements round-robin load balancing for AI models. Distributes requests evenly\nacross multiple configured AI models in a cyclic manner, ensuring equal request\nallocation over time and preventing overloading of any single model."
+}

--- a/docs/model-weighted-round-robin/v1.1/docs/model-weighted-round-robin.md
+++ b/docs/model-weighted-round-robin/v1.1/docs/model-weighted-round-robin.md
@@ -1,0 +1,271 @@
+---
+title: "Overview"
+---
+# Model Weighted Round Robin
+
+## Overview
+
+The Model Weighted Round Robin policy implements weighted round-robin load balancing for AI models. It distributes requests based on predefined weight values assigned to each model, enabling probabilistic control over request distribution and giving higher priority to models with greater processing power or availability. This policy is useful for distributing load proportionally across models based on their capacity, cost, or performance characteristics.
+
+## Features
+
+- Weighted distribution of requests across multiple models based on assigned weights
+- Proportional request allocation (models with higher weights receive more requests)
+- Optional per-target routing to additional LLM providers (multi-provider weighted round robin)
+- Automatic model suspension on failures (5xx or 429 responses), scoped to the selected provider/model pair
+- Configurable suspension duration for failed models
+- Support for extracting model identifier from payload, headers, query parameters, or path parameters
+- Dynamic model selection based on availability and weights
+
+## Configuration
+
+This policy requires configuration in both the API definition YAML and the LLM provider template.
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `models` | `WeightedModel` array | Yes | - | List of models with weights for weighted round-robin distribution. Each model must have a `model` name and `weight`. |
+| `suspendDuration` | integer | No | `30` | Suspension time in seconds for failed models. Set to `0` to disable failed-model suspension tracking. Must be >= 0. |
+
+### WeightedModel Configuration
+
+Each model in the `models` array is an object with the following properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `model` | string | Yes | The AI model name to use for load balancing. |
+| `weight` | integer | Yes | The weight assigned to this model for distribution. Higher weights mean more requests will be routed to this model. Weight is relative to total weight of all models. Must be at least 1. |
+| `provider` | string | No | Optionally routes this target to an additional LLM provider. Must match an `LlmProxy` `additionalProviders[].as` value, or the provider id when `as` is absent. When omitted, the request uses the `LlmProxy` primary/default provider. |
+
+#### Multi-provider routing
+
+Each weighted target can optionally name an additional provider. When a target
+specifies `provider`, the policy routes the request to that provider's named
+upstream during the request **header** phase (Envoy dynamic cluster selection)
+and records `selected_provider` in request metadata so conditional provider
+authentication and protocol transformers can adapt to the chosen provider. When
+`provider` is omitted, no upstream override is applied and `selected_provider` is
+not set, so the `LlmProxy` primary-provider fallback, authentication, and default
+cluster logic continue to apply unchanged. The provider is preserved through the
+weighted-sequence expansion, so a target's weight and provider are honored together.
+
+```yaml
+models:
+  - model: gpt-4o
+    weight: 3
+    # Omitted provider → LlmProxy primary/default provider.
+  - model: claude-sonnet-4-5-20250929
+    provider: anthropic-provider   # matches additionalProviders[].as (or provider id)
+    weight: 1
+```
+
+#### LLM provider template
+
+This policy depends on the `requestModel` configuration defined in the LLM provider template to identify and extract the model from incoming requests.
+
+> **Required:** The `requestModel` configuration must be provided; the policy will not function without it.
+
+### `requestModel` Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `requestModel.location` | string | Yes | Location of the model identifier: `payload`, `header`, `queryParam`, or `pathParam` |
+| `requestModel.identifier` | string | Yes | JSONPath (for payload), header name (for header), query param name (for queryParam), or regex pattern (for pathParam) to extract model |
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: model-weighted-round-robin
+  gomodule: github.com/wso2/gateway-controllers/policies/model-weighted-round-robin@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Basic Weighted Round Robin with Payload-based Model
+
+Deploy an LLM provider with weighted round-robin load balancing:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: weighted-round-robin-provider
+spec:
+  displayName: Weighted Round Robin Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: model-weighted-round-robin
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4
+                weight: 3
+              - model: gpt-3.5-turbo
+                weight: 2
+              - model: gpt-4-turbo
+                weight: 1
+            suspendDuration: 60
+```
+
+**Test the weighted round-robin distribution:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# Requests will be distributed: 50% gpt-4, 33.3% gpt-3.5-turbo, 16.7% gpt-4-turbo
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello"
+      }
+    ]
+  }'
+```
+
+### Example 2: Multi-Provider Weighted Round Robin
+
+Distribute weighted traffic across a primary provider and additional providers.
+Deploy the three `LlmProvider` resources first. The `LlmProxy` references their
+`metadata.name` values through `id`. Each `models[]` entry references an additional
+provider by its proxy-local `as` alias (or by `id` when `as` is omitted). Targets
+without a `provider` use the primary provider.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProxy
+metadata:
+  name: multi-provider-weighted-round-robin
+spec:
+  displayName: Multi Provider Weighted Round Robin
+  version: v1.0
+  provider:
+    id: openai-primary-provider
+  additionalProviders:
+    - id: anthropic-provider-resource
+      as: anthropic-provider
+    - id: bedrock-provider-resource
+      as: bedrock-provider
+      transformer:
+        type: openai-to-bedrock-transformer
+        version: v0
+  policies:
+    - name: model-weighted-round-robin
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            models:
+              - model: gpt-4o                          # primary provider
+                weight: 3
+              - model: claude-sonnet-4-5-20250929
+                provider: anthropic-provider
+                weight: 1
+              - model: anthropic.claude-3-5-sonnet-20240620-v1:0
+                provider: bedrock-provider
+                weight: 1
+            suspendDuration: 60
+```
+
+With a 3:1:1 weighting, roughly 60% of requests use the primary provider, 20% the
+anthropic-provider, and 20% the bedrock-provider. Requests routed to an additional
+provider carry `selected_provider` metadata so the provider's conditional
+authentication and any protocol transformer are applied.
+
+## How It Works
+
+#### Model Selection
+
+On each request, the policy selects the next available model in a weighted cyclic sequence.
+- **Weight Calculation**: During initialization, the policy computes total weight and builds a weighted sequence where each model appears proportional to its configured weight.
+- **Model Extraction**: The policy extracts the original model from the request (if configured) and stores it for reference.
+- **Model Modification**: The policy modifies the request to use the selected model based on the `requestModel` configuration.
+
+#### Request Model Locations
+
+The policy supports extracting the model identifier from different locations in the request:
+
+**Payload (JSONPath)**: Extract model from JSON payload using JSONPath:
+- **Location**: `payload`
+- **Identifier**: JSONPath expression (e.g., `$.model`, `$.messages[0].model`)
+
+**Header**: Extract model from HTTP header:
+- **Location**: `header`
+- **Identifier**: Header name (e.g., `X-Model-Name`, `X-LLM-Model`)
+
+**Query Parameter**: Extract model from URL query parameter:
+- **Location**: `queryParam`
+- **Identifier**: Query parameter name (e.g., `model`, `llm_model`)
+
+**Path Parameter**: Extract model from URL path using regex:
+- **Location**: `pathParam`
+- **Identifier**: Regex pattern to match model in path (e.g., `models/([a-zA-Z0-9.\-]+)`)
+
+#### Model Suspension
+
+When a model returns a 5xx or 429 response, the policy can automatically suspend that model for a configurable duration:
+
+- **Suspension Duration**: Configured via the `suspendDuration` parameter (in seconds)
+- **Automatic Recovery**: Suspended models are automatically re-enabled after the suspension period expires
+- **Availability Check**: Suspended models are skipped during weighted round-robin selection until they recover
+- **Weight Preservation**: When a model is suspended, the remaining models continue to be selected based on their relative weights
+
+#### Suspension Behavior
+
+- Suspension is tracked per **provider/model pair**, not by model name alone. The same
+  model name behind two different providers is suspended independently.
+- If all targets are suspended, the policy returns HTTP 503 with error: "All models are currently unavailable"
+- Suspension period starts from the time of failure
+- When a target is suspended, the weighted sequence is dynamically adjusted to exclude that provider/model pair
+
+#### Weight Calculation
+
+The policy builds a weighted sequence by repeating each model a number of times equal to its weight:
+
+- **Total Weight**: Sum of all model weights
+- **Sequence Length**: Equal to the total weight
+- **Distribution**: Each model appears in the sequence `weight` times
+- **Proportional Selection**: Over time, each model receives requests proportional to `model_weight / total_weight`
+
+
+
+## Notes
+
+- For path parameters, the regex pattern should include a capturing group to extract the model name. The policy uses the first capturing group as the model identifier.
+- This capability distributes requests proportionally across multiple models to balance capacity, cost, performance tiers, and migration rollout needs.
+- The weighted sequence is pre-computed once during policy initialization and reused for all requests. It is not rebuilt on each request.
+- The round-robin index is maintained per policy instance and increments for each request.
+- Model selection follows the weighted sequence in a deterministic cyclic pattern.
+- The original model from the request is stored in metadata but is replaced with the selected model for routing.
+- If `suspendDuration` is 0, failed models are not suspended and will continue to be selected in the weighted round-robin cycle.
+- Higher weights result in more frequent selection but do not guarantee exact proportional distribution in small request volumes.
+- The weighted sequence ensures long-term proportional distribution, but short-term distribution may vary due to suspension and availability.
+- The `requestModel` configuration is required and must be provided by the LLM provider template. There is no default behavior.
+- **State locality:** The weighted-sequence cursor and provider/model suspension state are
+  held in memory, local to each policy-engine instance. They are not shared across instances
+  and are reset on process restart or configuration reload. With multiple gateway replicas,
+  each replica advances its own cursor and tracks suspensions independently.

--- a/docs/model-weighted-round-robin/v1.1/metadata.json
+++ b/docs/model-weighted-round-robin/v1.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "model-weighted-round-robin",
+  "displayName": "Model Weighted Round Robin",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements weighted round-robin load balancing for AI models. Distributes requests\nbased on predefined weight values assigned to each model, enabling probabilistic\ncontrol over request distribution and giving higher priority to models with greater\nprocessing power or availability."
+}

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v1.0.3
+version: v1.1.0
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.
@@ -18,6 +18,14 @@ parameters:
           model:
             type: string
             description: Specifies the AI model name.
+            minLength: 1
+          provider:
+            type: string
+            description: |
+              Optionally routes this target to an additional LLM provider.
+              Must match an LlmProxy additionalProviders[].as value, or the
+              provider id when `as` is absent. When omitted, the request uses
+              the LlmProxy primary/default provider.
             minLength: 1
         required:
           - model

--- a/policies/model-round-robin/roundrobin.go
+++ b/policies/model-round-robin/roundrobin.go
@@ -36,9 +36,21 @@ import (
 const (
 	// Metadata keys for context storage
 	MetadataKeySelectedModel    = "model_roundrobin.selected_model"
+	MetadataKeySelectedProvider = "model_roundrobin.selected_provider"
 	MetadataKeyOriginalModel    = "model_roundrobin.original_model"
 	MetadataKeyHeadersProcessed = "model_roundrobin.headers_processed"
 	DefaultSuspendDuration      = 30
+
+	// MetadataKeyProviderRouting is the engine-level contract key consumed by
+	// conditional provider auth and protocol transformers to identify the
+	// additional provider a request was routed to. It is only set when the
+	// selected target specifies a provider.
+	MetadataKeyProviderRouting = "selected_provider"
+
+	// suspensionKeySeparator separates provider and model in the composite
+	// suspension key so the same model name on different providers is tracked
+	// independently. A NUL byte can never appear in a provider or model name.
+	suspensionKeySeparator = "\x00"
 )
 
 // ModelRoundRobinPolicyParams holds the parsed policy parameters
@@ -51,6 +63,17 @@ type ModelRoundRobinPolicyParams struct {
 // ModelConfig represents a single model configuration
 type ModelConfig struct {
 	Model string
+	// Provider optionally names an additional LLM provider to route this target to.
+	// It must match an LlmProxy additionalProviders[].as value (or the provider id
+	// when `as` is absent). Empty means the LlmProxy primary/default provider.
+	Provider string
+}
+
+// suspensionKey builds the composite key used to track failed targets. Keying on
+// provider + model (rather than model alone) keeps the same model name on
+// different providers independently suspendable.
+func suspensionKey(provider, model string) string {
+	return provider + suspensionKeySeparator + model
 }
 
 // RequestModelConfig holds the requestModel configuration
@@ -142,6 +165,16 @@ func parseParams(params map[string]interface{}) (ModelRoundRobinPolicyParams, er
 			return result, fmt.Errorf("'models[%d].model' must have a minimum length of 1", i)
 		}
 		modelConfig.Model = modelNameStr
+
+		// Parse provider (optional). Omitted or empty means the LlmProxy
+		// primary/default provider is used and no upstream override is applied.
+		if providerRaw, ok := modelMap["provider"]; ok {
+			providerStr, ok := providerRaw.(string)
+			if !ok {
+				return result, fmt.Errorf("'models[%d].provider' must be a string", i)
+			}
+			modelConfig.Provider = providerStr
+		}
 
 		result.Models = append(result.Models, modelConfig)
 	}
@@ -241,20 +274,20 @@ func (p *ModelRoundRobinPolicy) selectNextAvailableModel(models []ModelConfig) *
 	for attemptCount < totalModels {
 		// Get current model (copy to avoid returning pointer to slice element)
 		selectedModel := models[p.currentIndex]
-		modelName := selectedModel.Model
+		key := suspensionKey(selectedModel.Provider, selectedModel.Model)
 
 		// Move to next index for next call
 		p.currentIndex = (p.currentIndex + 1) % totalModels
 
-		// Check if model is suspended
-		if suspendedUntil, ok := p.suspendedModels[modelName]; ok {
+		// Check if this provider/model pair is suspended
+		if suspendedUntil, ok := p.suspendedModels[key]; ok {
 			if now.Before(suspendedUntil) {
-				// This model is still suspended, try next
+				// This target is still suspended, try next
 				attemptCount++
 				continue
 			}
 			// Suspension period has expired, remove from suspended list
-			delete(p.suspendedModels, modelName)
+			delete(p.suspendedModels, key)
 		}
 
 		return &selectedModel
@@ -280,9 +313,27 @@ func (p *ModelRoundRobinPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 		}
 	}
 
+	// Always record the selected model and its provider. The provider is stored
+	// under a policy-internal key so OnResponseHeaders can rebuild the composite
+	// suspension key even for the default (empty) provider.
 	reqCtx.Metadata[MetadataKeySelectedModel] = selectedModel.Model
+	reqCtx.Metadata[MetadataKeySelectedProvider] = selectedModel.Provider
 	reqCtx.Metadata[MetadataKeyHeadersProcessed] = true
-	slog.Debug("ModelRoundRobin: OnRequestHeaders selected model", "model", selectedModel.Model)
+	slog.Debug("ModelRoundRobin: OnRequestHeaders selected model", "model", selectedModel.Model, "provider", selectedModel.Provider)
+
+	mods := policy.UpstreamRequestHeaderModifications{}
+
+	// When the target names an additional provider, route to its named upstream in
+	// the header phase (so Envoy sees the selected cluster before forwarding) and
+	// expose it to conditional provider auth / protocol transformers via the
+	// engine's selected_provider metadata key. When the provider is empty we leave
+	// UpstreamName unset and do not set selected_provider, so the LlmProxy primary
+	// provider fallback, authentication, and default cluster logic keep working.
+	if selectedModel.Provider != "" {
+		providerName := selectedModel.Provider
+		mods.UpstreamName = &providerName
+		reqCtx.Metadata[MetadataKeyProviderRouting] = selectedModel.Provider
+	}
 
 	switch location {
 	case "header":
@@ -292,27 +343,19 @@ func (p *ModelRoundRobinPolicy) OnRequestHeaders(ctx context.Context, reqCtx *po
 				reqCtx.Metadata[MetadataKeyOriginalModel] = values[0]
 			}
 		}
-		return policy.UpstreamRequestHeaderModifications{
-			HeadersToSet: map[string]string{identifier: selectedModel.Model},
-		}
+		mods.HeadersToSet = map[string]string{identifier: selectedModel.Model}
 	case "queryParam":
 		newPath := p.modifyQueryParamInPath(reqCtx.Path, identifier, selectedModel.Model)
 		if newPath != reqCtx.Path {
-			return policy.UpstreamRequestHeaderModifications{
-				Path: &newPath,
-			}
+			mods.Path = &newPath
 		}
-		return policy.UpstreamRequestHeaderModifications{}
 	case "pathParam":
 		newPath := p.modifyPathParamInPath(reqCtx.Path, identifier, selectedModel.Model)
 		if newPath != reqCtx.Path {
-			return policy.UpstreamRequestHeaderModifications{
-				Path: &newPath,
-			}
+			mods.Path = &newPath
 		}
-		return policy.UpstreamRequestHeaderModifications{}
 	}
-	return policy.UpstreamRequestHeaderModifications{}
+	return mods
 }
 
 // OnResponseHeaders suspends a model in the response header phase when an error is detected.
@@ -324,11 +367,20 @@ func (p *ModelRoundRobinPolicy) OnResponseHeaders(ctx context.Context, respCtx *
 				selectedModel = modelStr
 			}
 		}
+		selectedProvider := ""
+		if provider, ok := respCtx.Metadata[MetadataKeySelectedProvider]; ok {
+			if providerStr, ok := provider.(string); ok {
+				selectedProvider = providerStr
+			}
+		}
 		if p.params.SuspendDuration > 0 && selectedModel != "" {
+			// Suspend only the selected provider/model pair, not the model name on
+			// every provider.
+			key := suspensionKey(selectedProvider, selectedModel)
 			p.mu.Lock()
-			p.suspendedModels[selectedModel] = time.Now().Add(time.Duration(p.params.SuspendDuration) * time.Second)
+			p.suspendedModels[key] = time.Now().Add(time.Duration(p.params.SuspendDuration) * time.Second)
 			p.mu.Unlock()
-			slog.Debug("ModelRoundRobin: OnResponseHeaders suspended model", "model", selectedModel, "duration", p.params.SuspendDuration)
+			slog.Debug("ModelRoundRobin: OnResponseHeaders suspended model", "model", selectedModel, "provider", selectedProvider, "duration", p.params.SuspendDuration)
 		}
 	}
 	return policy.DownstreamResponseHeaderModifications{}

--- a/policies/model-round-robin/roundrobin_test.go
+++ b/policies/model-round-robin/roundrobin_test.go
@@ -275,8 +275,8 @@ func TestModelRoundRobinPolicy_OnRequestHeaders_AllModelsSuspended(t *testing.T)
 	})
 
 	until := time.Now().Add(10 * time.Minute)
-	p.suspendedModels["gpt-4"] = until
-	p.suspendedModels["gpt-35"] = until
+	p.suspendedModels[suspensionKey("", "gpt-4")] = until
+	p.suspendedModels[suspensionKey("", "gpt-35")] = until
 
 	ctx := &policy.RequestHeaderContext{
 		SharedContext: rrSharedContext(),
@@ -317,7 +317,7 @@ func TestModelRoundRobinPolicy_OnResponseHeaders_SuspendsModelOnError(t *testing
 	if _, ok := action.(policy.DownstreamResponseHeaderModifications); !ok {
 		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
-	until, exists := p.suspendedModels["gpt-4"]
+	until, exists := p.suspendedModels[suspensionKey("", "gpt-4")]
 	if !exists {
 		t.Fatalf("expected model to be suspended")
 	}
@@ -329,7 +329,7 @@ func TestModelRoundRobinPolicy_OnResponseHeaders_SuspendsModelOnError(t *testing
 func TestModelRoundRobinPolicy_SelectNextAvailableModel_SkipsAndRecoversSuspended(t *testing.T) {
 	p := &ModelRoundRobinPolicy{
 		currentIndex:    0,
-		suspendedModels: map[string]time.Time{"a": time.Now().Add(5 * time.Minute)},
+		suspendedModels: map[string]time.Time{suspensionKey("", "a"): time.Now().Add(5 * time.Minute)},
 	}
 	models := []ModelConfig{{Model: "a"}, {Model: "b"}}
 
@@ -338,7 +338,7 @@ func TestModelRoundRobinPolicy_SelectNextAvailableModel_SkipsAndRecoversSuspende
 		t.Fatalf("expected to skip suspended a and pick b, got %+v", got)
 	}
 
-	p.suspendedModels["a"] = time.Now().Add(-1 * time.Minute)
+	p.suspendedModels[suspensionKey("", "a")] = time.Now().Add(-1 * time.Minute)
 	got2 := p.selectNextAvailableModel(models)
 	if got2 == nil || got2.Model != "a" {
 		t.Fatalf("expected expired suspension model a to be selected, got %+v", got2)
@@ -354,6 +354,133 @@ func TestModelRoundRobinPolicy_ExtractInt(t *testing.T) {
 	}
 	if _, err := extractInt(float64(4.2)); err == nil {
 		t.Fatalf("expected error for non-integer float")
+	}
+}
+
+func TestModelRoundRobinPolicy_GetPolicy_ProviderParsing(t *testing.T) {
+	// provider must be a string when present
+	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "gpt-4", "provider": 123},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "'models[0].provider' must be a string") {
+		t.Fatalf("expected provider type error, got %v", err)
+	}
+
+	// omitted provider defaults to empty; explicit provider is preserved
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "gpt-4o"},
+			map[string]interface{}{"model": "claude-sonnet-4-5-20250929", "provider": "anthropic-provider"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+	if p.params.Models[0].Provider != "" {
+		t.Fatalf("expected empty provider for first model, got %q", p.params.Models[0].Provider)
+	}
+	if p.params.Models[1].Provider != "anthropic-provider" {
+		t.Fatalf("expected anthropic-provider for second model, got %q", p.params.Models[1].Provider)
+	}
+}
+
+func TestModelRoundRobinPolicy_OnRequestHeaders_DefaultProvider(t *testing.T) {
+	// A target with no provider must not set UpstreamName or the selected_provider
+	// routing key, so the LlmProxy primary-provider fallback keeps working.
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models":       []interface{}{map[string]interface{}{"model": "gpt-4o"}},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	shared := rrSharedContext()
+	ctx := &policy.RequestHeaderContext{SharedContext: shared}
+	mods := mustRRRequestHeaderMods(t, p.OnRequestHeaders(context.Background(), ctx, nil))
+
+	if mods.UpstreamName != nil {
+		t.Fatalf("expected no UpstreamName for default provider, got %q", *mods.UpstreamName)
+	}
+	if _, ok := shared.Metadata[MetadataKeyProviderRouting]; ok {
+		t.Fatalf("expected selected_provider metadata to be unset for default provider")
+	}
+	if shared.Metadata[MetadataKeySelectedModel] != "gpt-4o" {
+		t.Fatalf("expected selected model metadata gpt-4o, got %v", shared.Metadata[MetadataKeySelectedModel])
+	}
+}
+
+func TestModelRoundRobinPolicy_OnRequestHeaders_AdditionalProvider(t *testing.T) {
+	// A target with a provider must route to its named upstream and expose the
+	// provider to conditional auth/transformers via selected_provider.
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "claude-sonnet-4-5-20250929", "provider": "anthropic-provider"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	shared := rrSharedContext()
+	ctx := &policy.RequestHeaderContext{SharedContext: shared}
+	mods := mustRRRequestHeaderMods(t, p.OnRequestHeaders(context.Background(), ctx, nil))
+
+	if mods.UpstreamName == nil || *mods.UpstreamName != "anthropic-provider" {
+		t.Fatalf("expected UpstreamName anthropic-provider, got %v", mods.UpstreamName)
+	}
+	if shared.Metadata[MetadataKeyProviderRouting] != "anthropic-provider" {
+		t.Fatalf("expected selected_provider metadata anthropic-provider, got %v", shared.Metadata[MetadataKeyProviderRouting])
+	}
+}
+
+func TestModelRoundRobinPolicy_IndependentSuspensionPerProvider(t *testing.T) {
+	// The same model name behind two providers must be suspended independently.
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "shared-model", "provider": "provider-a"},
+			map[string]interface{}{"model": "shared-model", "provider": "provider-b"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	// Suspend only provider-a/shared-model.
+	p.suspendedModels[suspensionKey("provider-a", "shared-model")] = time.Now().Add(10 * time.Minute)
+
+	got := p.selectNextAvailableModel(p.params.Models)
+	if got == nil || got.Provider != "provider-b" {
+		t.Fatalf("expected provider-b to remain available, got %+v", got)
+	}
+	if _, suspended := p.suspendedModels[suspensionKey("provider-b", "shared-model")]; suspended {
+		t.Fatalf("provider-b/shared-model should not be suspended")
+	}
+}
+
+func TestModelRoundRobinPolicy_OnResponseHeaders_SuspendsProviderModelPair(t *testing.T) {
+	// OnResponseHeaders must build the composite key from the selected provider
+	// metadata, suspending only that provider/model pair.
+	p := mustGetRRPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "shared-model", "provider": "provider-a"},
+			map[string]interface{}{"model": "shared-model", "provider": "provider-b"},
+		},
+		"suspendDuration": 60,
+		"requestModel":    map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	ctx := &policy.ResponseHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "id",
+			Metadata: map[string]interface{}{
+				MetadataKeySelectedModel:    "shared-model",
+				MetadataKeySelectedProvider: "provider-a",
+			},
+		},
+		ResponseStatus: 429,
+	}
+	p.OnResponseHeaders(context.Background(), ctx, nil)
+
+	if _, ok := p.suspendedModels[suspensionKey("provider-a", "shared-model")]; !ok {
+		t.Fatalf("expected provider-a/shared-model to be suspended")
+	}
+	if _, ok := p.suspendedModels[suspensionKey("provider-b", "shared-model")]; ok {
+		t.Fatalf("expected provider-b/shared-model to remain available")
 	}
 }
 

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-weighted-round-robin
-version: v1.0.3
+version: v1.1.0
 description: |
   Distribute requests across models using weighted round-robin so higher-weight models receive proportionally more traffic.
 
@@ -25,6 +25,14 @@ parameters:
               Weight is relative to total weight of all models.
             default: 1
             minimum: 1
+          provider:
+            type: string
+            description: |
+              Optionally routes this target to an additional LLM provider.
+              Must match an LlmProxy additionalProviders[].as value, or the
+              provider id when `as` is absent. When omitted, the request uses
+              the LlmProxy primary/default provider.
+            minLength: 1
         required:
           - model
           - weight

--- a/policies/model-weighted-round-robin/weightedroundrobin.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin.go
@@ -36,9 +36,21 @@ import (
 const (
 	// Metadata keys for context storage
 	MetadataKeySelectedModel    = "model_weighted_roundrobin.selected_model"
+	MetadataKeySelectedProvider = "model_weighted_roundrobin.selected_provider"
 	MetadataKeyOriginalModel    = "model_weighted_roundrobin.original_model"
 	MetadataKeyHeadersProcessed = "model_weighted_roundrobin.headers_processed"
 	DefaultSuspendDuration      = 30
+
+	// MetadataKeyProviderRouting is the engine-level contract key consumed by
+	// conditional provider auth and protocol transformers to identify the
+	// additional provider a request was routed to. It is only set when the
+	// selected target specifies a provider.
+	MetadataKeyProviderRouting = "selected_provider"
+
+	// suspensionKeySeparator separates provider and model in the composite
+	// suspension key so the same model name on different providers is tracked
+	// independently. A NUL byte can never appear in a provider or model name.
+	suspensionKeySeparator = "\x00"
 )
 
 // ModelWeightedRoundRobinPolicyParams holds the parsed policy parameters
@@ -52,6 +64,17 @@ type ModelWeightedRoundRobinPolicyParams struct {
 type WeightedModel struct {
 	Model  string
 	Weight int
+	// Provider optionally names an additional LLM provider to route this target to.
+	// It must match an LlmProxy additionalProviders[].as value (or the provider id
+	// when `as` is absent). Empty means the LlmProxy primary/default provider.
+	Provider string
+}
+
+// suspensionKey builds the composite key used to track failed targets. Keying on
+// provider + model (rather than model alone) keeps the same model name on
+// different providers independently suspendable.
+func suspensionKey(provider, model string) string {
+	return provider + suspensionKeySeparator + model
 }
 
 // RequestModelConfig holds the requestModel configuration
@@ -85,8 +108,9 @@ func GetPolicy(
 	weightedModels := make([]*WeightedModel, len(policyParams.Models))
 	for i, modelConfig := range policyParams.Models {
 		weightedModels[i] = &WeightedModel{
-			Model:  modelConfig.Model,
-			Weight: modelConfig.Weight,
+			Model:    modelConfig.Model,
+			Weight:   modelConfig.Weight,
+			Provider: modelConfig.Provider,
 		}
 	}
 
@@ -172,6 +196,16 @@ func parseParams(params map[string]interface{}) (ModelWeightedRoundRobinPolicyPa
 		}
 
 		modelConfig.Weight = weightInt
+
+		// Parse provider (optional). Omitted or empty means the LlmProxy
+		// primary/default provider is used and no upstream override is applied.
+		if providerRaw, ok := modelMap["provider"]; ok {
+			providerStr, ok := providerRaw.(string)
+			if !ok {
+				return result, fmt.Errorf("'models[%d].provider' must be a string", i)
+			}
+			modelConfig.Provider = providerStr
+		}
 
 		result.Models = append(result.Models, modelConfig)
 	}
@@ -280,15 +314,16 @@ func (p *ModelWeightedRoundRobinPolicy) selectNextAvailableWeightedModel() *Weig
 		selectedModel := sequence[p.currentIndex%len(sequence)]
 		p.currentIndex++
 
-		// Check if model is suspended
-		if suspendedUntil, ok := p.suspendedModels[selectedModel.Model]; ok {
+		// Check if this provider/model pair is suspended
+		key := suspensionKey(selectedModel.Provider, selectedModel.Model)
+		if suspendedUntil, ok := p.suspendedModels[key]; ok {
 			if now.Before(suspendedUntil) {
-				// This model is still suspended, try next
+				// This target is still suspended, try next
 				attemptCount++
 				continue
 			}
 			// Suspension period has expired, remove from suspended list
-			delete(p.suspendedModels, selectedModel.Model)
+			delete(p.suspendedModels, key)
 		}
 
 		return selectedModel
@@ -343,9 +378,27 @@ func (p *ModelWeightedRoundRobinPolicy) OnRequestHeaders(ctx context.Context, re
 		}
 	}
 
+	// Always record the selected model and its provider. The provider is stored
+	// under a policy-internal key so OnResponseHeaders can rebuild the composite
+	// suspension key even for the default (empty) provider.
 	reqCtx.Metadata[MetadataKeySelectedModel] = selectedModel.Model
+	reqCtx.Metadata[MetadataKeySelectedProvider] = selectedModel.Provider
 	reqCtx.Metadata[MetadataKeyHeadersProcessed] = true
-	slog.Debug("ModelWeightedRoundRobin: OnRequestHeaders selected model", "model", selectedModel.Model, "weight", selectedModel.Weight)
+	slog.Debug("ModelWeightedRoundRobin: OnRequestHeaders selected model", "model", selectedModel.Model, "weight", selectedModel.Weight, "provider", selectedModel.Provider)
+
+	mods := policy.UpstreamRequestHeaderModifications{}
+
+	// When the target names an additional provider, route to its named upstream in
+	// the header phase (so Envoy sees the selected cluster before forwarding) and
+	// expose it to conditional provider auth / protocol transformers via the
+	// engine's selected_provider metadata key. When the provider is empty we leave
+	// UpstreamName unset and do not set selected_provider, so the LlmProxy primary
+	// provider fallback, authentication, and default cluster logic keep working.
+	if selectedModel.Provider != "" {
+		providerName := selectedModel.Provider
+		mods.UpstreamName = &providerName
+		reqCtx.Metadata[MetadataKeyProviderRouting] = selectedModel.Provider
+	}
 
 	switch location {
 	case "header":
@@ -355,26 +408,19 @@ func (p *ModelWeightedRoundRobinPolicy) OnRequestHeaders(ctx context.Context, re
 				reqCtx.Metadata[MetadataKeyOriginalModel] = values[0]
 			}
 		}
-		return policy.UpstreamRequestHeaderModifications{
-			HeadersToSet: map[string]string{identifier: selectedModel.Model},
-		}
+		mods.HeadersToSet = map[string]string{identifier: selectedModel.Model}
 	case "queryParam":
 		newPath := p.modifyQueryParamInPath(reqCtx.Path, identifier, selectedModel.Model)
 		if newPath != reqCtx.Path {
-			return policy.UpstreamRequestHeaderModifications{
-				Path: &newPath,
-			}
+			mods.Path = &newPath
 		}
-		return policy.UpstreamRequestHeaderModifications{}
 	case "pathParam":
 		newPath := p.modifyPathParamInPath(reqCtx.Path, identifier, selectedModel.Model)
 		if newPath != reqCtx.Path {
-			return policy.UpstreamRequestHeaderModifications{
-				Path: &newPath,
-			}
+			mods.Path = &newPath
 		}
 	}
-	return policy.UpstreamRequestHeaderModifications{}
+	return mods
 }
 
 // OnResponseHeaders suspends a model in the response header phase when an error is detected.
@@ -386,11 +432,20 @@ func (p *ModelWeightedRoundRobinPolicy) OnResponseHeaders(ctx context.Context, r
 				selectedModel = modelStr
 			}
 		}
+		selectedProvider := ""
+		if provider, ok := respCtx.Metadata[MetadataKeySelectedProvider]; ok {
+			if providerStr, ok := provider.(string); ok {
+				selectedProvider = providerStr
+			}
+		}
 		if p.params.SuspendDuration > 0 && selectedModel != "" {
+			// Suspend only the selected provider/model pair, not the model name on
+			// every provider.
+			key := suspensionKey(selectedProvider, selectedModel)
 			p.mu.Lock()
-			p.suspendedModels[selectedModel] = time.Now().Add(time.Duration(p.params.SuspendDuration) * time.Second)
+			p.suspendedModels[key] = time.Now().Add(time.Duration(p.params.SuspendDuration) * time.Second)
 			p.mu.Unlock()
-			slog.Debug("ModelWeightedRoundRobin: OnResponseHeaders suspended model", "model", selectedModel, "duration", p.params.SuspendDuration)
+			slog.Debug("ModelWeightedRoundRobin: OnResponseHeaders suspended model", "model", selectedModel, "provider", selectedProvider, "duration", p.params.SuspendDuration)
 		}
 	}
 	return policy.DownstreamResponseHeaderModifications{}

--- a/policies/model-weighted-round-robin/weightedroundrobin_test.go
+++ b/policies/model-weighted-round-robin/weightedroundrobin_test.go
@@ -258,8 +258,8 @@ func TestModelWeightedRoundRobinPolicy_OnRequestHeaders_AllModelsSuspended(t *te
 	})
 
 	until := time.Now().Add(10 * time.Minute)
-	p.suspendedModels["gpt-4"] = until
-	p.suspendedModels["gpt-35"] = until
+	p.suspendedModels[suspensionKey("", "gpt-4")] = until
+	p.suspendedModels[suspensionKey("", "gpt-35")] = until
 
 	ctx := &policy.RequestHeaderContext{
 		SharedContext: weightedSharedContext(),
@@ -299,7 +299,7 @@ func TestModelWeightedRoundRobinPolicy_OnResponseHeaders_SuspendsSelectedModel(t
 	if _, ok := action.(policy.DownstreamResponseHeaderModifications); !ok {
 		t.Fatalf("expected DownstreamResponseHeaderModifications, got %T", action)
 	}
-	if until, exists := p.suspendedModels["gpt-4"]; !exists || !until.After(time.Now()) {
+	if until, exists := p.suspendedModels[suspensionKey("", "gpt-4")]; !exists || !until.After(time.Now()) {
 		t.Fatalf("expected selected model to be suspended")
 	}
 }
@@ -307,7 +307,7 @@ func TestModelWeightedRoundRobinPolicy_OnResponseHeaders_SuspendsSelectedModel(t
 func TestModelWeightedRoundRobinPolicy_SelectNextAvailable_SkipsSuspended(t *testing.T) {
 	p := &ModelWeightedRoundRobinPolicy{
 		suspendedModels: map[string]time.Time{
-			"a": time.Now().Add(5 * time.Minute),
+			suspensionKey("", "a"): time.Now().Add(5 * time.Minute),
 		},
 		weightedSequence: []*WeightedModel{
 			{Model: "a", Weight: 2},
@@ -318,6 +318,126 @@ func TestModelWeightedRoundRobinPolicy_SelectNextAvailable_SkipsSuspended(t *tes
 	got := p.selectNextAvailableWeightedModel()
 	if got == nil || got.Model != "b" {
 		t.Fatalf("expected to skip suspended model a and pick b, got %+v", got)
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_GetPolicy_ProviderParsing(t *testing.T) {
+	_, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "gpt-4", "weight": 1, "provider": 123},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "'models[0].provider' must be a string") {
+		t.Fatalf("expected provider type error, got %v", err)
+	}
+
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "gpt-4o", "weight": 3},
+			map[string]interface{}{"model": "claude-sonnet-4-5-20250929", "weight": 1, "provider": "anthropic-provider"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+	if p.params.Models[0].Provider != "" {
+		t.Fatalf("expected empty provider for first model, got %q", p.params.Models[0].Provider)
+	}
+	if p.params.Models[1].Provider != "anthropic-provider" {
+		t.Fatalf("expected anthropic-provider, got %q", p.params.Models[1].Provider)
+	}
+	// The provider must survive expansion into the weighted sequence.
+	for _, m := range p.weightedSequence {
+		if m.Model == "claude-sonnet-4-5-20250929" && m.Provider != "anthropic-provider" {
+			t.Fatalf("expected provider preserved in weighted sequence, got %q", m.Provider)
+		}
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnRequestHeaders_DefaultProvider(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models":       []interface{}{map[string]interface{}{"model": "gpt-4o", "weight": 1}},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	shared := weightedSharedContext()
+	ctx := &policy.RequestHeaderContext{SharedContext: shared}
+	mods := mustWeightedRequestHeaderMods(t, p.OnRequestHeaders(context.Background(), ctx, nil))
+
+	if mods.UpstreamName != nil {
+		t.Fatalf("expected no UpstreamName for default provider, got %q", *mods.UpstreamName)
+	}
+	if _, ok := shared.Metadata[MetadataKeyProviderRouting]; ok {
+		t.Fatalf("expected selected_provider metadata to be unset for default provider")
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnRequestHeaders_AdditionalProvider(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "claude-sonnet-4-5-20250929", "weight": 1, "provider": "anthropic-provider"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	shared := weightedSharedContext()
+	ctx := &policy.RequestHeaderContext{SharedContext: shared}
+	mods := mustWeightedRequestHeaderMods(t, p.OnRequestHeaders(context.Background(), ctx, nil))
+
+	if mods.UpstreamName == nil || *mods.UpstreamName != "anthropic-provider" {
+		t.Fatalf("expected UpstreamName anthropic-provider, got %v", mods.UpstreamName)
+	}
+	if shared.Metadata[MetadataKeyProviderRouting] != "anthropic-provider" {
+		t.Fatalf("expected selected_provider metadata anthropic-provider, got %v", shared.Metadata[MetadataKeyProviderRouting])
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_IndependentSuspensionPerProvider(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "shared-model", "weight": 1, "provider": "provider-a"},
+			map[string]interface{}{"model": "shared-model", "weight": 1, "provider": "provider-b"},
+		},
+		"requestModel": map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	p.suspendedModels[suspensionKey("provider-a", "shared-model")] = time.Now().Add(10 * time.Minute)
+
+	got := p.selectNextAvailableWeightedModel()
+	if got == nil || got.Provider != "provider-b" {
+		t.Fatalf("expected provider-b to remain available, got %+v", got)
+	}
+	if _, suspended := p.suspendedModels[suspensionKey("provider-b", "shared-model")]; suspended {
+		t.Fatalf("provider-b/shared-model should not be suspended")
+	}
+}
+
+func TestModelWeightedRoundRobinPolicy_OnResponseHeaders_SuspendsProviderModelPair(t *testing.T) {
+	p := mustGetWeightedPolicy(t, map[string]interface{}{
+		"models": []interface{}{
+			map[string]interface{}{"model": "shared-model", "weight": 1, "provider": "provider-a"},
+			map[string]interface{}{"model": "shared-model", "weight": 1, "provider": "provider-b"},
+		},
+		"suspendDuration": 60,
+		"requestModel":    map[string]interface{}{"location": "payload", "identifier": "$.model"},
+	})
+
+	ctx := &policy.ResponseHeaderContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "id",
+			Metadata: map[string]interface{}{
+				MetadataKeySelectedModel:    "shared-model",
+				MetadataKeySelectedProvider: "provider-a",
+			},
+		},
+		ResponseStatus: 429,
+	}
+	p.OnResponseHeaders(context.Background(), ctx, nil)
+
+	if _, ok := p.suspendedModels[suspensionKey("provider-a", "shared-model")]; !ok {
+		t.Fatalf("expected provider-a/shared-model to be suspended")
+	}
+	if _, ok := p.suspendedModels[suspensionKey("provider-b", "shared-model")]; ok {
+		t.Fatalf("expected provider-b/shared-model to remain available")
 	}
 }
 


### PR DESCRIPTION

## Purpose
Enable model round-robin and model weighted round-robin policies to route traffic across multiple providers, not only multiple models within a single provider.

This is needed so users can configure fallback/load distribution across provider backends such as primary, Anthropic, and Bedrock while preserving the existing single-provider round-robin behavior.

Resolves N/A

## Goals
- Add multi-provider support to `model-round-robin`.
- Add multi-provider support to `model-weighted-round-robin`.
- Preserve existing single-provider model round-robin and weighted round-robin behavior.
- Add documentation and metadata for the new `v1.1` policy versions.
- Add unit test coverage for provider-aware routing behavior.

## Approach
The policy definitions were extended to support `additionalProviders`.

The model round-robin and weighted round-robin policy implementations now select both the target model and, when configured, the selected provider. Existing single-provider configurations continue to work as before.

Documentation and metadata were added for:
- `docs/model-round-robin/v1.1/docs/model-round-robin.md`
- `docs/model-round-robin/v1.1/metadata.json`
- `docs/model-weighted-round-robin/v1.1/docs/model-weighted-round-robin.md`
- `docs/model-weighted-round-robin/v1.1/metadata.json`

No UI changes are included.

## User stories
As an API developer, I want to distribute model traffic across multiple AI providers using round-robin routing so that I can improve availability and provider-level load distribution.

As an API developer, I want to distribute model traffic across multiple AI providers using weighted round-robin routing so that I can control traffic percentage across providers and models.

As an existing user of single-provider model round-robin policies, I want my current configurations to continue working without behavior changes.

## Release note
Added multi-provider support for model round-robin and model weighted round-robin policies.

## Documentation
Documentation added in this PR:
- `docs/model-round-robin/v1.1/docs/model-round-robin.md`
- `docs/model-weighted-round-robin/v1.1/docs/model-weighted-round-robin.md`

## Training
N/A - no training content changes are included in this PR.

## Certification
N/A - this change extends policy configuration and routing behavior, but does not introduce certification exam impact.

## Marketing
N/A - no marketing content changes are included in this PR.

## Automation tests
- Unit tests
  - Added/updated unit tests for `model-round-robin`.
  - Added/updated unit tests for `model-weighted-round-robin`.
  - Verified policy unit tests pass.

- Integration tests
  - Integration test coverage is included in the related `api-platform-main` PR.
  - Verified both new multi-provider integration features.
  - Verified existing single-provider model round-robin and weighted round-robin integration features.
  - Added provider-specific auth proof in integration coverage to confirm provider-specific behavior executes only when that provider is selected.
 
<img width="619" height="959" alt="Screenshot 2026-07-27 at 11 44 18" src="https://github.com/user-attachments/assets/05d3be1f-2c09-48fb-acd8-464629695775" />


## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - no sample changes are included in this PR.

## Related PRs
- Related `api-platform-main` PR: N/A until PR is created

## Migrations (if applicable)
N/A - no migration steps are required. Existing single-provider configurations remain supported.

## Test environment
- macOS
- Go test environment
- Docker/Rancher Desktop for integration validation in the related `api-platform-main` repository

## Learning
Implemented by following the existing gateway policy patterns for model routing, policy configuration, and documentation structure. The change reuses the existing round-robin and weighted round-robin behavior while extending the selected backend context to include provider selection when multiple providers are configured.

