### PR TITLE
Fix token-based-ratelimit total_tokens quota charging 1 per request instead of actual usage

### DIFF
--- a/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
+++ b/docs/token-based-ratelimit/v1.0/docs/token-based-ratelimit.md
@@ -43,6 +43,8 @@ These parameters are configured per LLM provider path by the API developer:
 
 > **Note:** At least one of `promptTokenLimits`, `completionTokenLimits`, or `totalTokenLimits` should be configured for the policy to enforce any limits.
 
+> **Note:** `totalTokenLimits` is charged from the LLM provider template's `totalTokens` field when one is defined. If the template has no `totalTokens` field (for example, the built-in Anthropic template, whose Messages API response has no total-token field), the policy instead sums `promptTokens` + `completionTokens` so the quota is still charged the actual token count.
+
 #### Limit Configuration
 
 Each limit entry defines a quota for a specific time window:
@@ -132,6 +134,8 @@ Inside the `gateway/build.yaml`, ensure the policy module is added under `polici
 ## Reference Scenarios
 
 This policy is designed to be attached to an `LlmProvider`. Before attaching the policy, you must create an `LlmProviderTemplate` that defines the token extraction paths for your LLM backend.
+
+Attaching the policy provider-wide (`globalPolicies`) shares one token bucket across every resource of the provider, the same way `basic-ratelimit` shares one request bucket at that level. Attaching it per operation (`operationPolicies` on a specific path) gives that resource its own independent bucket.
 
 ### LLM Provider Template
 

--- a/policies/token-based-ratelimit/policy-definition.yaml
+++ b/policies/token-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: token-based-ratelimit
-version: v1.1.0
+version: v1.1.1
 description: |
   Enforces token-based rate limits for LLM traffic by resolving token extraction
   paths from provider templates and delegating enforcement to the

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -360,6 +360,16 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 						}
 					}
 					if len(groupSources) > 0 {
+						if len(group) > 1 && len(groupSources) < len(group) {
+							// A multi-field fallback group (e.g. promptTokens+completionTokens)
+							// resolved only some of its fields — the quota will still use what
+							// resolved, but the "total" it charges is incomplete and will
+							// undercount actual usage.
+							slog.Warn("addQuota: template defines only part of a multi-field cost fallback group; total will undercount actual usage",
+								"name", name,
+								"expectedFields", group,
+								"resolvedCount", len(groupSources))
+						}
 						sources = groupSources
 						break
 					}

--- a/policies/token-based-ratelimit/token_based_ratelimit.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit.go
@@ -212,7 +212,7 @@ func (p *TokenBasedRateLimitPolicy) resolveDelegate(providerName string, params 
 // This avoids double-fetching the template when called from resolveDelegate.
 func (p *TokenBasedRateLimitPolicy) createDelegateWithTemplate(providerName string, params map[string]interface{}, template map[string]interface{}) (policy.Policy, error) {
 	// Transform LLM limits into advanced-ratelimit parameters
-	rlParams := transformToRatelimitParams(params, template)
+	rlParams := transformToRatelimitParams(params, template, p.metadata.AttachedTo)
 
 	slog.Debug("createDelegateWithTemplate: parameters transformed",
 		"route", p.metadata.RouteName,
@@ -263,27 +263,69 @@ func randomString(length int) string {
 }
 
 // transformToRatelimitParams converts LLM-specific parameters to the advanced-ratelimit structure.
-func transformToRatelimitParams(params map[string]interface{}, template map[string]interface{}) map[string]interface{} {
+func transformToRatelimitParams(params map[string]interface{}, template map[string]interface{}, attachedTo policy.Level) map[string]interface{} {
 	slog.Debug("transformToRatelimitParams: starting parameter transformation",
 		"params", params,
-		"template", template)
+		"template", template,
+		"attachedTo", attachedTo)
 
 	var quotas []interface{}
+
+	// Provider-wide (API-level) quotas must share one bucket across every resource of the
+	// provider, mirroring basic-ratelimit's apiname switch for the same attachment level.
+	keyType := "routename"
+	if attachedTo == policy.LevelAPI {
+		keyType = "apiname"
+	}
 
 	consumerBased, _ := params["consumerBased"].(bool)
 	var keyExtraction []interface{}
 	if consumerBased {
 		keyExtraction = []interface{}{
-			map[string]interface{}{"type": "routename"},
+			map[string]interface{}{"type": keyType},
 			map[string]interface{}{"type": "metadata", "key": "x-wso2-application-id", "fallback": "default"},
 		}
 	} else {
 		keyExtraction = []interface{}{
-			map[string]interface{}{"type": "routename"},
+			map[string]interface{}{"type": keyType},
 		}
 	}
 
-	addQuota := func(name string, limitsKey string, templateKey string) {
+	// resolveCostSource maps a single template field to an advanced-ratelimit cost source,
+	// or returns nil if the field isn't defined on the template.
+	resolveCostSource := func(spec map[string]interface{}, templateKey string) map[string]interface{} {
+		usage, ok := spec[templateKey].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		path, ok := usage["identifier"].(string)
+		if !ok || path == "" {
+			return nil
+		}
+
+		location, _ := usage["location"].(string)
+		sourceConfig := map[string]interface{}{}
+		switch location {
+		case "header":
+			sourceConfig["type"] = "request_header"
+			sourceConfig["key"] = path
+		case "metadata":
+			sourceConfig["type"] = "metadata"
+			sourceConfig["key"] = path
+		default:
+			// "payload" or any other/unspecified location: response_body + jsonPath.
+			sourceConfig["type"] = "response_body"
+			sourceConfig["jsonPath"] = path
+		}
+		return sourceConfig
+	}
+
+	// addQuota builds a quota whose cost is extracted from the first templateKeyGroup that
+	// resolves at least one source. Groups are tried in order and are mutually exclusive —
+	// this lets total_tokens fall back to summing promptTokens+completionTokens when the
+	// template has no totalTokens field (e.g. Anthropic), without ever combining a resolved
+	// totalTokens source with prompt/completion sources and double-counting.
+	addQuota := func(name string, limitsKey string, templateKeyGroups ...[]string) {
 		limits := params[limitsKey]
 		if limits == nil {
 			slog.Debug("addQuota: no limits found, skipping",
@@ -306,55 +348,48 @@ func transformToRatelimitParams(params map[string]interface{}, template map[stri
 			"keyExtraction": keyExtraction,
 		}
 
+		var sources []interface{}
 		if template != nil {
 			// The template structure has spec directly: template["spec"]
 			if spec, ok := template["spec"].(map[string]interface{}); ok {
-				if usage, ok := spec[templateKey].(map[string]interface{}); ok {
-					if path, ok := usage["identifier"].(string); ok && path != "" {
-						// Map template location to cost extraction type
-						location, _ := usage["location"].(string)
-						sourceType := "response_body" // default
-						sourceConfig := map[string]interface{}{
-							"type": sourceType,
+				for _, group := range templateKeyGroups {
+					var groupSources []interface{}
+					for _, templateKey := range group {
+						if source := resolveCostSource(spec, templateKey); source != nil {
+							groupSources = append(groupSources, source)
 						}
-
-						switch location {
-						case "header":
-							sourceType = "request_header"
-							sourceConfig["type"] = sourceType
-							sourceConfig["key"] = path
-						case "metadata":
-							sourceType = "metadata"
-							sourceConfig["type"] = sourceType
-							sourceConfig["key"] = path
-						case "payload":
-							// payload location uses response_body type with jsonPath
-							sourceConfig["jsonPath"] = path
-						default:
-							// For any other location, assume payload/response_body
-							sourceConfig["jsonPath"] = path
-						}
-
-						slog.Debug("addQuota: configured cost extraction",
-							"name", name,
-							"location", location,
-							"sourceType", sourceType,
-							"path", path)
-
-						quota["costExtraction"] = map[string]interface{}{
-							"enabled": true,
-							"sources": []interface{}{sourceConfig},
-						}
+					}
+					if len(groupSources) > 0 {
+						sources = groupSources
+						break
 					}
 				}
 			}
 		}
+
+		if len(sources) > 0 {
+			slog.Debug("addQuota: configured cost extraction",
+				"name", name,
+				"sourceCount", len(sources))
+			quota["costExtraction"] = map[string]interface{}{
+				"enabled": true,
+				"sources": sources,
+			}
+		} else {
+			// Without costExtraction, advanced-ratelimit charges its flat default cost of 1
+			// per request instead of the actual token count — surface this loudly so a
+			// template gap doesn't silently degrade a token quota into a request quota.
+			slog.Warn("addQuota: no cost extraction source resolved from template; quota will charge 1 per request instead of actual token usage",
+				"name", name,
+				"limitsKey", limitsKey)
+		}
+
 		quotas = append(quotas, quota)
 	}
 
-	addQuota("prompt_tokens", "promptTokenLimits", "promptTokens")
-	addQuota("completion_tokens", "completionTokenLimits", "completionTokens")
-	addQuota("total_tokens", "totalTokenLimits", "totalTokens")
+	addQuota("prompt_tokens", "promptTokenLimits", []string{"promptTokens"})
+	addQuota("completion_tokens", "completionTokenLimits", []string{"completionTokens"})
+	addQuota("total_tokens", "totalTokenLimits", []string{"totalTokens"}, []string{"promptTokens", "completionTokens"})
 
 	rlParams := map[string]interface{}{
 		"quotas": quotas,

--- a/policies/token-based-ratelimit/token_based_ratelimit_test.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit_test.go
@@ -19,12 +19,26 @@
 package tokenbasedratelimit
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
+
+// captureSlog temporarily redirects the default slog logger to a buffer for the
+// duration of the calling test, restoring the previous logger on cleanup.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
 
 // stubChunkPolicer is a minimal delegate stub that records chunk calls.
 type stubChunkPolicer struct {
@@ -536,6 +550,50 @@ func TestTransformToRatelimitParams_TotalTokensNoFieldsAtAll(t *testing.T) {
 
 	if sources := getQuotaSources(t, quotas, "total_tokens"); sources != nil {
 		t.Fatalf("Expected no costExtraction sources when template defines no token fields, got %v", sources)
+	}
+}
+
+// TestTransformToRatelimitParams_TotalTokensPartialFallbackWarns verifies that when the
+// promptTokens+completionTokens fallback group resolves only one of its two fields, the
+// quota still uses the single resolved source (existing behavior is preserved) but a
+// warning is logged identifying the incomplete configuration, since the resulting
+// total_tokens charge will silently undercount actual usage.
+func TestTransformToRatelimitParams_TotalTokensPartialFallbackWarns(t *testing.T) {
+	buf := captureSlog(t)
+
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(30), "duration": "1h"},
+		},
+	}
+	template := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"promptTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.input_tokens",
+			},
+			// completionTokens intentionally omitted — partial fallback group.
+		},
+	}
+
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected quotas to be []interface{}, got %T", result["quotas"])
+	}
+
+	sources := getQuotaSources(t, quotas, "total_tokens")
+	if len(sources) != 1 {
+		t.Fatalf("Expected the single resolved source to still be used, got %d: %v", len(sources), sources)
+	}
+	source := sources[0].(map[string]interface{})
+	if source["type"] != "response_body" || source["jsonPath"] != "$.usage.input_tokens" {
+		t.Fatalf("Unexpected source for partial fallback: %v", source)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "only part of a multi-field cost fallback group") {
+		t.Fatalf("Expected a warning about the incomplete fallback group, got log output: %s", logOutput)
 	}
 }
 

--- a/policies/token-based-ratelimit/token_based_ratelimit_test.go
+++ b/policies/token-based-ratelimit/token_based_ratelimit_test.go
@@ -135,7 +135,7 @@ func TestTransformToRatelimitParams(t *testing.T) {
 		},
 	}
 
-	result := transformToRatelimitParams(params, template)
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
 
 	// Check quotas were created
 	quotas, ok := result["quotas"].([]interface{})
@@ -224,7 +224,7 @@ func TestTransformToRatelimitParams_NoLimits(t *testing.T) {
 
 	template := map[string]interface{}{}
 
-	result := transformToRatelimitParams(params, template)
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
 
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok {
@@ -267,7 +267,7 @@ func TestTransformToRatelimitParams_EmptyPromptAndCompletionLimits(t *testing.T)
 		},
 	}
 
-	result := transformToRatelimitParams(params, template)
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
 
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok {
@@ -302,7 +302,7 @@ func TestTransformToRatelimitParams_NoTemplatePaths(t *testing.T) {
 	// Template without proper spec paths
 	template := map[string]interface{}{}
 
-	result := transformToRatelimitParams(params, template)
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
 
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok {
@@ -357,7 +357,7 @@ func TestTokenBasedRateLimitPolicy_TransformToRatelimitParams_TemplateLocationMa
 		},
 	}
 
-	result := transformToRatelimitParams(params, template)
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok {
 		t.Fatalf("Expected quotas to be []interface{}, got %T", result["quotas"])
@@ -407,6 +407,223 @@ func TestTokenBasedRateLimitPolicy_TransformToRatelimitParams_TemplateLocationMa
 	totalSource := getSource("total_tokens")
 	if totalSource["type"] != "metadata" || totalSource["key"] != "usage.total_tokens" {
 		t.Fatalf("Unexpected total source mapping: %v", totalSource)
+	}
+}
+
+// getQuotaSources is a shared test helper that extracts the costExtraction sources
+// for a named quota, or nil if the quota has no costExtraction configured.
+func getQuotaSources(t *testing.T, quotas []interface{}, quotaName string) []interface{} {
+	t.Helper()
+	for _, q := range quotas {
+		qm, ok := q.(map[string]interface{})
+		if !ok || qm["name"] != quotaName {
+			continue
+		}
+		ce, ok := qm["costExtraction"].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		sources, _ := ce["sources"].([]interface{})
+		return sources
+	}
+	t.Fatalf("quota %q not found", quotaName)
+	return nil
+}
+
+// TestTransformToRatelimitParams_TotalTokensFallsBackToPromptPlusCompletion covers the
+// Anthropic-shaped template (no totalTokens field): the total_tokens quota must sum
+// promptTokens + completionTokens instead of falling back to a flat cost of 1.
+func TestTransformToRatelimitParams_TotalTokensFallsBackToPromptPlusCompletion(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(30), "duration": "1h"},
+		},
+	}
+	template := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"promptTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.input_tokens",
+			},
+			"completionTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.output_tokens",
+			},
+			// No totalTokens field — matches the built-in anthropic template.
+		},
+	}
+
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected quotas to be []interface{}, got %T", result["quotas"])
+	}
+
+	sources := getQuotaSources(t, quotas, "total_tokens")
+	if len(sources) != 2 {
+		t.Fatalf("Expected 2 fallback sources (prompt+completion) for total_tokens, got %d: %v", len(sources), sources)
+	}
+
+	first := sources[0].(map[string]interface{})
+	if first["type"] != "response_body" || first["jsonPath"] != "$.usage.input_tokens" {
+		t.Fatalf("Unexpected first fallback source: %v", first)
+	}
+	second := sources[1].(map[string]interface{})
+	if second["type"] != "response_body" || second["jsonPath"] != "$.usage.output_tokens" {
+		t.Fatalf("Unexpected second fallback source: %v", second)
+	}
+}
+
+// TestTransformToRatelimitParams_TotalTokensPreferredOverPromptPlusCompletion guards
+// against double-counting: when a template defines totalTokens AND promptTokens/
+// completionTokens (the common case — openai, mistral, gemini, etc.), the total_tokens
+// quota must use only the totalTokens source, never sum all three.
+func TestTransformToRatelimitParams_TotalTokensPreferredOverPromptPlusCompletion(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(1000), "duration": "1h"},
+		},
+	}
+	template := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"promptTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.prompt_tokens",
+			},
+			"completionTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.completion_tokens",
+			},
+			"totalTokens": map[string]interface{}{
+				"location":   "payload",
+				"identifier": "$.usage.total_tokens",
+			},
+		},
+	}
+
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected quotas to be []interface{}, got %T", result["quotas"])
+	}
+
+	sources := getQuotaSources(t, quotas, "total_tokens")
+	if len(sources) != 1 {
+		t.Fatalf("Expected exactly 1 source for total_tokens when totalTokens is defined, got %d: %v", len(sources), sources)
+	}
+	source := sources[0].(map[string]interface{})
+	if source["type"] != "response_body" || source["jsonPath"] != "$.usage.total_tokens" {
+		t.Fatalf("Unexpected total_tokens source: %v", source)
+	}
+}
+
+// TestTransformToRatelimitParams_TotalTokensNoFieldsAtAll verifies that a template with
+// none of totalTokens/promptTokens/completionTokens still produces a quota with no
+// costExtraction (existing "no template paths" behavior is preserved for total_tokens).
+func TestTransformToRatelimitParams_TotalTokensNoFieldsAtAll(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(30), "duration": "1h"},
+		},
+	}
+	template := map[string]interface{}{"spec": map[string]interface{}{}}
+
+	result := transformToRatelimitParams(params, template, policy.LevelRoute)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected quotas to be []interface{}, got %T", result["quotas"])
+	}
+
+	if sources := getQuotaSources(t, quotas, "total_tokens"); sources != nil {
+		t.Fatalf("Expected no costExtraction sources when template defines no token fields, got %v", sources)
+	}
+}
+
+// TestTransformToRatelimitParams_KeyExtraction_APILevel verifies that a policy attached
+// at API level (provider-wide / globalPolicies) keys quotas on apiname so all resources
+// of the provider share one bucket, mirroring basic-ratelimit's own apiname switch.
+func TestTransformToRatelimitParams_KeyExtraction_APILevel(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(1000), "duration": "1h"},
+		},
+	}
+
+	result := transformToRatelimitParams(params, nil, policy.LevelAPI)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok || len(keyExtraction) != 1 {
+		t.Fatalf("Expected 1 key extraction entry, got %v", quota["keyExtraction"])
+	}
+
+	entry := keyExtraction[0].(map[string]interface{})
+	if entry["type"] != "apiname" {
+		t.Errorf("Expected type 'apiname' for API-attached policy, got %v", entry["type"])
+	}
+}
+
+// TestTransformToRatelimitParams_KeyExtraction_RouteLevel verifies that a policy attached
+// at route level (operationPolicies / per-operation) keeps the existing routename keying,
+// giving each resource its own independent bucket.
+func TestTransformToRatelimitParams_KeyExtraction_RouteLevel(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(1000), "duration": "1h"},
+		},
+	}
+
+	result := transformToRatelimitParams(params, nil, policy.LevelRoute)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok || len(keyExtraction) != 1 {
+		t.Fatalf("Expected 1 key extraction entry, got %v", quota["keyExtraction"])
+	}
+
+	entry := keyExtraction[0].(map[string]interface{})
+	if entry["type"] != "routename" {
+		t.Errorf("Expected type 'routename' for route-attached policy, got %v", entry["type"])
+	}
+}
+
+// TestTransformToRatelimitParams_KeyExtraction_APILevel_ConsumerBased verifies that
+// consumerBased combines with API-level attachment: apiname + application-id metadata.
+func TestTransformToRatelimitParams_KeyExtraction_APILevel_ConsumerBased(t *testing.T) {
+	params := map[string]interface{}{
+		"totalTokenLimits": []interface{}{
+			map[string]interface{}{"count": float64(1000), "duration": "1h"},
+		},
+		"consumerBased": true,
+	}
+
+	result := transformToRatelimitParams(params, nil, policy.LevelAPI)
+	quotas, ok := result["quotas"].([]interface{})
+	if !ok || len(quotas) != 1 {
+		t.Fatal("Expected 1 quota")
+	}
+
+	quota := quotas[0].(map[string]interface{})
+	keyExtraction, ok := quota["keyExtraction"].([]interface{})
+	if !ok || len(keyExtraction) != 2 {
+		t.Fatalf("Expected 2 key extraction entries, got %v", quota["keyExtraction"])
+	}
+
+	first := keyExtraction[0].(map[string]interface{})
+	if first["type"] != "apiname" {
+		t.Errorf("Expected first entry type 'apiname', got %v", first["type"])
+	}
+	second := keyExtraction[1].(map[string]interface{})
+	if second["type"] != "metadata" || second["key"] != "x-wso2-application-id" {
+		t.Errorf("Expected second entry to be application-id metadata, got %v", second)
 	}
 }
 
@@ -490,7 +707,7 @@ func TestTransformToRatelimitParams_ConsumerBased_False(t *testing.T) {
 		"consumerBased": false,
 	}
 
-	result := transformToRatelimitParams(params, nil)
+	result := transformToRatelimitParams(params, nil, policy.LevelRoute)
 
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok || len(quotas) != 1 {
@@ -526,7 +743,7 @@ func TestTransformToRatelimitParams_ConsumerBased_True(t *testing.T) {
 		"consumerBased": true,
 	}
 
-	result := transformToRatelimitParams(params, nil)
+	result := transformToRatelimitParams(params, nil, policy.LevelRoute)
 
 	quotas, ok := result["quotas"].([]interface{})
 	if !ok || len(quotas) != 1 {


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-platform/issues/2932

Fixes an issue where provider-wide Token Count rate limits on an LLM provider decremented counters by `1` per request instead of the actual token count reported in the response. This silently converted token budgets into request budgets.

---

## Root cause

1. **Missing Token Cost Extraction**: `transformToRatelimitParams` in `token-based-ratelimit` only attempted to resolve `total_tokens` cost extraction from `spec.totalTokens`. Anthropic's Messages API response lacks a `totalTokens` field, defining only `promptTokens` and `completionTokens`. Lacking `totalTokens`, the quota resolved no `costExtraction` and silently defaulted to `advanced-ratelimit`'s flat cost of `1` per request.
2. **Resource-Siloed Buckets**: `keyExtraction` was hardcoded to `routename`. Consequently, even provider-wide quotas were siloed per resource instead of being shared across the entire provider, deviating from how `basic-ratelimit` handles API-level attachments.

---

## What changed

* **Token Sum Fallback**: `total_tokens` now falls back to summing `promptTokens` + `completionTokens` when `totalTokens` is missing. Templates explicitly defining `totalTokens` (OpenAI, Mistral, Gemini, Azure, AWS Bedrock, etc.) continue to prioritize that field directly to prevent double-counting.
* **Provider-Wide Bucket Keying**: `keyExtraction` now switches to `apiname` when attached at the API level (`attachedTo == LevelAPI`), matching `basic-ratelimit` so provider-wide quotas share a single bucket across all resources.
* **Warning Logging**: Emits a warning log if a configured token quota resolves no valid cost extraction source, preventing silent fallback bugs.
* **Version Bump & Docs**: Updated `token-based-ratelimit` policy version to `v1.1.1` and updated documentation covering fallback logic and bucket sharing.

---

## Testing

* **Unit Tests**:
  * Added/updated coverage for `promptTokens` + `completionTokens` fallback when `totalTokens` is absent.
  * Confirmed single-source `totalTokens` templates do not double-count.
  * Verified `apiname` vs. `routename` key extraction behavior for API-level policy attachments (with and without `consumerBased`).
  * `go test ./...` and `go vet ./...` passed cleanly in `policies/token-based-ratelimit`.

* **End-to-End Verification**:
  * **Anthropic**: Verified against a live gateway using the built-in `anthropic` template. A 75-token provider-wide quota was properly exhausted after a single request consuming 75 total tokens (50 input + 25 output), correctly shared across every resource.
  * **MistralAI**: Verified that templates defining `totalTokens` continue to charge exact token amounts without double-counting.