### PR TITLE
chore(policies): bump patch versions for 21 policies

### DIFF
--- a/policies/advanced-ratelimit/policy-definition.yaml
+++ b/policies/advanced-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: advanced-ratelimit
-version: v1.1.1
+version: v1.1.2
 description: |
   Applies advanced rate limits using fixed-window (default) or GCRA algorithms with multi-quota controls,
   configurable key and cost extraction, and memory or Redis storage.

--- a/policies/api-key-auth/policy-definition.yaml
+++ b/policies/api-key-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: api-key-auth
-version: v1.2.0
+version: v1.2.1
 description: |
   Secures APIs by validating API keys in incoming requests. API keys are
   provided through a configured HTTP header.

--- a/policies/backend-jwt/policy-definition.yaml
+++ b/policies/backend-jwt/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: backend-jwt
-version: v1.0.0
+version: v1.0.1
 description: |
   Generates a signed JWT and injects it into the upstream request header. Can be used
   standalone or after an authentication policy (e.g. jwt-auth, basic-auth, api-key-auth).

--- a/policies/basic-auth/policy-definition.yaml
+++ b/policies/basic-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-auth
-version: v1.0.2
+version: v1.0.3
 description: |
   Protects APIs using Basic Authentication by validating username and password credentials.
 

--- a/policies/basic-ratelimit/policy-definition.yaml
+++ b/policies/basic-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: basic-ratelimit
-version: v1.1.0
+version: v1.1.1
 description: |
   Limits request rates by restricting the number of requests allowed within one
   or more defined time windows.

--- a/policies/interceptor-service/policy-definition.yaml
+++ b/policies/interceptor-service/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: interceptor-service
-version: v1.0.0
+version: v1.0.1
 description: |
   Calls a user-defined HTTP interceptor service for request and/or response
   phases. The interceptor can mutate headers, body, path, route to a dynamic

--- a/policies/json-xml-mediator/policy-definition.yaml
+++ b/policies/json-xml-mediator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: json-xml-mediator
-version: v1.0.3
+version: v1.0.4
 description: |
   Mediates request and response payloads between downstream and upstream JSON/XML formats
 

