### PR TITLE
semantic-cache: scope cache entries per caller (v1.1.0)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ All available policies, sorted alphabetically.
 | [Remove Headers](./remove-headers/v1.0/docs/remove-headers.md) | Transformation, MCP, WebSub, WebBroker | This policy provides the capability to remove headers from either the request or the response. |
 | [Request Rewrite](./request-rewrite/v1.0/docs/request-rewrite.md) | Transformation | Rewrites incoming requests by updating path, query parameters, and/or HTTP method before forwarding to upstream services. |
 | [Respond](./respond/v1.0/docs/respond.md) | AI | Returns an immediate response to the client without forwarding the request to the upstream backend. |
-| [Semantic Cache](./semantic-cache/v1.0/docs/semantic-caching.md) | AI | Implements semantic caching for LLM responses using vector similarity search. |
+| [Semantic Cache](./semantic-cache/v1.1/docs/semantic-caching.md) | AI | Implements semantic caching for LLM responses using vector similarity search. |
 | [Semantic Prompt Guard](./semantic-prompt-guard/v1.0/docs/semantic-prompt-guard.md) | Guardrails, AI | Blocks or allows prompts based on semantic similarity to configured allow/deny phrase embeddings. |
 | [Semantic Tool Filtering](./semantic-tool-filtering/v1.0/docs/semantic-tool-filtering.md) | Guardrails, AI | Dynamically filters the tools provided within an API request based on their semantic relevance to the user query. |
 | [Sentence Count Guardrail](./sentence-count-guardrail/v1.0/docs/sentence-count.md) | Guardrails, AI | Validates the sentence count of request or response body content. |

