### PR TITLE
docs(mcp-auth): fix system param casing in config.toml examples

### DIFF
--- a/docs/mcp-auth/v0.2/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v0.2/docs/mcp-authentication.md
@@ -38,7 +38,7 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 | `errormessageformat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
 | `errormessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
 | `validateissuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayhost` | string | No | `"localhost"` | mcpauth_v0 | The outward facing gateway host name used when deriving the protected resource metadata URL and response. Falls back to this if no vhosts are defined in the MCP proxy configuration. |
+| `gatewayhost` | string | No | `"localhost"` | mcpauth_v0 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. Falls back to this if no vhosts are defined in the MCP proxy configuration. |
 
 #### KeyManager Configuration
 

--- a/docs/mcp-auth/v0.2/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v0.2/docs/mcp-authentication.md
@@ -25,24 +25,24 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 
 | Parameter | Type | Required | Default | Path | Description |
 |-----------|------|----------|---------|----------|-------------|
-| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
-| `jwksCacheTtl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
-| `jwksFetchTimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
-| `jwksFetchRetryCount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
-| `jwksFetchRetryInterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `keymanagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwkscachettl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksfetchtimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksfetchretrycount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
+| `jwksfetchretryinterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
 | `allowedAlgorithms` | string array | No | - | jwtauth_v0 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
 | `leeway` | string | No | - | jwtauth_v0 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
-| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
-| `headerName` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
-| `onFailureStatusCode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
-| `errorMessageFormat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
-| `errorMessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
-| `validateIssuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayHost` | string | No | `"localhost"` | mcpauth_v0 | The outward facing gateway host name used when deriving the protected resource metadata URL and response. Falls back to this if no vhosts are defined in the MCP proxy configuration. |
+| `authheaderscheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
+| `headername` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errormessageformat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errormessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
+| `validateissuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayhost` | string | No | `"localhost"` | mcpauth_v0 | The outward facing gateway host name used when deriving the protected resource metadata URL and response. Falls back to this if no vhosts are defined in the MCP proxy configuration. |
 
 #### KeyManager Configuration
 
-Each key manager in the `keyManagers` array supports the following structure:
+Each key manager in the `keymanagers` array supports the following structure:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -60,35 +60,35 @@ Each key manager in the `keyManagers` array supports the following structure:
 
 ```toml
 [policy_configurations.mcpauth_v0]
-gatewayHost = "gw.example.com"
+gatewayhost = "gw.example.com"
 
 [policy_configurations.jwtauth_v0]
-jwksCacheTtl = "5m"
-jwksFetchTimeout = "5s"
-jwksFetchRetryCount = 3
-jwksFetchRetryInterval = "2s"
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
 allowedAlgorithms = ["RS256", "ES256"]
 leeway = "30s"
-authHeaderScheme = "Bearer"
-headerName = "Authorization"
-onFailureStatusCode = 401
-errorMessageFormat = "json"
-errorMessage = "Authentication failed."
-validateIssuer = true
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed."
+validateissuer = true
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v0.keymanagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v0.keymanagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```
@@ -99,7 +99,7 @@ These parameters are configured per-API/route by the API developer:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `issuers` | string array | No | `[]` | List of issuer names (referencing entries in `system.keyManagers`). This list is sent as `authorization_servers` in the protected resource metadata response. If omitted, all configured key managers are used. |
+| `issuers` | string array | No | `[]` | List of issuer names (referencing entries in `system.keymanagers`). This list is sent as `authorization_servers` in the protected resource metadata response. If omitted, all configured key managers are used. |
 | `requiredScopes` | string array | No | `[]` | List of scopes that must be present in the token (space-delimited `scope` claim or array `scp`). These are also advertised in the protected resource metadata. |
 | `audiences` | string array | No | `[]` | List of acceptable audience values; token must contain at least one. |
 | `requiredClaims` | object | No | `{}` | Map of claimName → expectedValue for custom claim validation. |

--- a/docs/mcp-auth/v0.9/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v0.9/docs/mcp-authentication.md
@@ -27,24 +27,24 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 
 | Parameter | Type | Required | Default | Path | Description |
 |-----------|------|----------|---------|------|-------------|
-| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
-| `jwksCacheTtl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
-| `jwksFetchTimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
-| `jwksFetchRetryCount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
-| `jwksFetchRetryInterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `keymanagers` | `KeyManager` array | Yes | - | jwtauth_v0 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwkscachettl` | string | No | - | jwtauth_v0 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksfetchtimeout` | string | No | - | jwtauth_v0 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksfetchretrycount` | integer | No | - | jwtauth_v0 | Number of retries for JWKS fetch on transient failures. |
+| `jwksfetchretryinterval` | string | No | - | jwtauth_v0 | Interval between JWKS fetch retries (e.g., `"2s"`). |
 | `allowedAlgorithms` | string array | No | - | jwtauth_v0 | Allowed JWT signing algorithms (e.g., `["RS256", "ES256"]`). |
 | `leeway` | string | No | - | jwtauth_v0 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
-| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
-| `headerName` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
-| `onFailureStatusCode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
-| `errorMessageFormat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
-| `errorMessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
-| `validateIssuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayHost` | string | No | `"localhost"` | mcpauth_v0 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
+| `authheaderscheme` | string | No | `"Bearer"` | jwtauth_v0 | Expected scheme prefix in the authorization header. |
+| `headername` | string | No | `"Authorization"` | jwtauth_v0 | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | jwtauth_v0 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errormessageformat` | string | No | `"json"` | jwtauth_v0 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errormessage` | string | No | - | jwtauth_v0 | Custom error message to include in the response body on authentication failure. |
+| `validateissuer` | boolean | No | - | jwtauth_v0 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayhost` | string | No | `"localhost"` | mcpauth_v0 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
 
 #### KeyManager Configuration
 
-Each key manager in the `keyManagers` array supports the following structure:
+Each key manager in the `keymanagers` array supports the following structure:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -62,35 +62,35 @@ Each key manager in the `keyManagers` array supports the following structure:
 
 ```toml
 [policy_configurations.mcpauth_v0]
-gatewayHost = "gw.example.com"
+gatewayhost = "gw.example.com"
 
 [policy_configurations.jwtauth_v0]
-jwksCacheTtl = "5m"
-jwksFetchTimeout = "5s"
-jwksFetchRetryCount = 3
-jwksFetchRetryInterval = "2s"
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
 allowedAlgorithms = ["RS256", "ES256"]
 leeway = "30s"
