### PR TITLE
Update Go version for Oauth2 policy

### DIFF
--- a/policies/oauth2-generator/go.mod
+++ b/policies/oauth2-generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/gateway-controllers/policies/oauth2-generator
 
-go 1.26.5
+go 1.26.2
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0

--- a/policies/oauth2-generator/policy-definition.yaml
+++ b/policies/oauth2-generator/policy-definition.yaml
@@ -1,5 +1,5 @@
 name: oauth2-generator
-version: v0.9.0
+version: v0.9.1
 displayName: OAuth2 Generator
 description: |
   Injects an upstream OAuth2 credential into a request header before


### PR DESCRIPTION
This pull request includes minor maintenance updates for the `oauth2-generator` policy. The Go module version has been adjusted and the policy version has been incremented for release tracking.

- Versioning updates:
  * Bumped the policy version from `v0.9.0` to `v0.9.1` in `policy-definition.yaml` to reflect the new release.

- Build configuration:
  * Downgraded the Go module version from `1.26.5` to `1.26.2` in `go.mod` to ensure compatibility with the target environment.