--- a/docs/semantic-cache/v1.1/docs/semantic-caching.md
+++ b/docs/semantic-cache/v1.1/docs/semantic-caching.md
@@ -1,0 +1,273 @@
+---
+title: "Overview"
+---
+# Semantic Caching
+
+## Overview
+
+The Semantic Cache policy enables intelligent response caching for LLM (Large Language Model) APIs using vector similarity search. Unlike traditional key-based caching, semantic caching understands the meaning of requests and can serve cached responses for semantically similar queries, even when the exact wording differs. This dramatically improves performance and reduces costs by avoiding redundant API calls to upstream LLM services.
+
+The policy uses embedding models to convert request text into high-dimensional vectors, then performs similarity searches in a vector database to find previously cached responses. If a similar request is found within the configured similarity threshold, the cached response is returned immediately without calling the upstream service.
+
+Cache entries are scoped to the authenticated caller (application/subscriber identity) in addition to the API/route, so a response produced for one caller is never served to a different caller.
+
+## Features
+
+- **Vector-based similarity matching**: Uses embeddings to find semantically similar requests, not just exact matches
+- **Multiple embedding provider support**: Works with OpenAI, Mistral, and Azure OpenAI embedding services
+- **Multiple vector database support**: Supports Redis and Milvus as vector storage backends
+- **Configurable similarity threshold**: Control cache hit sensitivity (0.0 to 1.0)
+- **JSONPath extraction**: Extract specific fields from request body for embedding generation
+- **Per-caller cache isolation**: Cache entries are bound to the authenticated caller identity; no cross-caller sharing by default
+- **Cacheability gate**: Responses marked `Cache-Control: no-store`, `private`, or `no-cache` are never cached
+- **Automatic cache management**: Stores eligible successful responses (200) automatically after upstream calls
+- **Immediate response on cache hit**: Returns cached response with `X-Cache-Status: HIT` header without upstream call
+- **TTL support**: Configurable time-to-live for cache entries
+
+
+## Configuration
+
+The Semantic Cache policy uses a two-level configuration
+
+### System Parameters (From config.toml)
+
+These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all Semantic Cache policy instances, they can be customized for individual policies within the API configuration when necessary.
+
+##### Embedding Provider Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `embeddingProvider` | string | Yes | Embedding provider type. Must be one of: `OPENAI`, `MISTRAL`, `AZURE_OPENAI` |
+| `embeddingEndpoint` | string | Yes | Endpoint URL for the embedding service. Examples: OpenAI: `https://api.openai.com/v1/embeddings`, Mistral: `https://api.mistral.ai/v1/embeddings`, Azure OpenAI: Your Azure OpenAI endpoint URL |
+| `embeddingModel` | string | Conditional | - | Embedding model name. **Required for OPENAI and MISTRAL**, not required for AZURE_OPENAI (deployment name is in endpoint URL). Examples: OpenAI: `text-embedding-ada-002` or `text-embedding-3-small`, Mistral: `mistral-embed` |
+| `embeddingDimension` | integer | Yes | Dimension of embedding vectors. Common values: 1536 (OpenAI ada-002), 1024 (Mistral). Must match the model's output dimension. |
+| `apiKey` | string | Yes | API key for the embedding service authentication. The authentication header is automatically set to `api-key` for Azure OpenAI and `Authorization` for other providers. |
+
+##### Vector Database Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `vectorStoreProvider` | string | Yes | Vector database provider. Must be one of: `REDIS`, `MILVUS` |
+| `dbHost` | string | Yes | Vector database host address |
+| `dbPort` | integer | Yes | Vector database port number |
+| `username` | string | No | Database username for authentication (if required) |
+| `password` | string | No | Database password for authentication (if required) |
+| `database` | string | No | Database name or index number (for Redis) |
+| `ttl` | integer | No | Time-to-live for cache entries in seconds. Default is 3600 (1 hour). Set to 0 for no expiration. |
+
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+embedding_provider = "MISTRAL" # Supported: MISTRAL, OPENAI, AZURE_OPENAI
+embedding_provider_endpoint = "https://api.mistral.ai/v1/embeddings"
+embedding_provider_model = "mistral-embed"
+embedding_provider_dimension = 1024
+embedding_provider_api_key = ""
+
+vector_db_provider = "REDIS" # Supported: REDIS, MILVUS
+vector_db_provider_host = "redis"
+vector_db_provider_port = 6379
+vector_db_provider_database = "0"
+vector_db_provider_username = "default"
+vector_db_provider_password = "default"
+vector_db_provider_ttl = 3600
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `similarityThreshold` | number | Yes | `0.5` | Similarity threshold for cache hits (0.0 to 1.0). Higher values require more similarity. For example, 0.9 means 90% similarity required. Recommended: 0.85-0.95 for strict matching, 0.70-0.85 for more flexible matching. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract text from request body for embedding generation. If empty, uses the entire request body. Example: `"$.messages[-1].content"` to extract the last message's content. |
+| `cacheUnauthenticated` | boolean | No | `false` | Controls caching for requests with no resolvable caller identity (a fully public, unauthenticated API). See [Cache Scoping and Provenance](#cache-scoping-and-provenance) below before enabling. |
+
+#### JSONPath Support
+
+The policy supports JSONPath expressions to extract specific text from request bodies before generating embeddings. This is useful for:
+- Extracting message content from chat completion requests
+- Focusing on specific prompt fields while ignoring metadata
+- Handling structured JSON payloads
+
+**Common JSONPath Examples**
+
+- `$.messages[0].content` - First message's content in chat completions
+- `$.messages[-1].content` - Last message's content
+- `$.prompt` - Extract prompt field from completions API
+- `$.input` - Extract input field from embeddings API
+- `$` - Entire request body (default if jsonPath is not specified)
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: semantic-cache
+  gomodule: github.com/wso2/gateway-controllers/policies/semantic-cache@v1
+```
+
+## Reference Scenarios
+
+### Example 1: OpenAI Embeddings with Redis
+
+Deploy an LLM provider with semantic caching using OpenAI embeddings and Redis vector store:
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1alpha1
+kind: LlmProvider
+metadata:
+  name: cached-chat-provider
+spec:
+  displayName: OpenAI Cached Provider
+  version: v1.0
+  template: openai
+  vhost: openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  policies:
+    - name: semantic-cache
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            similarityThreshold: 0.85
+            jsonPath: "$.messages[0].content"
+
+```
+
+**Test the semantic cache:**
+
+**Note**: Ensure that "openai" is mapped to the appropriate IP address (e.g., 127.0.0.1) in your `/etc/hosts` file, or remove the vhost from the LLM provider configuration and use localhost to invoke.
+
+```bash
+# First request - cache miss, will call upstream
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -H "Authorization: Bearer <consumer-token>" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain quantum computing in simple terms"
+      }
+    ]
+  }'
+
+# Second request with similar but different wording, from the SAME caller - cache hit!
+curl -X POST http://openai:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Host: openai" \
+  -H "Authorization: Bearer <consumer-token>" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Can you describe quantum computing using simple language?"
+      }
+    ]
+  }'
+# Response will include: X-Cache-Status: HIT
+```
+
+## How It Works
+
+#### Request Phase
+
+1. **Text Extraction**: Extracts text from the request body using JSONPath (if configured) or uses the entire request body
+2. **Caller Identity Resolution**: Resolves the caller's identity (application/subscriber ID from authentication, or a JWT subject/client ID). If no identity can be resolved and `cacheUnauthenticated` is not enabled, the cache is bypassed entirely and the request proceeds to the upstream service (see [Cache Scoping and Provenance](#cache-scoping-and-provenance))
+3. **Embedding Generation**: Generates a vector embedding from the extracted text using the configured embedding provider
+4. **Cache Lookup**: Searches the vector database for semantically similar cached responses previously stored by the SAME caller, using cosine similarity
+5. **Threshold Check**: If a similar embedding is found with similarity >= similarityThreshold, returns the cached response immediately
+6. **Cache Miss**: If no similar response is found, the request proceeds to the upstream service
+
+#### Response Phase
+
+1. **Success Check**: Only processes responses with 200 status codes
+2. **Cacheability Check**: Responses marked `Cache-Control: no-store`, `private`, or `no-cache` are skipped and never stored
+3. **Embedding Retrieval**: Retrieves the embedding generated during the request phase from metadata
+4. **Response Storage**: Stores the response payload along with its embedding in the vector database, scoped to the resolved caller identity
+5. **TTL Application**: Applies the configured TTL to the cache entry
+
+
+#### Similarity Thresholds
+
+The `similarityThreshold` parameter controls how similar requests must be to trigger a cache hit:
+
+- **0.95-1.0**: Very strict matching. Only near-identical requests will hit cache. Use for exact-match scenarios.
+- **0.85-0.94**: Recommended for most use cases. Catches semantically equivalent requests with some wording variation.
+- **0.75-0.84**: More flexible matching. Useful for broader conceptual similarity.
+- **0.60-0.74**: Very flexible. May return cached responses for loosely related queries.
+- **Below 0.60**: Not recommended. Risk of returning irrelevant cached responses.
+
+**Recommendation**: Start with 0.85 and adjust based on your use case. Monitor cache hit rates and response relevance to fine-tune.
+
+## Cache Scoping and Provenance
+
+- **Per-caller isolation**: Every cache entry is bound to the caller who produced it (resolved from the application/subscriber identity established by an auth policy, or falling back to the JWT subject/client ID). Lookups only ever match entries written by the same caller — one caller can never receive another caller's cached response, and a caller cannot seed an entry another caller will be served.
+- **`cacheUnauthenticated` (default `false`)**: For a fully public, unauthenticated API where no caller identity is ever available, the cache is bypassed by default — nothing is stored or served. Setting `cacheUnauthenticated: true` restores a single shared, api-wide cache bucket for all identity-less callers.
+
+  > **Security warning**: enabling `cacheUnauthenticated` means any identity-less caller who can influence the upstream's response for a given prompt can seed an entry that is later served to a *different* identity-less caller as a trusted cache hit (cache poisoning), and a personalized or sensitive response produced for one identity-less caller can be replayed to another. Only enable this when every possible response the upstream can produce is safe to share across all unauthenticated callers of the API.
+- **`no-store` responses are never cached**: a response whose `Cache-Control` header contains `no-store`, `private`, or `no-cache` is skipped by the storage step regardless of caller identity.
+
+#### Cache Behavior
+
+- **Cache Hit**: When a similar request from the same caller (or the same shared bucket, if `cacheUnauthenticated` is enabled) is found, the policy immediately returns the cached response with a `200` status, adds the `X-Cache-Status: HIT` header, and avoids any upstream call, typically responding in under 50 ms.
+
+- **Cache Miss**: When no similar request exists for that caller, the request is forwarded to the upstream service, and upon a successful `200` response that is not marked non-shareable, the result is stored so that subsequent similar requests from the same caller can be served from the cache.
+
+- **Cache Storage**: Only eligible successful responses are cached along with their embeddings in the vector database, with a TTL applied to each entry and isolated cache namespaces maintained per route/API **and per caller** to prevent cross-contamination.
+
+
+#### Operational Resilience
+- **Graceful degradation**: If embedding generation, vector database access, cache storage, or JSONPath extraction fails, the request proceeds directly to the upstream service without blocking the client response.
+
+- **Non-blocking resilience**: Caching operations are best-effort and never interfere with normal request handling, ensuring uninterrupted service even when caching components are unavailable.
+
+
+- **Latency and efficiency trade-offs**: Embedding generation adds processing overhead, and vector database performance, embedding dimensions, and index creation time directly affect latency, storage, and search efficiency.
+
+- **Cache effectiveness**: Overall performance gains depend on achieving a healthy cache hit rate, with moderate hit ratios delivering meaningful cost and latency benefits that justify the added processing overhead.
+
+
+
+
+## Notes
+
+- This capability reduces cost and latency by serving cached responses, helps manage rate limits and high traffic, ensures consistent results, improves resilience during upstream outages, and supports faster development, testing, and experimentation such as A/B testing.
+
+- The policy requires both request and response phases to function properly (generates embeddings in request phase, stores responses in response phase).
+
+- Embedding generation adds latency to each request (~100-500ms). This overhead is typically offset by the performance gains from cache hits.
+
+- Cache entries are scoped per route/API **and per authenticated caller** to prevent cross-contamination between different APIs, routes, or callers. Identity-less (unauthenticated) requests are not cached unless `cacheUnauthenticated` is explicitly enabled — see [Cache Scoping and Provenance](#cache-scoping-and-provenance).
+
+- Only responses with 200 status code are cached. Errors and non-200 responses are never cached. Responses marked `Cache-Control: no-store`, `private`, or `no-cache` are also never cached.
+
+- The similarity search uses cosine similarity to compare embeddings. This is optimal for semantic similarity matching.
+
+- Vector database indexes are created automatically when the policy is first used. Ensure your vector database has sufficient resources.
+
+- The policy maintains provider instances per route for efficiency. Configuration changes require policy reinitialization.
+
+- TTL of 0 means no expiration. Use with caution as it may lead to unbounded cache growth.
+
+- JSONPath extraction is optional. If not specified, the entire request body (as string) is used for embedding generation.
+
+- The policy stores embeddings in metadata between request and response phases. Ensure metadata persistence is enabled in your gateway configuration.
+
+- For production deployments, monitor cache hit rates, embedding generation latency, and vector database performance metrics to optimize configuration.

--- a/docs/semantic-cache/v1.1/docs/semantic-caching.md
+++ b/docs/semantic-cache/v1.1/docs/semantic-caching.md
@@ -39,7 +39,7 @@ These parameters are usually set at the gateway level and automatically applied,
 |-----------|------|----------|-------------|
 | `embeddingProvider` | string | Yes | Embedding provider type. Must be one of: `OPENAI`, `MISTRAL`, `AZURE_OPENAI` |
 | `embeddingEndpoint` | string | Yes | Endpoint URL for the embedding service. Examples: OpenAI: `https://api.openai.com/v1/embeddings`, Mistral: `https://api.mistral.ai/v1/embeddings`, Azure OpenAI: Your Azure OpenAI endpoint URL |
-| `embeddingModel` | string | Conditional | - | Embedding model name. **Required for OPENAI and MISTRAL**, not required for AZURE_OPENAI (deployment name is in endpoint URL). Examples: OpenAI: `text-embedding-ada-002` or `text-embedding-3-small`, Mistral: `mistral-embed` |
+| `embeddingModel` | string | Conditional | Embedding model name. **Required for OPENAI and MISTRAL**, not required for AZURE_OPENAI (deployment name is in endpoint URL). Examples: OpenAI: `text-embedding-ada-002` or `text-embedding-3-small`, Mistral: `mistral-embed` |
 | `embeddingDimension` | integer | Yes | Dimension of embedding vectors. Common values: 1536 (OpenAI ada-002), 1024 (Mistral). Must match the model's output dimension. |
 | `apiKey` | string | Yes | API key for the embedding service authentication. The authentication header is automatically set to `api-key` for Azure OpenAI and `Authorization` for other providers. |
 
@@ -234,7 +234,7 @@ The `similarityThreshold` parameter controls how similar requests must be to tri
 
 
 #### Operational Resilience
-- **Graceful degradation**: If embedding generation, vector database access, cache storage, or JSONPath extraction fails, the request proceeds directly to the upstream service without blocking the client response.
+- **Graceful degradation**: If embedding generation, vector database access, or cache storage fails, the request proceeds directly to the upstream service without blocking the client response. A JSONPath extraction failure is the exception: the policy returns a `400` error response instead of proceeding to the upstream service.
 
 - **Non-blocking resilience**: Caching operations are best-effort and never interfere with normal request handling, ensuring uninterrupted service even when caching components are unavailable.
 

--- a/docs/semantic-cache/v1.1/docs/semantic-caching.md
+++ b/docs/semantic-cache/v1.1/docs/semantic-caching.md
@@ -33,7 +33,7 @@ The Semantic Cache policy uses a two-level configuration
 
 These parameters are usually set at the gateway level and automatically applied, but they can also be overridden in the params section of an API artifact definition. System-wide defaults can be configured in the gateway's `config.toml` file, and while these defaults apply to all Semantic Cache policy instances, they can be customized for individual policies within the API configuration when necessary.
 
-##### Embedding Provider Configuration
+#### Embedding Provider Configuration
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -43,7 +43,7 @@ These parameters are usually set at the gateway level and automatically applied,
 | `embeddingDimension` | integer | Yes | Dimension of embedding vectors. Common values: 1536 (OpenAI ada-002), 1024 (Mistral). Must match the model's output dimension. |
 | `apiKey` | string | Yes | API key for the embedding service authentication. The authentication header is automatically set to `api-key` for Azure OpenAI and `Authorization` for other providers. |
 
-##### Vector Database Configuration
+#### Vector Database Configuration
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -186,7 +186,7 @@ curl -X POST http://openai:8080/chat/completions \
 
 ## How It Works
 
-#### Request Phase
+### Request Phase
 
 1. **Text Extraction**: Extracts text from the request body using JSONPath (if configured) or uses the entire request body
 2. **Caller Identity Resolution**: Resolves the caller's identity (application/subscriber ID from authentication, or a JWT subject/client ID). If no identity can be resolved and `cacheUnauthenticated` is not enabled, the cache is bypassed entirely and the request proceeds to the upstream service (see [Cache Scoping and Provenance](#cache-scoping-and-provenance))
@@ -195,7 +195,7 @@ curl -X POST http://openai:8080/chat/completions \
 5. **Threshold Check**: If a similar embedding is found with similarity >= similarityThreshold, returns the cached response immediately
 6. **Cache Miss**: If no similar response is found, the request proceeds to the upstream service
 
-#### Response Phase
+### Response Phase
 
 1. **Success Check**: Only processes responses with 200 status codes
 2. **Cacheability Check**: Responses marked `Cache-Control: no-store`, `private`, or `no-cache` are skipped and never stored
@@ -204,7 +204,7 @@ curl -X POST http://openai:8080/chat/completions \
 5. **TTL Application**: Applies the configured TTL to the cache entry
 
 
-#### Similarity Thresholds
+### Similarity Thresholds
 
 The `similarityThreshold` parameter controls how similar requests must be to trigger a cache hit:
 
@@ -224,7 +224,7 @@ The `similarityThreshold` parameter controls how similar requests must be to tri
   > **Security warning**: enabling `cacheUnauthenticated` means any identity-less caller who can influence the upstream's response for a given prompt can seed an entry that is later served to a *different* identity-less caller as a trusted cache hit (cache poisoning), and a personalized or sensitive response produced for one identity-less caller can be replayed to another. Only enable this when every possible response the upstream can produce is safe to share across all unauthenticated callers of the API.
 - **`no-store` responses are never cached**: a response whose `Cache-Control` header contains `no-store`, `private`, or `no-cache` is skipped by the storage step regardless of caller identity.
 
-#### Cache Behavior
+### Cache Behavior
 
 - **Cache Hit**: When a similar request from the same caller (or the same shared bucket, if `cacheUnauthenticated` is enabled) is found, the policy immediately returns the cached response with a `200` status, adds the `X-Cache-Status: HIT` header, and avoids any upstream call, typically responding in under 50 ms.
 
@@ -233,7 +233,7 @@ The `similarityThreshold` parameter controls how similar requests must be to tri
 - **Cache Storage**: Only eligible successful responses are cached along with their embeddings in the vector database, with a TTL applied to each entry and isolated cache namespaces maintained per route/API **and per caller** to prevent cross-contamination.
 
 
-#### Operational Resilience
+### Operational Resilience
 - **Graceful degradation**: If embedding generation, vector database access, or cache storage fails, the request proceeds directly to the upstream service without blocking the client response. A JSONPath extraction failure is the exception: the policy returns a `400` error response instead of proceeding to the upstream service.
 
 - **Non-blocking resilience**: Caching operations are best-effort and never interfere with normal request handling, ensuring uninterrupted service even when caching components are unavailable.

--- a/docs/semantic-cache/v1.1/metadata.json
+++ b/docs/semantic-cache/v1.1/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "semantic-cache",
+  "displayName": "Semantic Cache",
+  "version": "1.1",
+  "provider": "WSO2",
+  "categories": [
+    "AI"
+  ],
+  "description": "Implements semantic caching for LLM responses using vector similarity search.\nGenerates embeddings from request bodies and checks for semantically similar cached responses.\nIf a cache hit is found, returns the cached response immediately without calling the upstream.\nStores successful upstream responses in the cache for future lookups.\nCache entries are bound to the authenticated caller so one caller can never receive another\ncaller's cached response, and responses marked Cache-Control: no-store/private/no-cache are\nnever cached.\n\nNote: This policy requires embedding providers (OpenAI, Mistral, Azure OpenAI) and vector database providers (Redis, Milvus) to be configured."
+}

--- a/policies/semantic-cache/go.mod
+++ b/policies/semantic-cache/go.mod
@@ -1,11 +1,11 @@
 module github.com/wso2/gateway-controllers/policies/semantic-cache
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/wso2/api-platform/sdk/ai v0.1.2
-	github.com/wso2/api-platform/sdk/core v0.2.4
+	github.com/wso2/api-platform/sdk/core v0.2.14
 )
 
 require (

--- a/policies/semantic-cache/go.sum
+++ b/policies/semantic-cache/go.sum
@@ -387,8 +387,8 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/wso2/api-platform/sdk/ai v0.1.2 h1:z1OUFVT4IDxmH40or5ZSPL8rVp2dc4QDnFKPpFjt9oo=
 github.com/wso2/api-platform/sdk/ai v0.1.2/go.mod h1:EFQ6w1Orv6uyjNhCDxAr9Sanh33NmgoBCQyA9qHMudk=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
+github.com/wso2/api-platform/sdk/core v0.2.14 h1:z3LgbgOBeXGoJ891YqrpbpLfgYHZIm4Asj4o3IP5wI4=
+github.com/wso2/api-platform/sdk/core v0.2.14/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/policies/semantic-cache/policy-definition.yaml
+++ b/policies/semantic-cache/policy-definition.yaml
@@ -1,9 +1,15 @@
 name: semantic-cache
-version: v1.0.1
+version: v1.1.0
 description: |
   Caches LLM responses using semantic similarity over request embeddings to
   reduce repeated upstream calls. Returns cached responses on similarity hits
   and stores successful upstream responses for future reuse.
+
+  Cache entries are bound to the authenticated caller (application/subscriber
+  identity), so one caller can never receive another caller's cached response.
+  Responses marked Cache-Control: no-store, private, or no-cache are never
+  cached. Requests with no resolvable caller identity are not cached unless
+  cacheUnauthenticated is explicitly enabled.
 
 parameters:
   type: object
@@ -31,6 +37,23 @@ parameters:
         delta event when caching streamed responses. Only needed if the upstream
         uses a non-OpenAI-compatible streaming format.
       default: "$.choices[0].delta.content"
+    cacheUnauthenticated:
+      type: boolean
+      x-wso2-policy-advanced-param: true
+      description: |
+        Controls caching behavior for requests with no resolvable caller
+        identity (e.g. a fully public, unauthenticated API). Defaults to false:
+        such requests are neither served from nor stored into the cache.
+
+        SECURITY WARNING: setting this to true makes all identity-less callers
+        of this API share a single cache bucket. Any caller who can influence
+        the upstream's response for a given prompt can seed an entry that is
+        later served to a DIFFERENT identity-less caller as a trusted cache
+        hit (cache poisoning), and a personalized or sensitive response
+        produced for one identity-less caller can be replayed to another.
+        Only enable this for APIs where every possible response is safe to
+        share across all unauthenticated callers.
+      default: false
   required:
   - similarityThreshold
 

--- a/policies/semantic-cache/provenance_test.go
+++ b/policies/semantic-cache/provenance_test.go
@@ -1,0 +1,382 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+ 
+package semanticcache
+
+import (
+	"context"
+	"testing"
+
+	vectordbproviders "github.com/wso2/api-platform/sdk/ai/vectordb"
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// These tests encode the FIXED, secure behavior for F-181 (cache poisoning /
+// missing provenance): cache entries must be bound to the authenticated
+// caller, a Cache-Control: no-store/private/no-cache response must never be
+// stored, and identity-less (unauthenticated) requests must not be cached
+// unless the operator explicitly opts in via cacheUnauthenticated.
+//
+// Run against the pre-fix code, these tests fail — that failure IS the
+// reproduction of the vulnerability. After the fix they must pass.
+
+const applicationIDMetadataKeyForTest = "x-wso2-application-id"
+
+// --- Cross-caller isolation: Retrieve (request phase) ----------------------
+
+func TestOnRequestBody_CrossCallerIsolation(t *testing.T) {
+	seenAPIIDs := map[string]bool{}
+
+	newPolicy := func() *SemanticCachePolicy {
+		return &SemanticCachePolicy{
+			embeddingProvider: &mockEmbeddingProvider{getEmbeddingFn: func(input string) ([]float32, error) {
+				return []float32{0.2, 0.3}, nil
+			}},
+			vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+				apiID, _ := filter["api_id"].(string)
+				seenAPIIDs[apiID] = true
+				return vectordbproviders.CacheResponse{}, nil
+			}},
+			threshold: 0.5,
+		}
+	}
+
+	callerACtx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:  "r-caller-a",
+			APIName:    "Books",
+			APIVersion: "v1",
+			Metadata:   map[string]interface{}{applicationIDMetadataKeyForTest: "app-A"},
+		},
+		Body: &policy.Body{Content: []byte("repeatable prompt"), Present: true},
+	}
+	callerBCtx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:  "r-caller-b",
+			APIName:    "Books",
+			APIVersion: "v1",
+			Metadata:   map[string]interface{}{applicationIDMetadataKeyForTest: "app-B"},
+		},
+		Body: &policy.Body{Content: []byte("repeatable prompt"), Present: true},
+	}
+
+	newPolicy().OnRequestBody(context.Background(), callerACtx, nil)
+	newPolicy().OnRequestBody(context.Background(), callerBCtx, nil)
+
+	if len(seenAPIIDs) != 2 {
+		t.Fatalf("expected two distinct caller-scoped api_id values (cross-caller isolation), got %v", seenAPIIDs)
+	}
+}
+
+// --- Cross-caller isolation: Store (response phase) -------------------------
+
+func TestOnResponseBody_CrossCallerIsolation(t *testing.T) {
+	var apiIDs []string
+
+	newPolicy := func() *SemanticCachePolicy {
+		return &SemanticCachePolicy{
+			vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+				apiID, _ := filter["api_id"].(string)
+				apiIDs = append(apiIDs, apiID)
+				return nil
+			}},
+		}
+	}
+
+	callerACtx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:  "req-a",
+			APIName:    "Books",
+			APIVersion: "v1",
+			Metadata: map[string]interface{}{
+				MetadataKeyEmbedding:            "[0.1,0.2]",
+				applicationIDMetadataKeyForTest: "app-A",
+			},
+		},
+		ResponseStatus: 200,
+		ResponseBody:   &policy.Body{Content: []byte(`{"answer":"a caller-A private answer"}`), Present: true},
+	}
+	callerBCtx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:  "req-b",
+			APIName:    "Books",
+			APIVersion: "v1",
+			Metadata: map[string]interface{}{
+				MetadataKeyEmbedding:            "[0.1,0.2]",
+				applicationIDMetadataKeyForTest: "app-B",
+			},
+		},
+		ResponseStatus: 200,
+		ResponseBody:   &policy.Body{Content: []byte(`{"answer":"a caller-B private answer"}`), Present: true},
+	}
+
+	newPolicy().OnResponseBody(context.Background(), callerACtx, nil)
+	newPolicy().OnResponseBody(context.Background(), callerBCtx, nil)
+
+	if len(apiIDs) != 2 {
+		t.Fatalf("expected Store to be called for both callers, got %d calls: %v", len(apiIDs), apiIDs)
+	}
+	if apiIDs[0] == apiIDs[1] {
+		t.Fatalf("caller A and caller B stored under the SAME api_id (%q) — a poisoned/private entry from one caller would be served to the other", apiIDs[0])
+	}
+}
+
+// --- no-store / private / no-cache gate -------------------------------------
+
+func TestOnResponseBody_NoStoreHeaderNotCached(t *testing.T) {
+	tests := []struct {
+		name          string
+		cacheControl  string
+		wantStoreCall bool
+	}{
+		{name: "no-store", cacheControl: "no-store", wantStoreCall: false},
+		{name: "private", cacheControl: "private", wantStoreCall: false},
+		{name: "no-cache", cacheControl: "no-cache", wantStoreCall: false},
+		{name: "max-age is cacheable", cacheControl: "max-age=3600", wantStoreCall: true},
+		{name: "no header is cacheable", cacheControl: "", wantStoreCall: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storeCalled := false
+			p := &SemanticCachePolicy{
+				vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+					storeCalled = true
+					return nil
+				}},
+			}
+
+			headers := map[string][]string{}
+			if tt.cacheControl != "" {
+				headers["cache-control"] = []string{tt.cacheControl}
+			}
+
+			ctx := &policy.ResponseContext{
+				SharedContext: &policy.SharedContext{
+					RequestID:  "req-1",
+					APIName:    "Books",
+					APIVersion: "v1",
+					Metadata: map[string]interface{}{
+						MetadataKeyEmbedding:            "[0.1,0.2]",
+						applicationIDMetadataKeyForTest: "app-A",
+					},
+				},
+				ResponseStatus:  200,
+				ResponseBody:    &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+				ResponseHeaders: policy.NewHeaders(headers),
+			}
+
+			p.OnResponseBody(context.Background(), ctx, nil)
+
+			if storeCalled != tt.wantStoreCall {
+				t.Fatalf("Cache-Control: %q — expected storeCalled=%v, got %v", tt.cacheControl, tt.wantStoreCall, storeCalled)
+			}
+		})
+	}
+}
+
+// --- default skip-without-identity behavior ---------------------------------
+
+func TestOnRequestBody_NoIdentity_DefaultSkipsRetrieve(t *testing.T) {
+	retrieveCalled := false
+	p := &SemanticCachePolicy{
+		embeddingProvider: &mockEmbeddingProvider{},
+		vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+			retrieveCalled = true
+			return vectordbproviders.CacheResponse{}, nil
+		}},
+		threshold: 0.5,
+		// cacheUnauthenticated left at zero value (false) — the secure default.
+	}
+
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{RequestID: "r1", APIName: "Books", APIVersion: "v1", Metadata: map[string]interface{}{}},
+		Body:          &policy.Body{Content: []byte("hello"), Present: true},
+	}
+
+	action := p.OnRequestBody(context.Background(), ctx, nil)
+
+	if retrieveCalled {
+		t.Fatal("expected cache Retrieve to be skipped for an identity-less request when cacheUnauthenticated is false (default)")
+	}
+	if _, ok := action.(policy.UpstreamRequestModifications); !ok {
+		t.Fatalf("expected pass-through to upstream, got %T", action)
+	}
+}
+
+func TestOnResponseBody_NoIdentity_DefaultSkipsStore(t *testing.T) {
+	storeCalled := false
+	p := &SemanticCachePolicy{
+		vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+			storeCalled = true
+			return nil
+		}},
+		// cacheUnauthenticated left at zero value (false) — the secure default.
+	}
+
+	ctx := &policy.ResponseContext{
+		SharedContext:  &policy.SharedContext{RequestID: "req-1", APIName: "Books", APIVersion: "v1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
+		ResponseStatus: 200,
+		ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+	}
+
+	p.OnResponseBody(context.Background(), ctx, nil)
+
+	if storeCalled {
+		t.Fatal("expected cache Store to be skipped for an identity-less response when cacheUnauthenticated is false (default)")
+	}
+}
+
+// --- opt-in shared bucket for identity-less requests ------------------------
+
+func TestOnRequestBody_NoIdentity_CacheUnauthenticatedOptIn(t *testing.T) {
+	var seenFilter map[string]interface{}
+	p := &SemanticCachePolicy{
+		embeddingProvider: &mockEmbeddingProvider{},
+		vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
+			seenFilter = filter
+			return vectordbproviders.CacheResponse{}, nil
+		}},
+		threshold:            0.5,
+		cacheUnauthenticated: true,
+	}
+
+	ctx := &policy.RequestContext{
+		SharedContext: &policy.SharedContext{RequestID: "r1", APIName: "Books", APIVersion: "v1", Metadata: map[string]interface{}{}},
+		Body:          &policy.Body{Content: []byte("hello"), Present: true},
+	}
+
+	p.OnRequestBody(context.Background(), ctx, nil)
+
+	if seenFilter == nil {
+		t.Fatal("expected Retrieve to be called when cacheUnauthenticated is true")
+	}
+	if seenFilter["api_id"] != "Books:v1" {
+		t.Fatalf("expected shared api-wide bucket api_id=Books:v1, got %v", seenFilter["api_id"])
+	}
+}
+
+func TestOnResponseBody_NoIdentity_CacheUnauthenticatedOptIn(t *testing.T) {
+	var seenFilter map[string]interface{}
+	p := &SemanticCachePolicy{
+		vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+			seenFilter = filter
+			return nil
+		}},
+		cacheUnauthenticated: true,
+	}
+
+	ctx := &policy.ResponseContext{
+		SharedContext:  &policy.SharedContext{RequestID: "req-1", APIName: "Books", APIVersion: "v1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
+		ResponseStatus: 200,
+		ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+	}
+
+	p.OnResponseBody(context.Background(), ctx, nil)
+
+	if seenFilter == nil {
+		t.Fatal("expected Store to be called when cacheUnauthenticated is true")
+	}
+	if seenFilter["api_id"] != "Books:v1" {
+		t.Fatalf("expected shared api-wide bucket api_id=Books:v1, got %v", seenFilter["api_id"])
+	}
+}
+
+// --- identity resolution precedence -----------------------------------------
+
+func TestCallerIdentity_Precedence(t *testing.T) {
+	tests := []struct {
+		name   string
+		sc     *policy.SharedContext
+		wantID string
+		wantOK bool
+	}{
+		{
+			name:   "no identity anywhere",
+			sc:     &policy.SharedContext{Metadata: map[string]interface{}{}},
+			wantOK: false,
+		},
+		{
+			name:   "metadata application id wins",
+			sc:     &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "app-A"}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
+			wantID: "app-A",
+			wantOK: true,
+		},
+		{
+			name:   "falls back to AuthContext.Subject",
+			sc:     &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
+			wantID: "user-1",
+			wantOK: true,
+		},
+		{
+			name:   "falls back to AuthContext.CredentialID",
+			sc:     &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{CredentialID: "client-1"}},
+			wantID: "client-1",
+			wantOK: true,
+		},
+		{
+			name:   "empty metadata string value is ignored",
+			sc:     &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: ""}, AuthContext: &policy.AuthContext{Subject: "user-1"}},
+			wantID: "user-1",
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := callerIdentity(tt.sc)
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v (id=%q)", tt.wantOK, ok, id)
+			}
+			if ok && id != tt.wantID {
+				t.Fatalf("expected id=%q, got %q", tt.wantID, id)
+			}
+		})
+	}
+}
+
+// --- RequestHash carries provenance, not a throwaway random value ----------
+
+func TestOnResponseBody_RequestHashCarriesCallerIdentity(t *testing.T) {
+	var stored vectordbproviders.CacheResponse
+	p := &SemanticCachePolicy{
+		vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
+			stored = response
+			return nil
+		}},
+	}
+
+	ctx := &policy.ResponseContext{
+		SharedContext: &policy.SharedContext{
+			RequestID:  "req-1",
+			APIName:    "Books",
+			APIVersion: "v1",
+			Metadata: map[string]interface{}{
+				MetadataKeyEmbedding:            "[0.1,0.2]",
+				applicationIDMetadataKeyForTest: "app-A",
+			},
+		},
+		ResponseStatus: 200,
+		ResponseBody:   &policy.Body{Content: []byte(`{"answer":"x"}`), Present: true},
+	}
+
+	p.OnResponseBody(context.Background(), ctx, nil)
+
+	if stored.RequestHash != "app-A" {
+		t.Fatalf("expected RequestHash to carry the resolved caller identity (%q), got %q", "app-A", stored.RequestHash)
+	}
+}

