### PR TITLE
Bring system level params to user levels for AWS Bedrock Guardrail

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ All available policies, sorted alphabetically.
 | [Analytics Header Filter](./analytics-header-filter/v1.0/docs/analytics-header-filter.md) | Logging, Analytics & Monitoring | The Analytics Header Filter policy allows you to control which request and response headers are included in analytics data using allow or deny modes. |
 | [API Key Auth](./api-key-auth/v1.2/docs/apikey-authentication.md) | Security, AI, WebSub, WebBroker | Implements API Key Authentication to protect APIs with pre-shared API keys. |
 | [AWS Authentication](./aws-authentication/v0.10/docs/aws-authentication.md) | Security, AI | Signs outbound requests to AWS-hosted backends using AWS Signature Version 4 (SigV4). |
-| [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.1/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
+| [AWS Bedrock Guardrail](./aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md) | Guardrails, AI | Validates request or response body content against AWS Bedrock Guardrails. |
 | [Azure Content Safety Content Moderation](./azure-content-safety-content-moderation/v1.0/docs/azure-content-safety.md) | Guardrails, AI | Validates request or response body content against Azure Content Safety API for content moderation. |
 | [Backend JWT](./backend-jwt/v1.0/docs/backend-jwt.md) | Security | Generates a signed JWT containing authenticated user information and injects it into the upstream request header. |
 | [Basic Auth](./basic-auth/v1.0/docs/basic-auth.md) | Security, AI, WebSub, WebBroker | Implements HTTP Basic Authentication to protect APIs with username and password credentials. |

--- a/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
@@ -49,12 +49,14 @@ The policy uses a two-level configuration. Every parameter can be set gateway-wi
 
 Each allowlist restricts what a policy attachment may select. An empty or unset allowlist places no restriction. Allowlists are checked against the **effective** value, so when you set one you must include the gateway's own default.
 
+`allowedRegions` and `allowedRoleARNs` accept a single trailing `*` as a prefix match. `allowedGuardrailIDs` and `allowedAuthTypes` are exact-match only.
+
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `allowedRegions` | string[] | Permitted values for the effective `region`. |
-| `allowedGuardrailIDs` | string[] | Permitted values for the effective `guardrailID`. |
-| `allowedRoleARNs` | string[] | Permitted values for the effective role ARN. An entry ending in `*` matches any ARN with that prefix. |
-| `allowedAuthTypes` | string[] | Permitted values for the **effective** `authenticationType`. An attachment that omits `awsAuth` resolves to `system`, so include `system` unless every attachment sets one explicitly. Omit `iam-user-access-key` to forbid attachment-level long-lived credentials while leaving every other parameter configurable per attachment. |
+| `allowedRegions` | string[] | Permitted values for the effective `region`. An entry ending in `*` matches any region with that prefix, e.g. `us-east-*`. |
+| `allowedGuardrailIDs` | string[] | Permitted values for the effective `guardrailID`. Exact matches only. |
+| `allowedRoleARNs` | string[] | Permitted values for the effective role ARN. An entry ending in `*` matches any ARN with that prefix. Cross-account patterns need one entry per account. |
+| `allowedAuthTypes` | string[] | Permitted values for the **effective** `authenticationType`. Exact matches only. An attachment that omits `awsAuth` resolves to `system`, so include `system` unless every attachment sets one explicitly. Omit `iam-user-access-key` to forbid attachment-level long-lived credentials while leaving every other parameter configurable per attachment. |
 
 #### Sample System Configuration
 
@@ -75,8 +77,8 @@ awsbedrock_role_external_id  = ""
 # Optional. Empty means unrestricted.
 awsbedrock_allowed_regions       = ["us-east-1", "eu-west-1"]
 awsbedrock_allowed_guardrail_ids = ["your-guardrail-id"]
-awsbedrock_allowed_role_arns     = ["arn:aws:iam::*:role/wso2-gw-guardrail-*"]
-awsbedrock_allowed_auth_types    = ["irsa", "sts-assume-role", "default-credential-chain"]
+awsbedrock_allowed_role_arns     = ["arn:aws:iam::444455556666:role/wso2-gw-guardrail-*"]
+awsbedrock_allowed_auth_types    = ["system", "irsa", "sts-assume-role", "default-credential-chain"]
 ```
 
 ### User Parameters (API Definition)
@@ -104,9 +106,20 @@ At least one of `request` or `response` must be provided.
 
 #### `awsAuth` — per-attachment AWS identity
 
-`awsAuth` is optional and defaults to `system`. If not set gateway-wide credential settings from `config.toml` are used, exactly as before.
+`awsAuth` is optional and defaults to `system`. If it is not set, the gateway-wide credential settings from `config.toml` are used, exactly as before.
 
-`authenticationType: system` states that deferral explicitly. Every other mode is self-contained: the attachment supplies its complete credential configuration and all gateway-wide credential settings are ignored.
+`authenticationType: system` states that deferral explicitly. **Every other mode ignores the gateway-wide credential settings entirely** — `awsbedrock_access_key_id`, `awsbedrock_role_arn` and the rest are not consulted, and cannot be mixed with what the attachment supplies.
+
+What each mode does use instead differs, and only one of them is fully described by the attachment:
+
+| Mode | Identity comes from | Attachment supplies |
+| ---- | ------------------- | ------------------- |
+| `irsa` | The gateway pod's projected service-account token (`AWS_WEB_IDENTITY_TOKEN_FILE`) | Optionally `awsRoleARN`; otherwise the injected `AWS_ROLE_ARN` is used |
+| `sts-assume-role` | The role named in `awsRoleARN`, assumed from a **base** identity | The target role and its external ID. The base identity is either the static key given here, or — if none is given — the gateway's own runtime credentials, which on EKS means its IRSA identity |
+| `default-credential-chain` | Whatever the AWS SDK resolves at runtime: environment, instance profile, ECS task role, or IRSA | Nothing |
+| `iam-user-access-key` | The key and secret in the attachment | Everything |
+
+So "self-contained" applies strictly only to `iam-user-access-key`. The others are self-contained with respect to *gateway-wide configuration*, while still relying on the runtime identity of the gateway process. That is the point of `sts-assume-role` with no static key: the pod's IRSA identity assumes the tenant's role, and no credential material appears in the API definition at all.
 
 One case is rejected rather than defaulted: an `awsAuth` block carrying credential fields but no `authenticationType`. Defaulting it to `system` would silently ignore those fields, leaving an attachment that looks like it configures an identity while the gateway-wide one is in use. Name the mode instead.
 
@@ -442,8 +455,8 @@ An operator allows per-attachment identity but not per-attachment long-lived sec
 ```toml
 awsbedrock_allowed_regions       = ["us-east-1", "eu-west-1"]
 awsbedrock_allowed_guardrail_ids = ["gr-default", "gr-eu-strict", "gr-tenant-a"]
-awsbedrock_allowed_role_arns     = ["arn:aws:iam::*:role/wso2-gw-guardrail-*"]
-awsbedrock_allowed_auth_types    = ["irsa", "sts-assume-role", "default-credential-chain"]
+awsbedrock_allowed_role_arns     = ["arn:aws:iam::444455556666:role/wso2-gw-guardrail-*"]
+awsbedrock_allowed_auth_types    = ["system", "irsa", "sts-assume-role", "default-credential-chain"]
 ```
 
 An attachment selecting `iam-user-access-key`, a region outside the list, or a role ARN outside the prefix is rejected at deploy time.
@@ -456,7 +469,7 @@ An attachment selecting `iam-user-access-key`, a region outside the list, or a r
 2. **Guardrail evaluation**: Calls `ApplyGuardrail` with the effective region, guardrail ID, and version, using the identity resolved from `awsAuth` or the gateway-wide settings.
 3. **PII processing**: With `redactPII: false`, masks PII with placeholders for later restoration. With `redactPII: true`, replaces PII with `*****` permanently.
 4. **Violation handling**: Blocks and returns HTTP `422` when Bedrock reports a violation.
-5. **Error strategy**: Applies `passthroughOnError` to transient failures only.
+5. **Error strategy**: When `passthroughOnError` is `true`, the request proceeds on any failure — JSONPath extraction, credential resolution, the Bedrock call, and response evaluation alike. When `false` (the default), each of those blocks with HTTP 422.
 
 #### Response Phase
 

--- a/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
@@ -1,0 +1,486 @@
+---
+title: "Overview"
+---
+# AWS Bedrock Guardrail
+
+## Overview
+
+The AWS Bedrock Guardrail policy validates request or response body content against AWS Bedrock Guardrails, which provide enterprise-grade content filtering, topic detection, word filtering, and PII (Personally Identifiable Information) detection and masking. This guardrail enables you to enforce content safety policies consistently across your LLM applications using AWS Bedrock's managed guardrail service.
+
+Every setting can be configured per policy attachment or gateway-wide. An attachment can select its own guardrail, its own region, and its own AWS identity — so a single gateway can enforce different content policies for different APIs, including guardrails that live in different AWS accounts.
+
+## Features
+
+- **Content filtering**: Detects and blocks prohibited content based on guardrail policies
+- **Topic detection**: Validates content against configured topic restrictions
+- **Word filtering**: Blocks content containing prohibited words or phrases
+- **PII detection and masking**: Identifies and masks PII entities (emails, phone numbers, SSNs, etc.)
+- **PII restoration**: Restores masked PII in responses when configured (masking mode)
+- **PII redaction**: Permanently removes PII by replacing with "*****" (redaction mode)
+- **Per-attachment guardrail selection**: Each attachment can set its own `region`, `guardrailID`, and `guardrailVersion`
+- **Per-attachment AWS identity**: Each attachment can set its own `awsAuth`, letting the guardrail live in a different AWS account
+- **Five credential modes**: gateway-wide (`system`, the default), IRSA, STS AssumeRole, default credential chain, or static access keys
+- **Gateway-level allowlists**: Operators can restrict which regions, guardrails, roles, and credential modes attachments may select
+- **JSONPath support**: Extract and validate specific fields within JSON payloads
+- **Separate request/response configuration**: Independent configuration for request and response phases
+- **Detailed assessment information**: Optional detailed violation information in error responses
+
+## Configuration
+
+The policy uses a two-level configuration. Every parameter can be set gateway-wide in `config.toml`, and an attachment can override it in the API definition. Where both levels set the same parameter, **the attachment value wins**.
+
+### System Parameters (from config.toml)
+
+#### Guardrail and credential defaults
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `region` | string | Yes* | AWS region where the Bedrock Guardrail is located (e.g. `us-east-1`). *Required unless every attachment sets its own. |
+| `guardrailID` | string | Yes* | Default AWS Bedrock Guardrail identifier. *Required unless every attachment sets its own. |
+| `guardrailVersion` | string | Yes* | Default guardrail version (e.g. `DRAFT`, `1`). *Required unless every attachment sets its own. |
+| `awsAccessKeyID` | string | No | AWS access key ID for the gateway's own identity. If omitted, the default AWS credential chain is used. |
+| `awsSecretAccessKey` | string | No | AWS secret access key paired with `awsAccessKeyID`. |
+| `awsSessionToken` | string | No | AWS session token, for temporary credentials. |
+| `awsRoleARN` | string | No | IAM role ARN to assume. If set, the gateway assumes this role instead of using static credentials. |
+| `awsRoleRegion` | string | No | AWS region for role assumption. Required if `awsRoleARN` is set. |
+| `awsRoleExternalID` | string | No | External ID for role assumption, for cross-account access. |
+
+#### Allowlists
+
+Each allowlist restricts what a policy attachment may select. An empty or unset allowlist places no restriction. Allowlists are checked against the **effective** value, so when you set one you must include the gateway's own default.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `allowedRegions` | string[] | Permitted values for the effective `region`. |
+| `allowedGuardrailIDs` | string[] | Permitted values for the effective `guardrailID`. |
+| `allowedRoleARNs` | string[] | Permitted values for the effective role ARN. An entry ending in `*` matches any ARN with that prefix. |
+| `allowedAuthTypes` | string[] | Permitted values for the **effective** `authenticationType`. An attachment that omits `awsAuth` resolves to `system`, so include `system` unless every attachment sets one explicitly. Omit `iam-user-access-key` to forbid attachment-level long-lived credentials while leaving every other parameter configurable per attachment. |
+
+#### Sample System Configuration
+
+Add the following configuration section under the root level in your `config.toml` file:
+
+```toml
+awsbedrock_guardrail_region  = "us-east-1"
+awsbedrock_guardrail_id      = "your-guardrail-id"
+awsbedrock_guardrail_version = "DRAFT"
+
+awsbedrock_access_key_id     = ""
+awsbedrock_secret_access_key = ""
+awsbedrock_session_token     = ""
+awsbedrock_role_arn          = ""
+awsbedrock_role_region       = ""
+awsbedrock_role_external_id  = ""
+
+# Optional. Empty means unrestricted.
+awsbedrock_allowed_regions       = ["us-east-1", "eu-west-1"]
+awsbedrock_allowed_guardrail_ids = ["your-guardrail-id"]
+awsbedrock_allowed_role_arns     = ["arn:aws:iam::*:role/wso2-gw-guardrail-*"]
+awsbedrock_allowed_auth_types    = ["irsa", "sts-assume-role", "default-credential-chain"]
+```
+
+### User Parameters (API Definition)
+
+| Parameter | Type | Required | Default | Description |
+| --------- | ---- | -------- | ------- | ----------- |
+| `region` | string | No | gateway-wide value | AWS region hosting the guardrail for this attachment. |
+| `guardrailID` | string | No | gateway-wide value | Guardrail identifier for this attachment. |
+| `guardrailVersion` | string | No | gateway-wide value | Guardrail version for this attachment. |
+| `localGuardrailID` | string | No | – | **Deprecated** — use `guardrailID`. Used only when `guardrailID` resolves to nothing. Retained for attachments authored against v1.1.0. |
+| `localGuardrailVersion` | string | No | – | **Deprecated** — use `guardrailVersion`. Used only when `guardrailVersion` resolves to nothing. |
+| `awsAuth` | object | No | `system` | AWS identity for this attachment. Omitting it uses the gateway-wide identity. See below. |
+| `request` | object | See note | – | Request-phase validation configuration. |
+| `response` | object | See note | – | Response-phase validation configuration. |
+
+At least one of `request` or `response` must be provided.
+
+`region`, `guardrailID`, and `guardrailVersion` resolve independently — an attachment can set only the version and inherit the rest.
+
+> **`localGuardrailID` / `localGuardrailVersion` are deprecated.** They still work, so existing attachments need no immediate change, but prefer `guardrailID` / `guardrailVersion` for new work.
+>
+> **Precedence:** the current parameter wins. `localGuardrailID` is consulted only when `guardrailID` resolves to nothing — from the attachment *or* from the gateway-wide `awsbedrock_guardrail_id`. Adding `guardrailID` to an attachment that already sets `localGuardrailID` therefore takes effect immediately; you can remove the `local` spelling in the same edit or later.
+>
+> **One case to check before upgrading:** if your gateway sets a non-empty `awsbedrock_guardrail_id` **and** an attachment sets only `localGuardrailID`, that attachment now resolves to the gateway-wide guardrail instead of its own. The merge that combines gateway-wide and attachment parameters erases which level a value came from, so this cannot be detected and rejected automatically. Give such attachments an explicit `guardrailID` (same value as their `localGuardrailID`) before upgrading. Attachments on a gateway that leaves `awsbedrock_guardrail_id` empty are unaffected.
+
+#### `awsAuth` — per-attachment AWS identity
+
+`awsAuth` is optional and defaults to `system`. If not set gateway-wide credential settings from `config.toml` are used, exactly as before.
+
+`authenticationType: system` states that deferral explicitly. Every other mode is self-contained: the attachment supplies its complete credential configuration and all gateway-wide credential settings are ignored.
+
+One case is rejected rather than defaulted: an `awsAuth` block carrying credential fields but no `authenticationType`. Defaulting it to `system` would silently ignore those fields, leaving an attachment that looks like it configures an identity while the gateway-wide one is in use. Name the mode instead.
+
+**The declared mode is authoritative.** If it fails — a role that cannot be assumed, an expired key, a missing IRSA environment — the attachment is rejected at deploy time or the request is blocked. It never silently falls back to the gateway-wide credentials, so a broken attachment-level identity cannot end up running under the gateway's own.
+
+| Parameter | Type | Required | Default | Description |
+| --------- | ---- | -------- | ------- | ----------- |
+| `authenticationType` | string | No | `system` | One of `system`, `irsa`, `sts-assume-role`, `default-credential-chain`, `iam-user-access-key`. Defaults to `system`, so an `awsAuth` block that names no mode uses the gateway-wide identity. |
+| `awsRoleARN` | string | Conditional | – | Required for `sts-assume-role`. Optional for `irsa` — falls back to the `AWS_ROLE_ARN` environment variable. |
+| `awsRoleRegion` | string | No | effective `region` | AWS region whose STS endpoint is used for the assumption. |
+| `awsRoleExternalID` | string | No | – | External ID required by the target role's trust policy. Only applicable to `sts-assume-role`. |
+| `awsRoleSessionName` | string | No | `bedrock-guardrail-session` | Session name used when assuming the role. This is what appears in the target account's CloudTrail, so prefer a value identifying this API. |
+| `awsAccessKeyID` | string | Conditional | – | Required for `iam-user-access-key`. Optional base credential for `sts-assume-role`. |
+| `awsSecretAccessKey` | string | Conditional | – | Required for `iam-user-access-key`. |
+| `awsSessionToken` | string | No | – | Only meaningful when the key/secret pair is already temporary. |
+
+##### Choosing a credential mode
+
+| Mode | Credential material in the API definition | When to use |
+| ---- | ----------------------------------------- | ----------- |
+| `system` | **None** | The attachment has no AWS identity of its own and should use the gateway-wide configuration. No other field in `awsAuth` may be set. |
+| `irsa` | **None** | Gateway runs on EKS with IAM Roles for Service Accounts. Preferred. |
+| `sts-assume-role` | None, when the base credentials come from IRSA or the gateway's instance role | Guardrail lives in another AWS account. Preferred for cross-account. |
+| `default-credential-chain` | **None** | Gateway compute already runs under the exact role needed. |
+| `iam-user-access-key` | **A long-lived AWS secret key** | Only when none of the above is possible. |
+
+> **Before using `iam-user-access-key`:** an access key placed in an API definition is stored with that definition. Unlike a role ARN and external ID, an access key is a bearer credential: it works from anywhere, against every AWS API its IAM identity permits, independently of this gateway. Scope the IAM identity behind it to `bedrock:ApplyGuardrail` on specific guardrail ARNs and nothing else, and prefer any of the other three modes. Operators can disable this mode entirely with `awsbedrock_allowed_auth_types`.
+
+For `irsa`, the web identity token file path is never a policy parameter — it is always read from the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable injected by the EKS Pod Identity Webhook, alongside `AWS_ROLE_ARN`.
+
+#### Request Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `true` | Enables validation for the request flow. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a value from the request payload. If empty, validates the entire payload as a string. |
+| `redactPII` | boolean | No | `false` | If `true`, redacts PII by replacing with `*****` (permanent). If `false`, masks PII with placeholders restorable in responses. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows the request to proceed when the Bedrock call fails, for any reason. See "Error handling" below. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+
+#### Response Configuration
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | boolean | No | `false` | Enables validation for the response flow. |
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a value from the response payload. |
+| `passthroughOnError` | boolean | No | `false` | As above. |
+| `showAssessment` | boolean | No | `false` | As above. |
+
+#### Error handling — what `passthroughOnError` covers
+
+`passthroughOnError` exists so that a Bedrock outage does not take your API down with it. When enabled, the request proceeds regardless of **why** the guardrail call failed — a timeout, a wrong guardrail ID, an unassumable role, or expired credentials all allow traffic through. This matches the behaviour of earlier versions.
+
+| Failure | `passthroughOnError: true` | `passthroughOnError: false` (default) |
+| ------- | -------------------------- | ------------------------------------- |
+| Timeout, connection failure, 5xx, throttling | Request proceeds | Blocked (HTTP 422) |
+| `ResourceNotFoundException` — wrong guardrail ID, version, or region | Request proceeds | Blocked |
+| `AccessDeniedException` — Bedrock or STS refuses | Request proceeds | Blocked |
+| `ValidationException` — malformed request | Request proceeds | Blocked |
+| Expired or unresolvable credentials | Request proceeds | Blocked |
+
+> **Understand what you are enabling.** A *transient* failure passed through costs you a few unscreened requests during an outage. A *permanent* one — a guardrail ID that does not exist, a role that cannot be assumed — means the guardrail never runs at all, on any request, while the API definition still shows it attached. There is no external signal that content is going unscreened.
+>
+> There is no distinct signal for this state — the policy does not separate transient from permanent failures, and a passed-through request is logged only at debug level. If you enable `passthroughOnError` in production, monitor for a sustained absence of guardrail interventions, or watch the Bedrock `ApplyGuardrail` error rate in CloudWatch.
+>
+> Consider `passthroughOnError: false` (the default) for guardrails that are enforcing a compliance requirement, and reserve `true` for availability-critical paths where unscreened traffic is the lesser risk.
+
+#### JSONPath Support
+
+The guardrail supports JSONPath expressions to extract and validate specific fields within JSON payloads. Common examples:
+
+- `$.messages` - Extracts the `messages` field from the root object
+- `$.data.content` - Extracts nested content from `data.content`
+- `$.items[0].text` - Extracts text from the first item in an array
+- `$.messages[0].content` - Extracts content from the first message in a messages array
+- `$.messages[-1].content` - Extracts content from the last message in a messages array
+
+If `jsonPath` is empty or not specified, the entire payload is treated as a string and validated.
+
+**Note:**
+
+Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
+
+```yaml
+- name: aws-bedrock-guardrail
+  gomodule: github.com/wso2/gateway-controllers/policies/aws-bedrock-guardrail@v1
+```
+
+## Reference Scenarios
+
+### Example 1: Gateway defaults
+
+Every guardrail setting comes from `config.toml`.
+
+```yaml
+apiVersion: gateway.api-platform.wso2.com/v1
+kind: LlmProvider
+metadata:
+  name: bedrock-guardrail-provider
+spec:
+  displayName: AWS Bedrock Guardrail Provider
+  version: v1.0
+  template: openai
+  context: /openai
+  upstream:
+    url: "https://api.openai.com/v1"
+    auth:
+      type: api-key
+      header: Authorization
+      value: Bearer <openai-apikey>
+  accessControl:
+    mode: deny_all
+    exceptions:
+      - path: /chat/completions
+        methods: [POST]
+  operationPolicies:
+    - name: aws-bedrock-guardrail
+      version: v1
+      paths:
+        - path: /chat/completions
+          methods: [POST]
+          params:
+            awsAuth:
+              authenticationType: system
+            request:
+              jsonPath: "$.messages[-1].content"
+              showAssessment: true
+            response:
+              enabled: true
+              jsonPath: "$.choices[0].message.content"
+```
+
+**Test the guardrail:**
+
+```bash
+# Request with prohibited content (should fail with HTTP 422)
+curl -X POST http://localhost:8080/openai/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "This is prohibited content"
+      }
+    ]
+  }'
+
+# Request with PII (should mask PII and proceed)
+curl -X POST http://localhost:8080/openai/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Contact me at user@example.com or call 555-123-4567"
+      }
+    ]
+  }'
+```
+
+### Example 2: Per-attachment guardrail and region
+
+Two APIs on one gateway, each with its own guardrail in its own region.
+
+```yaml
+operationPolicies:
+  - name: aws-bedrock-guardrail
+    version: v1
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          region: "eu-west-1"
+          guardrailID: "gr-eu-strict"
+          guardrailVersion: "3"
+          awsAuth:
+            authenticationType: system
+          request:
+            jsonPath: "$.messages[-1].content"
+            showAssessment: true
+          response:
+            enabled: true
+            jsonPath: "$.choices[0].message.content"
+```
+
+### Example 3: Guardrail in another AWS account, no secret in the API definition
+
+The gateway assumes a role in the tenant's account. On EKS the base credentials come from the gateway's IRSA identity, so no credential material appears in the API definition — the external ID is an anti-confused-deputy identifier, not a secret key.
+
+```yaml
+operationPolicies:
+  - name: aws-bedrock-guardrail
+    version: v1
+    paths:
+      - path: /chat/completions
+        methods: [POST]
+        params:
+          region: "eu-west-1"
+          guardrailID: "gr-tenant-a"
+          guardrailVersion: "3"
+          awsAuth:
+            authenticationType: sts-assume-role
+            awsRoleARN: "arn:aws:iam::444455556666:role/wso2-gw-guardrail-tenant-a"
+            awsRoleExternalID: "tnt-a-7f3c9e21"
+            awsRoleSessionName: "wso2-gw-support-api"
+          request:
+            enabled: true
+            jsonPath: "$.messages[-1].content"
+          response:
+            enabled: true
+            jsonPath: "$.choices[0].message.content"
+```
+
+The target role needs a trust policy naming the gateway principal and pinning the external ID:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::111122223333:role/gateway-bedrock-guardrail" },
+    "Action": "sts:AssumeRole",
+    "Condition": { "StringEquals": { "sts:ExternalId": "tnt-a-7f3c9e21" } }
+  }]
+}
+```
+
+and a permission policy allowing only the guardrail call:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "bedrock:ApplyGuardrail",
+    "Resource": "arn:aws:bedrock:eu-west-1:444455556666:guardrail/gr-tenant-a",
+    "Condition": { "StringEquals": { "aws:RequestedRegion": "eu-west-1" } }
+  }]
+}
+```
+
+The gateway's own identity needs only scoped assume-role permission — never `Resource: "*"`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Resource": "arn:aws:iam::*:role/wso2-gw-guardrail-*"
+  }]
+}
+```
+
+### Example 4: IRSA
+
+The gateway runs on EKS under a ServiceAccount annotated with `eks.amazonaws.com/role-arn`. No credential material and no role ARN are needed in the API definition.
+
+```yaml
+        params:
+          region: "us-east-1"
+          guardrailID: "gr-123"
+          guardrailVersion: "1"
+          awsAuth:
+            authenticationType: irsa
+          request:
+            jsonPath: "$.messages[-1].content"
+```
+
+### Example 5: PII redaction mode
+
+```yaml
+        params:
+          awsAuth:
+            authenticationType: system
+          request:
+            jsonPath: "$.messages[0].content"
+            redactPII: true
+            showAssessment: false
+          response:
+            enabled: true
+            jsonPath: "$.choices[0].message.content"
+```
+
+### Example 6: Error response
+
+When validation fails, the guardrail returns HTTP 422:
+
+```json
+{
+  "type": "AWS_BEDROCK_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "AWS Bedrock Guardrail",
+    "actionReason": "Violation of AWS Bedrock Guardrail detected.",
+    "direction": "REQUEST"
+  }
+}
+```
+
+If `showAssessment` is enabled, additional details are included:
+
+```json
+{
+  "type": "AWS_BEDROCK_GUARDRAIL",
+  "message": {
+    "action": "GUARDRAIL_INTERVENED",
+    "interveningGuardrail": "AWS Bedrock Guardrail",
+    "actionReason": "Violation of AWS Bedrock Guardrail detected.",
+    "direction": "REQUEST",
+    "assessments": {
+      "topicPolicy": {
+        "topics": ["Topic1", "Topic2"]
+      },
+      "contentPolicy": {
+        "filters": ["Filter1"]
+      },
+      "sensitiveInformationPolicy": {
+        "piiEntities": [...],
+        "regexes": [...]
+      }
+    }
+  }
+}
+```
+
+### Example 7: Restricting what attachments may select
+
+An operator allows per-attachment identity but not per-attachment long-lived secrets:
+
+```toml
+awsbedrock_allowed_regions       = ["us-east-1", "eu-west-1"]
+awsbedrock_allowed_guardrail_ids = ["gr-default", "gr-eu-strict", "gr-tenant-a"]
+awsbedrock_allowed_role_arns     = ["arn:aws:iam::*:role/wso2-gw-guardrail-*"]
+awsbedrock_allowed_auth_types    = ["irsa", "sts-assume-role", "default-credential-chain"]
+```
+
+An attachment selecting `iam-user-access-key`, a region outside the list, or a role ARN outside the prefix is rejected at deploy time.
+
+## How It Works
+
+#### Request Phase
+
+1. **Content extraction**: Extracts content using `jsonPath`, or uses the entire payload.
+2. **Guardrail evaluation**: Calls `ApplyGuardrail` with the effective region, guardrail ID, and version, using the identity resolved from `awsAuth` or the gateway-wide settings.
+3. **PII processing**: With `redactPII: false`, masks PII with placeholders for later restoration. With `redactPII: true`, replaces PII with `*****` permanently.
+4. **Violation handling**: Blocks and returns HTTP `422` when Bedrock reports a violation.
+5. **Error strategy**: Applies `passthroughOnError` to transient failures only.
+
+#### Response Phase
+
+1. **Content extraction**: Extracts content using `jsonPath`, or uses the entire payload.
+2. **Guardrail evaluation**: Validates response content through the guardrail.
+3. **PII restoration**: In masking mode, restores masked PII values when mappings are available from request metadata.
+4. **Violation handling**: Blocks and returns HTTP `422` on violation.
+5. **Error strategy**: As above.
+
+#### Credential resolution
+
+The credentials provider is built **once**, when the policy attachment is created, and reused across requests. Role assumption therefore happens on first use and on refresh near expiry, not on every request. A failure to build it — an unassumable role, a missing IRSA environment — rejects the attachment at deploy time rather than failing at request time.
+
+#### PII Handling Modes
+
+- **Masking mode (`redactPII: false`)**: PII entities are replaced with placeholders such as `EMAIL_0001`, `PHONE_0002`, restorable in the response phase.
+- **Redaction mode (`redactPII: true`)**: PII entities are permanently replaced with `*****`.
+
+## Notes
+
+- The guardrail must exist in AWS Bedrock before use, in the region the attachment selects. Cross-region calls are not supported: a guardrail in `eu-west-1` is not reachable from a `us-east-1` client.
+- Guardrail version `DRAFT` is useful for testing. Use numbered versions for production.
+- The IAM identity used must have `bedrock:ApplyGuardrail` on the target guardrail.
+- PII masking with restoration stores the mapping between original and masked values in request metadata.
+- Content modifications (PII masking) are forwarded upstream if no blocking violation occurs.
+- Request and response phases are validated independently when both are configured.
+- Credential material is never written to logs. The session name, not the credentials, is what identifies the gateway in the target account's CloudTrail.

