### PR TITLE
Add dynamic run-name to release and publish policy workflows

### DIFF
--- a/.github/workflows/publish-policy.yml
+++ b/.github/workflows/publish-policy.yml
@@ -11,6 +11,7 @@
 # rules and secrets — matching the structure of Release Policy.
 
 name: Publish Policy
+run-name: Publish Policy - ${{ inputs.policy_name }} v${{ inputs.minor_version }} (${{ inputs.publish_dev && 'Dev' || '' }}${{ inputs.publish_dev && inputs.publish_staging && ', ' || '' }}${{ inputs.publish_staging && 'Staging' || '' }}${{ inputs.publish_production && (inputs.publish_dev || inputs.publish_staging) && ', ' || '' }}${{ inputs.publish_production && 'Production' || '' }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -14,6 +14,7 @@
 # whatever HEAD is now.
 
 name: Release Policy
+run-name: Release Policy - ${{ inputs.policy }} v${{ inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request makes improvements to the GitHub Actions workflows for publishing and releasing policies by adding dynamic run names. This will make it easier to identify workflow runs in the Actions UI.

**Workflow enhancements:**

* [`.github/workflows/publish-policy.yml`](diffhunk://#diff-1a7244aaada6c87d731e2b3b392180d1de802a92425fd942155aff5596e957f8R14): Added a `run-name` that dynamically includes the policy name, minor version, and the environments being published to (Dev, Staging, Production).
* [`.github/workflows/release-policy.yml`](diffhunk://#diff-4865a54abf98b4cf37435a85ef63c75b1f921d975c8ea2db0c73a43464ec9bb0R17): Added a `run-name` that dynamically includes the policy name and version.
<img width="1231" height="333" alt="image" src="https://github.com/user-attachments/assets/1d1cc604-2a72-44b3-8e22-722408af4034" />