### PR TITLE
[ Set Headers ] add support request body phase

### DIFF
--- a/docs/set-headers/v1.1/docs/set-headers.md
+++ b/docs/set-headers/v1.1/docs/set-headers.md
@@ -38,6 +38,7 @@ These parameters are configured per-API/route by the API developer:
 |-----------|------|----------|---------|-------------|
 | `mode` | string | No | `set` | Controls how configured headers are applied. `set` overwrites any existing header with the same name; `append` adds the configured value while preserving existing values. Applies to both the request and response phases. Allowed values: `set`, `append`. |
 | `request` | object | No | - | Specifies request-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
+| `request.phase` | string | No | `header` | Controls when request headers are applied. Use `body` when header values depend on metadata produced while processing the request body. Allowed values: `header`, `body`. |
 | `response` | object | No | - | Specifies response-phase header settings. Must contain a `headers` array. At least one of `request` or `response` must be specified. |
 
 ### Request / Response Header Configuration
@@ -51,6 +52,12 @@ Each header entry in the `request.headers` or `response.headers` array must cont
 
 **Note:**
 At least one of `request` or `response` must be specified in the policy configuration. The policy will fail validation if both are omitted. If `mode` is specified, it must be either `set` or `append`.
+
+Request headers use the `header` phase by default. Set `request.phase` to `body`
+when a body-processing policy must run first, for example when model routing
+selects a provider and the provider-specific credentials are resolved from the
+resulting metadata. In body phase, the policy applies the configured request
+headers after the request body has been processed.
 
 Inside the `gateway/build.yaml`, ensure the policy module is added under `policies:`:
 

--- a/policies/set-headers/policy-definition.yaml
+++ b/policies/set-headers/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: set-headers
-version: v1.1.0
+version: v1.1.1
 description: |
   Sets or appends configured headers on requests and/or responses. In "set" mode
   (the default), an existing header with the same name is overwritten; if the same
@@ -28,6 +28,17 @@ parameters:
       additionalProperties: false
       description: Specifies request-phase header settings.
       properties:
+        phase:
+          type: string
+          x-wso2-policy-advanced-param: true
+          description: |
+            Specifies when request headers are applied. "header" preserves the
+            default request-header phase behavior. "body" applies headers during
+            the request-body phase after body-derived metadata is available.
+          enum:
+          - header
+          - body
+          default: header
         headers:
           type: array
           x-wso2-policy-advanced-param: false

--- a/policies/set-headers/setheaders.go
+++ b/policies/set-headers/setheaders.go
@@ -31,6 +31,11 @@ const (
 	ModeSet = "set"
 	// ModeAppend appends the configured value, preserving any existing values.
 	ModeAppend = "append"
+
+	// RequestPhaseHeader applies request headers during the header phase.
+	RequestPhaseHeader = "header"
+	// RequestPhaseBody applies request headers after body-derived routing metadata is available.
+	RequestPhaseBody = "body"
 )
 
 // HeaderEntry represents a single header to be set or appended
@@ -39,24 +44,27 @@ type HeaderEntry struct {
 	Value string
 }
 
-// SetHeadersPolicy implements header setting/appending for both request and response
-type SetHeadersPolicy struct{}
-
-var ins = &SetHeadersPolicy{}
+// SetHeadersPolicy implements header setting/appending for both request and response.
+type SetHeadersPolicy struct {
+	requestBodyPhase bool
+}
 
 // GetPolicy is the v1alpha2 factory entry point (loaded by v1alpha2 kernels).
 func GetPolicy(
 	metadata policy.PolicyMetadata,
 	params map[string]interface{},
 ) (policy.Policy, error) {
-	return ins, nil
+	return &SetHeadersPolicy{requestBodyPhase: requestPhaseFromParams(params) == RequestPhaseBody}, nil
 }
 
-
 func (p *SetHeadersPolicy) Mode() policy.ProcessingMode {
+	requestBodyMode := policy.BodyModeSkip
+	if p.requestBodyPhase {
+		requestBodyMode = policy.BodyModeBuffer
+	}
 	return policy.ProcessingMode{
 		RequestHeaderMode:  policy.HeaderModeProcess,
-		RequestBodyMode:    policy.BodyModeSkip,
+		RequestBodyMode:    requestBodyMode,
 		ResponseHeaderMode: policy.HeaderModeProcess,
 		ResponseBodyMode:   policy.BodyModeSkip,
 	}
@@ -89,6 +97,9 @@ func (p *SetHeadersPolicy) Validate(params map[string]interface{}) error {
 		if err := p.validateHeaderEntries(requestHeadersRaw, "request.headers"); err != nil {
 			return err
 		}
+		if err := p.validateRequestPhase(params); err != nil {
+			return err
+		}
 	}
 
 	// Validate response headers if present
@@ -98,6 +109,29 @@ func (p *SetHeadersPolicy) Validate(params map[string]interface{}) error {
 		}
 	}
 