--- a/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
@@ -19,11 +19,10 @@ Every setting can be configured per policy attachment or gateway-wide. An attach
 - **PII redaction**: Permanently removes PII by replacing with "*****" (redaction mode)
 - **Per-attachment guardrail selection**: Each attachment can set its own `region`, `guardrailID`, and `guardrailVersion`
 - **Per-attachment AWS identity**: Each attachment can set its own `awsAuth`, letting the guardrail live in a different AWS account
-- **Five credential modes**: gateway-wide (`system`, the default), IRSA, STS AssumeRole, default credential chain, or static access keys
+- **Credential modes**: gateway-wide (`system`, the default), IRSA, STS AssumeRole, default credential chain, or static access keys
 - **Gateway-level allowlists**: Operators can restrict which regions, guardrails, roles, and credential modes attachments may select
 - **JSONPath support**: Extract and validate specific fields within JSON payloads
 - **Separate request/response configuration**: Independent configuration for request and response phases
-- **Detailed assessment information**: Optional detailed violation information in error responses
 
 ## Configuration
 
@@ -47,7 +46,7 @@ The policy uses a two-level configuration. Every parameter can be set gateway-wi
 
 #### Allowlists
 
-Each allowlist restricts what a policy attachment may select. An empty or unset allowlist places no restriction. Allowlists are checked against the **effective** value, so when you set one you must include the gateway's own default.
+Each allowlist restricts what a policy attachment may select. An empty or unset allowlist places no restriction.
 
 `allowedRegions` and `allowedRoleARNs` accept a single trailing `*` as a prefix match. `allowedGuardrailIDs` and `allowedAuthTypes` are exact-match only.
 
@@ -98,19 +97,13 @@ At least one of `request` or `response` must be provided.
 
 `region`, `guardrailID`, and `guardrailVersion` resolve independently — an attachment can set only the version and inherit the rest.
 
-> **`localGuardrailID` / `localGuardrailVersion` are deprecated.** They still work, so existing attachments need no immediate change, but prefer `guardrailID` / `guardrailVersion` for new work.
->
-> **Precedence:** the current parameter wins. `localGuardrailID` is consulted only when `guardrailID` resolves to nothing — from the attachment *or* from the gateway-wide `awsbedrock_guardrail_id`. Adding `guardrailID` to an attachment that already sets `localGuardrailID` therefore takes effect immediately; you can remove the `local` spelling in the same edit or later.
->
-> **One case to check before upgrading:** if your gateway sets a non-empty `awsbedrock_guardrail_id` **and** an attachment sets only `localGuardrailID`, that attachment now resolves to the gateway-wide guardrail instead of its own. The merge that combines gateway-wide and attachment parameters erases which level a value came from, so this cannot be detected and rejected automatically. Give such attachments an explicit `guardrailID` (same value as their `localGuardrailID`) before upgrading. Attachments on a gateway that leaves `awsbedrock_guardrail_id` empty are unaffected.
+> **`localGuardrailID` / `localGuardrailVersion` are deprecated.** Still work exactly as previously, therefore no existing attachment needs changing. Prefer `guardrailID` / `guardrailVersion` for new attachments. Please migrate existing attachments to the new parameter names.
 
 #### `awsAuth` — per-attachment AWS identity
 
 `awsAuth` is optional and defaults to `system`. If it is not set, the gateway-wide credential settings from `config.toml` are used, exactly as before.
 
 `authenticationType: system` states that deferral explicitly. **Every other mode ignores the gateway-wide credential settings entirely** — `awsbedrock_access_key_id`, `awsbedrock_role_arn` and the rest are not consulted, and cannot be mixed with what the attachment supplies.
-
-What each mode does use instead differs, and only one of them is fully described by the attachment:
 
 | Mode | Identity comes from | Attachment supplies |
 | ---- | ------------------- | ------------------- |
@@ -119,18 +112,16 @@ What each mode does use instead differs, and only one of them is fully described
 | `default-credential-chain` | Whatever the AWS SDK resolves at runtime: environment, instance profile, ECS task role, or IRSA | Nothing |
 | `iam-user-access-key` | The key and secret in the attachment | Everything |
 
-So "self-contained" applies strictly only to `iam-user-access-key`. The others are self-contained with respect to *gateway-wide configuration*, while still relying on the runtime identity of the gateway process. That is the point of `sts-assume-role` with no static key: the pod's IRSA identity assumes the tenant's role, and no credential material appears in the API definition at all.
+Therefore "self-contained" applies strictly only to `iam-user-access-key`. The others are self-contained with respect to *gateway-wide configuration*, while still relying on the runtime identity of the gateway process
 
-One case is rejected rather than defaulted: an `awsAuth` block carrying credential fields but no `authenticationType`. Defaulting it to `system` would silently ignore those fields, leaving an attachment that looks like it configures an identity while the gateway-wide one is in use. Name the mode instead.
-
-**The declared mode is authoritative.** If it fails — a role that cannot be assumed, an expired key, a missing IRSA environment — the attachment is rejected at deploy time or the request is blocked. It never silently falls back to the gateway-wide credentials, so a broken attachment-level identity cannot end up running under the gateway's own.
+An `awsAuth` block with credential fields but no `authenticationType` resolves to `system`, and those fields are ignored — the gateway-wide identity is used. Name the mode explicitly if you intend the attachment to have its own.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
 | `authenticationType` | string | No | `system` | One of `system`, `irsa`, `sts-assume-role`, `default-credential-chain`, `iam-user-access-key`. Defaults to `system`, so an `awsAuth` block that names no mode uses the gateway-wide identity. |
 | `awsRoleARN` | string | Conditional | – | Required for `sts-assume-role`. Optional for `irsa` — falls back to the `AWS_ROLE_ARN` environment variable. |
 | `awsRoleRegion` | string | No | effective `region` | AWS region whose STS endpoint is used for the assumption. |
-| `awsRoleExternalID` | string | No | – | External ID required by the target role's trust policy. Only applicable to `sts-assume-role`. |
+| `awsRoleExternalID` | string | No | – | External ID required by the target role's trust policy. Used only by `sts-assume-role` — `irsa` calls `AssumeRoleWithWebIdentity`, which has no external-ID parameter, so a value set there is ignored. |
 | `awsRoleSessionName` | string | No | `bedrock-guardrail-session` | Session name used when assuming the role. This is what appears in the target account's CloudTrail, so prefer a value identifying this API. |
 | `awsAccessKeyID` | string | Conditional | – | Required for `iam-user-access-key`. Optional base credential for `sts-assume-role`. |
 | `awsSecretAccessKey` | string | Conditional | – | Required for `iam-user-access-key`. |
@@ -155,37 +146,19 @@ For `irsa`, the web identity token file path is never a policy parameter — it 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `enabled` | boolean | No | `true` | Enables validation for the request flow. |
-| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a value from the request payload. If empty, validates the entire payload as a string. |
-| `redactPII` | boolean | No | `false` | If `true`, redacts PII by replacing with `*****` (permanent). If `false`, masks PII with placeholders restorable in responses. |
-| `passthroughOnError` | boolean | No | `false` | If `true`, allows the request to proceed when the Bedrock call fails, for any reason. See "Error handling" below. |
-| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information in error responses. |
+| `jsonPath` | string | No | `"$.messages[-1].content"` | JSONPath expression to extract a specific value from the request JSON payload. If empty, validates the entire payload as a string. |
+| `redactPII` | boolean | No | `false` | If `true`, redacts PII by replacing with `*****` (permanent). If `false`, masks PII with placeholders that can be restored in responses. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows the request to proceed when the AWS Bedrock Guardrail API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information from AWS Bedrock Guardrail in error responses. |
 
 #### Response Configuration
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `enabled` | boolean | No | `false` | Enables validation for the response flow. |
-| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a value from the response payload. |
-| `passthroughOnError` | boolean | No | `false` | As above. |
-| `showAssessment` | boolean | No | `false` | As above. |
-
-#### Error handling — what `passthroughOnError` covers
-
-`passthroughOnError` exists so that a Bedrock outage does not take your API down with it. When enabled, the request proceeds regardless of **why** the guardrail call failed — a timeout, a wrong guardrail ID, an unassumable role, or expired credentials all allow traffic through. This matches the behaviour of earlier versions.
-
-| Failure | `passthroughOnError: true` | `passthroughOnError: false` (default) |
-| ------- | -------------------------- | ------------------------------------- |
-| Timeout, connection failure, 5xx, throttling | Request proceeds | Blocked (HTTP 422) |
-| `ResourceNotFoundException` — wrong guardrail ID, version, or region | Request proceeds | Blocked |
-| `AccessDeniedException` — Bedrock or STS refuses | Request proceeds | Blocked |
-| `ValidationException` — malformed request | Request proceeds | Blocked |
-| Expired or unresolvable credentials | Request proceeds | Blocked |
-
-> **Understand what you are enabling.** A *transient* failure passed through costs you a few unscreened requests during an outage. A *permanent* one — a guardrail ID that does not exist, a role that cannot be assumed — means the guardrail never runs at all, on any request, while the API definition still shows it attached. There is no external signal that content is going unscreened.
->
-> There is no distinct signal for this state — the policy does not separate transient from permanent failures, and a passed-through request is logged only at debug level. If you enable `passthroughOnError` in production, monitor for a sustained absence of guardrail interventions, or watch the Bedrock `ApplyGuardrail` error rate in CloudWatch.
->
-> Consider `passthroughOnError: false` (the default) for guardrails that are enforcing a compliance requirement, and reserve `true` for availability-critical paths where unscreened traffic is the lesser risk.
+| `jsonPath` | string | No | `"$.choices[0].message.content"` | JSONPath expression to extract a specific value from the response JSON payload. If empty, validates the entire payload as a string. |
+| `passthroughOnError` | boolean | No | `false` | If `true`, allows the response to proceed when the AWS Bedrock Guardrail API call fails. If `false`, blocks on API errors. |
+| `showAssessment` | boolean | No | `false` | If `true`, includes detailed assessment information from AWS Bedrock Guardrail in error responses. |
 
 #### JSONPath Support
 
@@ -469,7 +442,7 @@ An attachment selecting `iam-user-access-key`, a region outside the list, or a r
 2. **Guardrail evaluation**: Calls `ApplyGuardrail` with the effective region, guardrail ID, and version, using the identity resolved from `awsAuth` or the gateway-wide settings.
 3. **PII processing**: With `redactPII: false`, masks PII with placeholders for later restoration. With `redactPII: true`, replaces PII with `*****` permanently.
 4. **Violation handling**: Blocks and returns HTTP `422` when Bedrock reports a violation.
-5. **Error strategy**: When `passthroughOnError` is `true`, the request proceeds on any failure — JSONPath extraction, credential resolution, the Bedrock call, and response evaluation alike. When `false` (the default), each of those blocks with HTTP 422.
+5. **Error Strategy**: Applies `passthroughOnError` behavior to decide whether to fail closed or allow traffic on Bedrock API failures.
 
 #### Response Phase
 
@@ -477,7 +450,7 @@ An attachment selecting `iam-user-access-key`, a region outside the list, or a r
 2. **Guardrail evaluation**: Validates response content through the guardrail.
 3. **PII restoration**: In masking mode, restores masked PII values when mappings are available from request metadata.
 4. **Violation handling**: Blocks and returns HTTP `422` on violation.
-5. **Error strategy**: As above.
+5. **Error Strategy**: Applies `passthroughOnError` behavior for Bedrock API failures.
 
 #### Credential resolution
 

--- a/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
@@ -103,7 +103,7 @@ At least one of `request` or `response` must be provided.
 
 `awsAuth` is optional and defaults to `system`. If it is not set, the gateway-wide credential settings from `config.toml` are used, exactly as before.
 
-`authenticationType: system` states that deferral explicitly. **Every other mode ignores the gateway-wide credential settings entirely** — `awsbedrock_access_key_id`, `awsbedrock_role_arn` and the rest are not consulted, and cannot be mixed with what the attachment supplies.
+`authenticationType: system` states that deferral explicitly. **Every other mode ignores the gateway-wide credential settings entirely** — `awsbedrock_access_key_id`, `awsbedrock_role_arn` and the rest are not consulted, so an attachment-level identity is never blended with the gateway's.
 
 | Mode | Identity comes from | Attachment supplies |
 | ---- | ------------------- | ------------------- |
@@ -112,9 +112,14 @@ At least one of `request` or `response` must be provided.
 | `default-credential-chain` | Whatever the AWS SDK resolves at runtime: environment, instance profile, ECS task role, or IRSA | Nothing |
 | `iam-user-access-key` | The key and secret in the attachment | Everything |
 