--- a/policies/semantic-cache/provenance_test.go
+++ b/policies/semantic-cache/provenance_test.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
- 
+
 package semanticcache
 
 import (
@@ -300,10 +300,11 @@ func TestOnResponseBody_NoIdentity_CacheUnauthenticatedOptIn(t *testing.T) {
 
 func TestCallerIdentity_Precedence(t *testing.T) {
 	tests := []struct {
-		name   string
-		sc     *policy.SharedContext
-		wantID string
-		wantOK bool
+		name       string
+		sc         *policy.SharedContext
+		wantSource string
+		wantValue  string
+		wantOK     bool
 	}{
 		{
 			name:   "no identity anywhere",
@@ -311,41 +312,109 @@ func TestCallerIdentity_Precedence(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "metadata application id wins",
-			sc:     &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "app-A"}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
-			wantID: "app-A",
-			wantOK: true,
+			name:       "metadata application id wins",
+			sc:         &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "app-A"}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
+			wantSource: identitySourceApplicationID,
+			wantValue:  "app-A",
+			wantOK:     true,
 		},
 		{
-			name:   "falls back to AuthContext.Subject",
-			sc:     &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
-			wantID: "user-1",
-			wantOK: true,
+			name:       "falls back to AuthContext.Subject",
+			sc:         &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{Subject: "user-1", CredentialID: "client-1"}},
+			wantSource: identitySourceSubject,
+			wantValue:  "user-1",
+			wantOK:     true,
 		},
 		{
-			name:   "falls back to AuthContext.CredentialID",
-			sc:     &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{CredentialID: "client-1"}},
-			wantID: "client-1",
-			wantOK: true,
+			name:       "falls back to AuthContext.CredentialID",
+			sc:         &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{CredentialID: "client-1"}},
+			wantSource: identitySourceCredentialID,
+			wantValue:  "client-1",
+			wantOK:     true,
 		},
 		{
-			name:   "empty metadata string value is ignored",
-			sc:     &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: ""}, AuthContext: &policy.AuthContext{Subject: "user-1"}},
-			wantID: "user-1",
-			wantOK: true,
+			name:       "empty metadata string value is ignored",
+			sc:         &policy.SharedContext{Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: ""}, AuthContext: &policy.AuthContext{Subject: "user-1"}},
+			wantSource: identitySourceSubject,
+			wantValue:  "user-1",
+			wantOK:     true,
+		},
+		{
+			// api-key-auth sets neither Subject nor CredentialID for a key with
+			// no linked application (e.g. an LLM provider API key) - only
+			// TokenId, a hash of the raw credential. Confirmed against a live
+			// gateway: an LLM provider API key produced an empty-string
+			// Metadata[x-wso2-application-id] and a nil Subject/CredentialID.
+			name:       "falls back to AuthContext.TokenId when Subject and CredentialID are both empty",
+			sc:         &policy.SharedContext{Metadata: map[string]interface{}{}, AuthContext: &policy.AuthContext{TokenId: "token-hash-1"}},
+			wantSource: identitySourceTokenID,
+			wantValue:  "token-hash-1",
+			wantOK:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, ok := callerIdentity(tt.sc)
+			source, value, ok := callerIdentity(tt.sc)
 			if ok != tt.wantOK {
-				t.Fatalf("expected ok=%v, got %v (id=%q)", tt.wantOK, ok, id)
+				t.Fatalf("expected ok=%v, got %v (source=%q value=%q)", tt.wantOK, ok, source, value)
 			}
-			if ok && id != tt.wantID {
-				t.Fatalf("expected id=%q, got %q", tt.wantID, id)
+			if ok && (source != tt.wantSource || value != tt.wantValue) {
+				t.Fatalf("expected source=%q value=%q, got source=%q value=%q", tt.wantSource, tt.wantValue, source, value)
 			}
 		})
