### PR TITLE
Add concurrency controls to cancel obsolete PR workflow runs

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -12,7 +12,11 @@ permissions:
   issues: write
   contents: read
 
-env: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
   DEPENDENCY_SCOPE: api-platform # Change this value based on the repository. See https://github.com/wso2/engineering-governance/blob/main/dependency-registry/README.md#available-scopes
 
 jobs:

--- a/.github/workflows/gateway-integration-test.yml
+++ b/.github/workflows/gateway-integration-test.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   integration-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/validate-policy-catalog.yml
+++ b/.github/workflows/validate-policy-catalog.yml
@@ -3,6 +3,10 @@ name: Validate Policy Catalog
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate docs/README.md is up to date


### PR DESCRIPTION
This pull request adds concurrency controls to several GitHub Actions workflow files to prevent multiple runs of the same workflow from executing simultaneously for the same pull request. This helps avoid race conditions and redundant runs, improving the reliability and efficiency of CI processes.

**Workflow concurrency improvements:**

* Added a `concurrency` group to `.github/workflows/dependency-validation.yml` to ensure only one run per pull request is active at a time, canceling any in-progress runs for the same PR.
* Added a `concurrency` group to `.github/workflows/gateway-integration-test.yml` to prevent concurrent runs for the same pull request or workflow run, canceling previous runs if a new one is triggered.
* Added a `concurrency` group to `.github/workflows/validate-policy-catalog.yml` to limit workflow runs to one per pull request and cancel any in-progress runs for the same PR.