-Therefore "self-contained" applies strictly only to `iam-user-access-key`. The others are self-contained with respect to *gateway-wide configuration*, while still relying on the runtime identity of the gateway process
+Therefore "self-contained" applies strictly only to `iam-user-access-key`. The others are self-contained with respect to *gateway-wide configuration*, while still relying on the runtime identity of the gateway process.
 
-An `awsAuth` block with credential fields but no `authenticationType` resolves to `system`, and those fields are ignored — the gateway-wide identity is used. Name the mode explicitly if you intend the attachment to have its own.
+**A field the selected mode does not use is ignored.** `awsRoleARN` alongside `iam-user-access-key`, `awsAccessKeyID` alongside `irsa`, or any credential field alongside `system` — each is accepted and has no effect. The same applies when `authenticationType` is omitted, which resolves to `system`.
+
+Two consequences worth internalising:
+
+- A stale field left behind by an edit will not fail a deployment, but it will not do anything either. **Read `authenticationType` to determine which identity an attachment uses — not which fields are present.**
+- Fields a mode *requires* are still enforced. `sts-assume-role` without `awsRoleARN`, or `iam-user-access-key` without a key and secret, is rejected at deploy time.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
@@ -131,7 +136,7 @@ An `awsAuth` block with credential fields but no `authenticationType` resolves t
 
 | Mode | Credential material in the API definition | When to use |
 | ---- | ----------------------------------------- | ----------- |
-| `system` | **None** | The attachment has no AWS identity of its own and should use the gateway-wide configuration. No other field in `awsAuth` may be set. |
+| `system` | **None** | The attachment has no AWS identity of its own and uses the gateway-wide configuration. Any other field in `awsAuth` is ignored. |
 | `irsa` | **None** | Gateway runs on EKS with IAM Roles for Service Accounts. Preferred. |
 | `sts-assume-role` | None, when the base credentials come from IRSA or the gateway's instance role | Guardrail lives in another AWS account. Preferred for cross-account. |
 | `default-credential-chain` | **None** | Gateway compute already runs under the exact role needed. |

--- a/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
+++ b/docs/aws-bedrock-guardrail/v1.2/docs/aws-bedrock-guardrail.md
@@ -87,8 +87,8 @@ awsbedrock_allowed_auth_types    = ["system", "irsa", "sts-assume-role", "defaul
 | `region` | string | No | gateway-wide value | AWS region hosting the guardrail for this attachment. |
 | `guardrailID` | string | No | gateway-wide value | Guardrail identifier for this attachment. |
 | `guardrailVersion` | string | No | gateway-wide value | Guardrail version for this attachment. |
-| `localGuardrailID` | string | No | – | **Deprecated** — use `guardrailID`. Used only when `guardrailID` resolves to nothing. Retained for attachments authored against v1.1.0. |
-| `localGuardrailVersion` | string | No | – | **Deprecated** — use `guardrailVersion`. Used only when `guardrailVersion` resolves to nothing. |
+| `localGuardrailID` | string | No | – | **Deprecated** — use `guardrailID`. Retained so attachments authored against previous versions keep working unchanged; remove it when migrating. |
+| `localGuardrailVersion` | string | No | – | **Deprecated** — use `guardrailVersion`. Retained so attachments authored against previous versions keep working unchanged; remove it when migrating. |
 | `awsAuth` | object | No | `system` | AWS identity for this attachment. Omitting it uses the gateway-wide identity. See below. |
 | `request` | object | See note | – | Request-phase validation configuration. |
 | `response` | object | See note | – | Response-phase validation configuration. |

--- a/docs/aws-bedrock-guardrail/v1.2/metadata.json
+++ b/docs/aws-bedrock-guardrail/v1.2/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-bedrock-guardrail",
+  "displayName": "AWS Bedrock Guardrail",
+  "version": "1.2",
+  "provider": "WSO2",
+  "categories": [
+    "Guardrails",
+    "AI"
+  ],
+  "description": "Validates request or response body content against AWS Bedrock Guardrails.\nSupports content filtering, topic detection, word filtering, and PII detection/masking.\nSupports per-attachment guardrail selection (region/guardrailID/guardrailVersion) alongside gateway-wide defaults.\nSupports per-attachment AWS identity (awsAuth) so a guardrail can live in a different AWS account, with four credential modes: IRSA, STS AssumeRole, default credential chain, or static access keys.\nSupports gateway-level allowlists restricting which regions, guardrails, roles, and credential modes an attachment may select.\nSupports JSONPath extraction to validate specific fields within JSON payloads.\nSupports separate configuration for request and response phases."
+}

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -47,6 +48,47 @@ const (
 	ResponseFlowEnabledByDefault = false
 )
 
