### PR TITLE
[ Time Based Model Routing ] simplify day selector schema

### DIFF
--- a/policies/time-based-model-routing/policy-definition.yaml
+++ b/policies/time-based-model-routing/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: time-based-model-routing
-version: v0.9.0
+version: v0.9.1
 displayName: Time-Based Model Routing
 description: |
   Routes an LLM request to a configured model and optional provider according
@@ -52,43 +52,35 @@ parameters:
             minLength: 1
           days:
             title: Applicable days
+            type: object
+            additionalProperties: false
             description: |
               Enable the weekdays on which this schedule starts. All days are
               enabled by default; omitted switches remain enabled. At least one
               day must be enabled. Overnight windows continue into the next day.
-            oneOf:
-              - type: object
-                additionalProperties: false
-                x-wso2-policy-property-order: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
-                properties:
-                  Monday:
-                    type: boolean
-                    default: true
-                  Tuesday:
-                    type: boolean
-                    default: true
-                  Wednesday:
-                    type: boolean
-                    default: true
-                  Thursday:
-                    type: boolean
-                    default: true
-                  Friday:
-                    type: boolean
-                    default: true
-                  Saturday:
-                    type: boolean
-                    default: true
-                  Sunday:
-                    type: boolean
-                    default: true
-              - type: array
-                description: Legacy list of weekday names.
-                minItems: 1
-                uniqueItems: true
-                items:
-                  type: string
-                  enum: [Mon, Monday, Tue, Tuesday, Wed, Wednesday, Thu, Thursday, Fri, Friday, Sat, Saturday, Sun, Sunday]
+            x-wso2-policy-property-order: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
+            properties:
+              Monday:
+                type: boolean
+                default: true
+              Tuesday:
+                type: boolean
+                default: true
+              Wednesday:
+                type: boolean
+                default: true
+              Thursday:
+                type: boolean
+                default: true
+              Friday:
+                type: boolean
+                default: true
+              Saturday:
+                type: boolean
+                default: true
+              Sunday:
+                type: boolean
+                default: true
           model:
             title: Model
             type: object


### PR DESCRIPTION

## Purpose

Fixes an AI Workspace policy form rendering issue in the Time-Based Model Routing policy.

The `days` field was exposed in the policy definition using `oneOf` to support both the new weekday switch object format and the legacy weekday array format. Although valid as schema, AI Workspace did not render this nested `oneOf` cleanly inside `schedules[]`, causing the `days` field to appear as a generic/blank input instead of weekday switches.

## Goals

- Restore proper weekday switch rendering for `schedules[].days` in AI Workspace.
- Keep runtime backward compatibility for existing policy configurations that still use legacy weekday arrays.
- Release the fix as `time-based-model-routing` version `v0.9.1`.

## Approach

- Updated `policies/time-based-model-routing/policy-definition.yaml`.
- Bumped the policy version from `v0.9.0` to `v0.9.1`.
- Removed `oneOf` from the UI-facing `days` schema.
- Exposed `days` as a simple object with boolean weekday fields from `Monday` through `Sunday`.
- Left the Go runtime parser unchanged so it continues to accept both:
  - boolean object format
  - legacy string array format

## User stories

As an AI Workspace user, I want the Time-Based Model Routing policy form to show weekday selections as clear boolean controls, so that I can configure schedule days without manually editing raw array/object values.

## Release note

Fixed the Time-Based Model Routing policy form schema so weekday selections render correctly in AI Workspace while preserving backward compatibility for legacy weekday list configurations.

## Documentation

N/A. Existing documentation already describes the boolean weekday object format as the policy form format and notes that legacy weekday lists are still accepted by the runtime.

## Training

N/A. This is a form schema rendering fix and does not introduce a new user-facing feature requiring training content.

## Certification

N/A. This fix does not change product concepts or behavior relevant to certification exams.

## Marketing

N/A. This is a bug fix for policy form rendering and does not require marketing content.

## Automation tests

- Unit tests

  Ran focused unit tests for the Time-Based Model Routing policy:

  ```bash
  go test ./...
  ```

  Location:

  ```text
  policies/time-based-model-routing
  ```

  Existing tests cover weekday switch parsing, legacy weekday list parsing, defaults, validation, routing behavior, and overlap validation.

- Integration tests

  Not run. This change only updates the UI-facing policy schema and preserves existing runtime behavior.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A. No sample changes are required for this schema rendering fix.

## Related PRs

- Related to https://github.com/wso2/gateway-controllers/pull/291

## Migrations (if applicable)

No migration is required.

Existing configurations using legacy weekday arrays such as `days: [Mon, Wed]` continue to be accepted by the runtime. New or edited configurations through AI Workspace should use the boolean weekday object format.

## Test environment

- macOS
- Go test environment
- Policy: `time-based-model-routing`
- Command run:

  ```bash
  go test ./...
  ```

## Learning

The issue was caused by exposing backward-compatible schema alternatives through `oneOf` in the policy definition. Although this is valid schema, the AI Workspace form renderer does not render this nested schema pattern cleanly inside an array item. The fix keeps backward compatibility in runtime parsing while simplifying the UI-facing schema to the object format expected by the form renderer.
