### PR TITLE
[LLM COST] Handle transformed Anthropic and Gemini usage

### DIFF
--- a/policies/llm-cost/calculator_anthropic.go
+++ b/policies/llm-cost/calculator_anthropic.go
@@ -24,6 +24,8 @@ import (
 // AnthropicCalculator handles models with provider "anthropic".
 // Uses input_tokens/output_tokens field names and adds cache token fields.
 // The speed flag is not echoed in the response — it is read from the request body.
+// It also accepts Messages responses converted to the OpenAI Chat Completions
+// shape by openai-to-anthropic-transformer.
 type AnthropicCalculator struct{}
 
 func (c *AnthropicCalculator) Normalize(responseBody []byte, requestBody []byte) (Usage, error) {
@@ -34,21 +36,31 @@ func (c *AnthropicCalculator) Normalize(responseBody []byte, requestBody []byte)
 		CacheCreationInputTokens int64  `json:"cache_creation_input_tokens"`
 		CacheReadInputTokens     int64  `json:"cache_read_input_tokens"`
 		InferenceGeo             string `json:"inference_geo"`
-		CacheCreation *struct {
+		CacheCreation            *struct {
 			Ephemeral5mInputTokens int64 `json:"ephemeral_5m_input_tokens"`
 			Ephemeral1hInputTokens int64 `json:"ephemeral_1h_input_tokens"`
 		} `json:"cache_creation"`
 		ServerToolUse *struct {
 			WebSearchRequests int64 `json:"web_search_requests"`
 		} `json:"server_tool_use"`
+
+		// OpenAI shape emitted by openai-to-anthropic-transformer, for both
+		// buffered responses and the converted SSE stream.
+		PromptTokens        int64 `json:"prompt_tokens"`
+		CompletionTokens    int64 `json:"completion_tokens"`
+		TotalTokens         int64 `json:"total_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens        int64 `json:"cached_tokens"`
+			CacheCreationTokens int64 `json:"cache_creation_tokens"`
+		} `json:"prompt_tokens_details"`
 	}
 	var resp struct {
-		Model   string        `json:"model"`
-		Usage   anthropicUsage `json:"usage"`
+		Model string         `json:"model"`
+		Usage anthropicUsage `json:"usage"`
 		// Anthropic streaming wraps usage/model inside a "message" envelope
 		// in the message_start event. Check both locations.
 		Message *struct {
-			Model string        `json:"model"`
+			Model string         `json:"model"`
 			Usage anthropicUsage `json:"usage"`
 		} `json:"message"`
 	}
@@ -101,6 +113,36 @@ func (c *AnthropicCalculator) Normalize(responseBody []byte, requestBody []byte)
 				searchContextSize = req.WebSearchOptions.SearchContextSize
 			}
 		}
+	}
+
+	// Transformed responses carry OpenAI token names instead of Anthropic's.
+	// Native fields are checked first so a genuine Anthropic response is never
+	// routed here.
+	if resp.Usage.InputTokens == 0 && resp.Usage.OutputTokens == 0 &&
+		resp.Usage.CacheCreationInputTokens == 0 && resp.Usage.CacheReadInputTokens == 0 &&
+		(resp.Usage.PromptTokens != 0 || resp.Usage.CompletionTokens != 0) {
+		var cachedTokens, cacheCreationTokens int64
+		if d := resp.Usage.PromptTokensDetails; d != nil {
+			cachedTokens = d.CachedTokens
+			cacheCreationTokens = d.CacheCreationTokens
+		}
+		// The transformer reports prompt_tokens as Anthropic's regular-only
+		// input_tokens, so add the cache buckets back to rebuild the inclusive
+		// prompt count genericCalculateCost expects. total_tokens is already
+		// input+output, matching the native branch below.
+		promptTokens := resp.Usage.PromptTokens + cachedTokens + cacheCreationTokens
+		return Usage{
+			PromptTokens:          promptTokens,
+			CompletionTokens:      resp.Usage.CompletionTokens,
+			TotalTokens:           resp.Usage.TotalTokens,
+			InputTokensForTiering: promptTokens,
+			CachedReadTokens:      cachedTokens,
+			// The transformer does not preserve the cache_creation TTL split, so
+			// all writes bill at the default 5-minute rate.
+			CacheWriteTokens:  cacheCreationTokens,
+			Speed:             speed,
+			SearchContextSize: searchContextSize,
+		}, nil
 	}
 
 	u := resp.Usage

--- a/policies/llm-cost/calculator_gemini.go
+++ b/policies/llm-cost/calculator_gemini.go
@@ -22,7 +22,9 @@ import (
 )
 
 // GeminiCalculator handles models with provider "gemini", "vertex_ai", and
-// related subfamilies. Uses the "usageMetadata" response namespace.
+// related subfamilies. Uses the "usageMetadata" response namespace, and also
+// accepts generateContent responses converted to the OpenAI Chat Completions
+// shape by openai-to-gemini-transformer.
 // Grounding cost is applied in Adjust() as a fixed per-query fee.
 type GeminiCalculator struct{}
 
@@ -79,11 +81,41 @@ func (c *GeminiCalculator) Normalize(responseBody []byte, _ []byte) (Usage, erro
 			// Mapped to ServiceTier: "priority" or "flex" (ON_DEMAND → "").
 			TrafficType string `json:"trafficType"`
 		} `json:"usageMetadata"`
+
+		// OpenAI shape emitted by openai-to-gemini-transformer, for both buffered
+		// responses and the converted SSE stream.
+		Usage *struct {
+			PromptTokens        int64 `json:"prompt_tokens"`
+			CompletionTokens    int64 `json:"completion_tokens"`
+			TotalTokens         int64 `json:"total_tokens"`
+			PromptTokensDetails struct {
+				CachedTokens int64 `json:"cached_tokens"`
+			} `json:"prompt_tokens_details"`
+			CompletionTokensDetails struct {
+				ReasoningTokens int64 `json:"reasoning_tokens"`
+			} `json:"completion_tokens_details"`
+		} `json:"usage"`
 	}
 	if err := json.Unmarshal(responseBody, &resp); err != nil {
 		return Usage{}, err
 	}
 	m := resp.UsageMetadata
+
+	// Transformed responses carry OpenAI token names instead of usageMetadata.
+	// The native namespace is checked first so a genuine Gemini response is
+	// never routed here. Gemini's promptTokenCount and the transformer's
+	// prompt_tokens are both cache-inclusive, and completion_tokens already
+	// folds in thought tokens, so the fields map across directly.
+	if m.PromptTokenCount == 0 && m.CandidatesTokenCount == 0 && m.ResponseTokenCount == 0 &&
+		resp.Usage != nil && (resp.Usage.PromptTokens != 0 || resp.Usage.CompletionTokens != 0) {
+		return Usage{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+			ReasoningTokens:  resp.Usage.CompletionTokensDetails.ReasoningTokens,
+			CachedReadTokens: resp.Usage.PromptTokensDetails.CachedTokens,
+		}, nil
+	}
 
 	// Prompt modality tokens: promptTokensDetails gives totals (including cached);
 	// subtract cacheTokensDetails to get the non-cached portion billed at input rate.

--- a/policies/llm-cost/llm_cost_test.go
+++ b/policies/llm-cost/llm_cost_test.go
@@ -1330,6 +1330,175 @@ func TestAnthropicCalculator_Cost_WebSearch_ZeroRequests(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Transformed (OpenAI-shaped) Anthropic and Gemini responses
+//
+// openai-to-anthropic-transformer and openai-to-gemini-transformer rewrite both
+// buffered and streaming responses into the OpenAI Chat Completions shape. When
+// llm-cost runs after a transformer it therefore sees OpenAI token names rather
+// than the provider-native ones, and must still bill correctly.
+// ---------------------------------------------------------------------------
+
+// TestAnthropicCalculator_TransformedMatchesNative is the core guarantee: the
+// same underlying Anthropic token counts must produce identical Usage whether
+// llm-cost sees the native body or the transformer's OpenAI-shaped rewrite.
+func TestAnthropicCalculator_TransformedMatchesNative(t *testing.T) {
+	c := &AnthropicCalculator{}
+
+	native := []byte(`{"model":"claude-sonnet-4-20250514","usage":{
+		"input_tokens":25,"output_tokens":15,
+		"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`)
+	// What the transformer emits for those same counts.
+	transformed := []byte(`{"model":"claude-sonnet-4-20250514","usage":{
+		"prompt_tokens":25,"completion_tokens":15,"total_tokens":40,
+		"prompt_tokens_details":{"cached_tokens":10,"cache_creation_tokens":5}}}`)
+
+	nativeUsage, err := c.Normalize(native, nil)
+	if err != nil {
+		t.Fatalf("native normalize: %v", err)
+	}
+	transformedUsage, err := c.Normalize(transformed, nil)
+	if err != nil {
+		t.Fatalf("transformed normalize: %v", err)
+	}
+
+	if nativeUsage != transformedUsage {
+		t.Fatalf("transformed usage != native usage\nnative:      %+v\ntransformed: %+v",
+			nativeUsage, transformedUsage)
+	}
+	// Guard the specific trap: prompt_tokens is Anthropic's regular-only count,
+	// so the cache buckets must be added back to keep it cache-inclusive.
+	if transformedUsage.PromptTokens != 40 {
+		t.Errorf("PromptTokens = %d, want 40 (25 regular + 10 cache read + 5 cache write)",
+			transformedUsage.PromptTokens)
+	}
+}
+
+func TestAnthropicCalculator_TransformedCost(t *testing.T) {
+	pricing, ok := lookupPricing(testPricingMap, "claude-opus-4-6")
+	if !ok {
+		t.Skip("claude-opus-4-6 not in pricing map")
+	}
+	usage, err := (&AnthropicCalculator{}).Normalize([]byte(`{"usage":{
+		"prompt_tokens":25,"completion_tokens":15,"total_tokens":40,
+		"prompt_tokens_details":{"cached_tokens":10,"cache_creation_tokens":5}}}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := float64(25)*pricing.InputCostPerToken +
+		float64(15)*pricing.OutputCostPerToken +
+		float64(10)*pricing.CacheReadInputTokenCost +
+		float64(5)*pricing.CacheCreationInputTokenCost
+	if got := genericCalculateCost(usage, pricing); !almostEqual(got, want) {
+		t.Fatalf("transformed cost = %.10f, want %.10f", got, want)
+	}
+}
+
+// TestAnthropicCalculator_NativeWinsOverTransformed ensures a real Anthropic
+// body is never routed through the transformed branch.
+func TestAnthropicCalculator_NativeWinsOverTransformed(t *testing.T) {
+	usage, err := (&AnthropicCalculator{}).Normalize([]byte(`{"usage":{
+		"input_tokens":100,"output_tokens":50,
+		"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 100 || usage.CompletionTokens != 50 {
+		t.Fatalf("native fields must win, got %+v", usage)
+	}
+}
+
+func TestAnthropicCalculator_TransformedKeepsRequestSideFields(t *testing.T) {
+	usage, err := (&AnthropicCalculator{}).Normalize(
+		[]byte(`{"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`),
+		[]byte(`{"speed":"fast","web_search_options":{"search_context_size":"high"}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.Speed != "fast" || usage.SearchContextSize != "high" {
+		t.Errorf("request-side fields lost on the transformed path: %+v", usage)
+	}
+}
+
+// TestGeminiCalculator_TransformedMatchesNative mirrors the Anthropic guarantee.
+func TestGeminiCalculator_TransformedMatchesNative(t *testing.T) {
+	c := &GeminiCalculator{}
+
+	// Non-inclusive thinking case: prompt+candidates != total, so the native
+	// path adds thoughts into completion tokens (6 + 8 = 14).
+	native := []byte(`{"modelVersion":"gemini-2.5-pro","usageMetadata":{
+		"promptTokenCount":12,"candidatesTokenCount":6,"totalTokenCount":26,
+		"cachedContentTokenCount":4,"thoughtsTokenCount":8}}`)
+	transformed := []byte(`{"model":"gemini-2.5-pro","usage":{
+		"prompt_tokens":12,"completion_tokens":14,"total_tokens":26,
+		"prompt_tokens_details":{"cached_tokens":4},
+		"completion_tokens_details":{"reasoning_tokens":8}}}`)
+
+	nativeUsage, err := c.Normalize(native, nil)
+	if err != nil {
+		t.Fatalf("native normalize: %v", err)
+	}
+	transformedUsage, err := c.Normalize(transformed, nil)
+	if err != nil {
+		t.Fatalf("transformed normalize: %v", err)
+	}
+	if nativeUsage != transformedUsage {
+		t.Fatalf("transformed usage != native usage\nnative:      %+v\ntransformed: %+v",
+			nativeUsage, transformedUsage)
+	}
+	if transformedUsage.CompletionTokens != 14 || transformedUsage.ReasoningTokens != 8 {
+		t.Errorf("completion tokens must stay inclusive of reasoning: %+v", transformedUsage)
+	}
+}
+
+func TestGeminiCalculator_NativeWinsOverTransformed(t *testing.T) {
+	usage, err := (&GeminiCalculator{}).Normalize([]byte(`{"usageMetadata":{
+		"promptTokenCount":100,"candidatesTokenCount":50,"totalTokenCount":150},
+		"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 100 || usage.CompletionTokens != 50 {
+		t.Fatalf("native usageMetadata must win, got %+v", usage)
+	}
+}
+
+// TestOnResponseBodyChunk_SSE_AnthropicTransformed_Calculated drives the whole
+// policy over the SSE stream openai-to-anthropic-transformer now emits.
+func TestOnResponseBodyChunk_SSE_AnthropicTransformed_Calculated(t *testing.T) {
+	const model = "claude-sonnet-4-20250514"
+	p := &LLMCostPolicy{pricingMap: map[string]ModelPricing{
+		model: {Provider: "anthropic", InputCostPerToken: 3e-6, OutputCostPerToken: 15e-6},
+	}}
+	body := []byte(
+		"data: {\"id\":\"chatcmpl-01ABC\",\"model\":\"" + model + "\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-01ABC\",\"model\":\"" + model + "\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-01ABC\",\"model\":\"" + model + "\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4,\"total_tokens\":14}}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{body})
+	// 10 * 3e-6 + 4 * 15e-6 = 9e-5.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000900000")
+}
+
+// TestOnResponseBodyChunk_SSE_GeminiTransformed_Calculated does the same for the
+// Gemini transformer's converted stream.
+func TestOnResponseBodyChunk_SSE_GeminiTransformed_Calculated(t *testing.T) {
+	const model = "gemini-2.5-pro"
+	p := &LLMCostPolicy{pricingMap: map[string]ModelPricing{
+		model: {Provider: "gemini", InputCostPerToken: 1.25e-6, OutputCostPerToken: 1e-5},
+	}}
+	body := []byte(
+		"data: {\"id\":\"chatcmpl-r\",\"model\":\"" + model + "\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-r\",\"model\":\"" + model + "\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":6,\"total_tokens\":18}}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	ctx, action := sendChunks(p, [][]byte{body})
+	// 12 * 1.25e-6 + 6 * 1e-5 = 7.5e-5.
+	assertStreamCostMetadata(t, ctx, action, costStatusCalculated, "0.0000750000")
+}
+
 func TestGeminiCalculator_Normalize(t *testing.T) {
 	// INCLUSIVE case: promptTokenCount + candidatesTokenCount == totalTokenCount
 	// meaning candidatesTokenCount already contains thinking tokens.

--- a/policies/llm-cost/policy-definition.yaml
+++ b/policies/llm-cost/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: llm-cost
-version: v1.1.0
+version: v1.1.1
 description: |
   Calculates the monetary cost of LLM API calls at response time and stores the
   result in SharedContext.Metadata under "x-llm-cost" (USD float, e.g. "0.0000423100").


### PR DESCRIPTION
## Purpose

`llm-cost` calculates the monetary cost of every LLM request by reading token usage out of the
response body. It runs **after** the provider transformers in the response chain, so the body it
sees has already been rewritten into the OpenAI Chat Completions shape.

The Anthropic and Gemini calculators only recognised **provider-native** usage field names:

| Calculator looked for | A transformed body actually contains |
|---|---|
| `usage.input_tokens` (Anthropic) | `usage.prompt_tokens` |
| `usageMetadata.promptTokenCount` (Gemini) | `usage.prompt_tokens` |

The lookup found nothing and every token count came back zero. Reproduced before the fix:

```
AnthropicCalculator -> {PromptTokens:0 CompletionTokens:0 TotalTokens:0 ...} err=<nil>
```

`err == nil` is the dangerous part. `json.Unmarshal` does not complain about absent fields, so the
calculator reported **success** with zeroed usage and the gateway published `x-llm-cost: 0` with
status `calculated` — not `not_calculated`, and no warning logged. Every affected request was billed
at zero while looking completely healthy in logs, metrics and analytics.

This already affected **non-streaming** Anthropic and Gemini traffic today, independently of any
streaming work, because those responses have always been converted to the OpenAI shape.

Resolves #<issue>

## Goals

- Bill transformed Anthropic and Gemini responses correctly instead of silently at zero.
- Produce the *same* `Usage` for a given set of provider token counts regardless of whether
  `llm-cost` sees the native body or the transformer's rewrite.
- Change nothing about how native provider responses are normalized.

## Approach

Each calculator gains a fallback branch that reads the OpenAI usage shape when the native fields are
absent. This mirrors `calculator_bedrock.go`, which already had to learn the OpenAI shape when
`openai-to-bedrock-transformer` started converting streams (commit `4656178`).

Native fields are checked **first**, so a genuine provider response can never be routed through the
fallback.

**Gemini** maps directly — its `promptTokenCount` and the transformer's `prompt_tokens` are both
cache-inclusive, and `completion_tokens` already folds in thought tokens:

```go
if m.PromptTokenCount == 0 && m.CandidatesTokenCount == 0 && m.ResponseTokenCount == 0 &&
    resp.Usage != nil && (resp.Usage.PromptTokens != 0 || resp.Usage.CompletionTokens != 0) {
    return Usage{
        PromptTokens:     resp.Usage.PromptTokens,
        CompletionTokens: resp.Usage.CompletionTokens,
        TotalTokens:      resp.Usage.TotalTokens,
        ReasoningTokens:  resp.Usage.CompletionTokensDetails.ReasoningTokens,
        CachedReadTokens: resp.Usage.PromptTokensDetails.CachedTokens,
    }, nil
}
```

**Anthropic needs one correction that Bedrock does not**, and it is the whole engineering content of
this PR. Bedrock's transformer emits *cache-inclusive* `prompt_tokens`; Anthropic's emits Anthropic's
*regular-only* `input_tokens`. The pricing engine assumes `prompt_tokens` is the total and subtracts
the cache buckets back out:

```go
// pricing.go
regularPromptTokens := usage.PromptTokens - usage.CachedReadTokens - usage.CacheWriteTokens - ...
```

Mapping the field across naively would subtract tokens that were never added — under-billing, and
going negative when cache dominates. The fallback rebuilds the inclusive count:

```go
promptTokens := resp.Usage.PromptTokens + cachedTokens + cacheCreationTokens
```

## User stories

- As a platform operator, I am billed correctly for Anthropic and Gemini traffic served through an
  OpenAI-compatible proxy, in both streaming and non-streaming mode.
- As a platform operator, cost and token analytics for those providers reflect real usage instead of
  silently reporting zero.
- As a policy developer, I have a test that fails loudly if a future transformer change breaks the
  usage contract again, rather than a regression that only shows up in a billing report.

## Release note

Fixed LLM cost calculation for Anthropic and Gemini responses served through the OpenAI-compatible
transformers. Those responses are rewritten into the OpenAI format, and the cost calculators
previously did not recognise the OpenAI usage field names — reporting a cost of zero while marking
the calculation as successful. Cost and token analytics are now accurate for both streaming and
non-streaming traffic.

## Documentation

N/A for user-facing docs. This restores intended behaviour rather than changing a documented
contract; the `llm-cost` policy documentation already states that it supports Anthropic and Gemini,
which is what this makes true for transformed responses.

The `policy-definition.yaml` description already notes support for "Bedrock responses translated to
OpenAI format by the openai-to-bedrock-transformer policy". Worth extending to mention the Anthropic
and Gemini transformers in a follow-up if the description is regenerated — not done here to keep the
diff minimal.

## Training

N/A — internal billing-calculation behaviour with no training-content impact.

## Certification

N/A — a defect fix in usage parsing. It introduces no new configuration, concept or workflow that a
certification exam would assess.

## Marketing

N/A — restores correct billing behaviour rather than introducing a feature.

## Automation tests

- **Unit tests**

  11 tests added; 160 passing in the package. Package coverage 82.4%.

  | File | Coverage |
  |---|---|
  | `calculator_anthropic.go` | 84.2% |
  | `calculator_gemini.go` | 95.7% |

  The load-bearing tests assert **equivalence** — the same underlying provider token counts must
  produce an *identical* `Usage` struct through both the native and the transformed path, so the two
  cannot drift apart later:

  ```go
  if nativeUsage != transformedUsage { t.Fatalf(...) }
  ```

  Also covered: the cache-inclusive reconstruction specifically
  (`PromptTokens == 40` from 25 regular + 10 cache-read + 5 cache-creation); native-wins-over-
  transformed guards for both calculators, ensuring a genuine provider body is never routed through
  the fallback; request-side fields (`speed`, `search_context_size`) surviving the transformed path;
  end-to-end cost computation against the pricing table; and two tests driving the whole policy over
  the actual SSE the transformers emit.

- **Integration tests**

  No `.feature` added — the IT suite lives in `wso2/api-platform` and its workflow always checks that
  repo out at `main`, so a feature file cannot ship in this PR.

  Existing CI does exercise the changed code: `llm-cost-based-ratelimit.feature` attaches `llm-cost`
  and uses Claude models, which route to `AnthropicCalculator`. Its Prism fixtures return
  native-shaped usage (`input_tokens: 50`), which fails the fallback guard immediately and takes the
  unchanged native path — so behaviour is byte-identical for every existing scenario, verified by
  fixture inspection.

  Verified manually end to end on a locally built gateway with `llm-cost` attached to an
  Anthropic-backed proxy. Reading the published analytics metadata:

  ```
  x-llm-cost                   -> 0.00032175000000000004
  aitoken:prompttokencount     -> 40        (was 0 before the fix)
  aitoken:completiontokencount -> 15
  aitoken:modelid              -> claude-sonnet-4-5-20250929
  ```

  The cost reconciles exactly across all four rate tiers:
  `25 × $3.00e-6 + 10 × $0.30e-6 + 5 × $3.75e-6 + 15 × $15.0e-6 = 3.2175e-4`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs tool
  and does not apply to Go. `go vet` and `go test -race` were run clean instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
  **yes** — the diff contains only calculator logic and test fixtures with synthetic token counts.

Security-relevant note: this is a billing-integrity fix. Under-reporting usage as zero is a revenue
and accountability issue, and the silent nature of the failure (`err == nil`, status `calculated`)
meant it would not surface in monitoring. The fix also removes a potential avenue for a caller to
obtain unmetered inference by selecting a transformed provider.

## Samples

N/A — no sample changes. Existing `llm-cost` configurations work unchanged; they simply now compute
correct costs for Anthropic and Gemini traffic behind a transformer.

## Related PRs

- `feat(policies): convert Anthropic and Gemini streams to OpenAI SSE` — #270

  **This PR should merge first, or both together.** #270 converts streaming responses to the OpenAI
  shape, which extends the zero-billing described above from non-streaming to *all* Anthropic and
  Gemini traffic. This PR is standalone-correct and depends on nothing from #270 — it fixes the
  pre-existing non-streaming defect on its own.

- Prior art: `fix(llm-cost): handle Bedrock streaming usage and cache tiers` (`4656178`), which
  solved the identical problem for `calculator_bedrock.go`.

## Migrations (if applicable)

None. No configuration, schema or stored-data change, and no policy-parameter change.

Operational note: cost and token metrics for Anthropic and Gemini traffic behind a transformer will
step up from zero to real values after deployment. Any dashboard, budget threshold or
cost-based rate limit calibrated against the incorrect zero baseline should be reviewed — a
`llm-cost-based-ratelimit` budget tuned while these requests were free will begin enforcing.

## Test environment

- Go 1.26.5, `darwin/amd64` (module target `go 1.26.2`)
- macOS 15.7.7
- Docker 29.5.3-rd, Docker Compose
- Gateway runtime + controller `1.2.0-rc-SNAPSHOT`, built locally via `make build` with `llm-cost`
  wired in as a `dev-policies` `filePath` entry
- WSO2 policy SDK `github.com/wso2/api-platform/sdk/core v0.2.14`
- Pricing table: `model_prices.json` shipped in the runtime image (838 entries)
- No JDK, database or browser involvement — a Go policy module only

## Learning

The research was mostly archaeology in this repo rather than external material. `calculator_bedrock.go`
turned out to be the map: it reads *both* native Converse fields and OpenAI `prompt_tokens` /
`prompt_tokens_details`, which only makes sense if `llm-cost` sees post-transformation bodies. That
single observation established both that the bug was real for Anthropic and Gemini, and what the fix
should look like. Its git history (`4656178`) confirmed the same problem had already been hit once.