+// Credential-acquisition modes selectable through awsAuth.authenticationType.
+const (
+	// AuthTypeSystem defers to the gateway-wide credential configuration in
+	// config.toml. It is the explicit way for an attachment to say "I have no
+	// AWS identity of my own", replacing the pre-v1.2.0 behaviour of simply
+	// omitting the credential block.
+	AuthTypeSystem = "system"
+	// AuthTypeIRSA obtains credentials via STS AssumeRoleWithWebIdentity using
+	// the Kubernetes projected service account token (IAM Roles for Service
+	// Accounts). Requires no credential material in the API definition.
+	AuthTypeIRSA = "irsa"
+	// AuthTypeSTSAssumeRole obtains temporary credentials via STS AssumeRole.
+	AuthTypeSTSAssumeRole = "sts-assume-role"
+	// AuthTypeDefaultCredentialChain resolves credentials from the AWS SDK's
+	// default provider chain, with no role assumption and no configured keys.
+	AuthTypeDefaultCredentialChain = "default-credential-chain"
+	// AuthTypeIAMUserAccessKey uses a static, long-lived access key/secret pair.
+	AuthTypeIAMUserAccessKey = "iam-user-access-key"
+)
+
+const (
+	defaultRoleSessionName = "bedrock-guardrail-session"
+
+	// Environment variables injected by the EKS Pod Identity Webhook, used by
+	// AuthTypeIRSA. The token file path is never taken from a policy param.
+	envRoleARN              = "AWS_ROLE_ARN"
+	envWebIdentityTokenFile = "AWS_WEB_IDENTITY_TOKEN_FILE"
+)
+
+// credentialFields holds the credential configuration resolved for one policy
+// attachment, from either its awsAuth object or the gateway-wide settings.
+type credentialFields struct {
+	accessKeyID     string
+	secretAccessKey string
+	sessionToken    string
+	roleARN         string
+	roleRegion      string
+	roleExternalID  string
+	roleSessionName string
+}
+
 var textCleanRegexCompiled = regexp.MustCompile(TextCleanRegex)
 
 type bedrockGuardrailClient interface {
@@ -56,15 +98,20 @@ type bedrockGuardrailClient interface {
 // AWSBedrockGuardrailPolicy implements AWS Bedrock Guardrail validation
 type AWSBedrockGuardrailPolicy struct {
 	// Static configuration from params
-	region             string
-	guardrailID        string
-	guardrailVersion   string
-	awsAccessKeyID     string
-	awsSecretAccessKey string
-	awsSessionToken    string
-	awsRoleARN         string
-	awsRoleRegion      string
-	awsRoleExternalID  string
+	region           string
+	guardrailID      string
+	guardrailVersion string
+
+	// Resolved credential configuration. authType is one of the AuthType*
+	// constants; creds holds only the fields that mode uses.
+	authType string
+	creds    credentialFields
+
+	// credentialsProvider is built once at policy-instance creation time and
+	// reused across requests. For the role-assumption modes it wraps an
+	// aws.CredentialsCache, so temporary credentials are refreshed near expiry
+	// rather than re-fetched from STS on every request.
+	credentialsProvider aws.CredentialsProvider
 
 	// Dynamic configuration from params
 	hasRequestParams  bool
@@ -90,64 +137,63 @@ func GetPolicy(
 	metadata policy.PolicyMetadata,
 	params map[string]interface{},
 ) (policy.Policy, error) {
-	// Validate and extract static configuration from params
-	if err := validateAWSConfigParams(params); err != nil {
+	// System-level (systemParameters, from config.toml) and user-level
+	// (parameters, from the API definition) values arrive merged into this
+	// single map, with user-level values having overwritten system-level ones
+	// for any key both levels define.
+	region, err := resolveGuardrailIdentityParam(params, "", "region")
+	if err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	guardrailID, err := resolveGuardrailIdentityParam(params, "localGuardrailID", "guardrailID")
+	if err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	guardrailVersion, err := resolveGuardrailIdentityParam(params, "localGuardrailVersion", "guardrailVersion")
+	if err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
 
-	// guardrailID/guardrailVersion can each be set directly on this policy
-	// attachment (localGuardrailID/localGuardrailVersion), or left unset to
-	// use the gateway-wide systemParameters value of the same setting.
-	guardrailID, err := resolveGuardrailParam(params, "localGuardrailID", "guardrailID")
+	authType, creds, err := resolveCredentialSet(params, region, deriveRoleSessionName(metadata))
 	if err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
-	guardrailVersion, err := resolveGuardrailParam(params, "localGuardrailVersion", "guardrailVersion")
-	if err != nil {
+
+	if err := checkAllowlist(params, "allowedRegions", "region", region, false); err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if err := checkAllowlist(params, "allowedGuardrailIDs", "guardrailID", guardrailID, false); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if err := checkAllowlist(params, "allowedAuthTypes", "authenticationType", authType, false); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if creds.roleARN != "" {
+		if err := checkAllowlist(params, "allowedRoleARNs", "awsRoleARN", creds.roleARN, true); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
 	}
 
 	p := &AWSBedrockGuardrailPolicy{
-		region:           getStringParam(params, "region"),
+		region:           region,
 		guardrailID:      guardrailID,
 		guardrailVersion: guardrailVersion,
+		authType:         authType,
+		creds:            creds,
 	}
 	p.loadAWSConfigFunc = p.loadAWSConfig
 	p.newBedrockClientFunc = func(cfg aws.Config) bedrockGuardrailClient {
 		return bedrockruntime.NewFromConfig(cfg)
 	}
 
-	// Optional AWS credentials
-	if val, ok := params["awsAccessKeyID"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsAccessKeyID = str
-		}
+	// Build the credentials provider once, so that role assumption does not
+	// repeat on every request. A failure here is a configuration failure and
+	// rejects the attachment at deploy time rather than failing open later.
+	credentialsProvider, err := buildCredentialsProvider(context.Background(), authType, creds)
+	if err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
 	}
-	if val, ok := params["awsSecretAccessKey"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsSecretAccessKey = str
-		}
-	}
-	if val, ok := params["awsSessionToken"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsSessionToken = str
-		}
-	}
-	if val, ok := params["awsRoleARN"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsRoleARN = str
-		}
-	}
-	if val, ok := params["awsRoleRegion"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsRoleRegion = str
-		}
-	}
-	if val, ok := params["awsRoleExternalID"]; ok {
-		if str, ok := val.(string); ok {
-			p.awsRoleExternalID = str
-		}
-	}
+	p.credentialsProvider = credentialsProvider
 
 	// Extract and parse request parameters if present
 	if requestParamsRaw, ok := params["request"].(map[string]interface{}); ok {
@@ -177,7 +223,12 @@ func GetPolicy(
 		return nil, fmt.Errorf("at least one of 'request' or 'response' parameters must be provided")
 	}
 
-	slog.Debug("AWSBedrockGuardrail: Policy initialized", "region", p.region, "guardrailID", p.guardrailID, "guardrailVersion", p.guardrailVersion, "hasRequestParams", p.hasRequestParams, "hasResponseParams", p.hasResponseParams)
+	// Credential material is deliberately absent from this line: the secret
+	// access key, session token and role external ID must never be logged.
+	slog.Debug("AWSBedrockGuardrail: Policy initialized",
+		"region", p.region, "guardrailID", p.guardrailID, "guardrailVersion", p.guardrailVersion,
+		"authenticationType", p.authType, "roleARN", p.creds.roleARN,
+		"hasRequestParams", p.hasRequestParams, "hasResponseParams", p.hasResponseParams)
 
 	return p, nil
 }
@@ -261,201 +312,583 @@ func getStringParam(params map[string]interface{}, key string) string {
 	return ""
 }
 
-// resolveGuardrailParam returns the value for a guardrail identity setting
-// (guardrailID/guardrailVersion) that can be supplied directly on this policy
-// attachment (attachmentKey, from "parameters") or via the gateway-wide
-// systemParameters value of the same setting (systemKey, resolved from
-// config.toml into the same flat params map). At least one must resolve to a
-// non-empty string.
-func resolveGuardrailParam(params map[string]interface{}, attachmentKey, systemKey string) (string, error) {
-	if val, ok := params[attachmentKey]; ok {
-		str, ok := val.(string)
-		if !ok {
-			return "", fmt.Errorf("'%s' must be a string", attachmentKey)
-		}
-		if str == "" {
-			return "", fmt.Errorf("'%s' cannot be empty", attachmentKey)
-		}
-		return str, nil
+// resolveGuardrailIdentityParam returns the effective value for one guardrail
+// identity setting (region/guardrailID/guardrailVersion).
+//
+// User-level and system-level parameters share a key name and are merged
+// upstream into a single params map, with the user-level value overwriting the
+// system-level one, so canonicalKey already carries the effective value and
+// needs no fallback logic of its own.
+//
+// legacyKey, when non-empty, names the deprecated v1.1.0 spelling of the same
+// setting (localGuardrailID/localGuardrailVersion), kept purely for backward
+// compatibility. The canonical key wins when both are present; the legacy key is
+// consulted only as a fallback, so attachments authored against v1.1.0 keep
+// working untouched while an author adding the canonical name sees it take
+// effect immediately.
+//
+// Note the one behavioural consequence: when the system level supplies a
+// non-empty canonical value, an attachment that sets only the legacy key now
+// resolves to the system-level value rather than its own. The merge erases which
+// level a value came from, so this case cannot be detected and rejected - the
+// debug line below is what makes it diagnosable.
+func resolveGuardrailIdentityParam(params map[string]interface{}, legacyKey, canonicalKey string) (string, error) {
+	canonical, err := stringParam(params, canonicalKey)
+	if err != nil {
+		return "", err
 	}
-	if val, ok := params[systemKey]; ok {
-		str, ok := val.(string)
-		if !ok {
-			return "", fmt.Errorf("'%s' must be a string", systemKey)
+
+	var legacy string
+	if legacyKey != "" {
+		legacy, err = stringParam(params, legacyKey)
+		if err != nil {
+			return "", err
 		}
-		if str == "" {
-			return "", fmt.Errorf("'%s' cannot be empty", systemKey)
-		}
-		return str, nil
 	}
-	return "", fmt.Errorf("one of '%s' or '%s' parameter is required", attachmentKey, systemKey)
+
+	if canonical != "" {
+		if legacy != "" && legacy != canonical {
+			slog.Debug("AWSBedrockGuardrail: deprecated parameter ignored because the current one is set",
+				"deprecatedParam", legacyKey, "deprecatedValue", legacy,
+				"param", canonicalKey, "value", canonical)
+		}
+		return canonical, nil
+	}
+
+	if legacy != "" {
+		slog.Debug("AWSBedrockGuardrail: using deprecated parameter; prefer the current one",
+			"deprecatedParam", legacyKey, "param", canonicalKey)
+		return legacy, nil
+	}
+
+	if legacyKey != "" {
+		return "", fmt.Errorf("'%s' parameter is required: set it on the policy attachment or in the gateway configuration, or supply the deprecated '%s'", canonicalKey, legacyKey)
+	}
+	return "", fmt.Errorf("'%s' parameter is required: set it on the policy attachment or in the gateway configuration", canonicalKey)
 }
 
-// validateAWSConfigParams validates AWS configuration parameters (from params)
-func validateAWSConfigParams(params map[string]interface{}) error {
-	// Validate region (required)
-	regionRaw, ok := params["region"]
+// stringParam reads an optional string parameter, returning "" when absent and
+// an error when present with a non-string type.
+func stringParam(params map[string]interface{}, key string) (string, error) {
+	val, ok := params[key]
+	if !ok || val == nil {
+		return "", nil
+	}
+	str, ok := val.(string)
 	if !ok {
-		return fmt.Errorf("'region' parameter is required")
+		return "", fmt.Errorf("'%s' must be a string", key)
 	}
-	region, ok := regionRaw.(string)
+	return str, nil
+}
+
+// resolveCredentialSet determines the AWS identity this policy attachment uses,
+// choosing between the user-level awsAuth object and the system-level
+// (gateway-wide) credential parameters.
+//
+// The credential configuration resolves atomically rather than field by field.
+// When the user level supplies an awsAuth object it supplies the whole thing,
+// and every system-level credential field is ignored. Per-field fallback would
+// allow a user-level role ARN to pair with a system-level external ID, which is
+// precisely the cross-tenant role hijack the external ID exists to prevent.
+//
+// With no awsAuth object, the system-level fields are read and the mode is
+// inferred from which of them are populated, exactly as before this parameter
+// existed. That inference now lives behind authenticationType "system"; every
+// other mode states itself explicitly.
+func resolveCredentialSet(params map[string]interface{}, region, defaultSessionName string) (string, credentialFields, error) {
+	raw, hasAWSAuth := params["awsAuth"]
+	if !hasAWSAuth {
+		// Omitting the credential block means "use the system-level identity",
+		// which is what every attachment authored against v1.1.0 relied on.
+		return resolveSystemCredentialSet(params, region, defaultSessionName)
+	}
+
+	awsAuth, ok := raw.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("'region' must be a string")
-	}
-	if region == "" {
-		return fmt.Errorf("'region' cannot be empty")
+		return "", credentialFields{}, fmt.Errorf("'awsAuth' must be an object")
 	}
 
-	// Validate optional AWS credential parameters
-	if awsAccessKeyIDRaw, ok := params["awsAccessKeyID"]; ok {
-		awsAccessKeyID, ok := awsAccessKeyIDRaw.(string)
-		if !ok {
-			return fmt.Errorf("'awsAccessKeyID' must be a string")
+	authType, err := stringParam(awsAuth, "authenticationType")
+	if err != nil {
+		return "", credentialFields{}, fmt.Errorf("awsAuth: %w", err)
+	}
+	if authType == "" {
+		// The schema defaults authenticationType to "system", so this branch is
+		// normally only reached when the policy is constructed without going
+		// through schema validation. It is kept as a backstop and behaves the
+		// same way: credential fields without a mode are rejected rather than
+		// defaulted, because defaulting would silently ignore them and leave an
+		// attachment that looks like it configures an identity while the
+		// gateway-wide one is in use.
+		if err := rejectCredentialFieldsForSystem(awsAuth, "no authenticationType is set"); err != nil {
+			return "", credentialFields{}, err
 		}
-		if awsAccessKeyID == "" {
-			return fmt.Errorf("'awsAccessKeyID' cannot be empty")
-		}
+		return resolveSystemCredentialSet(params, region, defaultSessionName)
+	}
+	switch authType {
+	case AuthTypeSystem, AuthTypeIRSA, AuthTypeSTSAssumeRole, AuthTypeDefaultCredentialChain, AuthTypeIAMUserAccessKey:
+	default:
+		return "", credentialFields{}, fmt.Errorf("'awsAuth.authenticationType' must be one of %q, %q, %q, %q, %q",
+			AuthTypeSystem, AuthTypeIRSA, AuthTypeSTSAssumeRole, AuthTypeDefaultCredentialChain, AuthTypeIAMUserAccessKey)
 	}
 
-	if awsSecretAccessKeyRaw, ok := params["awsSecretAccessKey"]; ok {
-		awsSecretAccessKey, ok := awsSecretAccessKeyRaw.(string)
-		if !ok {
-			return fmt.Errorf("'awsSecretAccessKey' must be a string")
+	// "system" is the one mode that reads gateway-wide credentials. Every other
+	// mode is self-contained, so a failure in it is never masked by falling back
+	// to the gateway identity.
+	if authType == AuthTypeSystem {
+		if err := rejectCredentialFieldsForSystem(awsAuth, fmt.Sprintf("authenticationType is %q (the default when it is not set)", AuthTypeSystem)); err != nil {
+			return "", credentialFields{}, err
 		}
-		if awsSecretAccessKey == "" {
-			return fmt.Errorf("'awsSecretAccessKey' cannot be empty")
-		}
+		return resolveSystemCredentialSet(params, region, defaultSessionName)
 	}
 
-	if awsSessionTokenRaw, ok := params["awsSessionToken"]; ok {
-		_, ok := awsSessionTokenRaw.(string)
-		if !ok {
-			return fmt.Errorf("'awsSessionToken' must be a string")
+	creds := credentialFields{}
+	for key, field := range map[string]*string{
+		"awsAccessKeyID":     &creds.accessKeyID,
+		"awsSecretAccessKey": &creds.secretAccessKey,
+		"awsSessionToken":    &creds.sessionToken,
+		"awsRoleARN":         &creds.roleARN,
+		"awsRoleRegion":      &creds.roleRegion,
+		"awsRoleExternalID":  &creds.roleExternalID,
+		"awsRoleSessionName": &creds.roleSessionName,
+	} {
+		value, err := stringParam(awsAuth, key)
+		if err != nil {
+			return "", credentialFields{}, fmt.Errorf("awsAuth: %w", err)
 		}
+		*field = value
 	}
 
-	if awsRoleARNRaw, ok := params["awsRoleARN"]; ok {
-		awsRoleARN, ok := awsRoleARNRaw.(string)
-		if !ok {
-			return fmt.Errorf("'awsRoleARN' must be a string")
-		}
-
-		// If role ARN is provided, validate role region
-		if awsRoleARN != "" {
-			// If role ARN is provided and not empty, validate role region
-			awsRoleRegionRaw, ok := params["awsRoleRegion"]
-			if !ok {
-				return fmt.Errorf("'awsRoleRegion' is required when 'awsRoleARN' is specified")
-			}
-
-			awsRoleRegion, ok := awsRoleRegionRaw.(string)
-			if !ok {
-				return fmt.Errorf("'awsRoleRegion' must be a string")
-			}
-
-			if awsRoleRegion == "" {
-				return fmt.Errorf("'awsRoleRegion' cannot be empty when 'awsRoleARN' is specified")
-			}
-		}
+	if err := validateCredentialFields(authType, creds); err != nil {
+		return "", credentialFields{}, err
 	}
 
-	if awsRoleExternalIDRaw, ok := params["awsRoleExternalID"]; ok {
-		_, ok := awsRoleExternalIDRaw.(string)
-		if !ok {
-			return fmt.Errorf("'awsRoleExternalID' must be a string")
-		}
+	// Resolve the IRSA environment fallback here rather than leaving it to
+	// buildWebIdentityCredentialsProvider, so creds.roleARN always carries the
+	// role that will actually be assumed. Without this the allowlist check sees
+	// an empty ARN and lets the environment-supplied role through unexamined,
+	// while the identical role written out explicitly is checked.
+	if authType == AuthTypeIRSA && creds.roleARN == "" {
+		creds.roleARN = strings.TrimSpace(os.Getenv(envRoleARN))
 	}
 
+	applyCredentialDefaults(&creds, region, defaultSessionName)
+	return authType, creds, nil
+}
+
+// readSystemCredentialFields reads the system-level (gateway-wide) credential
+// parameters. These come from config.toml via the systemParameters block, as
+// opposed to the user-level parameters an API author sets on the attachment.
+func readSystemCredentialFields(params map[string]interface{}, region, defaultSessionName string) (credentialFields, error) {
+	creds := credentialFields{}
+	for key, field := range map[string]*string{
+		"awsAccessKeyID":     &creds.accessKeyID,
+		"awsSecretAccessKey": &creds.secretAccessKey,
+		"awsSessionToken":    &creds.sessionToken,
+		"awsRoleARN":         &creds.roleARN,
+		"awsRoleRegion":      &creds.roleRegion,
+		"awsRoleExternalID":  &creds.roleExternalID,
+	} {
+		value, err := stringParam(params, key)
+		if err != nil {
+			return credentialFields{}, err
+		}
+		*field = value
+	}
+
+	if err := validateCredentialFormats(creds); err != nil {
+		return credentialFields{}, err
+	}
+
+	applyCredentialDefaults(&creds, region, defaultSessionName)
+	return creds, nil
+}
+
+// Format constraints mirroring the patterns in policy-definition.yaml. They
+// are duplicated here deliberately: the schema is only enforced as well as the
+// control plane's validator enforces it, and a malformed value that slips
+// through would otherwise fail at request time - against STS, on live traffic -
+// instead of being rejected when the attachment is deployed.
+var (
+	roleARNPattern         = regexp.MustCompile(`^arn:aws(-cn|-us-gov|-iso[a-z]?)?:iam::[0-9]{12}:role/.+$`)
+	awsRegionPattern       = regexp.MustCompile(`^[a-z0-9-]{1,32}$`)
+	roleSessionNamePattern = regexp.MustCompile(`^[\w+=,.@-]{2,64}$`)
+)
+
+// validateCredentialFields enforces the per-mode requirements that JSON Schema
+// expresses only awkwardly, as a backstop to the allOf/if/then rules in
+// policy-definition.yaml, along with the field formats.
+func validateCredentialFields(authType string, creds credentialFields) error {
+	if err := validateCredentialFormats(creds); err != nil {
+		return err
+	}
+
+	switch authType {
+	case AuthTypeIAMUserAccessKey:
+		if creds.accessKeyID == "" {
+			return fmt.Errorf("'awsAuth.awsAccessKeyID' is required when authenticationType is %q", AuthTypeIAMUserAccessKey)
+		}
+		if creds.secretAccessKey == "" {
+			return fmt.Errorf("'awsAuth.awsSecretAccessKey' is required when authenticationType is %q", AuthTypeIAMUserAccessKey)
+		}
+	case AuthTypeSTSAssumeRole:
+		if creds.roleARN == "" {
+			return fmt.Errorf("'awsAuth.awsRoleARN' is required when authenticationType is %q", AuthTypeSTSAssumeRole)
+		}
+		if creds.accessKeyID != "" && creds.secretAccessKey == "" {
+			return fmt.Errorf("'awsAuth.awsSecretAccessKey' is required when 'awsAuth.awsAccessKeyID' is set")
+		}
+		if creds.secretAccessKey != "" && creds.accessKeyID == "" {
+			return fmt.Errorf("'awsAuth.awsAccessKeyID' is required when 'awsAuth.awsSecretAccessKey' is set")
+		}
+	case AuthTypeIRSA:
+		// awsRoleARN is intentionally not required: on EKS the Pod Identity
+		// Webhook injects AWS_ROLE_ARN once the ServiceAccount carries the
+		// "eks.amazonaws.com/role-arn" annotation, so the param is commonly
+		// left unset. buildWebIdentityCredentialsProvider falls back to that
+		// variable and fails there if neither source supplies a value.
+		if creds.roleExternalID != "" {
+			return fmt.Errorf("'awsAuth.awsRoleExternalID' is not supported when authenticationType is %q, because AssumeRoleWithWebIdentity does not accept an external ID", AuthTypeIRSA)
+		}
+	case AuthTypeDefaultCredentialChain:
+		// No credential fields apply: resolution is delegated entirely to the
+		// AWS SDK's default provider chain.
+	case AuthTypeSystem:
+		// Handled before this point: credential fields are rejected outright and
+		// the gateway-wide configuration supplies the identity.
+	}
 	return nil
 }
 
-// loadAWSConfig creates AWS configuration with custom credentials and role assumption
-func (p *AWSBedrockGuardrailPolicy) loadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
-	// Use AWS credentials from policy instance (params)
-	accessKeyID := p.awsAccessKeyID
-	secretAccessKey := p.awsSecretAccessKey
-	sessionToken := p.awsSessionToken
-	roleARN := p.awsRoleARN
-	roleRegion := p.awsRoleRegion
-	roleExternalID := p.awsRoleExternalID
-
-	// Check if role-based authentication should be used
-	if roleARN != "" && roleRegion != "" {
-		return p.loadAWSConfigWithAssumeRole(ctx, accessKeyID, secretAccessKey, sessionToken, roleARN, roleRegion, roleExternalID, region)
-	} else if accessKeyID != "" && secretAccessKey != "" {
-		return p.loadAWSConfigWithStaticCredentials(ctx, accessKeyID, secretAccessKey, sessionToken, region)
-	} else {
-		// Use default credential chain
-		return config.LoadDefaultConfig(ctx, config.WithRegion(region))
-	}
-}
-
-// loadAWSConfigWithStaticCredentials creates AWS config with static credentials
-func (p *AWSBedrockGuardrailPolicy) loadAWSConfigWithStaticCredentials(ctx context.Context, accessKeyID, secretAccessKey, sessionToken, region string) (aws.Config, error) {
-	var credsProvider aws.CredentialsProvider
-	if sessionToken != "" {
-		credsProvider = credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)
-	} else {
-		credsProvider = credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")
+// resolveSystemCredentialSet resolves the identity from the system-level
+// configuration. Reached when authenticationType is "system" and when the
+// user level supplies no credential block at all, which is equivalent.
+//
+// Which provider those fields imply is decided in buildSystemCredentialsProvider
+// rather than here, so the shape is worked out in exactly one place.
+func resolveSystemCredentialSet(params map[string]interface{}, region, defaultSessionName string) (string, credentialFields, error) {
+	// Validated here rather than in GetPolicy so that both routes into this
+	// path - an omitted awsAuth and an explicit authenticationType "system" -
+	// enforce exactly the same rules. They are meant to be equivalent, and
+	// validating in only one of them made the same gateway configuration
+	// deploy or fail depending on which spelling the attachment used.
+	if err := validateAWSConfigParams(params); err != nil {
+		return "", credentialFields{}, err
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(credsProvider),
-	)
+	creds, err := readSystemCredentialFields(params, region, defaultSessionName)
 	if err != nil {
-		return aws.Config{}, fmt.Errorf("failed to load AWS config with static credentials: %w", err)
+		return "", credentialFields{}, err
 	}
-
-	return cfg, nil
+	return AuthTypeSystem, creds, nil
 }
 
-// loadAWSConfigWithAssumeRole creates AWS config with role assumption
-func (p *AWSBedrockGuardrailPolicy) loadAWSConfigWithAssumeRole(ctx context.Context, accessKeyID, secretAccessKey, sessionToken, roleARN, roleRegion, roleExternalID, region string) (aws.Config, error) {
-	// Create base config for role assumption
-	var baseCfg aws.Config
-	var err error
+// validateCredentialFormats checks the field formats that both levels share.
+// Applied to system-level values as well as user-level ones, so a malformed
+// role ARN or region is rejected at deploy time wherever it was written rather
+// than failing against STS on live traffic.
+func validateCredentialFormats(creds credentialFields) error {
+	if creds.roleARN != "" && !roleARNPattern.MatchString(creds.roleARN) {
+		return fmt.Errorf("'awsRoleARN' is not a valid IAM role ARN: %q", creds.roleARN)
+	}
+	if creds.roleRegion != "" && !awsRegionPattern.MatchString(creds.roleRegion) {
+		return fmt.Errorf("'awsRoleRegion' is not a valid AWS region: %q", creds.roleRegion)
+	}
+	if creds.roleSessionName != "" && !roleSessionNamePattern.MatchString(creds.roleSessionName) {
+		return fmt.Errorf("'awsRoleSessionName' must match [\\w+=,.@-]{2,64}: %q", creds.roleSessionName)
+	}
+	return nil
+}
 
-	if accessKeyID != "" && secretAccessKey != "" {
-		var baseCredsProvider aws.CredentialsProvider
-		if sessionToken != "" {
-			baseCredsProvider = credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)
-		} else {
-			baseCredsProvider = credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")
+// rejectCredentialFieldsForSystem enforces that the system-level identity is not
+// paired with user-level credential fields. Accepting them silently would
+// leave an attachment that looks like it configures an identity while the
+// gateway-wide one is actually in use - the same class of invisible
+// misconfiguration the explicit authenticationType exists to remove.
+func rejectCredentialFieldsForSystem(awsAuth map[string]interface{}, because string) error {
+	for _, key := range []string{
+		"awsRoleARN", "awsRoleRegion", "awsRoleExternalID", "awsRoleSessionName",
+		"awsAccessKeyID", "awsSecretAccessKey", "awsSessionToken",
+	} {
+		if v, ok := awsAuth[key]; ok && v != nil && v != "" {
+			return fmt.Errorf("'awsAuth.%s' cannot be set when %s: the gateway-wide credential configuration supplies the identity. Set authenticationType to the mode this field belongs to", key, because)
 		}
+	}
+	return nil
+}
 
-		baseCfg, err = config.LoadDefaultConfig(ctx,
-			config.WithRegion(roleRegion),
-			config.WithCredentialsProvider(baseCredsProvider),
-		)
-	} else {
-		baseCfg, err = config.LoadDefaultConfig(ctx, config.WithRegion(roleRegion))
+// applyCredentialDefaults fills in the fields that have a derived default.
+//
+// roleRegion defaults to the guardrail region so that a user-level awsAuth need
+// not repeat it. Note this does not make the system level lenient: an incomplete
+// system-level role (ARN with no region) is still rejected by
+// validateAWSConfigParams before this runs, because there an operator writes
+// both keys in the same file and a missing one is a typo rather than an
+// omission the policy should guess at.
+func applyCredentialDefaults(creds *credentialFields, region, defaultSessionName string) {
+	if creds.roleRegion == "" {
+		creds.roleRegion = region
+	}
+	if creds.roleSessionName == "" {
+		creds.roleSessionName = defaultSessionName
+	}
+}
+
+// roleSessionNameDisallowed matches every character STS rejects in a role
+// session name, which permits only [\w+=,.@-].
+var roleSessionNameDisallowed = regexp.MustCompile(`[^\w+=,.@-]`)
+
+// deriveRoleSessionName builds the default STS session name for this policy
+// attachment from the API it is attached to.
+//
+// The session name is what identifies the caller in the *target account's*
+// CloudTrail. When a guardrail lives in a tenant's own AWS account, a constant
+// name would render every gateway action indistinguishable to the tenant
+// auditing their own logs, so the API name and version are used instead.
+// Falls back to the constant when no metadata is available.
+func deriveRoleSessionName(metadata policy.PolicyMetadata) string {
+	parts := make([]string, 0, 3)
+	if metadata.APIName != "" {
+		parts = append(parts, metadata.APIName)
+	}
+	if metadata.APIVersion != "" {
+		parts = append(parts, metadata.APIVersion)
+	}
+	if len(parts) == 0 {
+		return defaultRoleSessionName
 	}
 
+	name := roleSessionNameDisallowed.ReplaceAllString("wso2-gw-"+strings.Join(parts, "-"), "-")
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	name = strings.TrimRight(name, "-")
+	if len(name) < 2 {
+		return defaultRoleSessionName
+	}
+	return name
+}
+
+// checkAllowlist verifies an effective value against an operator-configured
+// allowlist. An empty or absent allowlist places no restriction.
+//
+// The check deliberately applies to the effective value rather than only to
+// attachment-supplied ones: the merge leaves no record of which level a value
+// came from, and an operator whose own gateway-wide default falls outside their
+// own allowlist has a misconfiguration worth surfacing at deploy time.
+//
+// When allowPrefix is set, an allowlist entry ending in "*" matches any value
+// with that prefix.
+func checkAllowlist(params map[string]interface{}, allowlistKey, valueName, value string, allowPrefix bool) error {
+	allowed, err := stringSliceParam(params, allowlistKey)
 	if err != nil {
-		return aws.Config{}, fmt.Errorf("failed to load base AWS config for role assumption: %w", err)
+		return err
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	for _, entry := range allowed {
+		if entry == value {
+			return nil
+		}
+		if allowPrefix && strings.HasSuffix(entry, "*") && strings.HasPrefix(value, strings.TrimSuffix(entry, "*")) {
+			return nil
+		}
+	}
+	return fmt.Errorf("'%s' value %q is not permitted by the gateway's %s configuration", valueName, value, allowlistKey)
+}
+
+// stringSliceParam reads an optional array-of-strings parameter.
+func stringSliceParam(params map[string]interface{}, key string) ([]string, error) {
+	val, ok := params[key]
+	if !ok || val == nil {
+		return nil, nil
+	}
+	switch typed := val.(type) {
+	case []string:
+		return typed, nil
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			str, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("'%s' must be an array of strings", key)
+			}
+			out = append(out, str)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("'%s' must be an array of strings", key)
+	}
+}
+
+// validateAWSConfigParams validates AWS configuration parameters (from params)
+// validateAWSConfigParams type-checks the system-level credential parameters.
+//
+// An empty string means "not configured", not "misconfigured": every
+// awsbedrock_* key ships in config.toml with an empty default, and those empty
+// values reach the policy verbatim rather than being dropped. Rejecting them
+// would make the documented default configuration unusable.
+//
+// The region requirement lives in resolveGuardrailIdentityParam, which knows
+// whether the user level supplied one.
+func validateAWSConfigParams(params map[string]interface{}) error {
+	for _, key := range []string{
+		"awsAccessKeyID", "awsSecretAccessKey", "awsSessionToken",
+		"awsRoleARN", "awsRoleRegion", "awsRoleExternalID",
+	} {
+		if raw, ok := params[key]; ok && raw != nil {
+			if _, ok := raw.(string); !ok {
+				return fmt.Errorf("'%s' must be a string", key)
+			}
+		}
 	}
 
-	// Create STS client for role assumption
+	// A role ARN still needs a region to assume it in, but only when one was
+	// actually supplied.
+	roleARN, err := stringParam(params, "awsRoleARN")
+	if err != nil {
+		return err
+	}
+	if roleARN != "" {
+		roleRegion, err := stringParam(params, "awsRoleRegion")
+		if err != nil {
+			return err
+		}
+		if roleRegion == "" {
+			return fmt.Errorf("'awsRoleRegion' is required when 'awsRoleARN' is specified")
+		}
+	}
+	return nil
+}
+
+// buildCredentialsProvider constructs the AWS credentials provider once, at
+// policy-instance creation time, from the resolved authentication mode.
+func buildCredentialsProvider(ctx context.Context, authType string, creds credentialFields) (aws.CredentialsProvider, error) {
+	slog.Debug("AWSBedrockGuardrail: building credentials provider", "authenticationType", authType)
+
+	switch authType {
+	case AuthTypeSystem:
+		// The system-level fields were resolved into creds already; pick the
+		// provider they imply, exactly as pre-v1.2.0 behaviour did.
+		return buildSystemCredentialsProvider(ctx, creds)
+	case AuthTypeIAMUserAccessKey:
+		return credentials.NewStaticCredentialsProvider(creds.accessKeyID, creds.secretAccessKey, creds.sessionToken), nil
+	case AuthTypeSTSAssumeRole:
+		return buildAssumeRoleCredentialsProvider(ctx, creds)
+	case AuthTypeIRSA:
+		return buildWebIdentityCredentialsProvider(creds)
+	case AuthTypeDefaultCredentialChain:
+		// Resolution is delegated to the SDK's own chain when the config is
+		// loaded, so there is no provider to construct here.
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported authenticationType %q", authType)
+	}
+}
+
+// buildSystemCredentialsProvider constructs the provider implied by the
+// system-level credential fields, preserving the pre-v1.2.0 inference: a role
+// ARN with its region assumes that role, a key/secret pair signs directly, and
+// anything else defers to the AWS SDK's default provider chain.
+func buildSystemCredentialsProvider(ctx context.Context, creds credentialFields) (aws.CredentialsProvider, error) {
+	switch {
+	case creds.roleARN != "" && creds.roleRegion != "":
+		return buildAssumeRoleCredentialsProvider(ctx, creds)
+	case creds.accessKeyID != "" && creds.secretAccessKey != "":
+		return credentials.NewStaticCredentialsProvider(creds.accessKeyID, creds.secretAccessKey, creds.sessionToken), nil
+	default:
+		return nil, nil
+	}
+}
+
+// buildAssumeRoleCredentialsProvider builds a provider that calls AWS STS
+// AssumeRole and caches the resulting temporary credentials until they are
+// close to expiry, refreshing automatically thereafter.
+func buildAssumeRoleCredentialsProvider(ctx context.Context, creds credentialFields) (aws.CredentialsProvider, error) {
+	slog.Debug("AWSBedrockGuardrail: building STS AssumeRole credentials provider",
+		"roleARN", creds.roleARN, "roleSessionName", creds.roleSessionName, "roleRegion", creds.roleRegion)
+
+	baseCfgOpts := []func(*config.LoadOptions) error{config.WithRegion(creds.roleRegion)}
+	if creds.accessKeyID != "" && creds.secretAccessKey != "" {
+		baseCfgOpts = append(baseCfgOpts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(creds.accessKeyID, creds.secretAccessKey, creds.sessionToken)))
+	}
+	// else: the default AWS SDK credential chain supplies the base credentials
+	// used to call sts:AssumeRole.
+
+	baseCfg, err := config.LoadDefaultConfig(ctx, baseCfgOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load base AWS config for role assumption: %w", err)
+	}
+
 	stsClient := sts.NewFromConfig(baseCfg)
-
-	// Create assume role credentials provider
-	assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, roleARN, func(o *stscreds.AssumeRoleOptions) {
-		if roleExternalID != "" {
-			o.ExternalID = aws.String(roleExternalID)
+	assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, creds.roleARN, func(o *stscreds.AssumeRoleOptions) {
+		if creds.roleExternalID != "" {
+			o.ExternalID = aws.String(creds.roleExternalID)
 		}
-		o.RoleSessionName = "bedrock-guardrail-session"
+		o.RoleSessionName = creds.roleSessionName
 	})
 
-	// Load final config with assumed role credentials for the target region
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(assumeRoleProvider),
-	)
-	if err != nil {
-		return aws.Config{}, fmt.Errorf("failed to load AWS config with assume role: %w", err)
+	return aws.NewCredentialsCache(assumeRoleProvider), nil
+}
+
+// buildWebIdentityCredentialsProvider builds a provider that calls AWS STS
+// AssumeRoleWithWebIdentity using a Kubernetes projected service account token
+// - the mechanism EKS calls IAM Roles for Service Accounts (IRSA) - and caches
+// the resulting temporary credentials until they are close to expiry.
+//
+// This mode needs no credential material in the API definition at all, which
+// is what allows a policy attachment to use its own AWS identity without
+// storing a secret alongside the API configuration.
+//
+// The awsRoleARN param takes precedence when set; if empty, this falls back to
+// the AWS_ROLE_ARN environment variable that the EKS Pod Identity Webhook
+// injects for a ServiceAccount annotated with "eks.amazonaws.com/role-arn".
+// The token file path is never taken from a policy param - it is always read
+// from AWS_WEB_IDENTITY_TOKEN_FILE, injected by the same webhook. If either
+// variable is missing, IRSA is not available in this environment and this
+// returns an error rather than silently falling back to another credential
+// source.
+func buildWebIdentityCredentialsProvider(creds credentialFields) (aws.CredentialsProvider, error) {
+	roleARN := creds.roleARN
+	if roleARN == "" {
+		roleARN = strings.TrimSpace(os.Getenv(envRoleARN))
+	}
+	if roleARN == "" {
+		return nil, fmt.Errorf("'awsAuth.awsRoleARN' is required when authenticationType is %q and the %s environment variable is not set", AuthTypeIRSA, envRoleARN)
 	}
 
+	tokenFile := strings.TrimSpace(os.Getenv(envWebIdentityTokenFile))
+	if tokenFile == "" {
+		return nil, fmt.Errorf("authenticationType %q requires the %s environment variable, which is normally injected by the EKS Pod Identity Webhook", AuthTypeIRSA, envWebIdentityTokenFile)
+	}
+
+	slog.Debug("AWSBedrockGuardrail: building STS AssumeRoleWithWebIdentity (IRSA) credentials provider",
+		"roleARN", roleARN, "roleSessionName", creds.roleSessionName, "webIdentityTokenFile", tokenFile)
+
+	stsClient := sts.NewFromConfig(aws.Config{Region: creds.roleRegion})
+	webIdentityProvider := stscreds.NewWebIdentityRoleProvider(stsClient, roleARN, stscreds.IdentityTokenFile(tokenFile), func(o *stscreds.WebIdentityRoleOptions) {
+		o.RoleSessionName = creds.roleSessionName
+	})
+
+	return aws.NewCredentialsCache(webIdentityProvider), nil
+}
+
+// loadAWSConfig builds the AWS configuration used for ApplyGuardrail calls,
+// reusing the credentials provider constructed at policy-instance creation
+// time. Role assumption therefore happens on first use and on refresh, not on
+// every request.
+func (p *AWSBedrockGuardrailPolicy) loadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if p.credentialsProvider != nil {
+		opts = append(opts, config.WithCredentialsProvider(p.credentialsProvider))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+	}
 	return cfg, nil
 }
 
@@ -750,7 +1183,14 @@ func (p *AWSBedrockGuardrailPolicy) buildAssessmentObject(reason string, validat
 
 	if showAssessment {
 		if validationError != nil {
-			assessment["assessments"] = []string{validationError.Error()}
+			// The underlying error text is deliberately withheld from the
+			// client and logged server-side instead. AWS distinguishes
+			// "no such guardrail" (ResourceNotFoundException) from "exists but
+			// you may not call it" (AccessDeniedException), so echoing the raw
+			// message would let a caller enumerate the guardrails and roles
+			// configured in the account. showAssessment widens the guardrail
+			// assessment detail, not AWS SDK diagnostics.
+			assessment["assessments"] = []string{reason}
 		} else if bedrockOutput, ok := output.(*bedrockruntime.ApplyGuardrailOutput); ok && bedrockOutput != nil {
 			if len(bedrockOutput.Assessments) > 0 {
 				firstAssessment := p.convertBedrockAssessmentToMap(bedrockOutput.Assessments[0])

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -326,17 +326,9 @@ func getStringParam(params map[string]interface{}, key string) string {
 // needs no fallback logic of its own.
 //
 // legacyKey, when non-empty, names the deprecated v1.1.0 spelling of the same
-// setting (localGuardrailID/localGuardrailVersion), kept purely for backward
-// compatibility. The canonical key wins when both are present; the legacy key is
-// consulted only as a fallback, so attachments authored against v1.1.0 keep
-// working untouched while an author adding the canonical name sees it take
-// effect immediately.
-//
-// Note the one behavioural consequence: when the system level supplies a
-// non-empty canonical value, an attachment that sets only the legacy key now
-// resolves to the system-level value rather than its own. The merge erases which
-// level a value came from, so this case cannot be detected and rejected - the
-// debug line below is what makes it diagnosable.
+// setting (localGuardrailID/localGuardrailVersion), kept for backward
+// compatibility. **The deprecated key wins when both are present**, which is the
+// order v1.1.0 used.
 func resolveGuardrailIdentityParam(params map[string]interface{}, legacyKey, canonicalKey string) (string, error) {
 	canonical, err := stringParam(params, canonicalKey)
 	if err != nil {
@@ -351,19 +343,17 @@ func resolveGuardrailIdentityParam(params map[string]interface{}, legacyKey, can
 		}
 	}
 
-	if canonical != "" {
-		if legacy != "" && legacy != canonical {
-			slog.Debug("AWSBedrockGuardrail: deprecated parameter ignored because the current one is set",
+	if legacy != "" {
+		if canonical != "" && canonical != legacy {
+			slog.Debug("AWSBedrockGuardrail: deprecated parameter takes precedence; remove it to use the current one",
 				"deprecatedParam", legacyKey, "deprecatedValue", legacy,
 				"param", canonicalKey, "value", canonical)
 		}
-		return canonical, nil
+		return legacy, nil
 	}
 
-	if legacy != "" {
-		slog.Debug("AWSBedrockGuardrail: using deprecated parameter; prefer the current one",
-			"deprecatedParam", legacyKey, "param", canonicalKey)
-		return legacy, nil
+	if canonical != "" {
+		return canonical, nil
 	}
 
 	if legacyKey != "" {
@@ -418,16 +408,10 @@ func resolveCredentialSet(params map[string]interface{}, region, defaultSessionN
 		return "", credentialFields{}, fmt.Errorf("awsAuth: %w", err)
 	}
 	if authType == "" {
-		// The schema defaults authenticationType to "system", so this branch is
-		// normally only reached when the policy is constructed without going
-		// through schema validation. It is kept as a backstop and behaves the
-		// same way: credential fields without a mode are rejected rather than
-		// defaulted, because defaulting would silently ignore them and leave an
-		// attachment that looks like it configures an identity while the
-		// gateway-wide one is in use.
-		if err := rejectCredentialFieldsForSystem(awsAuth, "no authenticationType is set"); err != nil {
-			return "", credentialFields{}, err
-		}
+		// The schema defaults authenticationType to "system"; this branch covers
+		// construction that bypasses schema validation and behaves the same way.
+		// Any credential fields present are ignored rather than rejected, which
+		// is how the policy treated fields a mode does not read before v1.2.0.
 		return resolveSystemCredentialSet(params, region, defaultSessionName)
 	}
 	switch authType {
@@ -441,9 +425,8 @@ func resolveCredentialSet(params map[string]interface{}, region, defaultSessionN
 	// mode is self-contained, so a failure in it is never masked by falling back
 	// to the gateway identity.
 	if authType == AuthTypeSystem {
-		if err := rejectCredentialFieldsForSystem(awsAuth, fmt.Sprintf("authenticationType is %q (the default when it is not set)", AuthTypeSystem)); err != nil {
-			return "", credentialFields{}, err
-		}
+		// Credential fields alongside "system" are ignored: the gateway-wide
+		// configuration supplies the identity.
 		return resolveSystemCredentialSet(params, region, defaultSessionName)
 	}
 
@@ -468,11 +451,6 @@ func resolveCredentialSet(params map[string]interface{}, region, defaultSessionN
 		return "", credentialFields{}, err
 	}
 
-	// Resolve the IRSA environment fallback here rather than leaving it to
-	// buildWebIdentityCredentialsProvider, so creds.roleARN always carries the
-	// role that will actually be assumed. Without this the allowlist check sees
-	// an empty ARN and lets the environment-supplied role through unexamined,
-	// while the identical role written out explicitly is checked.
 	if authType == AuthTypeIRSA && creds.roleARN == "" {
 		creds.roleARN = strings.TrimSpace(os.Getenv(envRoleARN))
 	}
@@ -552,18 +530,14 @@ func validateCredentialFields(authType string, creds credentialFields) error {
 		// "eks.amazonaws.com/role-arn" annotation, so the param is commonly
 		// left unset. buildWebIdentityCredentialsProvider falls back to that
 		// variable and fails there if neither source supplies a value.
-		if creds.roleExternalID != "" {
-			return fmt.Errorf("'awsAuth.awsRoleExternalID' is not supported when authenticationType is %q, because AssumeRoleWithWebIdentity does not accept an external ID", AuthTypeIRSA)
-		}
-		if err := rejectStaticCredentials(creds, AuthTypeIRSA); err != nil {
-			return err
-		}
+		//
+		// awsRoleExternalID is ignored here rather than rejected:
+		// AssumeRoleWithWebIdentity has no external-ID parameter, so the value
+		// simply goes unused, consistent with every other field a mode does not
+		// read.
 	case AuthTypeDefaultCredentialChain:
 		// Resolution is delegated entirely to the AWS SDK's default provider
 		// chain, so any key configured here would be parsed and then ignored.
-		if err := rejectStaticCredentials(creds, AuthTypeDefaultCredentialChain); err != nil {
-			return err
-		}
 	case AuthTypeSystem:
 		// Handled before this point: credential fields are rejected outright and
 		// the gateway-wide configuration supplies the identity.
@@ -574,15 +548,7 @@ func validateCredentialFields(authType string, creds credentialFields) error {
 // resolveSystemCredentialSet resolves the identity from the system-level
 // configuration. Reached when authenticationType is "system" and when the
 // user level supplies no credential block at all, which is equivalent.
-//
-// Which provider those fields imply is decided in buildSystemCredentialsProvider
-// rather than here, so the shape is worked out in exactly one place.
 func resolveSystemCredentialSet(params map[string]interface{}, region, defaultSessionName string) (string, credentialFields, error) {
-	// Validated here rather than in GetPolicy so that both routes into this
-	// path - an omitted awsAuth and an explicit authenticationType "system" -
-	// enforce exactly the same rules. They are meant to be equivalent, and
-	// validating in only one of them made the same gateway configuration
-	// deploy or fail depending on which spelling the attachment used.
 	if err := validateAWSConfigParams(params); err != nil {
 		return "", credentialFields{}, err
 	}
@@ -611,49 +577,7 @@ func validateCredentialFormats(creds credentialFields) error {
 	return nil
 }
 
-// rejectStaticCredentials refuses a key/secret pair on the modes that never sign
-// with one. Accepting them silently would leave an attachment that looks like it
-// configures an identity while a different one is used - the same class of
-// invisible misconfiguration rejectCredentialFieldsForSystem removes for
-// "system".
-func rejectStaticCredentials(creds credentialFields, authType string) error {
-	for name, value := range map[string]string{
-		"awsAccessKeyID":     creds.accessKeyID,
-		"awsSecretAccessKey": creds.secretAccessKey,
-		"awsSessionToken":    creds.sessionToken,
-	} {
-		if value != "" {
-			return fmt.Errorf("'awsAuth.%s' cannot be set when authenticationType is %q: that mode never signs with a static key", name, authType)
-		}
-	}
-	return nil
-}
-
-// rejectCredentialFieldsForSystem enforces that the system-level identity is not
-// paired with user-level credential fields. Accepting them silently would
-// leave an attachment that looks like it configures an identity while the
-// gateway-wide one is actually in use - the same class of invisible
-// misconfiguration the explicit authenticationType exists to remove.
-func rejectCredentialFieldsForSystem(awsAuth map[string]interface{}, because string) error {
-	for _, key := range []string{
-		"awsRoleARN", "awsRoleRegion", "awsRoleExternalID", "awsRoleSessionName",
-		"awsAccessKeyID", "awsSecretAccessKey", "awsSessionToken",
-	} {
-		if v, ok := awsAuth[key]; ok && v != nil && v != "" {
-			return fmt.Errorf("'awsAuth.%s' cannot be set when %s: the gateway-wide credential configuration supplies the identity. Set authenticationType to the mode this field belongs to", key, because)
-		}
-	}
-	return nil
-}
-
 // applyCredentialDefaults fills in the fields that have a derived default.
-//
-// roleRegion defaults to the guardrail region so that a user-level awsAuth need
-// not repeat it. Note this does not make the system level lenient: an incomplete
-// system-level role (ARN with no region) is still rejected by
-// validateAWSConfigParams before this runs, because there an operator writes
-// both keys in the same file and a missing one is a typo rather than an
-// omission the policy should guess at.
 func applyCredentialDefaults(creds *credentialFields, region, defaultSessionName string) {
 	if creds.roleRegion == "" {
 		creds.roleRegion = region
@@ -669,12 +593,6 @@ var roleSessionNameDisallowed = regexp.MustCompile(`[^\w+=,.@-]`)
 
 // deriveRoleSessionName builds the default STS session name for this policy
 // attachment from the API it is attached to.
-//
-// The session name is what identifies the caller in the *target account's*
-// CloudTrail. When a guardrail lives in a tenant's own AWS account, a constant
-// name would render every gateway action indistinguishable to the tenant
-// auditing their own logs, so the API name and version are used instead.
-// Falls back to the constant when no metadata is available.
 func deriveRoleSessionName(metadata policy.PolicyMetadata) string {
 	parts := make([]string, 0, 3)
 	if metadata.APIName != "" {
@@ -700,14 +618,6 @@ func deriveRoleSessionName(metadata policy.PolicyMetadata) string {
 
 // checkAllowlist verifies an effective value against an operator-configured
 // allowlist. An empty or absent allowlist places no restriction.
-//
-// The check deliberately applies to the effective value rather than only to
-// attachment-supplied ones: the merge leaves no record of which level a value
-// came from, and an operator whose own gateway-wide default falls outside their
-// own allowlist has a misconfiguration worth surfacing at deploy time.
-//
-// When allowPrefix is set, an allowlist entry ending in "*" matches any value
-// with that prefix.
 func checkAllowlist(params map[string]interface{}, allowlistKey, valueName, value string, allowPrefix bool) error {
 	allowed, err := stringSliceParam(params, allowlistKey)
 	if err != nil {
@@ -717,10 +627,6 @@ func checkAllowlist(params map[string]interface{}, allowlistKey, valueName, valu
 		return nil
 	}
 	for _, entry := range allowed {
-		// A "*" that is not a wildcard in this position is a literal, so the
-		// entry silently matches nothing and refuses every deployment with a
-		// message about the value rather than the configuration. Fail on the
-		// configuration instead.
 		if i := strings.Index(entry, "*"); i != -1 {
 			switch {
 			case !allowPrefix:
@@ -767,14 +673,6 @@ func stringSliceParam(params map[string]interface{}, key string) ([]string, erro
 
 // validateAWSConfigParams validates AWS configuration parameters (from params)
 // validateAWSConfigParams type-checks the system-level credential parameters.
-//
-// An empty string means "not configured", not "misconfigured": every
-// awsbedrock_* key ships in config.toml with an empty default, and those empty
-// values reach the policy verbatim rather than being dropped. Rejecting them
-// would make the documented default configuration unusable.
-//
-// The region requirement lives in resolveGuardrailIdentityParam, which knows
-// whether the user level supplied one.
 func validateAWSConfigParams(params map[string]interface{}) error {
 	for _, key := range []string{
 		"awsAccessKeyID", "awsSecretAccessKey", "awsSessionToken",
@@ -880,19 +778,6 @@ func buildAssumeRoleCredentialsProvider(ctx context.Context, creds credentialFie
 // AssumeRoleWithWebIdentity using a Kubernetes projected service account token
 // - the mechanism EKS calls IAM Roles for Service Accounts (IRSA) - and caches
 // the resulting temporary credentials until they are close to expiry.
-//
-// This mode needs no credential material in the API definition at all, which
-// is what allows a policy attachment to use its own AWS identity without
-// storing a secret alongside the API configuration.
-//
-// The awsRoleARN param takes precedence when set; if empty, this falls back to
-// the AWS_ROLE_ARN environment variable that the EKS Pod Identity Webhook
-// injects for a ServiceAccount annotated with "eks.amazonaws.com/role-arn".
-// The token file path is never taken from a policy param - it is always read
-// from AWS_WEB_IDENTITY_TOKEN_FILE, injected by the same webhook. If either
-// variable is missing, IRSA is not available in this environment and this
-// returns an error rather than silently falling back to another credential
-// source.
 func buildWebIdentityCredentialsProvider(creds credentialFields) (aws.CredentialsProvider, error) {
 	roleARN := creds.roleARN
 	if roleARN == "" {
@@ -1226,13 +1111,6 @@ func (p *AWSBedrockGuardrailPolicy) buildAssessmentObject(reason string, validat
 
 	if showAssessment {
 		if validationError != nil {
-			// The underlying error text is deliberately withheld from the
-			// client and logged server-side instead. AWS distinguishes
-			// "no such guardrail" (ResourceNotFoundException) from "exists but
-			// you may not call it" (AccessDeniedException), so echoing the raw
-			// message would let a caller enumerate the guardrails and roles
-			// configured in the account. showAssessment widens the guardrail
-			// assessment detail, not AWS SDK diagnostics.
 			assessment["assessments"] = []string{reason}
 		} else if bedrockOutput, ok := output.(*bedrockruntime.ApplyGuardrailOutput); ok && bedrockOutput != nil {
 			if len(bedrockOutput.Assessments) > 0 {

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail.go
@@ -159,7 +159,12 @@ func GetPolicy(
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
 
-	if err := checkAllowlist(params, "allowedRegions", "region", region, false); err != nil {
+	// Regions and role ARNs accept a trailing "*" as a prefix: "us-east-*" and
+	// one ARN prefix per account are both natural to write. Guardrail IDs are
+	// opaque strings where a prefix means nothing, and authenticationType is a
+	// short enum where "s*" would silently widen to both "system" and
+	// "sts-assume-role" - so those two stay exact.
+	if err := checkAllowlist(params, "allowedRegions", "region", region, true); err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
 	if err := checkAllowlist(params, "allowedGuardrailIDs", "guardrailID", guardrailID, false); err != nil {
@@ -550,9 +555,15 @@ func validateCredentialFields(authType string, creds credentialFields) error {
 		if creds.roleExternalID != "" {
 			return fmt.Errorf("'awsAuth.awsRoleExternalID' is not supported when authenticationType is %q, because AssumeRoleWithWebIdentity does not accept an external ID", AuthTypeIRSA)
 		}
+		if err := rejectStaticCredentials(creds, AuthTypeIRSA); err != nil {
+			return err
+		}
 	case AuthTypeDefaultCredentialChain:
-		// No credential fields apply: resolution is delegated entirely to the
-		// AWS SDK's default provider chain.
+		// Resolution is delegated entirely to the AWS SDK's default provider
+		// chain, so any key configured here would be parsed and then ignored.
+		if err := rejectStaticCredentials(creds, AuthTypeDefaultCredentialChain); err != nil {
+			return err
+		}
 	case AuthTypeSystem:
 		// Handled before this point: credential fields are rejected outright and
 		// the gateway-wide configuration supplies the identity.
@@ -596,6 +607,24 @@ func validateCredentialFormats(creds credentialFields) error {
 	}
 	if creds.roleSessionName != "" && !roleSessionNamePattern.MatchString(creds.roleSessionName) {
 		return fmt.Errorf("'awsRoleSessionName' must match [\\w+=,.@-]{2,64}: %q", creds.roleSessionName)
+	}
+	return nil
+}
+
+// rejectStaticCredentials refuses a key/secret pair on the modes that never sign
+// with one. Accepting them silently would leave an attachment that looks like it
+// configures an identity while a different one is used - the same class of
+// invisible misconfiguration rejectCredentialFieldsForSystem removes for
+// "system".
+func rejectStaticCredentials(creds credentialFields, authType string) error {
+	for name, value := range map[string]string{
+		"awsAccessKeyID":     creds.accessKeyID,
+		"awsSecretAccessKey": creds.secretAccessKey,
+		"awsSessionToken":    creds.sessionToken,
+	} {
+		if value != "" {
+			return fmt.Errorf("'awsAuth.%s' cannot be set when authenticationType is %q: that mode never signs with a static key", name, authType)
+		}
 	}
 	return nil
 }
@@ -686,6 +715,20 @@ func checkAllowlist(params map[string]interface{}, allowlistKey, valueName, valu
 	}
 	if len(allowed) == 0 {
 		return nil
+	}
+	for _, entry := range allowed {
+		// A "*" that is not a wildcard in this position is a literal, so the
+		// entry silently matches nothing and refuses every deployment with a
+		// message about the value rather than the configuration. Fail on the
+		// configuration instead.
+		if i := strings.Index(entry, "*"); i != -1 {
+			switch {
+			case !allowPrefix:
+				return fmt.Errorf("'%s' entry %q is invalid: this list does not support wildcards, list each value in full", allowlistKey, entry)
+			case i != len(entry)-1:
+				return fmt.Errorf("'%s' entry %q is invalid: '*' is only supported as the final character, where it matches a prefix. List each value in full, or use a single trailing '*'", allowlistKey, entry)
+			}
+		}
 	}
 	for _, entry := range allowed {
 		if entry == value {

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
 )
 
@@ -97,22 +98,40 @@ func TestResolveIdentity_EmptyAndNonStringRejected(t *testing.T) {
 		"'region' must be a string")
 }
 
-func TestResolveIdentity_CanonicalKeysTakePrecedenceOverDeprecated(t *testing.T) {
-	// guardrailID / guardrailVersion win over the deprecated local* spellings,
-	// so an author migrating an attachment sees the new parameter take effect
-	// immediately rather than being silently shadowed by the old one.
+func TestResolveIdentity_DeprecatedKeysTakePrecedence(t *testing.T) {
+	// The deprecated spelling wins, matching v1.1.0. This is what keeps an
+	// existing attachment pointed at its own guardrail on a gateway that also
+	// sets awsbedrock_guardrail_id: after the merge the canonical key carries
+	// the gateway-wide value whether the author wrote one or not, so preferring
+	// it would silently redirect every v1.1.0 attachment.
 	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
-		"guardrailID":           "gr-current",
+		"guardrailID":           "gr-gateway-wide",
 		"guardrailVersion":      "3",
-		"localGuardrailID":      "gr-deprecated",
+		"localGuardrailID":      "gr-attachment-own",
 		"localGuardrailVersion": "1",
 	}))
 
-	if p.guardrailID != "gr-current" {
-		t.Fatalf("expected guardrailID to win over localGuardrailID, got %q", p.guardrailID)
+	if p.guardrailID != "gr-attachment-own" {
+		t.Fatalf("expected localGuardrailID to win, got %q", p.guardrailID)
 	}
-	if p.guardrailVersion != "3" {
-		t.Fatalf("expected guardrailVersion to win over localGuardrailVersion, got %q", p.guardrailVersion)
+	if p.guardrailVersion != "1" {
+		t.Fatalf("expected localGuardrailVersion to win, got %q", p.guardrailVersion)
+	}
+}
+
+func TestResolveIdentity_V110AttachmentKeepsItsOwnGuardrail(t *testing.T) {
+	// The regression this ordering exists to prevent: a v1.1.0 attachment on a
+	// gateway with a non-empty awsbedrock_guardrail_id must keep using its own
+	// guardrail, not silently switch to the gateway-wide one.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"guardrailID":           "gr-gateway-wide", // as the system level supplies it
+		"guardrailVersion":      "DRAFT",
+		"localGuardrailID":      "gr-tenant-a", // all a v1.1.0 attachment sets
+		"localGuardrailVersion": "1",
+	}))
+
+	if p.guardrailID == "gr-gateway-wide" {
+		t.Fatal("v1.1.0 attachment was silently redirected to the gateway-wide guardrail")
 	}
 }
 
@@ -230,11 +249,6 @@ func TestCredentialSet_ModeValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "credential field with no authenticationType",
-			awsAuth: map[string]interface{}{"awsRoleARN": "arn:aws:iam::444455556666:role/tenant-a"},
-			wantErr: "cannot be set when no authenticationType is set",
-		},
-		{
 			name:    "unknown authenticationType",
 			awsAuth: map[string]interface{}{"authenticationType": "magic"},
 			wantErr: "'awsAuth.authenticationType' must be one of",
@@ -256,15 +270,6 @@ func TestCredentialSet_ModeValidation(t *testing.T) {
 			name:    "assume role without an ARN",
 			awsAuth: map[string]interface{}{"authenticationType": AuthTypeSTSAssumeRole},
 			wantErr: "'awsAuth.awsRoleARN' is required",
-		},
-		{
-			name: "irsa rejects an external ID",
-			awsAuth: map[string]interface{}{
-				"authenticationType": AuthTypeIRSA,
-				"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
-				"awsRoleExternalID":  "tnt-a-7f3c9e21",
-			},
-			wantErr: "does not accept an external ID",
 		},
 	}
 
@@ -828,12 +833,16 @@ func TestAWSAuth_DefaultsToSystemWhenTypeOmitted(t *testing.T) {
 	}
 }
 
-func TestAWSAuth_CredentialFieldsWithoutTypeAreRejected(t *testing.T) {
-	// Defaulting this to system would silently ignore the role ARN, so it is
-	// rejected and the author told to name the mode.
-	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+func TestAWSAuth_CredentialFieldsWithoutTypeAreIgnored(t *testing.T) {
+	// No authenticationType means "system". Credential fields alongside it are
+	// ignored rather than rejected, matching how the policy treated fields a
+	// mode does not read before v1.2.0.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
 		"awsAuth": map[string]interface{}{"awsRoleARN": "arn:aws:iam::444455556666:role/tenant-a"},
-	}), "no authenticationType is set")
+	}))
+	if p.authType != AuthTypeSystem {
+		t.Fatalf("expected %q, got %q", AuthTypeSystem, p.authType)
+	}
 }
 
 func TestAWSAuth_SystemModeUsesGatewayCredentials(t *testing.T) {
@@ -854,18 +863,29 @@ func TestAWSAuth_SystemModeUsesGatewayCredentials(t *testing.T) {
 	}
 }
 
-func TestAWSAuth_SystemModeRejectsCredentialFields(t *testing.T) {
-	// A credential field alongside "system" would be silently ignored, which is
-	// exactly the invisible misconfiguration the explicit mode exists to remove.
-	for _, k := range []string{"awsRoleARN", "awsAccessKeyID", "awsSecretAccessKey", "awsRoleExternalID", "awsRoleSessionName"} {
-		t.Run(k, func(t *testing.T) {
-			expectGetPolicyError(t, paramsWith(map[string]interface{}{
-				"awsAuth": map[string]interface{}{
-					"authenticationType": AuthTypeSystem,
-					k:                    "some-value",
-				},
-			}), fmt.Sprintf("'awsAuth.%s' cannot be set", k))
-		})
+func TestAWSAuth_SystemModeIgnoresCredentialFields(t *testing.T) {
+	// The gateway-wide identity is used; anything in awsAuth is ignored. The
+	// assertion that matters is that the attachment role does not leak into the
+	// resolved set, so the gateway identity really is the one in play.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":    "arn:aws:iam::111122223333:role/gateway-default",
+		"awsRoleRegion": "us-east-1",
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSystem,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/attachment-own",
+			"awsAccessKeyID":     "AKIAEXAMPLE",
+			"awsSecretAccessKey": "shh",
+		},
+	}))
+
+	if p.authType != AuthTypeSystem {
+		t.Fatalf("expected %q, got %q", AuthTypeSystem, p.authType)
+	}
+	if p.creds.roleARN != "arn:aws:iam::111122223333:role/gateway-default" {
+		t.Fatalf("system mode should use the gateway-wide role, got %q", p.creds.roleARN)
+	}
+	if p.creds.accessKeyID != "" {
+		t.Fatalf("attachment key leaked into the system credential set: %q", p.creds.accessKeyID)
 	}
 }
 
@@ -996,22 +1016,28 @@ func TestAllowlist_RejectsWildcardThatIsNotTrailing(t *testing.T) {
 	}))
 }
 
-func TestAWSAuth_ModesThatIgnoreStaticKeysRejectThem(t *testing.T) {
-	// irsa and default-credential-chain never sign with a static key, so
-	// accepting one would leave an attachment that looks configured while a
-	// different identity is used.
+func TestAWSAuth_ModesThatIgnoreStaticKeysAcceptThem(t *testing.T) {
+	// irsa and default-credential-chain never sign with a static key. Supplying
+	// one is accepted and ignored; the provider each mode builds is unaffected.
 	t.Setenv(envWebIdentityTokenFile, t.TempDir()+"/token")
 	t.Setenv(envRoleARN, "arn:aws:iam::367134611783:role/irsa")
 
 	for _, mode := range []string{AuthTypeIRSA, AuthTypeDefaultCredentialChain} {
 		t.Run(mode, func(t *testing.T) {
-			expectGetPolicyError(t, paramsWith(map[string]interface{}{
+			p := mustGetPolicy(t, paramsWith(map[string]interface{}{
 				"awsAuth": map[string]interface{}{
 					"authenticationType": mode,
 					"awsAccessKeyID":     "AKIAEXAMPLE",
 					"awsSecretAccessKey": "shh",
 				},
-			}), "never signs with a static key")
+			}))
+			if p.authType != mode {
+				t.Fatalf("expected %q, got %q", mode, p.authType)
+			}
+			// default-credential-chain defers to the SDK, so it builds none.
+			if mode == AuthTypeDefaultCredentialChain && p.credentialsProvider != nil {
+				t.Fatal("default-credential-chain should not build a provider")
+			}
 		})
 	}
 }
@@ -1050,4 +1076,25 @@ func TestAllowlist_RegionSupportsTrailingWildcard(t *testing.T) {
 		"region":         "us-east-1",
 		"allowedRegions": []interface{}{"us-*-1"},
 	}), "'*' is only supported as the final character")
+}
+
+func TestAWSAuth_StaticKeyModeIgnoresRoleFields(t *testing.T) {
+	// iam-user-access-key signs directly with the key. Role fields are accepted
+	// and ignored; the provider is still a static one.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeIAMUserAccessKey,
+			"awsAccessKeyID":     "AKIAEXAMPLE",
+			"awsSecretAccessKey": "shh",
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/never-assumed",
+			"awsRoleExternalID":  "unused-external-id",
+		},
+	}))
+
+	if p.authType != AuthTypeIAMUserAccessKey {
+		t.Fatalf("expected %q, got %q", AuthTypeIAMUserAccessKey, p.authType)
+	}
+	if _, ok := p.credentialsProvider.(credentials.StaticCredentialsProvider); !ok {
+		t.Fatalf("expected a static credentials provider, got %T", p.credentialsProvider)
+	}
 }

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
@@ -403,7 +403,7 @@ func TestAllowlists_RestrictEffectiveValues(t *testing.T) {
 		{
 			name: "role ARN outside allowedRoleARNs",
 			params: map[string]interface{}{
-				"allowedRoleARNs": []interface{}{"arn:aws:iam::*:role/wso2-gw-guardrail-*"},
+				"allowedRoleARNs": []interface{}{"arn:aws:iam::444455556666:role/wso2-gw-guardrail-*"},
 				"awsAuth": map[string]interface{}{
 					"authenticationType": AuthTypeSTSAssumeRole,
 					"awsRoleARN":         "arn:aws:iam::444455556666:role/some-other-role",
@@ -947,7 +947,7 @@ func TestAllowlist_IRSAEnvironmentRoleIsChecked(t *testing.T) {
 	t.Setenv(envWebIdentityTokenFile, t.TempDir()+"/token")
 	t.Setenv(envRoleARN, envARN)
 
-	restrictive := []interface{}{"arn:aws:iam::*:role/permitted-only-*"}
+	restrictive := []interface{}{"arn:aws:iam::367134611783:role/permitted-only-*"}
 
 	expectGetPolicyError(t, paramsWith(map[string]interface{}{
 		"allowedRoleARNs": restrictive,
@@ -972,4 +972,82 @@ func TestSystemLevel_MalformedValuesAreRejected(t *testing.T) {
 		"awsRoleARN":    "arn:aws:iam::111122223333:role/gw",
 		"awsRoleRegion": "Not A Region",
 	}), "not a valid AWS region")
+}
+
+func TestAllowlist_RejectsWildcardThatIsNotTrailing(t *testing.T) {
+	// "*" is a prefix marker, not a glob. An entry with "*" in the middle
+	// matches no real value, so every deployment would be refused with a
+	// message about the value rather than the configuration. Reject the entry.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedRoleARNs": []interface{}{"arn:aws:iam::*:role/team-*"},
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/team-a",
+		},
+	}), "'*' is only supported as the final character")
+
+	// A trailing wildcard still works.
+	mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"allowedRoleARNs": []interface{}{"arn:aws:iam::444455556666:role/team-*"},
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/team-a",
+		},
+	}))
+}
+
+func TestAWSAuth_ModesThatIgnoreStaticKeysRejectThem(t *testing.T) {
+	// irsa and default-credential-chain never sign with a static key, so
+	// accepting one would leave an attachment that looks configured while a
+	// different identity is used.
+	t.Setenv(envWebIdentityTokenFile, t.TempDir()+"/token")
+	t.Setenv(envRoleARN, "arn:aws:iam::367134611783:role/irsa")
+
+	for _, mode := range []string{AuthTypeIRSA, AuthTypeDefaultCredentialChain} {
+		t.Run(mode, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{
+				"awsAuth": map[string]interface{}{
+					"authenticationType": mode,
+					"awsAccessKeyID":     "AKIAEXAMPLE",
+					"awsSecretAccessKey": "shh",
+				},
+			}), "never signs with a static key")
+		})
+	}
+}
+
+func TestAllowlist_WildcardsRejectedOnNonPrefixLists(t *testing.T) {
+	// Only allowedRoleARNs treats a trailing "*" as a prefix. On the other
+	// lists it is a literal that matches nothing, which would refuse every
+	// deployment while pointing at the value rather than the configuration.
+	for _, tc := range []struct{ list, entry string }{
+		{"allowedGuardrailIDs", "gr-*"},
+		{"allowedAuthTypes", "s*"},
+	} {
+		t.Run(tc.list, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{
+				tc.list: []interface{}{tc.entry},
+			}), "does not support wildcards")
+		})
+	}
+}
+
+func TestAllowlist_RegionSupportsTrailingWildcard(t *testing.T) {
+	// "us-east-*" is a natural way to permit a whole region family.
+	mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"region":         "us-east-1",
+		"allowedRegions": []interface{}{"us-east-*"},
+	}))
+
+	// It is still a prefix, not a glob: a different family is refused.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"region":         "eu-west-1",
+		"allowedRegions": []interface{}{"us-east-*"},
+	}), "is not permitted")
+
+	// And a non-trailing wildcard remains a configuration error.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"region":         "us-east-1",
+		"allowedRegions": []interface{}{"us-*-1"},
+	}), "'*' is only supported as the final character")
 }

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_config_test.go
@@ -1,0 +1,975 @@
+package awsbedrockguardrail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	policy "github.com/wso2/api-platform/sdk/core/policy/v1alpha2"
+)
+
+// phaseParams returns the minimal request-phase configuration every attachment
+// needs, so credential tests can focus on the credential fields.
+func phaseParams() map[string]interface{} {
+	return map[string]interface{}{"jsonPath": "$.messages[-1].content"}
+}
+
+func paramsWith(overrides map[string]interface{}) map[string]interface{} {
+	params := baseParams()
+	params["request"] = phaseParams()
+	for k, v := range overrides {
+		if v == nil {
+			delete(params, k)
+			continue
+		}
+		params[k] = v
+	}
+	return params
+}
+
+func mustGetPolicy(t *testing.T, params map[string]interface{}) *AWSBedrockGuardrailPolicy {
+	t.Helper()
+	p, err := getPolicyForTest(params)
+	if err != nil {
+		t.Fatalf("GetPolicy returned an unexpected error: %v", err)
+	}
+	return p
+}
+
+func getPolicyForTest(params map[string]interface{}) (*AWSBedrockGuardrailPolicy, error) {
+	raw, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		return nil, err
+	}
+	p, ok := raw.(*AWSBedrockGuardrailPolicy)
+	if !ok {
+		return nil, fmt.Errorf("GetPolicy returned %T, want *AWSBedrockGuardrailPolicy", raw)
+	}
+	return p, nil
+}
+
+func expectGetPolicyError(t *testing.T, params map[string]interface{}, wantSubstring string) {
+	t.Helper()
+	_, err := getPolicyForTest(params)
+	if err == nil {
+		t.Fatalf("expected an error containing %q, got none", wantSubstring)
+	}
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Fatalf("expected an error containing %q, got: %v", wantSubstring, err)
+	}
+}
+
+// --- Guardrail identity resolution (design §5.4) ---------------------------
+
+func TestResolveIdentity_MergedValueIsUsed(t *testing.T) {
+	// The engine merges the user-level value over the system-level one before
+	// the policy sees it, so a single key carries the effective value.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"region":           "eu-west-1",
+		"guardrailID":      "gr-eu-strict",
+		"guardrailVersion": "3",
+	}))
+
+	if p.region != "eu-west-1" || p.guardrailID != "gr-eu-strict" || p.guardrailVersion != "3" {
+		t.Fatalf("unexpected identity: region=%q guardrailID=%q guardrailVersion=%q",
+			p.region, p.guardrailID, p.guardrailVersion)
+	}
+}
+
+func TestResolveIdentity_MissingValuesAreRejected(t *testing.T) {
+	for _, key := range []string{"region", "guardrailID", "guardrailVersion"} {
+		t.Run(key, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{key: nil}),
+				fmt.Sprintf("'%s' parameter is required", key))
+		})
+	}
+}
+
+func TestResolveIdentity_EmptyAndNonStringRejected(t *testing.T) {
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{"region": ""}),
+		"'region' parameter is required")
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{"region": 42}),
+		"'region' must be a string")
+}
+
+func TestResolveIdentity_CanonicalKeysTakePrecedenceOverDeprecated(t *testing.T) {
+	// guardrailID / guardrailVersion win over the deprecated local* spellings,
+	// so an author migrating an attachment sees the new parameter take effect
+	// immediately rather than being silently shadowed by the old one.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"guardrailID":           "gr-current",
+		"guardrailVersion":      "3",
+		"localGuardrailID":      "gr-deprecated",
+		"localGuardrailVersion": "1",
+	}))
+
+	if p.guardrailID != "gr-current" {
+		t.Fatalf("expected guardrailID to win over localGuardrailID, got %q", p.guardrailID)
+	}
+	if p.guardrailVersion != "3" {
+		t.Fatalf("expected guardrailVersion to win over localGuardrailVersion, got %q", p.guardrailVersion)
+	}
+}
+
+func TestResolveIdentity_DeprecatedKeysUsedWhenCurrentAbsent(t *testing.T) {
+	// A v1.1.0 attachment on a gateway that supplies no canonical value keeps
+	// resolving to its own guardrail.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"guardrailID":           nil,
+		"guardrailVersion":      nil,
+		"localGuardrailID":      "gr-tenant-a",
+		"localGuardrailVersion": "1",
+	}))
+
+	if p.guardrailID != "gr-tenant-a" || p.guardrailVersion != "1" {
+		t.Fatalf("expected the deprecated params to be used as fallback: id=%q version=%q",
+			p.guardrailID, p.guardrailVersion)
+	}
+}
+
+func TestResolveIdentity_EmptyCanonicalFallsBackToDeprecated(t *testing.T) {
+	// An empty system-level value must not shadow a deprecated user-level value.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"guardrailID":           "",
+		"guardrailVersion":      "",
+		"localGuardrailID":      "gr-tenant-a",
+		"localGuardrailVersion": "1",
+	}))
+
+	if p.guardrailID != "gr-tenant-a" || p.guardrailVersion != "1" {
+		t.Fatalf("empty canonical value shadowed the deprecated one: id=%q version=%q",
+			p.guardrailID, p.guardrailVersion)
+	}
+}
+
+func TestResolveIdentity_CanonicalKeysUsedWhenNoDeprecatedKeys(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(nil))
+	if p.guardrailID != "gr-123" || p.guardrailVersion != "DRAFT" {
+		t.Fatalf("unexpected identity: id=%q version=%q", p.guardrailID, p.guardrailVersion)
+	}
+}
+
+// --- Credential set resolution (design §5.3, §5.4) ------------------------
+
+func TestCredentialSet_AWSAuthIsAtomic(t *testing.T) {
+	// The system-level external ID must not combine with a user-level
+	// role ARN: that pairing is the cross-tenant role hijack the external ID
+	// exists to prevent.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":         "arn:aws:iam::111122223333:role/gateway-default",
+		"awsRoleRegion":      "us-east-1",
+		"awsRoleExternalID":  "gateway-wide-external-id",
+		"awsAccessKeyID":     "AKIAGATEWAY",
+		"awsSecretAccessKey": "gateway-secret",
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+
+	if p.authType != AuthTypeSTSAssumeRole {
+		t.Fatalf("expected %q, got %q", AuthTypeSTSAssumeRole, p.authType)
+	}
+	if p.creds.roleARN != "arn:aws:iam::444455556666:role/tenant-a" {
+		t.Fatalf("expected the attachment role ARN, got %q", p.creds.roleARN)
+	}
+	if p.creds.roleExternalID != "" {
+		t.Fatalf("system-level external ID leaked into a user-level credential set: %q", p.creds.roleExternalID)
+	}
+	if p.creds.accessKeyID != "" || p.creds.secretAccessKey != "" {
+		t.Fatalf("system-level static credentials leaked into a user-level credential set")
+	}
+}
+
+func TestCredentialSet_RoleRegionDefaultsToGuardrailRegion(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"region": "eu-west-1",
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+
+	if p.creds.roleRegion != "eu-west-1" {
+		t.Fatalf("expected role region to default to the guardrail region, got %q", p.creds.roleRegion)
+	}
+}
+
+func TestCredentialSet_SessionNameDefault(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+	if p.creds.roleSessionName != defaultRoleSessionName {
+		t.Fatalf("expected default session name %q, got %q", defaultRoleSessionName, p.creds.roleSessionName)
+	}
+
+	p = mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+			"awsRoleSessionName": "wso2-gw-support-api",
+		},
+	}))
+	if p.creds.roleSessionName != "wso2-gw-support-api" {
+		t.Fatalf("expected the configured session name, got %q", p.creds.roleSessionName)
+	}
+}
+
+func TestCredentialSet_ModeValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		awsAuth map[string]interface{}
+		wantErr string
+	}{
+		{
+			name:    "credential field with no authenticationType",
+			awsAuth: map[string]interface{}{"awsRoleARN": "arn:aws:iam::444455556666:role/tenant-a"},
+			wantErr: "cannot be set when no authenticationType is set",
+		},
+		{
+			name:    "unknown authenticationType",
+			awsAuth: map[string]interface{}{"authenticationType": "magic"},
+			wantErr: "'awsAuth.authenticationType' must be one of",
+		},
+		{
+			name:    "static credentials without a key",
+			awsAuth: map[string]interface{}{"authenticationType": AuthTypeIAMUserAccessKey},
+			wantErr: "'awsAuth.awsAccessKeyID' is required",
+		},
+		{
+			name: "static credentials without a secret",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeIAMUserAccessKey,
+				"awsAccessKeyID":     "AKIAEXAMPLE",
+			},
+			wantErr: "'awsAuth.awsSecretAccessKey' is required",
+		},
+		{
+			name:    "assume role without an ARN",
+			awsAuth: map[string]interface{}{"authenticationType": AuthTypeSTSAssumeRole},
+			wantErr: "'awsAuth.awsRoleARN' is required",
+		},
+		{
+			name: "irsa rejects an external ID",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeIRSA,
+				"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+				"awsRoleExternalID":  "tnt-a-7f3c9e21",
+			},
+			wantErr: "does not accept an external ID",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{"awsAuth": tc.awsAuth}), tc.wantErr)
+		})
+	}
+}
+
+func TestCredentialSet_AWSAuthWrongType(t *testing.T) {
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{"awsAuth": "sts-assume-role"}),
+		"'awsAuth' must be an object")
+}
+
+func TestCredentialSet_DefaultCredentialChainNeedsNothing(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{"authenticationType": AuthTypeDefaultCredentialChain},
+	}))
+
+	if p.authType != AuthTypeDefaultCredentialChain {
+		t.Fatalf("expected %q, got %q", AuthTypeDefaultCredentialChain, p.authType)
+	}
+	if p.credentialsProvider != nil {
+		t.Fatal("default credential chain should defer to the SDK rather than build a provider")
+	}
+}
+
+func TestCredentialSet_IRSARequiresEnvironment(t *testing.T) {
+	// Neither AWS_ROLE_ARN nor AWS_WEB_IDENTITY_TOKEN_FILE is set in tests, so
+	// IRSA must fail loudly at deploy time rather than silently falling back to
+	// another credential source.
+	t.Setenv(envRoleARN, "")
+	t.Setenv(envWebIdentityTokenFile, "")
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{"authenticationType": AuthTypeIRSA},
+	}), "'awsAuth.awsRoleARN' is required")
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeIRSA,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}), envWebIdentityTokenFile)
+}
+
+func TestCredentialSet_IRSABuildsProvider(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	t.Setenv(envWebIdentityTokenFile, tokenFile)
+	t.Setenv(envRoleARN, "arn:aws:iam::444455556666:role/from-env")
+
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{"authenticationType": AuthTypeIRSA},
+	}))
+
+	if p.authType != AuthTypeIRSA {
+		t.Fatalf("expected %q, got %q", AuthTypeIRSA, p.authType)
+	}
+	if p.credentialsProvider == nil {
+		t.Fatal("expected an IRSA credentials provider to be built at init")
+	}
+}
+
+// --- System-level credential path (design §5.4) ---------------------------
+
+func TestCredentialSet_SystemModeInference(t *testing.T) {
+	cases := []struct {
+		name     string
+		params   map[string]interface{}
+		wantType string
+	}{
+		{
+			name: "role ARN and region infer assume-role",
+			params: map[string]interface{}{
+				"awsRoleARN":    "arn:aws:iam::111122223333:role/gateway-default",
+				"awsRoleRegion": "us-east-1",
+			},
+			wantType: AuthTypeSTSAssumeRole,
+		},
+		{
+			name: "key and secret infer static credentials",
+			params: map[string]interface{}{
+				"awsAccessKeyID":     "AKIAEXAMPLE",
+				"awsSecretAccessKey": "secret",
+			},
+			wantType: AuthTypeIAMUserAccessKey,
+		},
+		{
+			name:     "nothing configured falls back to the default chain",
+			params:   map[string]interface{}{},
+			wantType: AuthTypeDefaultCredentialChain,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// authType is always "system" here; what varies is the provider
+			// the system-level fields imply.
+			p := mustGetPolicy(t, paramsWith(tc.params))
+			if p.authType != AuthTypeSystem {
+				t.Fatalf("expected %q, got %q", AuthTypeSystem, p.authType)
+			}
+			gotProvider := p.credentialsProvider != nil
+			wantProvider := tc.wantType != AuthTypeDefaultCredentialChain
+			if gotProvider != wantProvider {
+				t.Fatalf("%s: provider built = %v, want %v", tc.name, gotProvider, wantProvider)
+			}
+		})
+	}
+}
+
+// --- Allowlists (design §5.5) ---------------------------------------------
+
+func TestAllowlists_RestrictEffectiveValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		params  map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "region outside allowedRegions",
+			params: map[string]interface{}{
+				"region":         "ap-south-1",
+				"allowedRegions": []interface{}{"us-east-1", "eu-west-1"},
+			},
+			wantErr: "'region' value \"ap-south-1\" is not permitted",
+		},
+		{
+			name: "guardrail ID outside allowedGuardrailIDs",
+			params: map[string]interface{}{
+				"allowedGuardrailIDs": []interface{}{"gr-approved"},
+			},
+			wantErr: "'guardrailID' value \"gr-123\" is not permitted",
+		},
+		{
+			name: "role ARN outside allowedRoleARNs",
+			params: map[string]interface{}{
+				"allowedRoleARNs": []interface{}{"arn:aws:iam::*:role/wso2-gw-guardrail-*"},
+				"awsAuth": map[string]interface{}{
+					"authenticationType": AuthTypeSTSAssumeRole,
+					"awsRoleARN":         "arn:aws:iam::444455556666:role/some-other-role",
+				},
+			},
+			wantErr: "'awsRoleARN' value",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(tc.params), tc.wantErr)
+		})
+	}
+}
+
+func TestAllowlists_ARNPrefixMatching(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"allowedRoleARNs": []interface{}{"arn:aws:iam::444455556666:role/wso2-gw-guardrail-*"},
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/wso2-gw-guardrail-tenant-a",
+		},
+	}))
+	if p.creds.roleARN == "" {
+		t.Fatal("expected the prefix-matched role ARN to be accepted")
+	}
+}
+
+func TestAllowlists_ForbidUserLevelStaticCredentials(t *testing.T) {
+	// The control that lets an operator keep every parameter attachment-level
+	// while refusing attachment-level long-lived secrets.
+	allowed := []interface{}{AuthTypeIRSA, AuthTypeSTSAssumeRole, AuthTypeDefaultCredentialChain}
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedAuthTypes": allowed,
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeIAMUserAccessKey,
+			"awsAccessKeyID":     "AKIAEXAMPLE",
+			"awsSecretAccessKey": "secret",
+		},
+	}), "'authenticationType' value \"iam-user-access-key\" is not permitted")
+
+	mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"allowedAuthTypes": allowed,
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+}
+
+func TestAllowlists_EmptyMeansUnrestricted(t *testing.T) {
+	mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"allowedRegions":      []interface{}{},
+		"allowedGuardrailIDs": nil,
+		"allowedAuthTypes":    []interface{}{},
+	}))
+}
+
+func TestAllowlists_RejectMalformedConfiguration(t *testing.T) {
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedRegions": []interface{}{"us-east-1", 7},
+	}), "'allowedRegions' must be an array of strings")
+}
+
+func TestAllowlists_GatewayDefaultOutsideItsOwnAllowlistIsRejected(t *testing.T) {
+	// Checking the effective value also catches an operator misconfiguration,
+	// rather than only policing attachment-supplied values.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"region":         "us-east-1",
+		"allowedRegions": []interface{}{"eu-west-1"},
+	}), "not permitted")
+}
+
+// --- passthroughOnError behaviour -----------------------------------------
+
+// policyWithMockedBedrock builds a policy whose Bedrock call fails with err,
+// with passthroughOnError enabled on both phases.
+func policyWithMockedBedrock(err error, configErr error) *AWSBedrockGuardrailPolicy {
+	mockClient := &mockBedrockClient{err: err}
+	return &AWSBedrockGuardrailPolicy{
+		region:           "us-east-1",
+		guardrailID:      "gr-123",
+		guardrailVersion: "DRAFT",
+		hasRequestParams: true,
+		requestParams: AWSBedrockGuardrailPolicyParams{
+			Enabled:            true,
+			PassthroughOnError: true,
+		},
+		loadAWSConfigFunc: func(_ context.Context, _ string) (aws.Config, error) {
+			return aws.Config{}, configErr
+		},
+		newBedrockClientFunc: func(_ aws.Config) bedrockGuardrailClient {
+			return mockClient
+		},
+	}
+}
+
+func requestContextForTest() *policy.RequestContext {
+	return &policy.RequestContext{
+		SharedContext: &policy.SharedContext{Metadata: map[string]interface{}{}},
+		Body:          &policy.Body{Content: []byte(`hello`)},
+	}
+}
+
+func TestPassthroughOnError_ToleratesAnyFailure(t *testing.T) {
+	// passthroughOnError keeps pre-v1.2.0 semantics: when enabled, the request
+	// proceeds whatever the guardrail call failed with. The policy draws no
+	// distinction between a transient outage and a permanently broken
+	// configuration, so one representative error covers the behaviour.
+	p := policyWithMockedBedrock(errors.New("bedrock api unavailable"), nil)
+	result := p.OnRequestBody(context.Background(), requestContextForTest(), map[string]interface{}{})
+	if _, passedThrough := result.(policy.UpstreamRequestModifications); !passedThrough {
+		t.Fatalf("expected passthrough with passthroughOnError enabled, got blocked (%T)", result)
+	}
+}
+
+func TestPassthroughOnError_DisabledBlocks(t *testing.T) {
+	p := policyWithMockedBedrock(errors.New("bedrock api unavailable"), nil)
+	p.requestParams.PassthroughOnError = false
+	result := p.OnRequestBody(context.Background(), requestContextForTest(), map[string]interface{}{})
+	if _, passedThrough := result.(policy.UpstreamRequestModifications); passedThrough {
+		t.Fatal("expected block when passthroughOnError is off, got passthrough")
+	}
+}
+
+func TestPassthroughOnError_CoversCredentialResolutionFailure(t *testing.T) {
+	// A failure to build the AWS config is also tolerated, matching pre-v1.2.0.
+	p := policyWithMockedBedrock(nil, errors.New("failed to load AWS config: no credentials"))
+	result := p.OnRequestBody(context.Background(), requestContextForTest(), map[string]interface{}{})
+	if _, passedThrough := result.(policy.UpstreamRequestModifications); !passedThrough {
+		t.Fatal("expected passthrough on credential resolution failure with passthroughOnError enabled")
+	}
+}
+
+func TestDeriveRoleSessionName(t *testing.T) {
+	cases := []struct {
+		name     string
+		metadata policy.PolicyMetadata
+		want     string
+	}{
+		{"no metadata falls back", policy.PolicyMetadata{}, defaultRoleSessionName},
+		{"api name only", policy.PolicyMetadata{APIName: "support-api"}, "wso2-gw-support-api"},
+		{"name and version", policy.PolicyMetadata{APIName: "support-api", APIVersion: "v1.0"}, "wso2-gw-support-api-v1.0"},
+		{"disallowed characters replaced", policy.PolicyMetadata{APIName: "support/api tenant"}, "wso2-gw-support-api-tenant"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveRoleSessionName(tc.metadata); got != tc.want {
+				t.Fatalf("deriveRoleSessionName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveRoleSessionName_AlwaysSTSValid(t *testing.T) {
+	// STS accepts only [\w+=,.@-]{2,64}; a name it rejects would fail the
+	// assumption at request time rather than at deploy time.
+	valid := regexp.MustCompile(`^[\w+=,.@-]{2,64}$`)
+	metadatas := []policy.PolicyMetadata{
+		{},
+		{APIName: strings.Repeat("very-long-api-name", 10), APIVersion: "v1"},
+		{APIName: "!!!"},
+		{APIName: "アプリ", APIVersion: "v1"},
+		{APIName: "a/b\\c:d e"},
+	}
+
+	for _, md := range metadatas {
+		got := deriveRoleSessionName(md)
+		if !valid.MatchString(got) {
+			t.Fatalf("deriveRoleSessionName(%+v) = %q, which STS would reject", md, got)
+		}
+	}
+}
+
+func TestRoleSessionName_DerivedByDefaultAndOverridable(t *testing.T) {
+	md := policy.PolicyMetadata{APIName: "support-api", APIVersion: "v1.0"}
+
+	raw, err := GetPolicy(md, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := raw.(*AWSBedrockGuardrailPolicy).creds.roleSessionName; got != "wso2-gw-support-api-v1.0" {
+		t.Fatalf("expected a session name derived from the API, got %q", got)
+	}
+
+	raw, err = GetPolicy(md, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+			"awsRoleSessionName": "explicit-name",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := raw.(*AWSBedrockGuardrailPolicy).creds.roleSessionName; got != "explicit-name" {
+		t.Fatalf("expected the explicit session name to win, got %q", got)
+	}
+}
+
+// --- Credential caching (design §5.6) -------------------------------------
+
+func TestCredentialsProvider_CachesAcrossRequests(t *testing.T) {
+	// The provider is built once and wraps a credentials cache, so role
+	// assumption happens on first use and on refresh rather than per request.
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{
+			"authenticationType": AuthTypeSTSAssumeRole,
+			"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+		},
+	}))
+
+	if _, ok := p.credentialsProvider.(*aws.CredentialsCache); !ok {
+		t.Fatalf("expected the assume-role provider to be cached, got %T", p.credentialsProvider)
+	}
+}
+
+func TestCredentialsProvider_NotSharedBetweenAttachments(t *testing.T) {
+	// Two attachments naming the same role with different external IDs must not
+	// share credentials - one would otherwise borrow the other's identity.
+	newPolicy := func(externalID string) *AWSBedrockGuardrailPolicy {
+		return mustGetPolicy(t, paramsWith(map[string]interface{}{
+			"awsAuth": map[string]interface{}{
+				"authenticationType": AuthTypeSTSAssumeRole,
+				"awsRoleARN":         "arn:aws:iam::444455556666:role/shared-arn",
+				"awsRoleExternalID":  externalID,
+			},
+		}))
+	}
+
+	first := newPolicy("tenant-a-external-id")
+	second := newPolicy("tenant-b-external-id")
+
+	if first.credentialsProvider == second.credentialsProvider {
+		t.Fatal("two attachments share one credentials provider despite different external IDs")
+	}
+	if first.creds.roleExternalID == second.creds.roleExternalID {
+		t.Fatal("external IDs collapsed between attachments")
+	}
+}
+
+// --- Client-facing error hygiene (design §6.3, S10) -----------------------
+
+func TestErrorResponse_DoesNotLeakAWSErrorText(t *testing.T) {
+	// AWS distinguishes "no such guardrail" from "exists but denied", so
+	// echoing the raw message back would let a caller enumerate the guardrails
+	// and roles configured in the account.
+	awsErr := errors.New("operation error Bedrock Runtime: ApplyGuardrail, " +
+		"https response error StatusCode: 400, RequestID: abc-123, " +
+		"ResourceNotFoundException: Guardrail gr-secret-name not found in account 444455556666")
+
+	p := &AWSBedrockGuardrailPolicy{}
+	resp := p.buildErrorResponse("Error calling AWS Bedrock Guardrail", awsErr, false, true, nil)
+
+	imm, ok := resp.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", resp)
+	}
+
+	body := string(imm.Body)
+	for _, leaked := range []string{"gr-secret-name", "444455556666", "ResourceNotFoundException", "RequestID", "abc-123"} {
+		if strings.Contains(body, leaked) {
+			t.Fatalf("client response leaked %q from the AWS error: %s", leaked, body)
+		}
+	}
+}
+
+func TestErrorResponse_StillReportsGuardrailAssessments(t *testing.T) {
+	// Withholding SDK diagnostics must not withhold genuine guardrail
+	// assessment detail, which is what showAssessment is for.
+	p := &AWSBedrockGuardrailPolicy{}
+	resp := p.buildErrorResponse("reason", nil, false, true, makePIIIntervenedOutput("john@example.com"))
+
+	imm, ok := resp.(policy.ImmediateResponse)
+	if !ok {
+		t.Fatalf("expected ImmediateResponse, got %T", resp)
+	}
+	if !strings.Contains(string(imm.Body), "assessments") {
+		t.Fatalf("expected guardrail assessments in the response body, got: %s", imm.Body)
+	}
+}
+
+// --- Schema guard (design §5.1) -------------------------------------------
+
+// TestSchema_UserLevelIdentityParamsDeclareNoDefault guards the rule that makes
+// "omit to inherit the system-level value" true.
+//
+// System-level and user-level values are merged into one map before the
+// policy sees them. A `default:` on a user-level property materialises it on
+// every attachment, so the system-level value would never survive the merge and
+// the config.toml setting would silently stop doing anything. Nothing else in
+// the build catches that, hence this check.
+func TestSchema_UserLevelIdentityParamsDeclareNoDefault(t *testing.T) {
+	source, err := os.ReadFile("policy-definition.yaml")
+	if err != nil {
+		t.Fatalf("cannot read policy-definition.yaml: %v", err)
+	}
+	lines := strings.Split(string(source), "\n")
+
+	// Bound the scan to the user-level `parameters:` block; systemParameters
+	// may legitimately carry defaults.
+	start, end := -1, len(lines)
+	for i, line := range lines {
+		if line == "parameters:" {
+			start = i
+		} else if line == "systemParameters:" && start >= 0 {
+			end = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatal("could not locate the parameters: block in policy-definition.yaml")
+	}
+
+	const propIndent = "    " // properties of the top-level parameters object
+	for _, property := range []string{"region", "guardrailID", "guardrailVersion", "localGuardrailID", "localGuardrailVersion"} {
+		t.Run(property, func(t *testing.T) {
+			header := propIndent + property + ":"
+			from := -1
+			for i := start; i < end; i++ {
+				if lines[i] == header {
+					from = i + 1
+					break
+				}
+			}
+			if from < 0 {
+				t.Fatalf("property %q not found in the parameters: block", property)
+			}
+			for i := from; i < end; i++ {
+				line := lines[i]
+				// Stop at the next property at the same indentation level.
+				if strings.HasPrefix(line, propIndent) && !strings.HasPrefix(line, propIndent+" ") && strings.TrimSpace(line) != "" {
+					break
+				}
+				if strings.HasPrefix(strings.TrimSpace(line), "default:") {
+					t.Fatalf("%q declares a default, which would shadow the system-level value on every attachment", property)
+				}
+			}
+		})
+	}
+}
+
+func TestCredentialSet_FormatBackstop(t *testing.T) {
+	// Duplicated from the schema on purpose: the schema is only enforced as
+	// well as the control plane enforces it, and a malformed value slipping
+	// through would fail against STS on live traffic instead of at deploy time.
+	cases := []struct {
+		name    string
+		awsAuth map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "malformed role ARN",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeSTSAssumeRole,
+				"awsRoleARN":         "not-an-arn",
+			},
+			wantErr: "not a valid IAM role ARN",
+		},
+		{
+			name: "role ARN with a short account id",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeSTSAssumeRole,
+				"awsRoleARN":         "arn:aws:iam::4444:role/tenant-a",
+			},
+			wantErr: "not a valid IAM role ARN",
+		},
+		{
+			name: "malformed role region",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeSTSAssumeRole,
+				"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+				"awsRoleRegion":      "Not A Region",
+			},
+			wantErr: "not a valid AWS region",
+		},
+		{
+			name: "session name STS would reject",
+			awsAuth: map[string]interface{}{
+				"authenticationType": AuthTypeSTSAssumeRole,
+				"awsRoleARN":         "arn:aws:iam::444455556666:role/tenant-a",
+				"awsRoleSessionName": "has spaces and /slashes",
+			},
+			wantErr: "awsRoleSessionName",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{"awsAuth": tc.awsAuth}), tc.wantErr)
+		})
+	}
+}
+
+// --- authenticationType "system" and mandatory awsAuth (design decision) ----
+
+func TestAWSAuth_DefaultsToSystemWhenOmitted(t *testing.T) {
+	// v1.1.0 attachments carry no credential block at all and relied on the
+	// gateway-wide identity; they must keep working untouched.
+	p := paramsWith(nil)
+	delete(p, "awsAuth")
+	got := mustGetPolicy(t, p)
+	if got.authType != AuthTypeSystem {
+		t.Fatalf("expected omitted awsAuth to default to %q, got %q", AuthTypeSystem, got.authType)
+	}
+}
+
+func TestAWSAuth_DefaultsToSystemWhenTypeOmitted(t *testing.T) {
+	got := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{},
+	}))
+	if got.authType != AuthTypeSystem {
+		t.Fatalf("expected empty awsAuth to default to %q, got %q", AuthTypeSystem, got.authType)
+	}
+}
+
+func TestAWSAuth_CredentialFieldsWithoutTypeAreRejected(t *testing.T) {
+	// Defaulting this to system would silently ignore the role ARN, so it is
+	// rejected and the author told to name the mode.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsAuth": map[string]interface{}{"awsRoleARN": "arn:aws:iam::444455556666:role/tenant-a"},
+	}), "no authenticationType is set")
+}
+
+func TestAWSAuth_SystemModeUsesGatewayCredentials(t *testing.T) {
+	p := mustGetPolicy(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":    "arn:aws:iam::111122223333:role/gateway-default",
+		"awsRoleRegion": "us-east-1",
+		"awsAuth":       map[string]interface{}{"authenticationType": AuthTypeSystem},
+	}))
+
+	if p.authType != AuthTypeSystem {
+		t.Fatalf("expected %q, got %q", AuthTypeSystem, p.authType)
+	}
+	if p.creds.roleARN != "arn:aws:iam::111122223333:role/gateway-default" {
+		t.Fatalf("system mode did not pick up the gateway-wide role: %q", p.creds.roleARN)
+	}
+	if p.credentialsProvider == nil {
+		t.Fatal("expected a provider built from the gateway-wide role")
+	}
+}
+
+func TestAWSAuth_SystemModeRejectsCredentialFields(t *testing.T) {
+	// A credential field alongside "system" would be silently ignored, which is
+	// exactly the invisible misconfiguration the explicit mode exists to remove.
+	for _, k := range []string{"awsRoleARN", "awsAccessKeyID", "awsSecretAccessKey", "awsRoleExternalID", "awsRoleSessionName"} {
+		t.Run(k, func(t *testing.T) {
+			expectGetPolicyError(t, paramsWith(map[string]interface{}{
+				"awsAuth": map[string]interface{}{
+					"authenticationType": AuthTypeSystem,
+					k:                    "some-value",
+				},
+			}), fmt.Sprintf("'awsAuth.%s' cannot be set", k))
+		})
+	}
+}
+
+func TestAWSAuth_DeclaredModeNeverFallsBackToSystem(t *testing.T) {
+	// A gateway-wide identity is configured and would work, but the attachment
+	// declares irsa with no IRSA environment available. It must fail rather than
+	// quietly running under the gateway credentials.
+	t.Setenv(envRoleARN, "")
+	t.Setenv(envWebIdentityTokenFile, "")
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":    "arn:aws:iam::111122223333:role/gateway-default",
+		"awsRoleRegion": "us-east-1",
+		"awsAuth":       map[string]interface{}{"authenticationType": AuthTypeIRSA},
+	}), "awsRoleARN")
+}
+
+func TestAWSAuth_SystemIsSubjectToAllowedAuthTypes(t *testing.T) {
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedAuthTypes": []interface{}{AuthTypeIRSA, AuthTypeSTSAssumeRole},
+		"awsAuth":          map[string]interface{}{"authenticationType": AuthTypeSystem},
+	}), "'authenticationType' value \"system\" is not permitted")
+}
+
+func TestSystemLevel_EmptyStringDefaultsAreNotErrors(t *testing.T) {
+	// config.toml ships every awsbedrock_* key with an empty default, and those
+	// empty values reach the policy verbatim rather than being dropped. They
+	// must read as "not configured" or the documented default configuration is
+	// unusable.
+	p := paramsWith(map[string]interface{}{
+		"awsAccessKeyID":     "",
+		"awsSecretAccessKey": "",
+		"awsSessionToken":    "",
+		"awsRoleARN":         "",
+		"awsRoleRegion":      "",
+		"awsRoleExternalID":  "",
+	})
+	got := mustGetPolicy(t, p)
+	if got.authType != AuthTypeSystem {
+		t.Fatalf("expected %q, got %q", AuthTypeSystem, got.authType)
+	}
+	if got.credentialsProvider != nil {
+		t.Fatal("empty system credentials should defer to the SDK default chain")
+	}
+}
+
+func TestSystemLevel_BothRoutesValidateIdentically(t *testing.T) {
+	// Omitting awsAuth and declaring authenticationType "system" are meant to be
+	// equivalent. Validating in only one of them made the same gateway
+	// configuration deploy or fail depending on which spelling was used.
+	incomplete := func() map[string]interface{} {
+		return paramsWith(map[string]interface{}{
+			"awsRoleARN": "arn:aws:iam::111122223333:role/gw", // no awsRoleRegion
+			"awsAuth":    nil,                                 // removed below
+		})
+	}
+
+	omitted := incomplete()
+	delete(omitted, "awsAuth")
+	_, errOmitted := getPolicyForTest(omitted)
+
+	explicit := incomplete()
+	explicit["awsAuth"] = map[string]interface{}{"authenticationType": AuthTypeSystem}
+	_, errExplicit := getPolicyForTest(explicit)
+
+	if (errOmitted == nil) != (errExplicit == nil) {
+		t.Fatalf("the two equivalent shapes disagree: omitted=%v explicit=%v", errOmitted, errExplicit)
+	}
+	if errOmitted == nil {
+		t.Fatal("an incomplete system role config should be rejected on both routes")
+	}
+}
+
+func TestAllowlist_IRSAEnvironmentRoleIsChecked(t *testing.T) {
+	// The IRSA role can arrive from AWS_ROLE_ARN instead of the attachment.
+	// Both routes must face the same allowlist, or an operator who sets
+	// allowedRoleARNs finds it applies only to roles written out explicitly.
+	envARN := "arn:aws:iam::367134611783:role/env-injected-role"
+	t.Setenv(envWebIdentityTokenFile, t.TempDir()+"/token")
+	t.Setenv(envRoleARN, envARN)
+
+	restrictive := []interface{}{"arn:aws:iam::*:role/permitted-only-*"}
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedRoleARNs": restrictive,
+		"awsAuth":         map[string]interface{}{"authenticationType": AuthTypeIRSA, "awsRoleARN": envARN},
+	}), "not permitted")
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"allowedRoleARNs": restrictive,
+		"awsAuth":         map[string]interface{}{"authenticationType": AuthTypeIRSA},
+	}), "not permitted")
+}
+
+func TestSystemLevel_MalformedValuesAreRejected(t *testing.T) {
+	// System-level fields get the same format checks as user-level ones, so a
+	// typo is caught at deploy time rather than against STS on live traffic.
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":    "not-an-arn",
+		"awsRoleRegion": "us-east-1",
+	}), "not a valid IAM role ARN")
+
+	expectGetPolicyError(t, paramsWith(map[string]interface{}{
+		"awsRoleARN":    "arn:aws:iam::111122223333:role/gw",
+		"awsRoleRegion": "Not A Region",
+	}), "not a valid AWS region")
+}

