### PR TITLE
AWS Bedrock Guardrail: move region/guardrailID/guardrailVersion to policy params

### DIFF
--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -95,10 +95,22 @@ func GetPolicy(
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
 
+	// guardrailID/guardrailVersion can each be set directly on this policy
+	// attachment (localGuardrailID/localGuardrailVersion), or left unset to
+	// use the gateway-wide systemParameters value of the same setting.
+	guardrailID, err := resolveGuardrailParam(params, "localGuardrailID", "guardrailID")
+	if err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	guardrailVersion, err := resolveGuardrailParam(params, "localGuardrailVersion", "guardrailVersion")
+	if err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
 	p := &AWSBedrockGuardrailPolicy{
 		region:           getStringParam(params, "region"),
-		guardrailID:      getStringParam(params, "guardrailID"),
-		guardrailVersion: getStringParam(params, "guardrailVersion"),
+		guardrailID:      guardrailID,
+		guardrailVersion: guardrailVersion,
 	}
 	p.loadAWSConfigFunc = p.loadAWSConfig
 	p.newBedrockClientFunc = func(cfg aws.Config) bedrockGuardrailClient {
@@ -249,6 +261,36 @@ func getStringParam(params map[string]interface{}, key string) string {
 	return ""
 }
 
+// resolveGuardrailParam returns the value for a guardrail identity setting
+// (guardrailID/guardrailVersion) that can be supplied directly on this policy
+// attachment (attachmentKey, from "parameters") or via the gateway-wide
+// systemParameters value of the same setting (systemKey, resolved from
+// config.toml into the same flat params map). At least one must resolve to a
+// non-empty string.
+func resolveGuardrailParam(params map[string]interface{}, attachmentKey, systemKey string) (string, error) {
+	if val, ok := params[attachmentKey]; ok {
+		str, ok := val.(string)
+		if !ok {
+			return "", fmt.Errorf("'%s' must be a string", attachmentKey)
+		}
+		if str == "" {
+			return "", fmt.Errorf("'%s' cannot be empty", attachmentKey)
+		}
+		return str, nil
+	}
+	if val, ok := params[systemKey]; ok {
+		str, ok := val.(string)
+		if !ok {
+			return "", fmt.Errorf("'%s' must be a string", systemKey)
+		}
+		if str == "" {
+			return "", fmt.Errorf("'%s' cannot be empty", systemKey)
+		}
+		return str, nil
+	}
+	return "", fmt.Errorf("one of '%s' or '%s' parameter is required", attachmentKey, systemKey)
+}
+
 // validateAWSConfigParams validates AWS configuration parameters (from params)
 func validateAWSConfigParams(params map[string]interface{}) error {
 	// Validate region (required)
@@ -262,32 +304,6 @@ func validateAWSConfigParams(params map[string]interface{}) error {
 	}
 	if region == "" {
 		return fmt.Errorf("'region' cannot be empty")
-	}
-
-	// Validate guardrailID (required)
-	guardrailIDRaw, ok := params["guardrailID"]
-	if !ok {
-		return fmt.Errorf("'guardrailID' parameter is required")
-	}
-	guardrailID, ok := guardrailIDRaw.(string)
-	if !ok {
-		return fmt.Errorf("'guardrailID' must be a string")
-	}
-	if guardrailID == "" {
-		return fmt.Errorf("'guardrailID' cannot be empty")
-	}
-
-	// Validate guardrailVersion (required)
-	guardrailVersionRaw, ok := params["guardrailVersion"]
-	if !ok {
-		return fmt.Errorf("'guardrailVersion' parameter is required")
-	}
-	guardrailVersion, ok := guardrailVersionRaw.(string)
-	if !ok {
-		return fmt.Errorf("'guardrailVersion' must be a string")
-	}
-	if guardrailVersion == "" {
-		return fmt.Errorf("'guardrailVersion' cannot be empty")
 	}
 
 	// Validate optional AWS credential parameters

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,11 +1,25 @@
 name: aws-bedrock-guardrail
-version: v1.0.2
+version: v1.1.0
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 
 parameters:
   type: object
   properties:
+    localGuardrailID:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        AWS Bedrock Guardrail identifier for this policy attachment. Leave
+        unset to use the gateway-wide system parameter instead.
+      minLength: 1
+    localGuardrailVersion:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        AWS Bedrock Guardrail version (e.g., "DRAFT", "1") for this policy
+        attachment. Leave unset to use the gateway-wide system parameter instead.
+      minLength: 1
     request:
       type: object
       description: Configuration for request phase validation
@@ -73,6 +87,9 @@ parameters:
             If true, includes detailed assessment information from AWS Bedrock Guardrail in error responses.
             If false, returns minimal error information.
           default: false
+  anyOf:
+    - required: [ request ]
+    - required: [ response ]
 
 systemParameters:
   type: object
@@ -123,5 +140,3 @@ systemParameters:
       "wso2/defaultValue": "${config.awsbedrock_role_external_id}"
   required:
     - region
-    - guardrailID
-    - guardrailVersion


### PR DESCRIPTION

This pull request updates the AWS Bedrock Guardrail policy to allow policy attachments to specify their own `guardrailID` and `guardrailVersion` parameters, instead of requiring these values to be set globally. It introduces new parameters (`localGuardrailID` and `localGuardrailVersion`) and supporting logic to resolve these values, falling back to the gateway-wide system parameters if not set locally. The validation logic has also been updated to support these changes.

### Policy parameter enhancements

* Added `localGuardrailID` and `localGuardrailVersion` as optional parameters to the policy definition, allowing each policy attachment to override the global `guardrailID` and `guardrailVersion` if desired.
* Updated the policy logic in `awsbedrockguardrail.go` to resolve `guardrailID` and `guardrailVersion` from either the local attachment parameters or the system-wide settings, with error handling if neither is set. [[1]](diffhunk://#diff-b2a0e1b2ba047c070e98f86bb106387119e91129b05906826d92f11ff2890962R98-R113) [[2]](diffhunk://#diff-b2a0e1b2ba047c070e98f86bb106387119e91129b05906826d92f11ff2890962L252-R306)

### Validation and schema changes

* Updated parameter validation logic to only require `region` at the system level, removing the requirement for `guardrailID` and `guardrailVersion` to always be present globally. [[1]](diffhunk://#diff-b2a0e1b2ba047c070e98f86bb106387119e91129b05906826d92f11ff2890962L252-R306) [[2]](diffhunk://#diff-c17dd7c3069baf176a10432cddf74f7e85d71d669458586f12dc03d9880d0530L126-L127)
* Added an `anyOf` clause to the parameters schema, requiring at least one of `request` or `response` configuration to be set.

### Version update

* Bumped the policy version to `v1.1.0` to reflect these enhancements.


Tested the following scenarios with both LLM Provider and Proxy

- With bedrock id and version as system parameters
- With bedrock id and version as policy parameters
- With a different bedrock id and version as system parameters