+	return nil
+}
+
+func (p *SetHeadersPolicy) validateRequestPhase(params map[string]interface{}) error {
+	requestRaw, ok := params["request"]
+	if !ok {
+		return nil
+	}
+	requestMap, ok := requestRaw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	phaseRaw, ok := requestMap["phase"]
+	if !ok {
+		return nil
+	}
+	phase, ok := phaseRaw.(string)
+	if !ok {
+		return fmt.Errorf("request.phase must be a string")
+	}
+	if phase != RequestPhaseHeader && phase != RequestPhaseBody {
+		return fmt.Errorf("request.phase must be either '%s' or '%s'", RequestPhaseHeader, RequestPhaseBody)
+	}
 	return nil
 }
 
@@ -125,6 +159,26 @@ func (p *SetHeadersPolicy) getMode(params map[string]interface{}) string {
 		}
 	}
 	return ModeSet
+}
+
+func (p *SetHeadersPolicy) getRequestPhase(params map[string]interface{}) string {
+	return requestPhaseFromParams(params)
+}
+
+func requestPhaseFromParams(params map[string]interface{}) string {
+	requestRaw, ok := params["request"]
+	if !ok {
+		return RequestPhaseHeader
+	}
+	requestMap, ok := requestRaw.(map[string]interface{})
+	if !ok {
+		return RequestPhaseHeader
+	}
+	phase, ok := requestMap["phase"].(string)
+	if !ok || phase != RequestPhaseBody {
+		return RequestPhaseHeader
+	}
+	return RequestPhaseBody
 }
 
 // getPhaseHeaders extracts headers for a phase, supporting both nested
