### PR TITLE
[LLM COST] Add Version v1.1.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ All available policies, sorted alphabetically.
 | [JSON Schema Guardrail](./json-schema-guardrail/v1.0/docs/json-schema.md) | Guardrails, AI | Validates request or response body content against a JSON Schema. |
 | [JSON/XML Mediator](./json-xml-mediator/v1.0/docs/json-xml-mediator.md) | Transformation | Mediates request and response payloads between downstream and upstream JSON/XML formats. |
 | [JWT Auth](./jwt-auth/v1.3/docs/jwt-authentication.md) | Security, AI, WebSub, WebBroker | Validates JWT access tokens included in API requests. |
-| [LLM Cost](./llm-cost/v1.0/docs/llm-cost.md) | AI | Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. |
+| [LLM Cost](./llm-cost/v1.1/docs/llm-cost.md) | AI | Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. |
 | [LLM Cost Based Ratelimit](./llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md) | AI | A specialized rate limiting policy that enforces monetary budget limits on LLM API usage. |
 | [LLM Header Router](./llm-header-router/v0.9/docs/llm-header-router.md) | AI | Selects an LLM provider for OpenAI Chat Completions requests using a configurable request header. |
 | [Log Message](./log-message/v1.0/docs/log-message.md) | Logging, Analytics & Monitoring, MCP, WebSub, WebBroker | This policy provides the capability to log the payload and headers of a request/response. |