--- a/policies/llm-cost-based-ratelimit/policy-definition.yaml
+++ b/policies/llm-cost-based-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost-based-ratelimit
-version: v1.1.0
+version: v1.1.1
 description: |
   A specialized rate limiting policy for LLMs that limits usage based on monetary budgets.
   The policy reads costs from SharedContext.Metadata under "x-llm-cost" (set by the llm-cost

--- a/policies/log-message/policy-definition.yaml
+++ b/policies/log-message/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: log-message
-version: v1.0.2
+version: v1.0.3
 description: |
   Log request and response payloads and headers for observability without changing traffic.
 

--- a/policies/mcp-acl-list/policy-definition.yaml
+++ b/policies/mcp-acl-list/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-acl-list
-version: v1.0.2
+version: v1.0.3
 description: |
   Control MCP tool, resource, and prompt access with allow/deny mode plus exceptions, apply the same rules to requests and list responses, and avoid rewriting capability names or entry fields.
 

--- a/policies/mcp-ratelimit/policy-definition.yaml
+++ b/policies/mcp-ratelimit/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-ratelimit
-version: v1.1.0
+version: v1.1.1
 description: |
   Applies rate limits to MCP traffic per tool, resource, prompt, or JSON-RPC method.
   Each entry targets a capability by name (or "*") and declares one or more

--- a/policies/mcp-rewrite/policy-definition.yaml
+++ b/policies/mcp-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: mcp-rewrite
-version: v1.0.2
+version: v1.0.3
 description: |
   Rewrite MCP tool, resource, and prompt names between client-facing and backend values, and optionally filter list responses to configured entries (omit to allow all, set `[]` to deny all).
 

--- a/policies/model-round-robin/policy-definition.yaml
+++ b/policies/model-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-round-robin
-version: v1.1.0
+version: v1.1.1
 description: |
   Distributes requests across configured AI models in round-robin order to
   balance traffic and reduce overloading on any single model.

--- a/policies/model-weighted-round-robin/policy-definition.yaml
+++ b/policies/model-weighted-round-robin/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: model-weighted-round-robin
-version: v1.1.0
+version: v1.1.1
 description: |
   Distribute requests across models using weighted round-robin so higher-weight models receive proportionally more traffic.
 

--- a/policies/opaque-token-auth/policy-definition.yaml
+++ b/policies/opaque-token-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: opaque-token-auth
-version: v1.0.0
+version: v1.0.1
 description: |
   Validates opaque OAuth 2.0 access tokens by calling an authorization server's
   RFC 7662 token introspection endpoint. The gateway forwards the bearer token to

--- a/policies/openai-to-bedrock-transformer/policy-definition.yaml
+++ b/policies/openai-to-bedrock-transformer/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: openai-to-bedrock-transformer
-version: v0.9.0
+version: v0.9.1
 description: |
   Translates OpenAI Chat Completions requests to the AWS Bedrock Converse API
   (/model/{modelId}/converse and /converse-stream) and rewrites Bedrock

--- a/policies/pii-masking-regex/policy-definition.yaml
+++ b/policies/pii-masking-regex/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: pii-masking-regex
-version: v1.0.1
+version: v1.0.3
 description: |
   Masks or redacts Personally Identifiable Information (PII) in request and
   response payloads.

--- a/policies/redirect/policy-definition.yaml
+++ b/policies/redirect/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: redirect
-version: v0.9.0
+version: v0.9.1
 description: |
   Issue an HTTP redirect to the client without forwarding the request upstream
   (Gateway-API RequestRedirect semantics).

--- a/policies/request-rewrite/policy-definition.yaml
+++ b/policies/request-rewrite/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: request-rewrite
-version: v1.0.1
+version: v1.0.2
 description: |
   Rewrite request paths, query parameters, and HTTP methods before forwarding upstream, with optional header and query match conditions to apply rewrites only when criteria are met.
 

--- a/policies/subscription-validation/policy-definition.yaml
+++ b/policies/subscription-validation/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: subscription-validation
-version: v1.0.2
+version: v1.0.3
 description: |
   Validates that the request has an active subscription to the
   requested API. Checks the Subscription-Key header first; if not found,

--- a/policies/websub-hmac-auth/policy-definition.yaml
+++ b/policies/websub-hmac-auth/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: websub-hmac-auth
-version: v1.0.0
+version: v1.0.1
 description: |
   Validates HMAC signatures on incoming WebSub hub event notification requests.
   The policy reads the X-Hub-Signature-256 (or X-Hub-Signature) header sent by


### PR DESCRIPTION
## Purpose

Bump `policy-definition.yaml` versions for all policies that have unreleased code changes but no parameter schema modifications, making them ready for the next release wave.

## Approach

- All 21 policies received a **patch** bump — no parameter additions, removals, or renames were found in any `policy-definition.yaml` since the corresponding last-released version.
- `pii-masking-regex` skips `v1.0.2` (already released as a source-only change without a definition update) and lands directly at `v1.0.3`.
- The following policies with `needs_release=yes` already had their versions bumped (minor or patch) in earlier commits and are not included here: `cors`, `jwt-auth`, `mcp-auth`, `mcp-authz`, `semantic-cache`, `token-based-ratelimit`.

| Policy | Old | New |
|--------|-----|-----|
| advanced-ratelimit | v1.1.1 | v1.1.2 |
| api-key-auth | v1.2.0 | v1.2.1 |
| backend-jwt | v1.0.0 | v1.0.1 |
| basic-auth | v1.0.2 | v1.0.3 |
| basic-ratelimit | v1.1.0 | v1.1.1 |
| interceptor-service | v1.0.0 | v1.0.1 |
| json-xml-mediator | v1.0.3 | v1.0.4 |
| llm-cost-based-ratelimit | v1.1.0 | v1.1.1 |
| log-message | v1.0.2 | v1.0.3 |
| mcp-acl-list | v1.0.2 | v1.0.3 |
| mcp-ratelimit | v1.1.0 | v1.1.1 |
| mcp-rewrite | v1.0.2 | v1.0.3 |
| model-round-robin | v1.1.0 | v1.1.1 |
| model-weighted-round-robin | v1.1.0 | v1.1.1 |
| opaque-token-auth | v1.0.0 | v1.0.1 |
| openai-to-bedrock-transformer | v0.9.0 | v0.9.1 |
| pii-masking-regex | v1.0.1 | v1.0.3 |
| redirect | v0.9.0 | v0.9.1 |
| request-rewrite | v1.0.1 | v1.0.2 |
| subscription-validation | v1.0.2 | v1.0.3 |
| websub-hmac-auth | v1.0.0 | v1.0.1 |

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)