+	}
+}
+
+// --- cache scope collision across identity sources --------------------------
+
+func TestCacheScopeID_NoCollisionAcrossIdentitySources(t *testing.T) {
+	p := &SemanticCachePolicy{}
+	const apiID = "Books:v1"
+
+	// Two callers resolved from DIFFERENT identity sources but with the SAME
+	// raw string value must never land in the same partition.
+	appIDScope, ok := p.cacheScopeID(&policy.SharedContext{
+		Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "victim"},
+	}, apiID)
+	if !ok {
+		t.Fatal("expected application-id-based scope to be cacheable")
+	}
+
+	subjectScope, ok := p.cacheScopeID(&policy.SharedContext{
+		Metadata:    map[string]interface{}{},
+		AuthContext: &policy.AuthContext{Subject: "victim"},
+	}, apiID)
+	if !ok {
+		t.Fatal("expected subject-based scope to be cacheable")
+	}
+
+	if appIDScope == subjectScope {
+		t.Fatalf("application-id and subject identities with the same raw value %q collided on scope %q", "victim", appIDScope)
+	}
+
+	// A crafted value containing what looks like another source's tag must not
+	// let one source impersonate another: base64-encoding the raw value (rather
+	// than concatenating it verbatim after the tag) means a value like
+	// "subject:victim" supplied AS an application id can never equal the scope
+	// produced for an actual subject "victim".
+	craftedScope, ok := p.cacheScopeID(&policy.SharedContext{
+		Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "subject:victim"},
+	}, apiID)
+	if !ok {
+		t.Fatal("expected crafted-value scope to be cacheable")
+	}
+	if craftedScope == subjectScope {
+		t.Fatalf("crafted application-id value impersonated the subject scope: %q", craftedScope)
+	}
+
+	// Same source, same value -> same scope (sanity check the encoding is
+	// deterministic, not merely "always different").
+	appIDScopeAgain, ok := p.cacheScopeID(&policy.SharedContext{
+		Metadata: map[string]interface{}{applicationIDMetadataKeyForTest: "victim"},
+	}, apiID)
+	if !ok || appIDScopeAgain != appIDScope {
+		t.Fatalf("expected identical identity to produce the same scope, got %q vs %q", appIDScope, appIDScopeAgain)
 	}
 }
 

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -19,6 +19,7 @@ package semanticcache
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -47,8 +48,17 @@ const (
 	MetadataKeyAPIID = "semantic_cache_api_id"
 	// applicationIDMetadataKey is the shared inter-policy metadata key that carries the caller's application identity.
 	applicationIDMetadataKey = "x-wso2-application-id"
-	// cacheScopeSeparator joins apiID and caller identity into the cache partition key.
+	// cacheScopeSeparator joins apiID and the encoded caller identity into the cache partition key.
 	cacheScopeSeparator = "|"
+	// identitySourceSeparator joins an identity source tag and its base64-encoded
+	// value. Safe unconditionally: the tag is always one of the constants below
+	// (never user input) and base64.RawURLEncoding never emits ':'.
+	identitySourceSeparator = ":"
+
+	identitySourceApplicationID = "appid"
+	identitySourceSubject       = "subject"
+	identitySourceCredentialID  = "credential"
+	identitySourceTokenID       = "token"
 )
 
 // SemanticCachePolicy implements semantic caching for LLM responses
