### PR TITLE
chore(policies): bump dep pins for advanced-ratelimit and jwt-auth dependents

### DIFF
--- a/policies/basic-ratelimit/go.mod
+++ b/policies/basic-ratelimit/go.mod
@@ -1,10 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/basic-ratelimit
 
-go 1.26.1
+go 1.26.2
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
+	github.com/wso2/api-platform/sdk/core v0.3.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2
 )
 
 require (

--- a/policies/basic-ratelimit/go.sum
+++ b/policies/basic-ratelimit/go.sum
@@ -35,10 +35,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/wso2/api-platform/sdk/core v0.3.4 h1:0QkrwZeeFppOiaU79swRa+5kRZ4cBqmF4absQ+rs4Z8=
+github.com/wso2/api-platform/sdk/core v0.3.4/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2 h1:IVqkX4qj9RRviCC+6tKkwc91IOgTCaiD5ubw7Pf3/8k=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2/go.mod h1:rGlm3MwH3j49M0MWWfYftqT92+a9K6lZuoXcpLUpD6Q=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/llm-cost-based-ratelimit/go.mod
+++ b/policies/llm-cost-based-ratelimit/go.mod
@@ -1,10 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/llm-cost-based-ratelimit
 
-go 1.26.1
+go 1.26.2
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
+	github.com/wso2/api-platform/sdk/core v0.3.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2
 )
 
 require (

--- a/policies/llm-cost-based-ratelimit/go.sum
+++ b/policies/llm-cost-based-ratelimit/go.sum
@@ -35,10 +35,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/wso2/api-platform/sdk/core v0.3.4 h1:0QkrwZeeFppOiaU79swRa+5kRZ4cBqmF4absQ+rs4Z8=
+github.com/wso2/api-platform/sdk/core v0.3.4/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2 h1:IVqkX4qj9RRviCC+6tKkwc91IOgTCaiD5ubw7Pf3/8k=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2/go.mod h1:rGlm3MwH3j49M0MWWfYftqT92+a9K6lZuoXcpLUpD6Q=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/mcp-auth/go.mod
+++ b/policies/mcp-auth/go.mod
@@ -4,6 +4,6 @@ go 1.26.2
 
 require github.com/wso2/api-platform/sdk/core v0.3.4
 
-require github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.3
+require github.com/wso2/gateway-controllers/policies/jwt-auth v1.3.0
 
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/policies/mcp-auth/go.sum
+++ b/policies/mcp-auth/go.sum
@@ -1,10 +1,6 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/wso2/api-platform/sdk/core v0.3.1 h1:D9esKYiddfsut22j+JtdkjnysVJH+5qh7UqWCHjsV5Q=
-github.com/wso2/api-platform/sdk/core v0.3.1/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
-github.com/wso2/api-platform/sdk/core v0.3.4-alpha h1:VwiyWHh/BdxW00J6w0CM/2JzpuizMcoHPviBiwf/O1w=
-github.com/wso2/api-platform/sdk/core v0.3.4-alpha/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/wso2/api-platform/sdk/core v0.3.4 h1:0QkrwZeeFppOiaU79swRa+5kRZ4cBqmF4absQ+rs4Z8=
 github.com/wso2/api-platform/sdk/core v0.3.4/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.3 h1:tLOWVgHzhjT1blRJoOnN9CgLuddliLSmLWI+Wm61mps=
-github.com/wso2/gateway-controllers/policies/jwt-auth v1.2.3/go.mod h1:KMe/jdM4m5Lbj/Sk9aZLH4HFWoxW7pCSzyhVljXjL/4=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.3.0 h1:Hc1Sn+vdSB0R3zjUglr0ZVN6BO8eEELXtmeBmYlnhHY=
+github.com/wso2/gateway-controllers/policies/jwt-auth v1.3.0/go.mod h1:QF3OggJlW5TnKAYQHfIfBkZ49Ai5e6P7ONnmFdLtbNI=

--- a/policies/mcp-ratelimit/go.mod
+++ b/policies/mcp-ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/wso2/api-platform/sdk/core v0.3.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2
 )
 
 require (

--- a/policies/mcp-ratelimit/go.sum
+++ b/policies/mcp-ratelimit/go.sum
@@ -32,14 +32,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/wso2/api-platform/sdk/core v0.3.1 h1:D9esKYiddfsut22j+JtdkjnysVJH+5qh7UqWCHjsV5Q=
-github.com/wso2/api-platform/sdk/core v0.3.1/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
-github.com/wso2/api-platform/sdk/core v0.3.4-alpha h1:VwiyWHh/BdxW00J6w0CM/2JzpuizMcoHPviBiwf/O1w=
-github.com/wso2/api-platform/sdk/core v0.3.4-alpha/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
 github.com/wso2/api-platform/sdk/core v0.3.4 h1:0QkrwZeeFppOiaU79swRa+5kRZ4cBqmF4absQ+rs4Z8=
 github.com/wso2/api-platform/sdk/core v0.3.4/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2 h1:IVqkX4qj9RRviCC+6tKkwc91IOgTCaiD5ubw7Pf3/8k=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2/go.mod h1:rGlm3MwH3j49M0MWWfYftqT92+a9K6lZuoXcpLUpD6Q=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=

--- a/policies/token-based-ratelimit/go.mod
+++ b/policies/token-based-ratelimit/go.mod
@@ -1,10 +1,10 @@
 module github.com/wso2/gateway-controllers/policies/token-based-ratelimit
 
-go 1.26.1
+go 1.26.2
 
 require (
-	github.com/wso2/api-platform/sdk/core v0.2.4
-	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0
+	github.com/wso2/api-platform/sdk/core v0.3.4
+	github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2
 	golang.org/x/sync v0.20.0
 )
 

--- a/policies/token-based-ratelimit/go.sum
+++ b/policies/token-based-ratelimit/go.sum
@@ -35,10 +35,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wso2/api-platform/sdk/core v0.2.4 h1:dwwe7QROmf1HIeCqhfiv82/34n6oAe2b0hazYljpPS0=
-github.com/wso2/api-platform/sdk/core v0.2.4/go.mod h1:vgNVzR16g9k5cun3VXZ7wDg8UGbPxsVU2TW8EbRCv0o=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0 h1:aATwzwxL2dpP0AAVwmzDmFuit6+ZFMFsCVylRhWL/Do=
-github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.0/go.mod h1:yDg8RCH45yWPnEzr+lVYZTeNUyIB9bkv3kSYy+MuNkg=
+github.com/wso2/api-platform/sdk/core v0.3.4 h1:0QkrwZeeFppOiaU79swRa+5kRZ4cBqmF4absQ+rs4Z8=
+github.com/wso2/api-platform/sdk/core v0.3.4/go.mod h1:TgjpOk3QBPc7xEQC+NctWcNq5dSPBkn7wSKh+hULTj8=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2 h1:IVqkX4qj9RRviCC+6tKkwc91IOgTCaiD5ubw7Pf3/8k=
+github.com/wso2/gateway-controllers/policies/advanced-ratelimit v1.1.2/go.mod h1:rGlm3MwH3j49M0MWWfYftqT92+a9K6lZuoXcpLUpD6Q=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=


### PR DESCRIPTION
## Purpose

After releasing `advanced-ratelimit v1.1.2` and `jwt-auth v1.3.0`, the policies that depend on them still had stale dependency pins in their `go.mod` files, preventing them from being dispatched by the release script. This PR updates those pins so all 5 dependent policies are ready to tag.

## Approach

- Bump `advanced-ratelimit` pin `v1.1.0 → v1.1.2` in `basic-ratelimit`, `llm-cost-based-ratelimit`, `mcp-ratelimit`, and `token-based-ratelimit`
- Bump `jwt-auth` pin `v1.2.3 → v1.3.0` in `mcp-auth`
- Run `go mod tidy` for all 5 policies; also picks up `sdk/core v0.3.4` transitively for the three policies still on `v0.2.4`
- No version bumps — existing unreleased yaml versions are reused as-is

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)