@@ -262,6 +316,9 @@ func (p *SetHeadersPolicy) buildRequestHeaderEntries(params map[string]interface
 
 // OnRequestHeaders sets or appends headers on the request (v2alpha.RequestHeaderPolicy).
 func (p *SetHeadersPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.RequestHeaderContext, params map[string]interface{}) policy.RequestHeaderAction {
+	if p.getRequestPhase(params) == RequestPhaseBody {
+		return policy.UpstreamRequestHeaderModifications{}
+	}
 	entries := p.buildRequestHeaderEntries(params)
 	if p.getMode(params) == ModeAppend {
 		return policy.UpstreamRequestHeaderModifications{
@@ -271,6 +328,18 @@ func (p *SetHeadersPolicy) OnRequestHeaders(ctx context.Context, reqCtx *policy.
 	return policy.UpstreamRequestHeaderModifications{
 		HeadersToSet: p.convertToSetHeaderMap(entries),
 	}
+}
+
+// OnRequestBody supports provider credentials that depend on a body-phase router.
+func (p *SetHeadersPolicy) OnRequestBody(ctx context.Context, reqCtx *policy.RequestContext, params map[string]interface{}) policy.RequestAction {
+	if p.getRequestPhase(params) != RequestPhaseBody {
+		return policy.UpstreamRequestModifications{}
+	}
+	entries := p.buildRequestHeaderEntries(params)
+	if p.getMode(params) == ModeAppend {
+		return policy.UpstreamRequestModifications{HeadersToAppend: p.convertToAppendHeaderMap(entries)}
+	}
+	return policy.UpstreamRequestModifications{HeadersToSet: p.convertToSetHeaderMap(entries)}
 }
 
 // buildResponseHeaderEntries extracts and parses response header entries from params.

--- a/policies/set-headers/setheaders_test.go
+++ b/policies/set-headers/setheaders_test.go
@@ -382,6 +382,61 @@ func TestSetHeadersPolicy_BothRequestAndResponse(t *testing.T) {
 	}
 }
 
+func TestSetHeadersPolicy_BodyPhase(t *testing.T) {
+	params := map[string]interface{}{
+		"request": map[string]interface{}{
+			"phase": "body",
+			"headers": []interface{}{
+				map[string]interface{}{"name": "Authorization", "value": "Bearer provider-secret"},
+			},
+		},
+	}
+	raw, err := GetPolicy(policy.PolicyMetadata{}, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := raw.(*SetHeadersPolicy)
+	if p.Mode().RequestBodyMode != policy.BodyModeBuffer {
+		t.Fatalf("body mode = %v, want buffer", p.Mode().RequestBodyMode)
+	}
+	if err := p.Validate(params); err != nil {
+		t.Fatal(err)
+	}
+	headerMods := p.OnRequestHeaders(context.Background(), &policy.RequestHeaderContext{}, params).(policy.UpstreamRequestHeaderModifications)
+	if len(headerMods.HeadersToSet) != 0 {
+		t.Fatalf("body-phase headers were applied during header phase: %v", headerMods.HeadersToSet)
+	}
+	bodyMods := p.OnRequestBody(context.Background(), &policy.RequestContext{}, params).(policy.UpstreamRequestModifications)
+	if bodyMods.HeadersToSet["authorization"] != "Bearer provider-secret" {
+		t.Fatalf("body-phase header missing: %v", bodyMods.HeadersToSet)
+	}
+}
+
+func TestSetHeadersPolicy_DefaultRemainsHeaderPhase(t *testing.T) {
+	raw, err := GetPolicy(policy.PolicyMetadata{}, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw.Mode().RequestBodyMode != policy.BodyModeSkip {
+		t.Fatalf("default request body mode = %v, want skip", raw.Mode().RequestBodyMode)
+	}
+}
+
+func TestSetHeadersPolicy_RejectsInvalidRequestPhase(t *testing.T) {
+	p := &SetHeadersPolicy{}
+	err := p.Validate(map[string]interface{}{
+		"request": map[string]interface{}{
+			"phase": "request_body",
+			"headers": []interface{}{
+				map[string]interface{}{"name": "Authorization", "value": "secret"},
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "request.phase must be either 'header' or 'body'") {
+		t.Fatalf("expected invalid request phase error, got %v", err)
+	}
+}
+
 func TestSetHeadersPolicy_EmptyHeadersList(t *testing.T) {
 	p := &SetHeadersPolicy{}
 	ctx := &policy.RequestHeaderContext{


### PR DESCRIPTION

## Purpose

The Set Headers policy currently applies request headers during the request-header phase. For body-based model routing policies, the target provider is selected only after the request body is processed.

Applying authentication headers before routing may use credentials belonging to the primary provider instead of the provider selected by the routing policy. The Set Headers policy therefore needs an optional body-phase execution mode.

## Goals

- Allow request headers to be applied during the request-body phase.
- Ensure provider-specific credentials can be resolved after model routing selects a provider.
- Preserve the existing request-header phase as the default behavior.
- Support both `set` and `append` modes during body-phase execution.
- Validate unsupported request phase values.

## Approach

Added an optional `request.phase` parameter to the Set Headers policy:

```yaml
request:
  phase: body
  headers:
    - name: Authorization
      value: "<resolved-provider-credential>"
```

The supported values are:

- `header`: Applies headers during the request-header phase. This remains the default.
- `body`: Applies headers during the request-body phase, after body-derived routing metadata is available.

When `body` is configured, the policy enables buffered request-body processing, skips applying the configured headers during `OnRequestHeaders`, and applies them through `OnRequestBody`.

The policy version was updated from `v1.1.0` to `v1.1.1`.

This change does not affect the UI.

```mermaid
flowchart TD
    A[Client sends LLM request] --> B{request.phase}

    B -->|header or omitted| C[Set Headers applies headers before routing]
    C --> D[Body-based router processes request body]
    D --> E[Router selects model and provider]
    E --> F[Forward request with headers selected before routing]
    F --> G[Upstream provider]

    B -->|body| H[Body-based router processes request body]
    H --> I[Router selects model and provider]
    I --> J[Selected provider stored in request metadata]
    J --> K[Resolve provider-specific header values]
    K --> L[Set Headers applies headers during body phase]
    L --> M[Forward request with selected provider credentials]
    M --> G
```

## User stories

- As an API developer, I want provider authentication headers to be applied after a body-based routing policy selects the target provider.
- As an existing Set Headers user, I want the policy to continue applying request headers during the header phase unless I explicitly select the body phase.
- As an API developer, I want both `set` and `append` behavior to work during body-phase execution.

## Release note

The Set Headers policy now supports applying request headers during the request-body phase using `request.phase: body`. This allows header values such as provider credentials to be resolved after body-based routing policies have selected a target provider.

## Documentation

Updated the Set Headers documentation to describe the `request.phase` parameter, supported values, default behavior, and body-based model-routing use case.

## Training

N/A. No training content changes are required.

## Certification

N/A. This change does not affect certification exams.

## Marketing

N/A. No marketing content is required.

## Automation tests

- Unit tests
  - Added coverage for applying request headers during the body phase.
  - Verified body-phase headers are not applied during the header phase.
  - Verified the default remains the request-header phase.
  - Verified invalid `request.phase` values are rejected.
  - Existing Set Headers tests continue to pass.
  - Ran `go test -race ./...`.

- Integration tests
  - Not added. The change is covered by policy-level unit tests.

## Security checks

- Followed secure coding standards in [[WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? Yes
- Ran FindSecurityBugs plugin and verified report? N/A — this is a Go module.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples

The documentation includes a configuration example showing how to use `request.phase: body` for headers that depend on metadata generated during request-body processing.

## Related PRs

- https://github.com/wso2/gateway-controllers/pull/284
- https://github.com/wso2/gateway-controllers/pull/295
- https://github.com/wso2/gateway-controllers/pull/290
- https://github.com/wso2/gateway-controllers/pull/284

## Migrations (if applicable)

No migration is required. Existing configurations omit `request.phase` and continue using the request-header phase by default.

## Test environment

- Go 1.26.2
- macOS
- No database required
- No browser-specific behavior

Validation performed:

```sh
GOWORK=off go test -race ./...
GOWORK=off go vet ./...
make validate-catalog
git diff --check
```

## Learning

Reviewed the gateway policy processing modes and request lifecycle to ensure headers are applied only once in the configured phase. The implementation uses the existing buffered request-body policy interface and upstream request modification types from the WSO2 API Platform SDK.