-authHeaderScheme = "Bearer"
-headerName = "Authorization"
-onFailureStatusCode = 401
-errorMessageFormat = "json"
-errorMessage = "Authentication failed."
-validateIssuer = true
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed."
+validateissuer = true
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v0.keymanagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v0.keyManagers]]
+[[policy_configurations.jwtauth_v0.keymanagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v0.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v0.keymanagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```
@@ -107,7 +107,7 @@ These parameters are configured per-API/route by the API developer:
 | `resources` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP resources. |
 | `prompts` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP prompts. |
 | `methods` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP (JSON-RPC) methods. |
-| `issuers` | string array | No | `[]` | List of issuer names from `system.keyManagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
+| `issuers` | string array | No | `[]` | List of issuer names from `system.keymanagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
 | `requiredScopes` | string array | No | `[]` | List of scopes that should be included in the token generated through MCP auth flow. These are advertised in the protected resource metadata but **not enforced** by this policy. Use the MCP Authorization policy to enforce scopes. |
 | `claimMappings` | object | No | `{}` | Map of claimName → downstream header or context key to expose claims for downstream services. |
 

--- a/docs/mcp-auth/v1.0/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v1.0/docs/mcp-authentication.md
@@ -28,23 +28,23 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 
 | Parameter | Type | Required | Default | Path | Description |
 |-----------|------|----------|---------|------|-------------|
-| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v1 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
-| `jwksCacheTtl` | string | No | - | jwtauth_v1 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
-| `jwksFetchTimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
-| `jwksFetchRetryCount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
-| `jwksFetchRetryInterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `keymanagers` | `KeyManager` array | Yes | - | jwtauth_v1 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwkscachettl` | string | No | - | jwtauth_v1 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksfetchtimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksfetchretrycount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
+| `jwksfetchretryinterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
 | `leeway` | string | No | - | jwtauth_v1 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
-| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
-| `headerName` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
-| `onFailureStatusCode` | integer | No | `401` | jwtauth_v1 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
-| `errorMessageFormat` | string | No | `"json"` | jwtauth_v1 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
-| `errorMessage` | string | No | - | jwtauth_v1 | Custom error message to include in the response body on authentication failure. |
-| `validateIssuer` | boolean | No | - | jwtauth_v1 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayHost` | string | No | `"localhost"` | mcpauth_v1 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
+| `authheaderscheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
+| `headername` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | jwtauth_v1 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errormessageformat` | string | No | `"json"` | jwtauth_v1 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errormessage` | string | No | - | jwtauth_v1 | Custom error message to include in the response body on authentication failure. |
+| `validateissuer` | boolean | No | - | jwtauth_v1 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayhost` | string | No | `"localhost"` | mcpauth_v1 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
 
 #### KeyManager Configuration
 
-Each key manager in the `keyManagers` array supports the following structure:
+Each key manager in the `keymanagers` array supports the following structure:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -62,34 +62,34 @@ Each key manager in the `keyManagers` array supports the following structure:
 
 ```toml
 [policy_configurations.mcpauth_v1]
-gatewayHost = "gw.example.com"
+gatewayhost = "gw.example.com"
 
 [policy_configurations.jwtauth_v1]
-jwksCacheTtl = "5m"
-jwksFetchTimeout = "5s"
-jwksFetchRetryCount = 3
-jwksFetchRetryInterval = "2s"
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
 leeway = "30s"
-authHeaderScheme = "Bearer"
-headerName = "Authorization"
-onFailureStatusCode = 401
-errorMessageFormat = "json"
-errorMessage = "Authentication failed."
-validateIssuer = true
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed."
+validateissuer = true
 
-[[policy_configurations.jwtauth_v1.keyManagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v1.keyManagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```
@@ -106,7 +106,7 @@ These parameters are configured per-API/route by the API developer:
 | `resources` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP resources. |
 | `prompts` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP prompts. |
 | `methods` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP (JSON-RPC) methods. |
-| `issuers` | string array | No | `[]` | List of issuer names from `system.keyManagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
+| `issuers` | string array | No | `[]` | List of issuer names from `system.keymanagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
 | `requiredScopes` | string array | No | `[]` | List of scopes that should be included in the token generated through MCP auth flow. These are advertised in the protected resource metadata but **not enforced** by this policy. Use the MCP Authorization policy to enforce scopes. If empty, `scopes_supported` is omitted from the metadata document (it is OPTIONAL per RFC 9728). |
 | `claimMappings` | object | No | `{}` | Map of claimName → downstream header or context key to expose claims for downstream services. |
 

--- a/docs/mcp-auth/v1.2/docs/mcp-authentication.md
+++ b/docs/mcp-auth/v1.2/docs/mcp-authentication.md
@@ -31,23 +31,23 @@ Configured by the administrator in `config.toml` under `policy_configurations.mc
 
 | Parameter | Type | Required | Default | Path | Description |
 |-----------|------|----------|---------|------|-------------|
-| `keyManagers` | `KeyManager` array | Yes | - | jwtauth_v1 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
-| `jwksCacheTtl` | string | No | - | jwtauth_v1 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
-| `jwksFetchTimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
-| `jwksFetchRetryCount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
-| `jwksFetchRetryInterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
+| `keymanagers` | `KeyManager` array | Yes | - | jwtauth_v1 | List of key manager definitions. Each entry must include a unique `name` and `issuer`, and either `jwks.remote` or `jwks.local` configuration. |
+| `jwkscachettl` | string | No | - | jwtauth_v1 | Duration string for JWKS caching (e.g., `"5m"`). If omitted a default is used. |
+| `jwksfetchtimeout` | string | No | - | jwtauth_v1 | Timeout for HTTP fetch of JWKS (e.g., `"5s"`). |
+| `jwksfetchretrycount` | integer | No | - | jwtauth_v1 | Number of retries for JWKS fetch on transient failures. |
+| `jwksfetchretryinterval` | string | No | - | jwtauth_v1 | Interval between JWKS fetch retries (e.g., `"2s"`). |
 | `leeway` | string | No | - | jwtauth_v1 | Clock skew allowance for `exp`/`nbf` checks (e.g., `"30s"`). |
-| `authHeaderScheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
-| `headerName` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
-| `onFailureStatusCode` | integer | No | `401` | jwtauth_v1 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
-| `errorMessageFormat` | string | No | `"json"` | jwtauth_v1 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
-| `errorMessage` | string | No | - | jwtauth_v1 | Custom error message to include in the response body on authentication failure. |
-| `validateIssuer` | boolean | No | - | jwtauth_v1 | Whether to validate the token's issuer claim against configured key managers. |
-| `gatewayHost` | string | No | `"localhost"` | mcpauth_v1 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
+| `authheaderscheme` | string | No | `"Bearer"` | jwtauth_v1 | Expected scheme prefix in the authorization header. |
+| `headername` | string | No | `"Authorization"` | jwtauth_v1 | Header name to extract the token from. |
+| `onfailurestatuscode` | integer | No | `401` | jwtauth_v1 | HTTP status code returned on authentication failure. Allowed values: `401`, `403`. |
+| `errormessageformat` | string | No | `"json"` | jwtauth_v1 | Format of the error response. Allowed values: `"json"`, `"plain"`, `"minimal"`. |
+| `errormessage` | string | No | - | jwtauth_v1 | Custom error message to include in the response body on authentication failure. |
+| `validateissuer` | boolean | No | - | jwtauth_v1 | Whether to validate the token's issuer claim against configured key managers. |
+| `gatewayhost` | string | No | `"localhost"` | mcpauth_v1 | The outward-facing gateway host name used when deriving the protected resource metadata URL and response. |
 
 #### KeyManager Configuration
 
-Each key manager in the `keyManagers` array supports the following structure:
+Each key manager in the `keymanagers` array supports the following structure:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -65,34 +65,34 @@ Each key manager in the `keyManagers` array supports the following structure:
 
 ```toml
 [policy_configurations.mcpauth_v1]
-gatewayHost = "gw.example.com"
+gatewayhost = "gw.example.com"
 
 [policy_configurations.jwtauth_v1]
-jwksCacheTtl = "5m"
-jwksFetchTimeout = "5s"
-jwksFetchRetryCount = 3
-jwksFetchRetryInterval = "2s"
+jwkscachettl = "5m"
+jwksfetchtimeout = "5s"
+jwksfetchretrycount = 3
+jwksfetchretryinterval = "2s"
 leeway = "30s"
-authHeaderScheme = "Bearer"
-headerName = "Authorization"
-onFailureStatusCode = 401
-errorMessageFormat = "json"
-errorMessage = "Authentication failed."
-validateIssuer = true
+authheaderscheme = "Bearer"
+headername = "Authorization"
+onfailurestatuscode = 401
+errormessageformat = "json"
+errormessage = "Authentication failed."
+validateissuer = true
 
-[[policy_configurations.jwtauth_v1.keyManagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "PrimaryIDP"
 issuer = "https://idp.example.com/oauth2/token"
 
-[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://idp.example.com/oauth2/jwks"
 skipTlsVerify = false
 
-[[policy_configurations.jwtauth_v1.keyManagers]]
+[[policy_configurations.jwtauth_v1.keymanagers]]
 name = "SecondaryIDP"
 issuer = "https://auth.example.org/oauth2/token"
 
-[policy_configurations.jwtauth_v1.keyManagers.jwks.remote]
+[policy_configurations.jwtauth_v1.keymanagers.jwks.remote]
 uri = "https://auth.example.org/oauth2/jwks"
 skipTlsVerify = false
 ```
@@ -109,7 +109,7 @@ These parameters are configured per-API/route by the API developer:
 | `resources` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP resources. |
 | `prompts` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP prompts. |
 | `methods` | `SecurityConfig` object | No | `{"enabled": true}` | Security configuration for MCP (JSON-RPC) methods. |
-| `issuers` | string array | No | `[]` | List of issuer names from `system.keyManagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
+| `issuers` | string array | No | `[]` | List of issuer names from `system.keymanagers` to publish in protected resource metadata and use for token validation. If empty, runtime uses all configured key managers. |
 | `requiredScopes` | string array | No | `[]` | Scopes to advertise in protected-resource metadata for the MCP authorization flow. They are **not enforced** by this policy; use the MCP Authorization policy to enforce scopes. |
 | `claimMappings` | object | No | `{}` | Map of claimName → downstream header or context key to expose claims for downstream services. |
 | `userIdClaim` | string | No | `"sub"` | Claim name used to extract the user ID for analytics. |
@@ -143,7 +143,7 @@ MCP servers are frequently third-party processes, so this policy does **not** re
 
 | `forwardToken` | What the upstream receives |
 |----------------|----------------------------|
-| `false` (default) | Nothing. The inbound token header (`system.headerName`, default `Authorization`) is removed before the request is proxied. |
+| `false` (default) | Nothing. The inbound token header (`system.headername`, default `Authorization`) is removed before the request is proxied. |
 | `true` | The token under `forwardedTokenHeader` (default `x-forwarded-authorization`). The inbound token header is still removed unless `forwardedTokenHeader` names that same header. |
 
 `forwardTokenStripScheme` controls the shape of the forwarded value: `false` (default) forwards `Bearer eyJ...`, `true` forwards `eyJ...`.
@@ -435,9 +435,9 @@ The client's token is validated by `mcp-auth`, and the MCP server receives the s
 
 | Situation | Status | Body |
 |-----------|--------|------|
-| Token missing, expired, or otherwise invalid | `onFailureStatusCode` (default `401`) | Shaped by `errorMessageFormat`; accompanied by a `WWW-Authenticate: Bearer resource_metadata="…"` header. |
-| Request body is not valid JSON, or not a valid JSON-RPC request object | `400` | A JSON-RPC 2.0 error object — code `-32700` (Parse error) for invalid JSON syntax, `-32600` (Invalid Request) otherwise. Not affected by `errorMessageFormat`. |
-| Policy configuration is invalid (e.g. a malformed `keyManagers` entry) | `500` | JSON error object. |
+| Token missing, expired, or otherwise invalid | `onfailurestatuscode` (default `401`) | Shaped by `errormessageformat`; accompanied by a `WWW-Authenticate: Bearer resource_metadata="…"` header. |
+| Request body is not valid JSON, or not a valid JSON-RPC request object | `400` | A JSON-RPC 2.0 error object — code `-32700` (Parse error) for invalid JSON syntax, `-32600` (Invalid Request) otherwise. Not affected by `errormessageformat`. |
+| Policy configuration is invalid (e.g. a malformed `keymanagers` entry) | `500` | JSON error object. |
 
 ## Related Policies
 


### PR DESCRIPTION
## Purpose

All mcp-auth doc versions (v0.2, v0.9, v1.0, v1.2) used camelCase for system-level `config.toml` keys (e.g. `keyManagers`, `jwksCacheTtl`, `authHeaderScheme`, `gatewayHost`). The jwt-auth docs and working deployment configs (e.g. `gw-perf/claim-ratelimit/jwt-values-patch.yaml`) consistently use all-lowercase for these keys, which is the correct convention for the TOML config layer. This PR aligns the mcp-auth docs with that convention.

## Approach

- Fix parameter tables: `keyManagers` → `keymanagers`, `authHeaderScheme` → `authheaderscheme`, `gatewayHost` → `gatewayhost`, `jwksCacheTtl` → `jwkscachettl`, `onFailureStatusCode` → `onfailurestatuscode`, `errorMessageFormat` → `errormessageformat`, `validateIssuer` → `validateissuer`, and the remaining multi-word params
- Fix TOML code examples in the System Configuration Example sections, including `[[...keymanagers]]` table headers
- Fix prose references: `system.keyManagers` → `system.keymanagers`, `system.headerName` → `system.headername`
- Applied consistently across all four versions: v0.2, v0.9, v1.0, v1.2

## Related Issues

Fix https://github.com/wso2/api-platform/issues/3146

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)