--- a/docs/llm-cost/v1.1/docs/llm-cost.md
+++ b/docs/llm-cost/v1.1/docs/llm-cost.md
@@ -1,0 +1,166 @@
+---
+title: "Overview"
+---
+# LLM Cost
+
+## Overview
+
+The LLM Cost policy calculates the monetary cost of an LLM API call at response time and stores the result in `SharedContext.Metadata`. The cost is not exposed as a response header -- it is only available to other policies in the same request pipeline, such as the [LLM Cost Based Ratelimit](../../../llm-cost-based-ratelimit/v1.0/docs/llm-cost-based-ratelimit.md) policy.
+
+The policy reads the model name from the response body or request context, looks it up in a pricing database, and computes the cost using provider-specific calculators that normalise token usage fields across different response formats.
+
+Use this policy when you need to:
+
+- Track the monetary cost of each LLM API call for billing or observability.
+- Feed downstream policies (such as budget-based rate limiting) with accurate per-call cost data.
+- Support cost attribution across multiple LLM providers from a single gateway.
+
+## Features
+
+- **Automatic Cost Calculation**: Computes cost from token usage fields in the LLM response -- no manual configuration per model.
+- **Multi-Provider Support**: Built-in calculators for OpenAI, Anthropic, Gemini (Google AI Studio and Vertex AI), Mistral, and AWS Bedrock.
+- **AWS Bedrock Support**: Handles native Converse, ConverseStream, InvokeModel, and InvokeModelWithResponseStream responses, as well as responses converted to OpenAI format by the OpenAI-to-Bedrock Transformer policy.
+- **Bedrock Pricing Lookup**: Resolves foundation model IDs, cross-region inference profile IDs, and Bedrock ARNs against the pricing database.
+- **Prompt Cache Pricing**: Accounts for Bedrock cache reads and both 5-minute and 1-hour cache writes, including applicable long-context pricing tiers.
+- **Pricing Database**: Model pricing is loaded once at startup from a JSON file shipped with the gateway image.
+- **SharedContext Integration**: Stores the calculated cost in `SharedContext.Metadata` under `x-llm-cost` for use by downstream policies.
+- **Analytics Integration**: Publishes the calculated cost, model ID, and normalised prompt, completion, and total token counts as analytics metadata.
+- **Non-Blocking on Failure**: If the model is not found in the pricing database or usage cannot be parsed, the cost is set to `0.0000000000` and the request is not blocked.
+- **Status Metadata**: Sets `x-llm-cost-status` to `calculated` or `not_calculated` to disambiguate a zero cost from a failed calculation.
+
+## Configuration
+
+This policy has no user parameters. All configuration is handled by the gateway administrator via system parameters.
+
+### System Parameters (From config.toml)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pricing_file` | string | Yes | - | Path to the model pricing JSON file shipped with the gateway image. Can be overridden by the gateway administrator via `config.toml`. |
+
+#### Sample System Configuration
+
+```toml
+[policy_configurations.llm_cost_v1]
+pricing_file = "/etc/gateway/pricing.json"
+```
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: llm-cost
+  gomodule: github.com/wso2/gateway-controllers/policies/llm-cost@v1
+```
+
+## Reference Scenarios
+
+This policy runs in the response phase and is designed to be placed before cost-consuming policies in the policy chain (such as `llm-cost-based-ratelimit`).
+
+### Example 1: Attach LLM Cost Policy to an OpenAI Provider
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: llm-cost
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+After each successful response, the policy stores the calculated cost in `SharedContext.Metadata`:
+
+- `x-llm-cost`: USD dollar amount formatted to 10 decimal places (for example, `"0.0000423100"`).
+- `x-llm-cost-status`: `"calculated"` if the cost was computed successfully, or `"not_calculated"` if the model was not found in the pricing database or parsing failed.
+
+### Example 2: Use with LLM Cost Based Ratelimit
+
+The primary use case is pairing this policy with `llm-cost-based-ratelimit` to enforce monetary budget limits. Place `llm-cost-based-ratelimit` before `llm-cost` in the policy list -- because response-phase policies execute in reverse order, `llm-cost` runs first in the response to calculate the cost, and then `llm-cost-based-ratelimit` deducts it:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: openai-provider
+spec:
+  displayName: OpenAI Provider
+  version: v1.0
+  context: /openai
+  upstream:
+    url: https://api.openai.com
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer ${OPENAI_API_KEY}
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: llm-cost-based-ratelimit
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            budgetLimits:
+              - amount: 10
+                duration: "24h"
+    - name: llm-cost
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+```
+
+### Example 3: Attach LLM Cost Policy to AWS Bedrock
+
+Attach the policy to the Bedrock runtime paths used by your provider. The policy obtains the model ID from the `/model/{modelId}/...` request path when the response does not include it:
+
+```yaml
+policies:
+  - name: llm-cost
+    version: v1
+    paths:
+      - path: /model/*
+        methods: [POST]
+```
+
+Both native Amazon event-stream responses and buffered JSON responses are supported. Pricing lookup accepts standard model IDs, cross-region inference profiles such as `us.anthropic.claude-3-7-sonnet-20250219-v1:0`, and URL-encoded Bedrock model ARNs.
+
+## How It Works
+
+1. **Response phase**: The response body or stream is accumulated and parsed.
+2. The model name is extracted from `$.model` in the response body. For Gemini native format, `$.modelVersion` is used as a fallback. For Bedrock, the model ID is extracted from the request path when necessary.
+3. The model name is looked up in the pricing database loaded at startup. Bedrock provider prefixes, ARNs, and inference profile IDs are normalised during lookup.
+4. A provider-specific calculator normalises the usage fields (prompt tokens, completion tokens, and provider-specific fields such as cache read tokens, cache write tokens, or reasoning tokens) into a common `Usage` struct.
+5. The cost is calculated using the normalised usage and the pricing entry, then adjusted for provider-specific multipliers and pricing tiers.
+6. The final cost, status, and analytics metadata are written to `SharedContext`, and the response continues unmodified.
+
+## Notes
+
+- The pricing file is loaded once at process startup using a singleton pattern. All APIs and routes that attach this policy share the same pricing data.
+- If the model name is not found in the pricing database, `x-llm-cost` is set to `0.0000000000`, `x-llm-cost-status` is set to `not_calculated`, and a warning is logged. The request is **not** blocked.
+- The cost is stored internally only and is never sent to the client as a response header.
+- Supported providers: **OpenAI**, **Anthropic**, **Gemini** (Google AI Studio and Vertex AI), **Mistral**, and **AWS Bedrock**.

--- a/docs/llm-cost/v1.1/docs/llm-cost.md
+++ b/docs/llm-cost/v1.1/docs/llm-cost.md
@@ -36,7 +36,7 @@ This policy has no user parameters. All configuration is handled by the gateway 
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `pricing_file` | string | Yes | - | Path to the model pricing JSON file shipped with the gateway image. Can be overridden by the gateway administrator via `config.toml`. |
+| `pricing_file` | string | Yes | - | Path to the model pricing JSON file shipped with the gateway image. Gateway administrators can override this path in `config.toml`. |
 
 #### Sample System Configuration
 