--- a/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
+++ b/policies/aws-bedrock-guardrail/awsbedrockguardrail_test.go
@@ -43,6 +43,9 @@ func baseParams() map[string]interface{} {
 		"region":           "us-east-1",
 		"guardrailID":      "gr-123",
 		"guardrailVersion": "DRAFT",
+		// awsAuth is mandatory; "system" defers to the gateway-wide credentials,
+		// which is what these tests exercise unless they override it.
+		"awsAuth": map[string]interface{}{"authenticationType": AuthTypeSystem},
 	}
 }
 
@@ -138,10 +141,12 @@ func TestValidateAWSConfigParams_RoleRegionRequirement(t *testing.T) {
 		t.Fatalf("expected missing awsRoleRegion error, got: %v", err)
 	}
 
+	// An empty string means "not configured", so it fails the same way an
+	// absent value does rather than with a distinct "cannot be empty" error.
 	params["awsRoleRegion"] = ""
 	err = validateAWSConfigParams(params)
-	if err == nil || !strings.Contains(err.Error(), "'awsRoleRegion' cannot be empty") {
-		t.Fatalf("expected empty awsRoleRegion error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "'awsRoleRegion' is required") {
+		t.Fatalf("expected empty awsRoleRegion to be treated as missing, got: %v", err)
 	}
 
 	params["awsRoleRegion"] = "us-east-1"

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -1,25 +1,196 @@
 name: aws-bedrock-guardrail
-version: v1.1.0
+version: v1.2.0
 description: |
   Validate request or response content with AWS Bedrock Guardrails.
 
 parameters:
   type: object
   properties:
-    localGuardrailID:
+    region:
+      type: string
+      x-wso2-policy-advanced-param: false
+      description: |
+        AWS region hosting the Bedrock Guardrail for this policy attachment
+        (e.g., "us-east-1"). Leave unset to use the gateway-wide system
+        parameter instead.
+      pattern: "^[a-z0-9-]{1,32}$"
+      minLength: 1
+    guardrailID:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
         AWS Bedrock Guardrail identifier for this policy attachment. Leave
         unset to use the gateway-wide system parameter instead.
       minLength: 1
-    localGuardrailVersion:
+    guardrailVersion:
       type: string
       x-wso2-policy-advanced-param: false
       description: |
         AWS Bedrock Guardrail version (e.g., "DRAFT", "1") for this policy
         attachment. Leave unset to use the gateway-wide system parameter instead.
       minLength: 1
+    localGuardrailID:
+      type: string
+      x-wso2-policy-advanced-param: false
+      x-wso2-policy-deprecated-param: true
+      description: >-
+        DEPRECATED - use `guardrailID` instead. AWS Bedrock Guardrail identifier
+        for this policy attachment. Retained so attachments authored against
+        v1.1.0 keep working. Ignored when `guardrailID` is configured.
+      minLength: 1
+    localGuardrailVersion:
+      type: string
+      x-wso2-policy-advanced-param: false
+      x-wso2-policy-deprecated-param: true
+      description: >-
+        DEPRECATED - use `guardrailVersion` instead. AWS Bedrock Guardrail
+        version (e.g., "DRAFT", "1") for this policy attachment. Retained so
+        attachments authored against v1.1.0 keep working. Ignored when
+        `guardrailVersion` is configured.
+      minLength: 1
+    awsAuth:
+      type: object
+      x-wso2-policy-advanced-param: true
+      additionalProperties: false
+      description: |
+        AWS identity used for this policy attachment's ApplyGuardrail calls,
+        allowing the guardrail to live in a different AWS account from the
+        gateway. Use authenticationType "system" to defer to the gateway-wide
+        credential configuration; any other mode supplies its complete credential
+        configuration here and the gateway-wide settings are ignored entirely.
+
+        Both this object and its authenticationType are optional: omitting either
+        is equivalent to authenticationType "system", which is what attachments
+        authored against v1.1.0 relied on.
+      properties:
+        authenticationType:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            Selects how AWS credentials are obtained. "system" defers to the
+            gateway-wide credential configuration in config.toml and is the
+            option to use when the attachment has no AWS identity of its own;
+            no other field in this object may be set alongside it. "irsa" uses
+            the gateway's Kubernetes projected service account token (IAM Roles
+            for Service Accounts) and requires no credential material in the API
+            definition. "sts-assume-role" assumes the given role from the
+            gateway's own identity. "default-credential-chain" resolves
+            credentials from the AWS SDK's default provider chain.
+            "iam-user-access-key" places a long-lived AWS secret in the API
+            definition - prefer any of the others where possible.
+          enum:
+            - system
+            - irsa
+            - sts-assume-role
+            - default-credential-chain
+            - iam-user-access-key
+          default: system
+        awsRoleARN:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            ARN of the IAM role to assume. Required when authenticationType is
+            "sts-assume-role". Optional for "irsa": if omitted, falls back to
+            the AWS_ROLE_ARN environment variable injected by the EKS Pod
+            Identity Webhook.
+          pattern: "^arn:aws(-cn|-us-gov|-iso[a-z]?)?:iam::[0-9]{12}:role/.+$"
+        awsRoleRegion:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            AWS region whose STS endpoint is used for the role assumption.
+            Defaults to the effective guardrail region.
+          pattern: "^[a-z0-9-]{1,32}$"
+          minLength: 1
+        awsRoleExternalID:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            External ID required by the target role's trust policy, for
+            cross-account role assumption hardening. Must be unique per tenant.
+            Only applicable to "sts-assume-role" - AssumeRoleWithWebIdentity,
+            used by "irsa", does not support an External ID.
+          minLength: 8
+        awsRoleSessionName:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            Session name used when assuming the role. This is what appears in
+            the target account's CloudTrail, so prefer a value identifying this
+            API. Defaults to "bedrock-guardrail-session".
+          pattern: "^[\\w+=,.@-]{2,64}$"
+        awsAccessKeyID:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            AWS access key ID. Required when authenticationType is
+            "iam-user-access-key". Optional base credential for
+            "sts-assume-role".
+          minLength: 1
+        awsSecretAccessKey:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            AWS secret access key paired with awsAccessKeyID. Required when
+            authenticationType is "iam-user-access-key". Stored as a literal
+            value in the API definition.
+          minLength: 1
+        awsSessionToken:
+          type: string
+          x-wso2-policy-advanced-param: false
+          description: |
+            Optional AWS session token, only meaningful when awsAccessKeyID and
+            awsSecretAccessKey already represent temporary credentials.
+          minLength: 1
+      allOf:
+        - if:
+            properties:
+              authenticationType:
+                const: iam-user-access-key
+            required: [ authenticationType ]
+          then:
+            required: [ awsAccessKeyID, awsSecretAccessKey ]
+        - if:
+            properties:
+              authenticationType:
+                const: sts-assume-role
+            required: [ authenticationType ]
+          then:
+            required: [ awsRoleARN ]
+        - if:
+            properties:
+              authenticationType:
+                const: irsa
+            required: [ authenticationType ]
+          then:
+            not:
+              required: [ awsRoleExternalID ]
+        # A key/secret pair must be supplied together in every mode that accepts
+        # them. Mirrors validateCredentialFields, which rejects a half-supplied
+        # pair at runtime.
+        - if:
+            required: [ awsAccessKeyID ]
+          then:
+            required: [ awsSecretAccessKey ]
+        - if:
+            required: [ awsSecretAccessKey ]
+          then:
+            required: [ awsAccessKeyID ]
+        - if:
+            properties:
+              authenticationType:
+                const: system
+            required: [ authenticationType ]
+          then:
+            not:
+              anyOf:
+                - required: [ awsRoleARN ]
+                - required: [ awsRoleRegion ]
+                - required: [ awsRoleExternalID ]
+                - required: [ awsRoleSessionName ]
+                - required: [ awsAccessKeyID ]
+                - required: [ awsSecretAccessKey ]
+                - required: [ awsSessionToken ]
     request:
       type: object
       description: Configuration for request phase validation