@@ -64,33 +74,48 @@ type SemanticCachePolicy struct {
 	cacheUnauthenticated bool
 }
 
-// callerIdentity resolves the caller principal from metadata, falling back to auth context.
-func callerIdentity(sc *policy.SharedContext) (string, bool) {
+// callerIdentity resolves the caller principal from metadata, falling back to
+// auth context. The returned source tags which field the value came from, so
+// equal values from different sources (e.g. an application ID that happens to
+// match another caller's JWT subject) can be told apart by cacheScopeID.
+func callerIdentity(sc *policy.SharedContext) (source string, value string, ok bool) {
 	if sc == nil {
-		return "", false
+		return "", "", false
 	}
 	if sc.Metadata != nil {
 		if v, ok := sc.Metadata[applicationIDMetadataKey]; ok {
 			if s, ok := v.(string); ok && s != "" {
-				return s, true
+				return identitySourceApplicationID, s, true
 			}
 		}
 	}
 	if sc.AuthContext != nil {
 		if sc.AuthContext.Subject != "" {
-			return sc.AuthContext.Subject, true
+			return identitySourceSubject, sc.AuthContext.Subject, true
 		}
 		if sc.AuthContext.CredentialID != "" {
-			return sc.AuthContext.CredentialID, true
+			return identitySourceCredentialID, sc.AuthContext.CredentialID, true
+		}
+		// api-key-auth sets neither Subject nor CredentialID for a key with no
+		// linked application (e.g. an LLM provider API key) - TokenId (a hash of
+		// the raw credential) is the last remaining per-caller signal in that case.
+		if sc.AuthContext.TokenId != "" {
+			return identitySourceTokenID, sc.AuthContext.TokenId, true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
-// cacheScopeID folds the caller identity into the api_id partition key used by Retrieve/Store.
+// cacheScopeID folds the caller identity into the api_id partition key used by
+// Retrieve/Store. The identity value is base64-encoded and tagged with its
+// source so two different sources can never collide on an equal raw value
+// (e.g. an application ID "victim" vs. a JWT subject "victim" get distinct
+// partitions, and a value crafted to contain a separator/tag can't be
+// mistaken for a different source).
 func (p *SemanticCachePolicy) cacheScopeID(sc *policy.SharedContext, apiID string) (string, bool) {
-	if identity, ok := callerIdentity(sc); ok {
-		return apiID + cacheScopeSeparator + identity, true
+	if source, value, ok := callerIdentity(sc); ok {
+		encoded := source + identitySourceSeparator + base64.RawURLEncoding.EncodeToString([]byte(value))
+		return apiID + cacheScopeSeparator + encoded, true
 	}
 	if p.cacheUnauthenticated {
 		return apiID, true
@@ -569,7 +594,7 @@ func (p *SemanticCachePolicy) processResponseBody(respCtx *policy.ResponseContex
 	// instead of a throwaway random value; falls back to a UUID only in the
 	// identity-less shared-bucket case (cacheUnauthenticated=true).
 	requestHash := uuid.New().String()
-	if identity, ok := callerIdentity(respCtx.SharedContext); ok {
+	if _, identity, ok := callerIdentity(respCtx.SharedContext); ok {
 		requestHash = identity
 	}
 

--- a/policies/semantic-cache/semanticcache.go
+++ b/policies/semantic-cache/semanticcache.go
@@ -45,6 +45,10 @@ const (
 	MetadataKeyEmbedding = "semantic_cache_embedding"
 	// MetadataKeyAPIID is the key used to store API ID in metadata
 	MetadataKeyAPIID = "semantic_cache_api_id"
+	// applicationIDMetadataKey is the shared inter-policy metadata key that carries the caller's application identity.
+	applicationIDMetadataKey = "x-wso2-application-id"
+	// cacheScopeSeparator joins apiID and caller identity into the cache partition key.
+	cacheScopeSeparator = "|"
 )
 
 // SemanticCachePolicy implements semantic caching for LLM responses
@@ -56,6 +60,56 @@ type SemanticCachePolicy struct {
 	jsonPath            string
 	streamingJsonPath   string
 	threshold           float64
+	// cacheUnauthenticated allows caching for callers with no resolvable identity
+	cacheUnauthenticated bool
+}
+
+// callerIdentity resolves the caller principal from metadata, falling back to auth context.
+func callerIdentity(sc *policy.SharedContext) (string, bool) {
+	if sc == nil {
+		return "", false
+	}
+	if sc.Metadata != nil {
+		if v, ok := sc.Metadata[applicationIDMetadataKey]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s, true
+			}
+		}
+	}
+	if sc.AuthContext != nil {
+		if sc.AuthContext.Subject != "" {
+			return sc.AuthContext.Subject, true
+		}
+		if sc.AuthContext.CredentialID != "" {
+			return sc.AuthContext.CredentialID, true
+		}
+	}
+	return "", false
+}
+
+// cacheScopeID folds the caller identity into the api_id partition key used by Retrieve/Store.
+func (p *SemanticCachePolicy) cacheScopeID(sc *policy.SharedContext, apiID string) (string, bool) {
+	if identity, ok := callerIdentity(sc); ok {
+		return apiID + cacheScopeSeparator + identity, true
+	}
+	if p.cacheUnauthenticated {
+		return apiID, true
+	}
+	return "", false
+}
+
+// isNoStoreResponse reports whether Cache-Control marks the response as non-shareable.
+func isNoStoreResponse(headers *policy.Headers) bool {
+	if headers == nil {
+		return false
+	}
+	for _, v := range headers.Get("cache-control") {
+		lower := strings.ToLower(v)
+		if strings.Contains(lower, "no-store") || strings.Contains(lower, "private") || strings.Contains(lower, "no-cache") {
+			return true
+		}
+	}
+	return false
 }
 
 // GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
@@ -238,6 +292,15 @@ func parseParams(params map[string]interface{}, p *SemanticCachePolicy) error {
 		}
 	}
 
+	// Optional: opt in to caching for callers with no resolvable identity
+	if cacheUnauthenticatedRaw, ok := params["cacheUnauthenticated"]; ok {
+		cacheUnauthenticated, ok := cacheUnauthenticatedRaw.(bool)
+		if !ok {
+			return fmt.Errorf("'cacheUnauthenticated' must be a boolean")
+		}
+		p.cacheUnauthenticated = cacheUnauthenticated
+	}
+
 	return nil
 }
 
@@ -371,6 +434,13 @@ func (p *SemanticCachePolicy) OnRequestBody(ctx context.Context, reqCtx *policy.
 	// Get API ID from context (use APIName and APIVersion to create unique ID)
 	apiID := fmt.Sprintf("%s:%s", reqCtx.APIName, reqCtx.APIVersion)
 
+	// Scope the lookup to the caller so responses are never cross-served
+	scopeID, cacheable := p.cacheScopeID(reqCtx.SharedContext, apiID)
+	if !cacheable {
+		slog.Debug("SemanticCache: No caller identity resolved and cacheUnauthenticated is disabled, skipping cache lookup", "apiID", apiID)
+		return policy.UpstreamRequestModifications{}
+	}
+
 	// Cosine similarity embedders (e.g. Mistral) have a floor of ~0.6 — even completely
 	// unrelated texts score that high. Map [0.6, 1.0] → [0, 1] so the user-supplied
 	// threshold works across the full semantic range.
@@ -382,7 +452,7 @@ func (p *SemanticCachePolicy) OnRequestBody(ctx context.Context, reqCtx *policy.
 	// Threshold needs to be a string for the vector DB provider
 	cacheFilter := map[string]interface{}{
 		"threshold": fmt.Sprintf("%.4f", effectiveThreshold),
-		"api_id":    apiID,
+		"api_id":    scopeID,
 		"ctx":       context.Background(), // Vector DB providers need context
 	}
 
@@ -477,25 +547,51 @@ func (p *SemanticCachePolicy) processResponseBody(respCtx *policy.ResponseContex
 		apiID = respCtx.RequestID
 	}
 
+	// Never persist a response the upstream marked non-shareable (defense in
+	// depth alongside per-caller scoping below). Best-effort: if headers are
+	// unavailable, the response is treated as cacheable.
+	if isNoStoreResponse(respCtx.ResponseHeaders) {
+		slog.Debug("SemanticCache: Response marked no-store/private/no-cache, skipping cache storage", "apiID", apiID)
+		return policy.DownstreamResponseModifications{}
+	}
+
+	// Bind the stored entry to the caller so it can only ever be served back to
+	// that same caller (F-181: cache poisoning / missing provenance).
+	// Identity-less responses are not stored unless the operator has explicitly
+	// opted in via cacheUnauthenticated.
+	scopeID, cacheable := p.cacheScopeID(respCtx.SharedContext, apiID)
+	if !cacheable {
+		slog.Debug("SemanticCache: No caller identity resolved and cacheUnauthenticated is disabled, skipping cache storage", "apiID", apiID)
+		return policy.DownstreamResponseModifications{}
+	}
+
+	// RequestHash records the resolved caller identity as meaningful provenance
+	// instead of a throwaway random value; falls back to a UUID only in the
+	// identity-less shared-bucket case (cacheUnauthenticated=true).
+	requestHash := uuid.New().String()
+	if identity, ok := callerIdentity(respCtx.SharedContext); ok {
+		requestHash = identity
+	}
+
 	// Store in cache
 	cacheResponse := vectordbproviders.CacheResponse{
 		ResponsePayload:     responseData,
-		RequestHash:         uuid.New().String(),
+		RequestHash:         requestHash,
 		ResponseFetchedTime: time.Now(),
 	}
 
 	cacheFilter := map[string]interface{}{
-		"api_id": apiID,
+		"api_id": scopeID,
 		"ctx":    context.Background(), // Vector DB providers need context
 	}
 
 	if err := p.vectorStoreProvider.Store(embedding, cacheResponse, cacheFilter); err != nil {
-		slog.Debug("SemanticCache: Error storing in cache", "error", err, "apiID", apiID)
+		slog.Debug("SemanticCache: Error storing in cache", "error", err, "apiID", scopeID)
 		// Log error but don't modify response
 		return policy.DownstreamResponseModifications{}
 	}
 
-	slog.Debug("SemanticCache: Response cached successfully", "apiID", apiID)
+	slog.Debug("SemanticCache: Response cached successfully", "apiID", scopeID)
 	return policy.DownstreamResponseModifications{}
 }
 

--- a/policies/semantic-cache/semanticcache_test.go
+++ b/policies/semantic-cache/semanticcache_test.go
@@ -376,7 +376,8 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 					}
 					return vectordbproviders.CacheResponse{}, nil
 				}},
-				threshold: 0.7,
+				threshold:            0.7,
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx: &policy.RequestContext{
 				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
@@ -394,7 +395,8 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
 					return vectordbproviders.CacheResponse{ResponsePayload: map[string]interface{}{"answer": "cached"}}, nil
 				}},
-				threshold: 0.5,
+				threshold:            0.5,
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx: &policy.RequestContext{
 				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
@@ -411,7 +413,8 @@ func TestSemanticCachePolicy_OnRequest(t *testing.T) {
 				vectorStoreProvider: &mockVectorDBProvider{retrieveFn: func(embeddings []float32, filter map[string]interface{}) (vectordbproviders.CacheResponse, error) {
 					return vectordbproviders.CacheResponse{}, errors.New("redis down")
 				}},
-				threshold: 0.5,
+				threshold:            0.5,
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx: &policy.RequestContext{
 				SharedContext: &policy.SharedContext{RequestID: "r1", Metadata: map[string]interface{}{}, APIName: "Books", APIVersion: "v1"},
@@ -513,6 +516,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 				vectorStoreProvider: &mockVectorDBProvider{storeFn: func(embeddings []float32, response vectordbproviders.CacheResponse, filter map[string]interface{}) error {
 					return errors.New("store failed")
 				}},
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx:       newResponseContext(200, []byte(`{"answer":"x"}`), map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}),
 			assertion: assertUpstreamResponseMods,
@@ -541,6 +545,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 					}
 					return nil
 				}},
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx: &policy.ResponseContext{
 				SharedContext:  &policy.SharedContext{RequestID: "req-1", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}},
@@ -558,6 +563,7 @@ func TestSemanticCachePolicy_OnResponse(t *testing.T) {
 					}
 					return nil
 				}},
+				cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 			},
 			ctx: &policy.ResponseContext{
 				SharedContext:  &policy.SharedContext{RequestID: "req-2", Metadata: map[string]interface{}{MetadataKeyEmbedding: "[0.1,0.2]"}, APIName: "Books", APIVersion: "v2"},
@@ -685,6 +691,7 @@ func TestSemanticCachePolicy_OnResponse_SSE(t *testing.T) {
 			storedResponse = response
 			return nil
 		}},
+		cacheUnauthenticated: true, // exercises the api_id-only shared bucket path; per-caller scoping is covered by provenance_test.go
 	}
 
 	ctx := &policy.ResponseContext{


### PR DESCRIPTION
## Purpose

Improves cache isolation in the `semantic-cache` policy.