--- a/docs/llm-cost/v1.1/metadata.json
+++ b/docs/llm-cost/v1.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "llm-cost",
+  "displayName": "LLM Cost",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Calculates the monetary cost of LLM API calls at response time and stores the result in SharedContext for use by downstream policies. Supports OpenAI, Anthropic, Gemini, Mistral, and AWS Bedrock providers with automatic model pricing lookup."
+}

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,9 +1,5 @@
 name: llm-cost
-<<<<<<< HEAD
-version: v1.0.4
-=======
 version: v1.1.0
->>>>>>> 8a72e8f (release(llm-cost): add v1.1.0 documentation)
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,9 @@
 name: llm-cost
+<<<<<<< HEAD
 version: v1.0.4
+=======
+version: v1.1.0
+>>>>>>> 8a72e8f (release(llm-cost): add v1.1.0 documentation)
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").


### PR DESCRIPTION

## Purpose

Release LLM Cost policy version `v1.1.0` and publish the corresponding documentation for the existing AWS Bedrock cost-calculation support.

This ensures the policy catalog exposes the latest LLM Cost documentation and accurately describes the supported Bedrock request and response formats.

Related issue: N/A

## Goals

- Release the LLM Cost policy as `v1.1.0`.
- Add versioned documentation under `docs/llm-cost/v1.1`.
- Document AWS Bedrock cost calculation and pricing lookup.
- Update the policy catalog to reference the latest documentation.
- Preserve documentation for previous policy versions.

## Approach

- Updated `policies/llm-cost/policy-definition.yaml` to version `v1.1.0`.
- Created the `docs/llm-cost/v1.1` documentation directory following the existing versioned documentation structure.
- Added metadata for documentation version `1.1`.
- Documented support for:
  - Bedrock Converse and ConverseStream
  - Bedrock InvokeModel and InvokeModelWithResponseStream
  - Responses transformed into the OpenAI response format
  - Foundation model IDs, inference profile IDs, and Bedrock ARNs
  - Prompt-cache reads and 5-minute and 1-hour cache writes
  - LLM cost and token analytics metadata
- Regenerated `docs/README.md` to reference LLM Cost documentation version `v1.1`.

## User stories

- As a gateway administrator, I want to use the latest LLM Cost policy release so that the configured policy version is clearly identified.
- As a developer, I want documentation for AWS Bedrock cost calculation so that I can configure the policy correctly for Bedrock providers.
- As an operator, I want Bedrock model and prompt-cache pricing behavior documented so that calculated costs can be understood and verified.
- As a documentation user, I want the policy catalog to link to the latest LLM Cost documentation.

## Release note

Released LLM Cost policy `v1.1.0` with updated documentation for AWS Bedrock cost calculation, including native and streaming response formats, model pricing lookup, prompt caching, and analytics metadata.

## Documentation

- `docs/llm-cost/v1.1/docs/llm-cost.md`
- `docs/llm-cost/v1.1/metadata.json`
- `docs/README.md`

## Training

N/A — this change does not require updates to WSO2 training content.

## Certification

N/A — this documentation and policy version update does not affect existing certification examinations.

## Marketing

N/A — no dedicated marketing content is required for this policy version and documentation update.

## Automation tests

- Unit tests
  - Executed the complete LLM Cost policy Go test suite.
  - All tests passed.
  - No new executable policy logic is introduced by this PR.

- Integration tests
  - N/A — this PR contains a policy version update and documentation changes.
  - Existing LLM Cost and AWS Bedrock behavior remains covered by the policy test suite.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **No — this PR does not introduce Java code or executable policy logic**
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes**

## Samples

The documentation includes example policy configurations for:

- Attaching LLM Cost to an OpenAI provider.
- Using LLM Cost with LLM Cost Based Ratelimit.
- Attaching LLM Cost to AWS Bedrock runtime paths.

## Related PRs

N/A

## Migrations (if applicable)

No migration is required.

Existing users can continue using the `v1` Go module reference. The new policy definition version is `v1.1.0`, and previous versioned documentation remains available.

## Test environment

- Operating system: macOS
- Runtime: Go toolchain defined by the policy module
- Databases: N/A
- JDK: N/A
- Browsers: N/A

## Learning

Reviewed the existing versioned policy documentation conventions and AWS Bedrock response formats already supported by the LLM Cost policy. The new documentation follows the repository’s established policy metadata, catalog, and version-folder structure.