@@ -138,5 +309,51 @@ systemParameters:
       description: External ID for role assumption (optional, for cross-account access).
       minLength: 1
       "wso2/defaultValue": "${config.awsbedrock_role_external_id}"
-  required:
-    - region
+    allowedRegions:
+      type: array
+      items:
+        type: string
+      description: |
+        If non-empty, restricts the effective guardrail region to one of these
+        values. Must include the gateway-wide region when set. Empty (default)
+        places no restriction.
+      "wso2/defaultValue": "${config.awsbedrock_allowed_regions}"
+    allowedGuardrailIDs:
+      type: array
+      items:
+        type: string
+      description: |
+        If non-empty, restricts the effective guardrail identifier to one of
+        these values. Must include the gateway-wide guardrail ID when set.
+        Empty (default) places no restriction.
+      "wso2/defaultValue": "${config.awsbedrock_allowed_guardrail_ids}"
+    allowedRoleARNs:
+      type: array
+      items:
+        type: string
+      description: |
+        If non-empty, restricts the effective role ARN to one of these values.
+        An entry ending in "*" matches any ARN with that prefix. Must cover the
+        gateway-wide role ARN when set. Empty (default) places no restriction.
+      "wso2/defaultValue": "${config.awsbedrock_allowed_role_arns}"
+    allowedAuthTypes:
+      type: array
+      items:
+        type: string
+        enum:
+          - system
+          - irsa
+          - sts-assume-role
+          - default-credential-chain
+          - iam-user-access-key
+      description: |
+        If non-empty, restricts the authenticationType a policy attachment
+        resolves to. The check applies to the effective value, so an attachment
+        that omits awsAuth resolves to "system" and is checked against that:
+        include "system" unless every attachment sets an explicit
+        authenticationType. Omit "iam-user-access-key" to forbid
+        attachment-level long-lived credentials while leaving every other
+        parameter configurable per attachment. Empty (default) places no
+        restriction.
+      "wso2/defaultValue": "${config.awsbedrock_allowed_auth_types}"
+  required: []

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -67,7 +67,7 @@ parameters:
             Selects how AWS credentials are obtained. "system" defers to the
             gateway-wide credential configuration in config.toml and is the
             option to use when the attachment has no AWS identity of its own;
