### PR TITLE
Fix truncated responses from pii-masking-regex streaming restore

### DIFF
--- a/policies/pii-masking-regex/piimaskingregex.go
+++ b/policies/pii-masking-regex/piimaskingregex.go
@@ -18,7 +18,6 @@
 package piimaskingregex
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -43,6 +42,11 @@ const (
 	DefaultEmailRegex         = `(?i)\b[a-z0-9.!#$%&'*+/=?^_{|}~-]+@(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])\b`
 	DefaultPhoneRegex         = `(?:\+?1[-.\s]?)?(?:\([2-9][0-9]{2}\)|[2-9][0-9]{2})[-.\s]?[2-9][0-9]{2}[-.\s]?[0-9]{4}\b`
 	DefaultSSNRegex           = `(?:00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6(?:[0-57-9][0-9]|6[0-57-9])|[7-8][0-9]{2})[- ]?(?:0[1-9]|[1-9][0-9])[- ]?(?:000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})\b`
+
+	// metadataKeyAccJSONBody accumulates a non-SSE (plain JSON) response body
+	// across streaming chunks so the full body can be restored and emitted once
+	// at end of stream. See OnResponseBodyChunk.
+	metadataKeyAccJSONBody = "piimaskingregex:acc_json_body"
 
 	// SSE constants for streaming responses
 	sseDataPrefix  = "data: "
@@ -79,7 +83,6 @@ func GetPolicy(
 
 	return p, nil
 }
-
 
 // Mode returns the processing mode for the PII masking regex policy.
 func (p *PIIMaskingRegexPolicy) Mode() policy.ProcessingMode {
@@ -482,7 +485,16 @@ func (p *PIIMaskingRegexPolicy) NeedsMoreResponseData(accumulated []byte) bool {
 	s := string(accumulated)
 
 	if !isSSEChunk(s) {
-		return !json.Valid(bytes.TrimSpace(accumulated))
+		// Non-SSE (plain JSON) body delivered over chunked transfer. Restoration
+		// must rewrite placeholders anywhere in the body, so we buffer the whole
+		// body ourselves in OnResponseBodyChunk (via respCtx.Metadata) and emit
+		// the restored body at EndOfStream. Returning false hands us every chunk
+		// directly, matching the streaming contract the other response policies
+		// use (see regex-guardrail / word-count-guardrail). The previous
+		// json.Valid gate here relied on kernel-level accumulation that did not
+		// deliver the complete body as a single chunk, truncating the response to
+		// an early fragment.
+		return false
 	}
 
 	content, openBracketDataLineIdx, totalDataLines := extractSSEDeltaContentTracked(s)
@@ -512,9 +524,12 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 	if p.params.RedactPII {
 		return policy.ForwardResponseChunk{}
 	}
-	if chunk == nil || len(chunk.Chunk) == 0 {
+	if chunk == nil {
 		return policy.ForwardResponseChunk{}
 	}
+	// Note: unlike validate-only policies we do NOT early-return on an empty
+	// chunk, because an empty EndOfStream sentinel is the signal to flush a body
+	// we have been accumulating below.
 
 	maskedPII, exists := respCtx.Metadata[MetadataKeyPIIEntities]
 	if !exists {
@@ -535,7 +550,24 @@ func (p *PIIMaskingRegexPolicy) OnResponseBodyChunk(ctx context.Context, respCtx
 	if isSSEChunk(chunkStr) {
 		return p.restoreSSEChunk(chunkStr, restoreMap)
 	}
-	return p.restoreJSONChunk(chunkStr, restoreMap)
+
+	// Non-SSE (plain JSON) body over chunked transfer. A placeholder can span a
+	// chunk boundary and restoration rewrites the whole body, so we cannot
+	// forward chunks as they arrive. Accumulate across chunks and emit the
+	// restored body exactly once, at EndOfStream. Intermediate chunks emit
+	// nothing ([]byte{} = suppress this flush; nil would pass the raw,
+	// still-masked bytes through).
+	if respCtx.Metadata == nil {
+		respCtx.Metadata = make(map[string]interface{})
+	}
+	prev, _ := respCtx.Metadata[metadataKeyAccJSONBody].(string)
+	full := prev + chunkStr
+	if !chunk.EndOfStream {
+		respCtx.Metadata[metadataKeyAccJSONBody] = full
+		return policy.ForwardResponseChunk{Body: []byte{}}
+	}
+	delete(respCtx.Metadata, metadataKeyAccJSONBody)
+	return policy.ForwardResponseChunk{Body: []byte(p.restoreJSONBytes(full, restoreMap))}
 }
 
 // ─── SSE / Streaming helpers ─────────────────────────────────────────────────
@@ -693,13 +725,23 @@ func updateDeltaContentInLine(line, newContent string) string {
 // Placeholders are replaced directly in the raw JSON bytes so that key order,
 // whitespace, and any trailing newline from the LLM are preserved exactly.
 func (p *PIIMaskingRegexPolicy) restoreJSONChunk(chunkStr string, maskedMap map[string]string) policy.ForwardResponseChunk {
-	result := chunkStr
+	result := p.restoreJSONBytes(chunkStr, maskedMap)
+	if result == chunkStr {
+		return policy.ForwardResponseChunk{}
+	}
+	return policy.ForwardResponseChunk{Body: []byte(result)}
+}
+
+// restoreJSONBytes replaces every placeholder with its original value directly in
+// the raw JSON string, preserving key order, whitespace, and any trailing
+// newline. Replacements are JSON-encoded so special characters (", \, etc.) stay
+// correctly escaped. Returns the input unchanged when no placeholder is present.
+func (p *PIIMaskingRegexPolicy) restoreJSONBytes(s string, maskedMap map[string]string) string {
+	result := s
 	for placeholder, original := range maskedMap {
 		if !strings.Contains(result, placeholder) {
 			continue
 		}
-		// JSON-encode the replacement so special characters (", \, etc.) are
-		// properly escaped. Strip the surrounding quotes that json.Marshal adds.
 		encodedBytes, err := json.Marshal(original)
 		if err != nil {
 			continue
@@ -707,10 +749,7 @@ func (p *PIIMaskingRegexPolicy) restoreJSONChunk(chunkStr string, maskedMap map[
 		escapedOriginal := string(encodedBytes[1 : len(encodedBytes)-1])
 		result = strings.ReplaceAll(result, placeholder, escapedOriginal)
 	}
-	if result == chunkStr {
-		return policy.ForwardResponseChunk{}
-	}
-	return policy.ForwardResponseChunk{Body: []byte(result)}
+	return result
 }
 
 // restoreInChoices parses a JSON string, restores PII placeholders in

--- a/policies/pii-masking-regex/piimaskingregex_stream_test.go
+++ b/policies/pii-masking-regex/piimaskingregex_stream_test.go
@@ -1,0 +1,224 @@
+package piimaskingregex
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// driveResponseStream simulates the kernel driving the streaming response phase:
+// it delivers each chunk to OnResponseBodyChunk (EndOfStream set on the last),
+// and reconstructs the bytes sent downstream using the documented action
+// semantics — ForwardResponseChunk.Body nil = pass the original chunk through,
+// non-nil = replace the chunk with those bytes (empty slice = emit nothing).
+// See sdk action.go and openai-to-bedrock-transformer for the same contract.
+func driveResponseStream(t *testing.T, p *PIIMaskingRegexPolicy, respCtx *policy.ResponseStreamContext, chunks []string) string {
+	t.Helper()
+	var out strings.Builder
+	for i, c := range chunks {
+		sb := &policy.StreamBody{
+			Chunk:       []byte(c),
+			EndOfStream: i == len(chunks)-1,
+			Index:       uint64(i),
+		}
+		action := p.OnResponseBodyChunk(context.Background(), respCtx, sb, nil)
+		switch a := action.(type) {
+		case policy.ForwardResponseChunk:
+			if a.Body == nil {
+				out.WriteString(c) // passthrough original chunk
+			} else {
+				out.Write(a.Body) // replace (empty = nothing)
+			}
+		case policy.TerminateResponseChunk:
+			if a.Body != nil {
+				out.Write(a.Body)
+			}
+			return out.String()
+		default:
+			t.Fatalf("chunk %d: unexpected action type %T", i, action)
+		}
+	}
+	return out.String()
+}
+
+func streamingRespCtxWithPII(mapping map[string]string) *policy.ResponseStreamContext {
+	return &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{
+			RequestID: "req-id",
+			Metadata: map[string]interface{}{
+				MetadataKeyPIIEntities: mapping,
+			},
+		},
+	}
+}
+
+// splitEvery breaks s into chunks of at most n bytes, mimicking arbitrary TCP /
+// chunked-transfer framing boundaries.
+func splitEvery(s string, n int) []string {
+	var chunks []string
+	for len(s) > n {
+		chunks = append(chunks, s[:n])
+		s = s[n:]
+	}
+	if len(s) > 0 {
+		chunks = append(chunks, s)
+	}
+	return chunks
+}
+
+const maskedMenuBody = `{
+  "id": "chatcmpl-ECLSc2xRestoreTest",
+  "object": "chat.completion",
+  "created": 1786611132,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Thanks! I've sent the confirmation to [EMAIL_0000]. Call us on [PHONE_0001] if anything changes."
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+`
+
+// TestOnResponseBodyChunk_NonSSE_RestoresAcrossChunkBoundaries is the core
+// regression test. The body is delivered in small chunks (27 bytes first, to
+// mirror the production truncation report) and a placeholder is deliberately
+// split across a chunk boundary. The full restored body must be reconstructed
+// exactly, with every placeholder replaced and nothing truncated.
+func TestOnResponseBodyChunk_NonSSE_RestoresAcrossChunkBoundaries(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"email": true, "phone": true})
+	respCtx := streamingRespCtxWithPII(map[string]string{
+		"guest@example.com": "[EMAIL_0000]",
+		"212-555-0175":      "[PHONE_0001]",
+	})
+
+	out := driveResponseStream(t, p, respCtx, splitEvery(maskedMenuBody, 27))
+
+	if !json.Valid([]byte(strings.TrimSpace(out))) {
+		t.Fatalf("restored body is not valid JSON:\n%s", out)
+	}
+	if strings.Contains(out, "[EMAIL_0000]") || strings.Contains(out, "[PHONE_0001]") {
+		t.Fatalf("placeholders were not fully restored:\n%s", out)
+	}
+	if !strings.Contains(out, "guest@example.com") || !strings.Contains(out, "212-555-0175") {
+		t.Fatalf("original PII values missing from restored body:\n%s", out)
+	}
+	// Byte-for-byte: the output must equal the masked body with placeholders
+	// swapped for originals — no bytes dropped anywhere.
+	want := strings.NewReplacer(
+		"[EMAIL_0000]", "guest@example.com",
+		"[PHONE_0001]", "212-555-0175",
+	).Replace(maskedMenuBody)
+	if out != want {
+		t.Fatalf("restored body mismatch\n got: %q\nwant: %q", out, want)
+	}
+}
+
+// TestOnResponseBodyChunk_NonSSE_NoPlaceholderInResponse is the exact production
+// failure: a request tripped a PII regex (metadata is set), but the response
+// body contains no placeholder. The whole body must still be forwarded intact —
+// previously it was truncated to an early chunk.
+func TestOnResponseBodyChunk_NonSSE_NoPlaceholderInResponse(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"phone": true})
+	respCtx := streamingRespCtxWithPII(map[string]string{"212-555-0175": "[PHONE_0000]"})
+
+	body := `{
+  "id": "chatcmpl-ECLSc2xNoPlaceholder",
+  "object": "chat.completion",
+  "choices": [{"index":0,"message":{"role":"assistant","content":"How can I help you today?"},"finish_reason":"stop"}]
+}
+`
+	out := driveResponseStream(t, p, respCtx, splitEvery(body, 27))
+	if out != body {
+		t.Fatalf("body was altered or truncated\n got: %q\nwant: %q", out, body)
+	}
+}
+
+// TestOnResponseBodyChunk_NonSSE_IntermediateChunksSuppressed verifies the
+// withhold-then-emit mechanism: every non-final chunk emits an empty (non-nil)
+// body, and the final chunk carries the entire restored body.
+func TestOnResponseBodyChunk_NonSSE_IntermediateChunksSuppressed(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"email": true})
+	respCtx := streamingRespCtxWithPII(map[string]string{"guest@example.com": "[EMAIL_0000]"})
+
+	chunks := splitEvery(maskedMenuBody, 40)
+	var emittedBeforeLast int
+	for i, c := range chunks {
+		sb := &policy.StreamBody{Chunk: []byte(c), EndOfStream: i == len(chunks)-1, Index: uint64(i)}
+		action := p.OnResponseBodyChunk(context.Background(), respCtx, sb, nil)
+		fwd, ok := action.(policy.ForwardResponseChunk)
+		if !ok {
+			t.Fatalf("chunk %d: expected ForwardResponseChunk, got %T", i, action)
+		}
+		if i < len(chunks)-1 {
+			if fwd.Body == nil || len(fwd.Body) != 0 {
+				t.Fatalf("chunk %d: expected suppressed ([]byte{}) body, got %q (nil=%v)", i, fwd.Body, fwd.Body == nil)
+			}
+			emittedBeforeLast += len(fwd.Body)
+		} else {
+			if len(fwd.Body) == 0 {
+				t.Fatalf("final chunk: expected full restored body, got empty")
+			}
+			if strings.Contains(string(fwd.Body), "[EMAIL_0000]") {
+				t.Fatalf("final chunk still contains placeholder:\n%s", fwd.Body)
+			}
+		}
+	}
+	if emittedBeforeLast != 0 {
+		t.Fatalf("expected 0 bytes emitted before final chunk, got %d", emittedBeforeLast)
+	}
+}
+
+// TestOnResponseBodyChunk_NonSSE_EmptyEndOfStreamSentinel covers the case where
+// the terminating EndOfStream arrives as a separate empty chunk after the
+// content chunks. The accumulated body must still be flushed and restored.
+func TestOnResponseBodyChunk_NonSSE_EmptyEndOfStreamSentinel(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"email": true})
+	respCtx := streamingRespCtxWithPII(map[string]string{"guest@example.com": "[EMAIL_0000]"})
+
+	// Content chunks (none marked EndOfStream) followed by an empty sentinel.
+	chunks := append(splitEvery(maskedMenuBody, 50), "")
+	out := driveResponseStream(t, p, respCtx, chunks)
+
+	want := strings.Replace(maskedMenuBody, "[EMAIL_0000]", "guest@example.com", 1)
+	want = strings.Replace(want, "[PHONE_0001]", "[PHONE_0001]", 1) // PHONE not in mapping; unchanged
+	if out != want {
+		t.Fatalf("empty-sentinel flush mismatch\n got: %q\nwant: %q", out, want)
+	}
+}
+
+// TestNeedsMoreResponseData_NonSSE_ReturnsFalse ensures we no longer gate
+// non-SSE bodies on kernel-level accumulation (which truncated the response);
+// each chunk is handed to us directly.
+func TestNeedsMoreResponseData_NonSSE_ReturnsFalse(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"email": true})
+	// A partial (invalid) JSON fragment — the old code returned true here.
+	if p.NeedsMoreResponseData([]byte(`{` + "\n" + `  "id": "chatcmpl-ECLSc2x`)) {
+		t.Fatal("expected NeedsMoreResponseData=false for a non-SSE JSON fragment")
+	}
+	// A complete JSON body — also false.
+	if p.NeedsMoreResponseData([]byte(`{"a":"b"}`)) {
+		t.Fatal("expected NeedsMoreResponseData=false for a complete non-SSE JSON body")
+	}
+}
+
+// TestOnResponseBodyChunk_NoMetadata_StreamsThrough verifies that responses for
+// requests that masked no PII stream through unchanged, chunk by chunk (no
+// withholding, no added latency).
+func TestOnResponseBodyChunk_NoMetadata_StreamsThrough(t *testing.T) {
+	p := mustGetPIIPolicy(t, map[string]interface{}{"email": true})
+	respCtx := &policy.ResponseStreamContext{
+		SharedContext: &policy.SharedContext{RequestID: "req-id", Metadata: map[string]interface{}{}},
+	}
+	out := driveResponseStream(t, p, respCtx, splitEvery(maskedMenuBody, 33))
+	if out != maskedMenuBody {
+		t.Fatalf("expected passthrough of full body, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

`pii-masking-regex` intermittently truncates non-SSE (plain JSON) LLM responses. The client receives an HTTP **200** with `content-type: application/json` but a body cut off after a few bytes (e.g. `{\n  "id": "chatcmpl-…`), producing a downstream `JSONDecodeError: Unterminated string ...`. It only happens when the request contained masked PII (restore metadata present), which is why it is non-deterministic.

## Root cause

The response phase runs in `BodyModeStream` (`Mode()`), so the executing code is `NeedsMoreResponseData` + `OnResponseBodyChunk` — **not** the buffered `OnResponseBody` that the unit tests exercise (the streaming response path had no test coverage).

For a non-SSE body the policy:
1. returned `!json.Valid(accumulated)` from `NeedsMoreResponseData`, i.e. it asked the kernel to keep accumulating until the whole body was valid JSON; and
2. processed whatever `OnResponseBodyChunk` received with `restoreJSONChunk(chunk)` **independently per chunk** — no cross-chunk accumulation, no `EndOfStream` handling.

That combination does not reliably deliver the complete body as a single chunk to `OnResponseBodyChunk`; the response ends up truncated to an early fragment and flushed downstream as a partial 200. Because it is gated on `MetadataKeyPIIEntities` (only set when the request tripped a detector), it fires only on some turns.

Sibling response policies that modify/inspect the streamed body (`regex-guardrail`, `word-count-guardrail`, `openai-to-bedrock-transformer`) all follow a different, working contract: `NeedsMoreResponseData` returns `false`, they accumulate across chunks in `respCtx.Metadata`, and act at `EndOfStream`. `pii-masking-regex` was the outlier.

## Fix

Rewrite the **non-SSE** path to follow that same contract, adapted for a policy that must *rewrite* (not just validate) the body:

- `NeedsMoreResponseData` returns `false` for non-SSE bodies so the kernel hands us every chunk directly. **SSE gating is unchanged.**
- `OnResponseBodyChunk` accumulates the body across chunks in `respCtx.Metadata`, **suppresses intermediate output** (`Body: []byte{}` — empty replaces the flush with nothing; `nil` would pass the raw masked bytes through), and emits the **fully restored body once at `EndOfStream`**.

Side effect: also fixes restoration of a placeholder split across a chunk boundary (`[EMAIL_` | `0000]`), which the per-chunk logic could never match.

Behavior for responses **without** masked PII is unchanged — they stream through chunk-by-chunk with no withholding.

## Tests

Adds `piimaskingregex_stream_test.go` (streaming response phase was previously untested), with a kernel simulation using the documented action semantics (`nil` = passthrough, non-nil = replace, empty = suppress):

- restore across small chunk boundaries incl. a split placeholder — asserts byte-exact full body
- request masked PII but response has no placeholder — full body forwarded intact (the exact production failure)
- intermediate chunks suppressed, full restored body only on the final chunk
- empty `EndOfStream` sentinel still flushes the accumulated body
- `NeedsMoreResponseData` returns false for non-SSE
- no-metadata passthrough

`go build`, `go vet`, `gofmt -l`, and `go test ./...` all clean.

## Note for reviewers

The exact truncation happens inside the gateway ext_proc kernel, which is not in the public SDK, so the root-cause mechanism was inferred from the SDK contract (`action.go` / `context.go`) and the patterns in the sibling policies above. The fix makes the policy self-contained (it no longer relies on kernel-level accumulation for non-SSE), which is robust regardless of the kernel's accumulation semantics — but an integration test against the running gateway would be worth adding.

Opened as a **draft** pending WSO2-side integration verification (and CLA, if required).