-            no other field in this object may be set alongside it. "irsa" uses
+            any other field in this object is then ignored. "irsa" uses
             the gateway's Kubernetes projected service account token (IAM Roles
             for Service Accounts) and requires no credential material in the API
             definition. "sts-assume-role" assumes the given role from the

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -35,8 +35,7 @@ parameters:
       x-wso2-policy-deprecated-param: true
       description: >-
         DEPRECATED - use `guardrailID` instead. AWS Bedrock Guardrail identifier
-        for this policy attachment. Retained so attachments authored against
-        v1.1.0 keep working. Ignored when `guardrailID` is configured.
+        for this policy attachment.
       minLength: 1
     localGuardrailVersion:
       type: string
@@ -44,9 +43,7 @@ parameters:
       x-wso2-policy-deprecated-param: true
       description: >-
         DEPRECATED - use `guardrailVersion` instead. AWS Bedrock Guardrail
-        version (e.g., "DRAFT", "1") for this policy attachment. Retained so
-        attachments authored against v1.1.0 keep working. Ignored when
-        `guardrailVersion` is configured.
+        version (e.g., "DRAFT", "1") for this policy attachment.
       minLength: 1
     awsAuth:
       type: object
@@ -108,8 +105,9 @@ parameters:
           description: |
             External ID required by the target role's trust policy, for
             cross-account role assumption hardening. Must be unique per tenant.
-            Only applicable to "sts-assume-role" - AssumeRoleWithWebIdentity,
-            used by "irsa", does not support an External ID.
+            Only used by "sts-assume-role"; AssumeRoleWithWebIdentity, which
+            "irsa" calls, has no external-ID parameter, so a value set there is
+            ignored.
           minLength: 8
         awsRoleSessionName:
           type: string
@@ -157,14 +155,6 @@ parameters:
             required: [ authenticationType ]
           then:
             required: [ awsRoleARN ]
-        - if:
-            properties:
-              authenticationType:
-                const: irsa
-            required: [ authenticationType ]
-          then:
-            not:
-              required: [ awsRoleExternalID ]
         # A key/secret pair must be supplied together in every mode that accepts
         # them. Mirrors validateCredentialFields, which rejects a half-supplied
         # pair at runtime.
@@ -176,21 +166,6 @@ parameters:
             required: [ awsSecretAccessKey ]
           then:
             required: [ awsAccessKeyID ]
-        - if:
-            properties:
-              authenticationType:
-                const: system
-            required: [ authenticationType ]
-          then:
-            not:
-              anyOf:
-                - required: [ awsRoleARN ]
-                - required: [ awsRoleRegion ]
-                - required: [ awsRoleExternalID ]
-                - required: [ awsRoleSessionName ]
-                - required: [ awsAccessKeyID ]
-                - required: [ awsSecretAccessKey ]
-                - required: [ awsSessionToken ]
     request:
       type: object
       description: Configuration for request phase validation

--- a/policies/aws-bedrock-guardrail/policy-definition.yaml
+++ b/policies/aws-bedrock-guardrail/policy-definition.yaml
@@ -315,8 +315,10 @@ systemParameters:
         type: string
       description: |
         If non-empty, restricts the effective guardrail region to one of these
-        values. Must include the gateway-wide region when set. Empty (default)
-        places no restriction.
+        values. An entry ending in "*" matches any region with that prefix, for
+        example "us-east-*"; "*" in any other position is rejected as invalid
+        configuration. Must include the gateway-wide region when set. Empty
+        (default) places no restriction.
       "wso2/defaultValue": "${config.awsbedrock_allowed_regions}"
     allowedGuardrailIDs:
       type: array
@@ -324,8 +326,8 @@ systemParameters:
         type: string
       description: |
         If non-empty, restricts the effective guardrail identifier to one of
-        these values. Must include the gateway-wide guardrail ID when set.
-        Empty (default) places no restriction.
+        these values. Exact matches only. Must include the gateway-wide
+        guardrail ID when set. Empty (default) places no restriction.
       "wso2/defaultValue": "${config.awsbedrock_allowed_guardrail_ids}"
     allowedRoleARNs:
       type: array
@@ -333,8 +335,9 @@ systemParameters:
         type: string
       description: |
         If non-empty, restricts the effective role ARN to one of these values.
-        An entry ending in "*" matches any ARN with that prefix. Must cover the
-        gateway-wide role ARN when set. Empty (default) places no restriction.
+        An entry ending in "*" matches any ARN with that prefix. "*" is only
+        honoured as the final character. Must cover the gateway-wide 
+        role ARN when set. Empty (default) places no restriction.
       "wso2/defaultValue": "${config.awsbedrock_allowed_role_arns}"
     allowedAuthTypes:
       type: array


### PR DESCRIPTION
This pull request introduces version 1.2 of the `aws-bedrock-guardrail` policy, adding major enhancements for AWS credential configuration, guardrail selection, and system-level restrictions. The update includes new parameters for per-attachment AWS identity selection, deprecates old parameters in favor of clearer ones, and adds system-level allowlists for increased security and flexibility.
Related to https://github.com/wso2/api-platform/issues/3204

**Key changes:**

### Policy configuration and parameters

* Added the `awsAuth` parameter to the policy, allowing each attachment to specify its own AWS authentication method and credentials, supporting multiple modes (system, IRSA, STS AssumeRole, default credential chain, IAM user access key). This enables guardrails to reside in different AWS accounts and supports advanced credential management. (`policy-definition.yaml`, `metadata.json`) [[1]](diffhunk://#diff-c17dd7c3069baf176a10432cddf74f7e85d71d669458586f12dc03d9880d0530L2-R193) [[2]](diffhunk://#diff-92690dd4eb9b69b2da9f31cc15366e6661cef163d0feee355ade4c3bc8ff26d3R1-R11)
* Introduced new parameters (`region`, `guardrailID`, `guardrailVersion`) and marked the old `localGuardrailID` and `localGuardrailVersion` as deprecated for backward compatibility. (`policy-definition.yaml`)
* Updated the test suite to require the `awsAuth` parameter, reflecting its new mandatory status for policy attachments. (`awsbedrockguardrail_test.go`)

### System-level restrictions and allowlists

* Added system parameters (`allowedRegions`, `allowedGuardrailIDs`, `allowedRoleARNs`, `allowedAuthTypes`) to restrict which regions, guardrail IDs, IAM roles, and authentication types can be used by attachments, improving security and governance. (`policy-definition.yaml`)

### Documentation and metadata

* Updated documentation and metadata to reflect the new version (`v1.2.0`), new features, and parameter changes. Updated the main policy list to point to the new documentation. (`README.md`, `metadata.json`) [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L36-R36) [[2]](diffhunk://#diff-92690dd4eb9b69b2da9f31cc15366e6661cef163d0feee355ade4c3bc8ff26d3R1-R11)

### Validation logic

* Improved validation logic for the `awsRoleRegion` parameter, treating empty strings as missing values for consistency. (`awsbedrockguardrail_test.go`)